### PR TITLE
[A2] Packet Generator

### DIFF
--- a/src/IntentSystem.Projection/PacketGenerator.cs
+++ b/src/IntentSystem.Projection/PacketGenerator.cs
@@ -1,0 +1,33 @@
+using IntentSystem.Projection.Models;
+using IntentSystem.Projection.Rendering;
+
+namespace IntentSystem.Projection;
+
+public sealed record GeneratedPacket
+{
+    public required string ImplementationMarkdown { get; init; }
+    public required string ReviewContextMarkdown { get; init; }
+    public required string PacketYaml { get; init; }
+    public required ResolvedPacketPaths Paths { get; init; }
+}
+
+public static class PacketGenerator
+{
+    public static GeneratedPacket Generate(SubSliceRow row, ProjectionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var implementationPacket = ProjectionMapper.ToImplementationPacket(row, context);
+        var reviewContextPacket = ProjectionMapper.ToReviewContextPacket(row, context);
+        var paths = PacketPathResolver.Resolve(row.SourceExecutionUnit);
+
+        return new GeneratedPacket
+        {
+            ImplementationMarkdown = ImplementationMarkdownRenderer.Render(implementationPacket),
+            ReviewContextMarkdown = ReviewContextMarkdownRenderer.Render(reviewContextPacket),
+            PacketYaml = PacketYamlRenderer.Render(implementationPacket),
+            Paths = paths
+        };
+    }
+}

--- a/src/IntentSystem.Projection/PacketGenerator.cs
+++ b/src/IntentSystem.Projection/PacketGenerator.cs
@@ -26,7 +26,7 @@ public static class PacketGenerator
         {
             ImplementationMarkdown = ImplementationMarkdownRenderer.Render(implementationPacket),
             ReviewContextMarkdown = ReviewContextMarkdownRenderer.Render(reviewContextPacket),
-            PacketYaml = PacketYamlRenderer.Render(implementationPacket),
+            PacketYaml = PacketYamlRenderer.Render(implementationPacket, reviewContextPacket),
             Paths = paths
         };
     }

--- a/src/IntentSystem.Projection/PacketPathResolver.cs
+++ b/src/IntentSystem.Projection/PacketPathResolver.cs
@@ -2,7 +2,7 @@ namespace IntentSystem.Projection;
 
 public static class PacketPathResolver
 {
-    private const string PacketsDirectory = ".takt/packets";
+    private const string PacketsDirectory = ".intent-cli/issues";
     private const string ImplementationFileName = "implementation.md";
     private const string ReviewContextFileName = "review-context.md";
     private const string PacketYamlFileName = "packet.yaml";

--- a/src/IntentSystem.Projection/PacketPathResolver.cs
+++ b/src/IntentSystem.Projection/PacketPathResolver.cs
@@ -1,0 +1,35 @@
+namespace IntentSystem.Projection;
+
+public static class PacketPathResolver
+{
+    private const string PacketsDirectory = ".takt/packets";
+    private const string ImplementationFileName = "implementation.md";
+    private const string ReviewContextFileName = "review-context.md";
+    private const string PacketYamlFileName = "packet.yaml";
+
+    public static ResolvedPacketPaths Resolve(string executionUnit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var sanitized = SanitizeExecutionUnit(executionUnit);
+
+        return new ResolvedPacketPaths
+        {
+            Implementation = $"{PacketsDirectory}/{sanitized}/{ImplementationFileName}",
+            ReviewContext = $"{PacketsDirectory}/{sanitized}/{ReviewContextFileName}",
+            Yaml = $"{PacketsDirectory}/{sanitized}/{PacketYamlFileName}"
+        };
+    }
+
+    private static string SanitizeExecutionUnit(string executionUnit)
+    {
+        return executionUnit.Trim().ToLowerInvariant();
+    }
+}
+
+public sealed record ResolvedPacketPaths
+{
+    public required string Implementation { get; init; }
+    public required string ReviewContext { get; init; }
+    public required string Yaml { get; init; }
+}

--- a/src/IntentSystem.Projection/Rendering/ImplementationMarkdownRenderer.cs
+++ b/src/IntentSystem.Projection/Rendering/ImplementationMarkdownRenderer.cs
@@ -1,0 +1,116 @@
+using System.Text;
+using IntentSystem.Projection.Models;
+
+namespace IntentSystem.Projection.Rendering;
+
+public static class ImplementationMarkdownRenderer
+{
+    public static string Render(ImplementationIssuePacket packet)
+    {
+        ArgumentNullException.ThrowIfNull(packet);
+
+        var sb = new StringBuilder();
+
+        AppendHeader(sb, packet);
+        AppendSection(sb, "Goal", packet.Goal);
+        AppendListSection(sb, "In Scope", packet.InScope);
+        AppendListSection(sb, "Out Of Scope", packet.OutOfScope);
+        AppendTargetSection(sb, packet);
+        AppendListSection(sb, "Dependencies", packet.Dependencies);
+        AppendListSection(sb, "Technical Baseline", packet.TechnicalBaseline);
+        AppendListSection(sb, "Project Local Guide", packet.ProjectLocalGuide);
+        AppendListSection(sb, "Intent Baseline", packet.IntentBaseline);
+        AppendListSection(sb, "Intent References", packet.IntentReferences);
+        AppendListSection(sb, "Rules And Specs", packet.RulesAndSpecs);
+        AppendListSection(sb, "Acceptance Criteria", packet.AcceptanceCriteria);
+        AppendVerificationSection(sb, packet);
+        AppendWorkflowSection(sb, packet);
+
+        return sb.ToString();
+    }
+
+    private static void AppendHeader(StringBuilder sb, ImplementationIssuePacket packet)
+    {
+        sb.AppendLine($"# {packet.IssueTitle}");
+        sb.AppendLine();
+        sb.AppendLine($"- **kind**: `{FormatIssueKind(packet.IssueKind)}`");
+        sb.AppendLine($"- **execution-unit**: `{packet.SourceExecutionUnit}`");
+        sb.AppendLine();
+    }
+
+    private static void AppendSection(StringBuilder sb, string heading, string content)
+    {
+        sb.AppendLine($"## {heading}");
+        sb.AppendLine();
+        sb.AppendLine(content);
+        sb.AppendLine();
+    }
+
+    private static void AppendListSection(StringBuilder sb, string heading, IReadOnlyList<string> items)
+    {
+        sb.AppendLine($"## {heading}");
+        sb.AppendLine();
+
+        if (items.Count == 0)
+        {
+            sb.AppendLine("(none)");
+        }
+        else
+        {
+            for (var i = 0; i < items.Count; i++)
+            {
+                sb.AppendLine($"- {items[i]}");
+            }
+        }
+
+        sb.AppendLine();
+    }
+
+    private static void AppendTargetSection(StringBuilder sb, ImplementationIssuePacket packet)
+    {
+        sb.AppendLine("## Target");
+        sb.AppendLine();
+        sb.AppendLine($"- **repo**: `{packet.TargetRepo}`");
+        sb.AppendLine($"- **path**: `{packet.TargetPath}`");
+        sb.AppendLine($"- **part**: `{packet.TargetPart}`");
+        sb.AppendLine();
+    }
+
+    private static void AppendVerificationSection(StringBuilder sb, ImplementationIssuePacket packet)
+    {
+        sb.AppendLine("## Verification");
+        sb.AppendLine();
+        sb.AppendLine("- required evidence:");
+
+        for (var i = 0; i < packet.VerificationEvidence.Count; i++)
+        {
+            sb.AppendLine($"  - `{packet.VerificationEvidence[i]}`");
+        }
+
+        sb.AppendLine();
+    }
+
+    private static void AppendWorkflowSection(StringBuilder sb, ImplementationIssuePacket packet)
+    {
+        sb.AppendLine("## Workflow");
+        sb.AppendLine();
+        sb.AppendLine($"- **review-mode**: `{packet.ReviewMode}`");
+        sb.AppendLine($"- **completion-action**: `{packet.CompletionAction}`");
+        sb.AppendLine($"- **landing-policy**: `{packet.LandingPolicy}`");
+        sb.AppendLine();
+    }
+
+    private static string FormatIssueKind(IssueKind kind)
+    {
+        return kind switch
+        {
+            IssueKind.Feature => "feature",
+            IssueKind.Bugfix => "bugfix",
+            IssueKind.BoundaryFix => "boundary-fix",
+            IssueKind.Verification => "verification",
+            IssueKind.Refactor => "refactor",
+            IssueKind.ClarificationFollowup => "clarification-followup",
+            _ => kind.ToString().ToLowerInvariant()
+        };
+    }
+}

--- a/src/IntentSystem.Projection/Rendering/PacketYamlRenderer.cs
+++ b/src/IntentSystem.Projection/Rendering/PacketYamlRenderer.cs
@@ -5,67 +5,89 @@ namespace IntentSystem.Projection.Rendering;
 
 public static class PacketYamlRenderer
 {
-    public static string Render(ImplementationIssuePacket packet)
+    public static string Render(ImplementationIssuePacket implementationPacket, ReviewContextPacket reviewContextPacket)
     {
-        ArgumentNullException.ThrowIfNull(packet);
+        ArgumentNullException.ThrowIfNull(implementationPacket);
+        ArgumentNullException.ThrowIfNull(reviewContextPacket);
 
         var sb = new StringBuilder();
 
-        AppendScalar(sb, "issue_title", packet.IssueTitle);
-        AppendScalar(sb, "issue_kind", FormatIssueKind(packet.IssueKind));
-        AppendScalar(sb, "source_execution_unit", packet.SourceExecutionUnit);
-        AppendScalar(sb, "goal", packet.Goal);
-        AppendList(sb, "in_scope", packet.InScope);
-        AppendList(sb, "out_of_scope", packet.OutOfScope);
-        AppendScalar(sb, "target_repo", packet.TargetRepo);
-        AppendScalar(sb, "target_path", packet.TargetPath);
-        AppendScalar(sb, "target_part", packet.TargetPart);
-        AppendList(sb, "dependencies", packet.Dependencies);
-        AppendList(sb, "technical_baseline", packet.TechnicalBaseline);
-        AppendList(sb, "project_local_guide", packet.ProjectLocalGuide);
-        AppendList(sb, "intent_baseline", packet.IntentBaseline);
-        AppendList(sb, "intent_references", packet.IntentReferences);
-        AppendList(sb, "rules_and_specs", packet.RulesAndSpecs);
-        AppendList(sb, "acceptance_criteria", packet.AcceptanceCriteria);
-        AppendList(sb, "verification_evidence", packet.VerificationEvidence);
-        AppendScalar(sb, "review_mode", packet.ReviewMode);
-        AppendScalar(sb, "completion_action", packet.CompletionAction);
-        AppendScalar(sb, "landing_policy", packet.LandingPolicy);
+        sb.AppendLine("implementation_issue_packet:");
+        AppendImplementationSection(sb, implementationPacket);
+        sb.AppendLine("review_context_packet:");
+        AppendReviewContextSection(sb, reviewContextPacket);
 
         return sb.ToString();
     }
 
-    private static void AppendScalar(StringBuilder sb, string key, string value)
+    private static void AppendImplementationSection(StringBuilder sb, ImplementationIssuePacket packet)
     {
+        AppendScalar(sb, "issue_title", packet.IssueTitle, indent: 2);
+        AppendScalar(sb, "issue_kind", FormatIssueKind(packet.IssueKind), indent: 2);
+        AppendScalar(sb, "source_execution_unit", packet.SourceExecutionUnit, indent: 2);
+        AppendScalar(sb, "goal", packet.Goal, indent: 2);
+        AppendList(sb, "in_scope", packet.InScope, indent: 2);
+        AppendList(sb, "out_of_scope", packet.OutOfScope, indent: 2);
+        AppendScalar(sb, "target_repo", packet.TargetRepo, indent: 2);
+        AppendScalar(sb, "target_path", packet.TargetPath, indent: 2);
+        AppendScalar(sb, "target_part", packet.TargetPart, indent: 2);
+        AppendList(sb, "dependencies", packet.Dependencies, indent: 2);
+        AppendList(sb, "technical_baseline", packet.TechnicalBaseline, indent: 2);
+        AppendList(sb, "project_local_guide", packet.ProjectLocalGuide, indent: 2);
+        AppendList(sb, "intent_baseline", packet.IntentBaseline, indent: 2);
+        AppendList(sb, "intent_references", packet.IntentReferences, indent: 2);
+        AppendList(sb, "rules_and_specs", packet.RulesAndSpecs, indent: 2);
+        AppendList(sb, "acceptance_criteria", packet.AcceptanceCriteria, indent: 2);
+        AppendList(sb, "verification_evidence", packet.VerificationEvidence, indent: 2);
+        AppendScalar(sb, "review_mode", packet.ReviewMode, indent: 2);
+        AppendScalar(sb, "completion_action", packet.CompletionAction, indent: 2);
+        AppendScalar(sb, "landing_policy", packet.LandingPolicy, indent: 2);
+    }
+
+    private static void AppendReviewContextSection(StringBuilder sb, ReviewContextPacket packet)
+    {
+        AppendScalar(sb, "source_execution_unit", packet.SourceExecutionUnit, indent: 2);
+        AppendScalar(sb, "parent_intent_root", packet.ParentIntentRoot, indent: 2);
+        AppendList(sb, "intent_references", packet.IntentReferences, indent: 2);
+        AppendList(sb, "rules_and_specs", packet.RulesAndSpecs, indent: 2);
+        AppendList(sb, "acceptance_criteria", packet.AcceptanceCriteria, indent: 2);
+        AppendList(sb, "deterministic_review_checks", packet.DeterministicReviewChecks, indent: 2);
+        AppendScalar(sb, "clarification_return_path", packet.ClarificationReturnPath, indent: 2);
+    }
+
+    private static void AppendScalar(StringBuilder sb, string key, string value, int indent)
+    {
+        var prefix = new string(' ', indent);
         if (NeedsQuoting(value))
         {
-            sb.AppendLine($"{key}: \"{EscapeYamlString(value)}\"");
+            sb.AppendLine($"{prefix}{key}: \"{EscapeYamlString(value)}\"");
         }
         else
         {
-            sb.AppendLine($"{key}: {value}");
+            sb.AppendLine($"{prefix}{key}: {value}");
         }
     }
 
-    private static void AppendList(StringBuilder sb, string key, IReadOnlyList<string> items)
+    private static void AppendList(StringBuilder sb, string key, IReadOnlyList<string> items, int indent)
     {
+        var prefix = new string(' ', indent);
         if (items.Count == 0)
         {
-            sb.AppendLine($"{key}: []");
+            sb.AppendLine($"{prefix}{key}: []");
             return;
         }
 
-        sb.AppendLine($"{key}:");
+        sb.AppendLine($"{prefix}{key}:");
         for (var i = 0; i < items.Count; i++)
         {
             var item = items[i];
             if (NeedsQuoting(item))
             {
-                sb.AppendLine($"  - \"{EscapeYamlString(item)}\"");
+                sb.AppendLine($"{prefix}  - \"{EscapeYamlString(item)}\"");
             }
             else
             {
-                sb.AppendLine($"  - {item}");
+                sb.AppendLine($"{prefix}  - {item}");
             }
         }
     }

--- a/src/IntentSystem.Projection/Rendering/PacketYamlRenderer.cs
+++ b/src/IntentSystem.Projection/Rendering/PacketYamlRenderer.cs
@@ -1,0 +1,126 @@
+using System.Text;
+using IntentSystem.Projection.Models;
+
+namespace IntentSystem.Projection.Rendering;
+
+public static class PacketYamlRenderer
+{
+    public static string Render(ImplementationIssuePacket packet)
+    {
+        ArgumentNullException.ThrowIfNull(packet);
+
+        var sb = new StringBuilder();
+
+        AppendScalar(sb, "issue_title", packet.IssueTitle);
+        AppendScalar(sb, "issue_kind", FormatIssueKind(packet.IssueKind));
+        AppendScalar(sb, "source_execution_unit", packet.SourceExecutionUnit);
+        AppendScalar(sb, "goal", packet.Goal);
+        AppendList(sb, "in_scope", packet.InScope);
+        AppendList(sb, "out_of_scope", packet.OutOfScope);
+        AppendScalar(sb, "target_repo", packet.TargetRepo);
+        AppendScalar(sb, "target_path", packet.TargetPath);
+        AppendScalar(sb, "target_part", packet.TargetPart);
+        AppendList(sb, "dependencies", packet.Dependencies);
+        AppendList(sb, "technical_baseline", packet.TechnicalBaseline);
+        AppendList(sb, "project_local_guide", packet.ProjectLocalGuide);
+        AppendList(sb, "intent_baseline", packet.IntentBaseline);
+        AppendList(sb, "intent_references", packet.IntentReferences);
+        AppendList(sb, "rules_and_specs", packet.RulesAndSpecs);
+        AppendList(sb, "acceptance_criteria", packet.AcceptanceCriteria);
+        AppendList(sb, "verification_evidence", packet.VerificationEvidence);
+        AppendScalar(sb, "review_mode", packet.ReviewMode);
+        AppendScalar(sb, "completion_action", packet.CompletionAction);
+        AppendScalar(sb, "landing_policy", packet.LandingPolicy);
+
+        return sb.ToString();
+    }
+
+    private static void AppendScalar(StringBuilder sb, string key, string value)
+    {
+        if (NeedsQuoting(value))
+        {
+            sb.AppendLine($"{key}: \"{EscapeYamlString(value)}\"");
+        }
+        else
+        {
+            sb.AppendLine($"{key}: {value}");
+        }
+    }
+
+    private static void AppendList(StringBuilder sb, string key, IReadOnlyList<string> items)
+    {
+        if (items.Count == 0)
+        {
+            sb.AppendLine($"{key}: []");
+            return;
+        }
+
+        sb.AppendLine($"{key}:");
+        for (var i = 0; i < items.Count; i++)
+        {
+            var item = items[i];
+            if (NeedsQuoting(item))
+            {
+                sb.AppendLine($"  - \"{EscapeYamlString(item)}\"");
+            }
+            else
+            {
+                sb.AppendLine($"  - {item}");
+            }
+        }
+    }
+
+    private static bool NeedsQuoting(string value)
+    {
+        if (value.Length == 0)
+        {
+            return true;
+        }
+
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (c is ':' or '#' or '\'' or '"' or '{' or '}' or '[' or ']'
+                or ',' or '&' or '*' or '?' or '|' or '<' or '>'
+                or '=' or '!' or '%' or '@' or '`' or '\n' or '\r')
+            {
+                return true;
+            }
+        }
+
+        if (value.StartsWith(' ') || value.EndsWith(' '))
+        {
+            return true;
+        }
+
+        if (value.StartsWith('-'))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string EscapeYamlString(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal);
+    }
+
+    private static string FormatIssueKind(IssueKind kind)
+    {
+        return kind switch
+        {
+            IssueKind.Feature => "feature",
+            IssueKind.Bugfix => "bugfix",
+            IssueKind.BoundaryFix => "boundary-fix",
+            IssueKind.Verification => "verification",
+            IssueKind.Refactor => "refactor",
+            IssueKind.ClarificationFollowup => "clarification-followup",
+            _ => kind.ToString().ToLowerInvariant()
+        };
+    }
+}

--- a/src/IntentSystem.Projection/Rendering/ReviewContextMarkdownRenderer.cs
+++ b/src/IntentSystem.Projection/Rendering/ReviewContextMarkdownRenderer.cs
@@ -1,0 +1,60 @@
+using System.Text;
+using IntentSystem.Projection.Models;
+
+namespace IntentSystem.Projection.Rendering;
+
+public static class ReviewContextMarkdownRenderer
+{
+    public static string Render(ReviewContextPacket packet)
+    {
+        ArgumentNullException.ThrowIfNull(packet);
+
+        var sb = new StringBuilder();
+
+        AppendHeader(sb, packet);
+        AppendSection(sb, "Parent Intent Root", packet.ParentIntentRoot);
+        AppendListSection(sb, "Intent References", packet.IntentReferences);
+        AppendListSection(sb, "Rules And Specs", packet.RulesAndSpecs);
+        AppendListSection(sb, "Acceptance Criteria", packet.AcceptanceCriteria);
+        AppendListSection(sb, "Deterministic Review Checks", packet.DeterministicReviewChecks);
+        AppendSection(sb, "Clarification Return Path", packet.ClarificationReturnPath);
+
+        return sb.ToString();
+    }
+
+    private static void AppendHeader(StringBuilder sb, ReviewContextPacket packet)
+    {
+        sb.AppendLine("# Review Context");
+        sb.AppendLine();
+        sb.AppendLine($"- **execution-unit**: `{packet.SourceExecutionUnit}`");
+        sb.AppendLine();
+    }
+
+    private static void AppendSection(StringBuilder sb, string heading, string content)
+    {
+        sb.AppendLine($"## {heading}");
+        sb.AppendLine();
+        sb.AppendLine(content);
+        sb.AppendLine();
+    }
+
+    private static void AppendListSection(StringBuilder sb, string heading, IReadOnlyList<string> items)
+    {
+        sb.AppendLine($"## {heading}");
+        sb.AppendLine();
+
+        if (items.Count == 0)
+        {
+            sb.AppendLine("(none)");
+        }
+        else
+        {
+            for (var i = 0; i < items.Count; i++)
+            {
+                sb.AppendLine($"- {items[i]}");
+            }
+        }
+
+        sb.AppendLine();
+    }
+}

--- a/tests/IntentSystem.Projection.Tests/ImplementationMarkdownRendererTests.cs
+++ b/tests/IntentSystem.Projection.Tests/ImplementationMarkdownRendererTests.cs
@@ -1,0 +1,116 @@
+using IntentSystem.Projection.Models;
+using IntentSystem.Projection.Rendering;
+
+namespace IntentSystem.Projection.Tests;
+
+public sealed class ImplementationMarkdownRendererTests
+{
+    [Fact]
+    public void Render_GivenPacket_StartsWithIssueTitleAsH1()
+    {
+        var markdown = ImplementationMarkdownRenderer.Render(CreatePacket());
+
+        Assert.StartsWith("# [A2] Packet Generator", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenPacket_IncludesKindAndExecutionUnitInHeader()
+    {
+        var markdown = ImplementationMarkdownRenderer.Render(CreatePacket());
+
+        Assert.Contains("**kind**: `feature`", markdown, StringComparison.Ordinal);
+        Assert.Contains("**execution-unit**: `A2`", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenPacket_IncludesTargetSection()
+    {
+        var markdown = ImplementationMarkdownRenderer.Render(CreatePacket());
+
+        Assert.Contains("## Target", markdown, StringComparison.Ordinal);
+        Assert.Contains("**repo**: `J-Tech-Japan/intent-system`", markdown, StringComparison.Ordinal);
+        Assert.Contains("**path**: `.`", markdown, StringComparison.Ordinal);
+        Assert.Contains("**part**: `projection generator`", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenPacket_IncludesVerificationWithBacktickEvidence()
+    {
+        var markdown = ImplementationMarkdownRenderer.Render(CreatePacket());
+
+        Assert.Contains("`contract-reviewed`", markdown, StringComparison.Ordinal);
+        Assert.Contains("`tests-passing`", markdown, StringComparison.Ordinal);
+        Assert.Contains("`acceptance-criteria-checked`", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenPacket_IncludesWorkflowSection()
+    {
+        var markdown = ImplementationMarkdownRenderer.Render(CreatePacket());
+
+        Assert.Contains("## Workflow", markdown, StringComparison.Ordinal);
+        Assert.Contains("**review-mode**: `manual-review`", markdown, StringComparison.Ordinal);
+        Assert.Contains("**completion-action**: `open-pr`", markdown, StringComparison.Ordinal);
+        Assert.Contains("**landing-policy**: `squash`", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenEmptyDependencies_ShowsNone()
+    {
+        var packet = CreatePacket() with { Dependencies = [] };
+        var markdown = ImplementationMarkdownRenderer.Render(packet);
+
+        var dependenciesIndex = markdown.IndexOf("## Dependencies", StringComparison.Ordinal);
+        var nextSectionIndex = markdown.IndexOf("## Technical Baseline", StringComparison.Ordinal);
+        var dependenciesSection = markdown[dependenciesIndex..nextSectionIndex];
+
+        Assert.Contains("(none)", dependenciesSection, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenSamePacket_ProducesIdenticalOutput()
+    {
+        var packet = CreatePacket();
+
+        var first = ImplementationMarkdownRenderer.Render(packet);
+        var second = ImplementationMarkdownRenderer.Render(packet);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Render_GivenBugfixKind_FormatsBugfixKebabStyle()
+    {
+        var packet = CreatePacket() with { IssueKind = IssueKind.BoundaryFix };
+        var markdown = ImplementationMarkdownRenderer.Render(packet);
+
+        Assert.Contains("**kind**: `boundary-fix`", markdown, StringComparison.Ordinal);
+    }
+
+    private static ImplementationIssuePacket CreatePacket()
+    {
+        return new ImplementationIssuePacket
+        {
+            IssueTitle = "[A2] Packet Generator",
+            IssueKind = IssueKind.Feature,
+            SourceExecutionUnit = "A2",
+            Goal = "Create packet generator for Markdown and YAML artifacts.",
+            InScope = ["projection generator", "Markdown artifact generation"],
+            OutOfScope = ["queue-state update logic", "workflow engine"],
+            TargetRepo = "J-Tech-Japan/intent-system",
+            TargetPath = ".",
+            TargetPart = "projection generator",
+            Dependencies = ["A1"],
+            TechnicalBaseline = ["C# / .NET", ".NET 10.0.100+ baseline"],
+            ProjectLocalGuide = ["AGENTS.md", "CLAUDE.md"],
+            IntentBaseline = ["A1 is complete"],
+            IntentReferences = ["intents/intent-cli/intent-tree/00-map.md"],
+            RulesAndSpecs = ["intents/rules/issue-projection-format.md"],
+            AcceptanceCriteria = ["generates implementation.md", "generates packet.yaml"],
+            VerificationEvidence = ["contract-reviewed", "tests-passing", "acceptance-criteria-checked"],
+            ReviewMode = "manual-review",
+            CompletionAction = "open-pr",
+            LandingPolicy = "squash"
+        };
+    }
+}

--- a/tests/IntentSystem.Projection.Tests/PacketGeneratorTests.cs
+++ b/tests/IntentSystem.Projection.Tests/PacketGeneratorTests.cs
@@ -1,0 +1,150 @@
+using IntentSystem.Projection.Models;
+
+namespace IntentSystem.Projection.Tests;
+
+public sealed class PacketGeneratorTests
+{
+    [Fact]
+    public void Generate_GivenCompleteRowAndContext_ProducesImplementationMarkdown()
+    {
+        var result = PacketGenerator.Generate(CreateRow(), CreateContext());
+
+        Assert.Contains("# [A2] Packet Generator", result.ImplementationMarkdown, StringComparison.Ordinal);
+        Assert.Contains("## Goal", result.ImplementationMarkdown, StringComparison.Ordinal);
+        Assert.Contains("## In Scope", result.ImplementationMarkdown, StringComparison.Ordinal);
+        Assert.Contains("## Out Of Scope", result.ImplementationMarkdown, StringComparison.Ordinal);
+        Assert.Contains("## Target", result.ImplementationMarkdown, StringComparison.Ordinal);
+        Assert.Contains("## Dependencies", result.ImplementationMarkdown, StringComparison.Ordinal);
+        Assert.Contains("## Acceptance Criteria", result.ImplementationMarkdown, StringComparison.Ordinal);
+        Assert.Contains("## Verification", result.ImplementationMarkdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Generate_GivenCompleteRowAndContext_ProducesReviewContextMarkdown()
+    {
+        var result = PacketGenerator.Generate(CreateRow(), CreateContext());
+
+        Assert.Contains("# Review Context", result.ReviewContextMarkdown, StringComparison.Ordinal);
+        Assert.Contains("## Parent Intent Root", result.ReviewContextMarkdown, StringComparison.Ordinal);
+        Assert.Contains("## Acceptance Criteria", result.ReviewContextMarkdown, StringComparison.Ordinal);
+        Assert.Contains("## Deterministic Review Checks", result.ReviewContextMarkdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Generate_GivenCompleteRowAndContext_ProducesPacketYaml()
+    {
+        var result = PacketGenerator.Generate(CreateRow(), CreateContext());
+
+        Assert.Contains("issue_title:", result.PacketYaml, StringComparison.Ordinal);
+        Assert.Contains("issue_kind: feature", result.PacketYaml, StringComparison.Ordinal);
+        Assert.Contains("source_execution_unit: A2", result.PacketYaml, StringComparison.Ordinal);
+        Assert.Contains("goal:", result.PacketYaml, StringComparison.Ordinal);
+        Assert.Contains("acceptance_criteria:", result.PacketYaml, StringComparison.Ordinal);
+        Assert.Contains("verification_evidence:", result.PacketYaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Generate_GivenCompleteRowAndContext_ResolvesDeterministicPaths()
+    {
+        var result = PacketGenerator.Generate(CreateRow(), CreateContext());
+
+        Assert.Equal(".takt/packets/a2/implementation.md", result.Paths.Implementation);
+        Assert.Equal(".takt/packets/a2/review-context.md", result.Paths.ReviewContext);
+        Assert.Equal(".takt/packets/a2/packet.yaml", result.Paths.Yaml);
+    }
+
+    [Fact]
+    public void Generate_GivenSameInputs_ProducesIdenticalOutput()
+    {
+        var row = CreateRow();
+        var context = CreateContext();
+
+        var first = PacketGenerator.Generate(row, context);
+        var second = PacketGenerator.Generate(row, context);
+
+        Assert.Equal(first.ImplementationMarkdown, second.ImplementationMarkdown);
+        Assert.Equal(first.ReviewContextMarkdown, second.ReviewContextMarkdown);
+        Assert.Equal(first.PacketYaml, second.PacketYaml);
+        Assert.Equal(first.Paths, second.Paths);
+    }
+
+    [Fact]
+    public void Generate_GivenNullRow_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => PacketGenerator.Generate(null!, CreateContext()));
+    }
+
+    [Fact]
+    public void Generate_GivenNullContext_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => PacketGenerator.Generate(CreateRow(), null!));
+    }
+
+    private static SubSliceRow CreateRow()
+    {
+        return new SubSliceRow
+        {
+            SourceExecutionUnit = "A2",
+            Goal = "Create packet generator that renders Markdown and YAML artifacts.",
+            TargetRepo = "J-Tech-Japan/intent-system",
+            TargetPath = ".",
+            TargetPart = "projection generator",
+            DependsOnSubslices = ["A1"],
+            RelatedIntents = ["intents/intent-cli/intent-tree/00-map.md"],
+            SourceConcepts =
+            [
+                "intents/rules/issue-projection-format.md",
+                "intents/intent-cli/specs/02-packet-generator-contract.md",
+                "notes/domain-language.md"
+            ],
+            SuccessSignal = "packet generator produces deterministic Markdown and YAML from projection input",
+            ReviewMode = "manual-review",
+            CompletionAction = "open-pr",
+            LandingPolicy = "squash"
+        };
+    }
+
+    private static ProjectionContext CreateContext()
+    {
+        return new ProjectionContext
+        {
+            IssueTitle = "[A2] Packet Generator",
+            IssueKind = IssueKind.Feature,
+            ParentIntentRoot = "intents/intent-cli/intent-tree/00-map.md",
+            ClarificationReturnPath = "intents/rules/issue-template-and-review-context.md",
+            AcceptanceCriteria =
+            [
+                "projection input generates implementation.md and review-context.md",
+                "projection input generates packet.yaml",
+                "artifact path is deterministic from execution_unit",
+                "same input produces same packet",
+                "generator does not modify source data"
+            ],
+            DeterministicReviewChecks =
+            [
+                "packet generator does not carry queue policy",
+                "Markdown and YAML outputs can drop current projection schema",
+                "artifact path is stable per execution unit"
+            ],
+            VerificationEvidence =
+            [
+                "contract-reviewed",
+                "tests-passing",
+                "acceptance-criteria-checked"
+            ],
+            TechnicalBaseline =
+            [
+                "C# / .NET",
+                ".NET 10.0.100+ baseline"
+            ],
+            ProjectLocalGuide = ["AGENTS.md", "CLAUDE.md"],
+            IntentBaseline =
+            [
+                "A1 is complete and projection schema field contract is fixed",
+                "generator does not update source of truth"
+            ],
+            AdditionalInScope = ["Markdown artifact generation", "YAML artifact generation"],
+            OutOfScope = ["projection schema redefinition", "queue-state update logic", "workflow engine"]
+        };
+    }
+}

--- a/tests/IntentSystem.Projection.Tests/PacketGeneratorTests.cs
+++ b/tests/IntentSystem.Projection.Tests/PacketGeneratorTests.cs
@@ -35,12 +35,13 @@ public sealed class PacketGeneratorTests
     {
         var result = PacketGenerator.Generate(CreateRow(), CreateContext());
 
+        Assert.Contains("implementation_issue_packet:", result.PacketYaml, StringComparison.Ordinal);
+        Assert.Contains("review_context_packet:", result.PacketYaml, StringComparison.Ordinal);
         Assert.Contains("issue_title:", result.PacketYaml, StringComparison.Ordinal);
         Assert.Contains("issue_kind: feature", result.PacketYaml, StringComparison.Ordinal);
         Assert.Contains("source_execution_unit: A2", result.PacketYaml, StringComparison.Ordinal);
-        Assert.Contains("goal:", result.PacketYaml, StringComparison.Ordinal);
-        Assert.Contains("acceptance_criteria:", result.PacketYaml, StringComparison.Ordinal);
-        Assert.Contains("verification_evidence:", result.PacketYaml, StringComparison.Ordinal);
+        Assert.Contains("deterministic_review_checks:", result.PacketYaml, StringComparison.Ordinal);
+        Assert.Contains("clarification_return_path:", result.PacketYaml, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -48,9 +49,9 @@ public sealed class PacketGeneratorTests
     {
         var result = PacketGenerator.Generate(CreateRow(), CreateContext());
 
-        Assert.Equal(".takt/packets/a2/implementation.md", result.Paths.Implementation);
-        Assert.Equal(".takt/packets/a2/review-context.md", result.Paths.ReviewContext);
-        Assert.Equal(".takt/packets/a2/packet.yaml", result.Paths.Yaml);
+        Assert.Equal(".intent-cli/issues/a2/implementation.md", result.Paths.Implementation);
+        Assert.Equal(".intent-cli/issues/a2/review-context.md", result.Paths.ReviewContext);
+        Assert.Equal(".intent-cli/issues/a2/packet.yaml", result.Paths.Yaml);
     }
 
     [Fact]

--- a/tests/IntentSystem.Projection.Tests/PacketPathResolverTests.cs
+++ b/tests/IntentSystem.Projection.Tests/PacketPathResolverTests.cs
@@ -7,9 +7,9 @@ public sealed class PacketPathResolverTests
     {
         var paths = PacketPathResolver.Resolve("A2");
 
-        Assert.Equal(".takt/packets/a2/implementation.md", paths.Implementation);
-        Assert.Equal(".takt/packets/a2/review-context.md", paths.ReviewContext);
-        Assert.Equal(".takt/packets/a2/packet.yaml", paths.Yaml);
+        Assert.Equal(".intent-cli/issues/a2/implementation.md", paths.Implementation);
+        Assert.Equal(".intent-cli/issues/a2/review-context.md", paths.ReviewContext);
+        Assert.Equal(".intent-cli/issues/a2/packet.yaml", paths.Yaml);
     }
 
     [Fact]
@@ -26,7 +26,7 @@ public sealed class PacketPathResolverTests
     {
         var paths = PacketPathResolver.Resolve("  B1  ");
 
-        Assert.Equal(".takt/packets/b1/implementation.md", paths.Implementation);
+        Assert.Equal(".intent-cli/issues/b1/implementation.md", paths.Implementation);
     }
 
     [Fact]

--- a/tests/IntentSystem.Projection.Tests/PacketPathResolverTests.cs
+++ b/tests/IntentSystem.Projection.Tests/PacketPathResolverTests.cs
@@ -1,0 +1,48 @@
+namespace IntentSystem.Projection.Tests;
+
+public sealed class PacketPathResolverTests
+{
+    [Fact]
+    public void Resolve_GivenExecutionUnit_ReturnsDeterministicPaths()
+    {
+        var paths = PacketPathResolver.Resolve("A2");
+
+        Assert.Equal(".takt/packets/a2/implementation.md", paths.Implementation);
+        Assert.Equal(".takt/packets/a2/review-context.md", paths.ReviewContext);
+        Assert.Equal(".takt/packets/a2/packet.yaml", paths.Yaml);
+    }
+
+    [Fact]
+    public void Resolve_GivenSameExecutionUnit_ReturnsSamePaths()
+    {
+        var first = PacketPathResolver.Resolve("A2");
+        var second = PacketPathResolver.Resolve("A2");
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Resolve_GivenExecutionUnitWithWhitespace_TrimsAndNormalizes()
+    {
+        var paths = PacketPathResolver.Resolve("  B1  ");
+
+        Assert.Equal(".takt/packets/b1/implementation.md", paths.Implementation);
+    }
+
+    [Fact]
+    public void Resolve_GivenMixedCaseExecutionUnit_NormalizesToLowerCase()
+    {
+        var paths = PacketPathResolver.Resolve("A2");
+        var pathsLower = PacketPathResolver.Resolve("a2");
+
+        Assert.Equal(paths, pathsLower);
+    }
+
+    [Fact]
+    public void Resolve_GivenNullOrWhitespace_ThrowsArgumentException()
+    {
+        Assert.ThrowsAny<ArgumentException>(() => PacketPathResolver.Resolve(null!));
+        Assert.ThrowsAny<ArgumentException>(() => PacketPathResolver.Resolve(""));
+        Assert.ThrowsAny<ArgumentException>(() => PacketPathResolver.Resolve("   "));
+    }
+}

--- a/tests/IntentSystem.Projection.Tests/PacketYamlRendererTests.cs
+++ b/tests/IntentSystem.Projection.Tests/PacketYamlRendererTests.cs
@@ -6,32 +6,45 @@ namespace IntentSystem.Projection.Tests;
 public sealed class PacketYamlRendererTests
 {
     [Fact]
-    public void Render_GivenPacket_IncludesAllTopLevelKeys()
+    public void Render_GivenPackets_IncludesBothTopLevelSections()
     {
-        var yaml = PacketYamlRenderer.Render(CreatePacket());
+        var yaml = PacketYamlRenderer.Render(CreateImplementationPacket(), CreateReviewContextPacket());
 
-        Assert.Contains("issue_title:", yaml, StringComparison.Ordinal);
-        Assert.Contains("issue_kind:", yaml, StringComparison.Ordinal);
-        Assert.Contains("source_execution_unit:", yaml, StringComparison.Ordinal);
-        Assert.Contains("goal:", yaml, StringComparison.Ordinal);
-        Assert.Contains("in_scope:", yaml, StringComparison.Ordinal);
-        Assert.Contains("out_of_scope:", yaml, StringComparison.Ordinal);
-        Assert.Contains("target_repo:", yaml, StringComparison.Ordinal);
-        Assert.Contains("target_path:", yaml, StringComparison.Ordinal);
-        Assert.Contains("target_part:", yaml, StringComparison.Ordinal);
-        Assert.Contains("dependencies:", yaml, StringComparison.Ordinal);
-        Assert.Contains("technical_baseline:", yaml, StringComparison.Ordinal);
-        Assert.Contains("acceptance_criteria:", yaml, StringComparison.Ordinal);
-        Assert.Contains("verification_evidence:", yaml, StringComparison.Ordinal);
-        Assert.Contains("review_mode:", yaml, StringComparison.Ordinal);
-        Assert.Contains("completion_action:", yaml, StringComparison.Ordinal);
-        Assert.Contains("landing_policy:", yaml, StringComparison.Ordinal);
+        Assert.Contains("implementation_issue_packet:", yaml, StringComparison.Ordinal);
+        Assert.Contains("review_context_packet:", yaml, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void Render_GivenPacket_FormatsIssueKindAsKebabCase()
+    public void Render_GivenPackets_IncludesImplementationFields()
     {
-        var yaml = PacketYamlRenderer.Render(CreatePacket());
+        var yaml = PacketYamlRenderer.Render(CreateImplementationPacket(), CreateReviewContextPacket());
+
+        Assert.Contains("  issue_title:", yaml, StringComparison.Ordinal);
+        Assert.Contains("  issue_kind:", yaml, StringComparison.Ordinal);
+        Assert.Contains("  source_execution_unit:", yaml, StringComparison.Ordinal);
+        Assert.Contains("  goal:", yaml, StringComparison.Ordinal);
+        Assert.Contains("  in_scope:", yaml, StringComparison.Ordinal);
+        Assert.Contains("  out_of_scope:", yaml, StringComparison.Ordinal);
+        Assert.Contains("  target_repo:", yaml, StringComparison.Ordinal);
+        Assert.Contains("  acceptance_criteria:", yaml, StringComparison.Ordinal);
+        Assert.Contains("  verification_evidence:", yaml, StringComparison.Ordinal);
+        Assert.Contains("  review_mode:", yaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenPackets_IncludesReviewContextFields()
+    {
+        var yaml = PacketYamlRenderer.Render(CreateImplementationPacket(), CreateReviewContextPacket());
+
+        Assert.Contains("  parent_intent_root:", yaml, StringComparison.Ordinal);
+        Assert.Contains("  deterministic_review_checks:", yaml, StringComparison.Ordinal);
+        Assert.Contains("  clarification_return_path:", yaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenPackets_FormatsIssueKindAsKebabCase()
+    {
+        var yaml = PacketYamlRenderer.Render(CreateImplementationPacket(), CreateReviewContextPacket());
 
         Assert.Contains("issue_kind: feature", yaml, StringComparison.Ordinal);
     }
@@ -39,8 +52,8 @@ public sealed class PacketYamlRendererTests
     [Fact]
     public void Render_GivenBoundaryFixKind_FormatsAsKebabCase()
     {
-        var packet = CreatePacket() with { IssueKind = IssueKind.BoundaryFix };
-        var yaml = PacketYamlRenderer.Render(packet);
+        var implPacket = CreateImplementationPacket() with { IssueKind = IssueKind.BoundaryFix };
+        var yaml = PacketYamlRenderer.Render(implPacket, CreateReviewContextPacket());
 
         Assert.Contains("issue_kind: boundary-fix", yaml, StringComparison.Ordinal);
     }
@@ -48,41 +61,42 @@ public sealed class PacketYamlRendererTests
     [Fact]
     public void Render_GivenEmptyList_RendersEmptyArraySyntax()
     {
-        var packet = CreatePacket() with { RulesAndSpecs = [] };
-        var yaml = PacketYamlRenderer.Render(packet);
+        var implPacket = CreateImplementationPacket() with { RulesAndSpecs = [] };
+        var yaml = PacketYamlRenderer.Render(implPacket, CreateReviewContextPacket());
 
         Assert.Contains("rules_and_specs: []", yaml, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void Render_GivenListItems_RendersAsBulletedItems()
+    public void Render_GivenListItems_RendersAsIndentedBulletedItems()
     {
-        var yaml = PacketYamlRenderer.Render(CreatePacket());
+        var yaml = PacketYamlRenderer.Render(CreateImplementationPacket(), CreateReviewContextPacket());
 
-        Assert.Contains("  - A1", yaml, StringComparison.Ordinal);
+        Assert.Contains("    - A1", yaml, StringComparison.Ordinal);
     }
 
     [Fact]
     public void Render_GivenValueWithSpecialChars_QuotesTheValue()
     {
-        var packet = CreatePacket() with { Goal = "Fix the projection: schema contract" };
-        var yaml = PacketYamlRenderer.Render(packet);
+        var implPacket = CreateImplementationPacket() with { Goal = "Fix the projection: schema contract" };
+        var yaml = PacketYamlRenderer.Render(implPacket, CreateReviewContextPacket());
 
         Assert.Contains("goal: \"Fix the projection: schema contract\"", yaml, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void Render_GivenSamePacket_ProducesIdenticalOutput()
+    public void Render_GivenSamePackets_ProducesIdenticalOutput()
     {
-        var packet = CreatePacket();
+        var implPacket = CreateImplementationPacket();
+        var reviewPacket = CreateReviewContextPacket();
 
-        var first = PacketYamlRenderer.Render(packet);
-        var second = PacketYamlRenderer.Render(packet);
+        var first = PacketYamlRenderer.Render(implPacket, reviewPacket);
+        var second = PacketYamlRenderer.Render(implPacket, reviewPacket);
 
         Assert.Equal(first, second);
     }
 
-    private static ImplementationIssuePacket CreatePacket()
+    private static ImplementationIssuePacket CreateImplementationPacket()
     {
         return new ImplementationIssuePacket
         {
@@ -106,6 +120,24 @@ public sealed class PacketYamlRendererTests
             ReviewMode = "manual-review",
             CompletionAction = "open-pr",
             LandingPolicy = "squash"
+        };
+    }
+
+    private static ReviewContextPacket CreateReviewContextPacket()
+    {
+        return new ReviewContextPacket
+        {
+            SourceExecutionUnit = "A2",
+            ParentIntentRoot = "intents/intent-cli/intent-tree/00-map.md",
+            IntentReferences = ["intents/intent-cli/intent-tree/00-map.md"],
+            RulesAndSpecs = ["intents/rules/issue-projection-format.md"],
+            AcceptanceCriteria = ["generates implementation.md", "generates packet.yaml"],
+            DeterministicReviewChecks =
+            [
+                "packet generator does not carry queue policy",
+                "artifact path is stable per execution unit"
+            ],
+            ClarificationReturnPath = "intents/rules/issue-template-and-review-context.md"
         };
     }
 }

--- a/tests/IntentSystem.Projection.Tests/PacketYamlRendererTests.cs
+++ b/tests/IntentSystem.Projection.Tests/PacketYamlRendererTests.cs
@@ -1,0 +1,111 @@
+using IntentSystem.Projection.Models;
+using IntentSystem.Projection.Rendering;
+
+namespace IntentSystem.Projection.Tests;
+
+public sealed class PacketYamlRendererTests
+{
+    [Fact]
+    public void Render_GivenPacket_IncludesAllTopLevelKeys()
+    {
+        var yaml = PacketYamlRenderer.Render(CreatePacket());
+
+        Assert.Contains("issue_title:", yaml, StringComparison.Ordinal);
+        Assert.Contains("issue_kind:", yaml, StringComparison.Ordinal);
+        Assert.Contains("source_execution_unit:", yaml, StringComparison.Ordinal);
+        Assert.Contains("goal:", yaml, StringComparison.Ordinal);
+        Assert.Contains("in_scope:", yaml, StringComparison.Ordinal);
+        Assert.Contains("out_of_scope:", yaml, StringComparison.Ordinal);
+        Assert.Contains("target_repo:", yaml, StringComparison.Ordinal);
+        Assert.Contains("target_path:", yaml, StringComparison.Ordinal);
+        Assert.Contains("target_part:", yaml, StringComparison.Ordinal);
+        Assert.Contains("dependencies:", yaml, StringComparison.Ordinal);
+        Assert.Contains("technical_baseline:", yaml, StringComparison.Ordinal);
+        Assert.Contains("acceptance_criteria:", yaml, StringComparison.Ordinal);
+        Assert.Contains("verification_evidence:", yaml, StringComparison.Ordinal);
+        Assert.Contains("review_mode:", yaml, StringComparison.Ordinal);
+        Assert.Contains("completion_action:", yaml, StringComparison.Ordinal);
+        Assert.Contains("landing_policy:", yaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenPacket_FormatsIssueKindAsKebabCase()
+    {
+        var yaml = PacketYamlRenderer.Render(CreatePacket());
+
+        Assert.Contains("issue_kind: feature", yaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenBoundaryFixKind_FormatsAsKebabCase()
+    {
+        var packet = CreatePacket() with { IssueKind = IssueKind.BoundaryFix };
+        var yaml = PacketYamlRenderer.Render(packet);
+
+        Assert.Contains("issue_kind: boundary-fix", yaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenEmptyList_RendersEmptyArraySyntax()
+    {
+        var packet = CreatePacket() with { RulesAndSpecs = [] };
+        var yaml = PacketYamlRenderer.Render(packet);
+
+        Assert.Contains("rules_and_specs: []", yaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenListItems_RendersAsBulletedItems()
+    {
+        var yaml = PacketYamlRenderer.Render(CreatePacket());
+
+        Assert.Contains("  - A1", yaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenValueWithSpecialChars_QuotesTheValue()
+    {
+        var packet = CreatePacket() with { Goal = "Fix the projection: schema contract" };
+        var yaml = PacketYamlRenderer.Render(packet);
+
+        Assert.Contains("goal: \"Fix the projection: schema contract\"", yaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenSamePacket_ProducesIdenticalOutput()
+    {
+        var packet = CreatePacket();
+
+        var first = PacketYamlRenderer.Render(packet);
+        var second = PacketYamlRenderer.Render(packet);
+
+        Assert.Equal(first, second);
+    }
+
+    private static ImplementationIssuePacket CreatePacket()
+    {
+        return new ImplementationIssuePacket
+        {
+            IssueTitle = "[A2] Packet Generator",
+            IssueKind = IssueKind.Feature,
+            SourceExecutionUnit = "A2",
+            Goal = "Create packet generator for Markdown and YAML artifacts.",
+            InScope = ["projection generator", "Markdown artifact generation"],
+            OutOfScope = ["queue-state update logic"],
+            TargetRepo = "J-Tech-Japan/intent-system",
+            TargetPath = ".",
+            TargetPart = "projection generator",
+            Dependencies = ["A1"],
+            TechnicalBaseline = ["C# / .NET"],
+            ProjectLocalGuide = ["AGENTS.md"],
+            IntentBaseline = ["A1 is complete"],
+            IntentReferences = ["intents/intent-cli/intent-tree/00-map.md"],
+            RulesAndSpecs = ["intents/rules/issue-projection-format.md"],
+            AcceptanceCriteria = ["generates implementation.md", "generates packet.yaml"],
+            VerificationEvidence = ["contract-reviewed", "tests-passing", "acceptance-criteria-checked"],
+            ReviewMode = "manual-review",
+            CompletionAction = "open-pr",
+            LandingPolicy = "squash"
+        };
+    }
+}

--- a/tests/IntentSystem.Projection.Tests/ReviewContextMarkdownRendererTests.cs
+++ b/tests/IntentSystem.Projection.Tests/ReviewContextMarkdownRendererTests.cs
@@ -1,0 +1,74 @@
+using IntentSystem.Projection.Models;
+using IntentSystem.Projection.Rendering;
+
+namespace IntentSystem.Projection.Tests;
+
+public sealed class ReviewContextMarkdownRendererTests
+{
+    [Fact]
+    public void Render_GivenPacket_StartsWithReviewContextH1()
+    {
+        var markdown = ReviewContextMarkdownRenderer.Render(CreatePacket());
+
+        Assert.StartsWith("# Review Context", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenPacket_IncludesExecutionUnitInHeader()
+    {
+        var markdown = ReviewContextMarkdownRenderer.Render(CreatePacket());
+
+        Assert.Contains("**execution-unit**: `A2`", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenPacket_IncludesAllSections()
+    {
+        var markdown = ReviewContextMarkdownRenderer.Render(CreatePacket());
+
+        Assert.Contains("## Parent Intent Root", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Intent References", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Rules And Specs", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Acceptance Criteria", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Deterministic Review Checks", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Clarification Return Path", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenPacket_ListsAcceptanceCriteriaAsBullets()
+    {
+        var markdown = ReviewContextMarkdownRenderer.Render(CreatePacket());
+
+        Assert.Contains("- generates implementation.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("- generates packet.yaml", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_GivenSamePacket_ProducesIdenticalOutput()
+    {
+        var packet = CreatePacket();
+
+        var first = ReviewContextMarkdownRenderer.Render(packet);
+        var second = ReviewContextMarkdownRenderer.Render(packet);
+
+        Assert.Equal(first, second);
+    }
+
+    private static ReviewContextPacket CreatePacket()
+    {
+        return new ReviewContextPacket
+        {
+            SourceExecutionUnit = "A2",
+            ParentIntentRoot = "intents/intent-cli/intent-tree/00-map.md",
+            IntentReferences = ["intents/intent-cli/intent-tree/00-map.md"],
+            RulesAndSpecs = ["intents/rules/issue-projection-format.md"],
+            AcceptanceCriteria = ["generates implementation.md", "generates packet.yaml"],
+            DeterministicReviewChecks =
+            [
+                "packet generator does not carry queue policy",
+                "artifact path is stable per execution unit"
+            ],
+            ClarificationReturnPath = "intents/rules/issue-template-and-review-context.md"
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- projection input から `implementation.md`、`review-context.md`、`packet.yaml` を deterministic に生成する packet generator を実装
- `PacketPathResolver` で execution unit から安定した artifact path を決定（`.takt/packets/{unit}/`）
- 外部依存なしの YAML レンダラーを含む Markdown/YAML rendering pipeline を構築
- 全 40 テスト（新規 32 + 既存 8）が passing

## Implementation

| Component | File | Purpose |
|---|---|---|
| `PacketGenerator` | `src/IntentSystem.Projection/PacketGenerator.cs` | SubSliceRow + ProjectionContext → GeneratedPacket (統合エントリーポイント) |
| `PacketPathResolver` | `src/IntentSystem.Projection/PacketPathResolver.cs` | execution unit → deterministic file paths |
| `ImplementationMarkdownRenderer` | `src/IntentSystem.Projection/Rendering/` | ImplementationIssuePacket → implementation.md |
| `ReviewContextMarkdownRenderer` | `src/IntentSystem.Projection/Rendering/` | ReviewContextPacket → review-context.md |
| `PacketYamlRenderer` | `src/IntentSystem.Projection/Rendering/` | ImplementationIssuePacket → packet.yaml |

## Acceptance Criteria

- [x] projection input から `implementation.md` と `review-context.md` を生成できる
- [x] projection input から `packet.yaml` を生成できる
- [x] artifact path を `execution_unit` から deterministic に決められる
- [x] 同じ入力から同じ packet が再生成できる
- [x] generator が source data を変更しない

## Test plan

- [x] `PacketPathResolverTests` — path の determinism、正規化、バリデーション
- [x] `ImplementationMarkdownRendererTests` — 全セクション出力、kind フォーマット、idempotency
- [x] `ReviewContextMarkdownRendererTests` — 全セクション出力、idempotency
- [x] `PacketYamlRendererTests` — 全キー出力、enum フォーマット、空リスト、特殊文字クォート
- [x] `PacketGeneratorTests` — 統合テスト、determinism、null ガード
- [x] 既存テスト全 passing を確認

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)