### PR TITLE
[B2] Queue Manager

### DIFF
--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -1,0 +1,289 @@
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Supervisor;
+
+/// <summary>
+/// Manages deterministic state transitions on a queue snapshot.
+/// Each method returns a new QueueState (immutable) and the RunEvent to append.
+/// The caller is responsible for persisting the snapshot and appending the event.
+/// </summary>
+public static class QueueManager
+{
+    /// <summary>
+    /// Transition a queued item to active.
+    /// </summary>
+    public static QueueTransitionResult Activate(
+        QueueState state, string executionUnit, string by, DateTimeOffset ts)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(by);
+
+        var item = FindItem(state, executionUnit);
+        AssertState(item, QueueItemState.Queued, "activate");
+
+        return ApplyTransition(state, executionUnit, QueueItemState.Active, new RunEvent
+        {
+            Ts = ts,
+            ExecutionUnit = executionUnit,
+            Event = "activated",
+            By = by
+        });
+    }
+
+    /// <summary>
+    /// Transition an active item to review.
+    /// </summary>
+    public static QueueTransitionResult SubmitForReview(
+        QueueState state, string executionUnit, string by, DateTimeOffset ts,
+        string? linkedPr = null)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(by);
+
+        var item = FindItem(state, executionUnit);
+        AssertState(item, QueueItemState.Active, "submit-for-review");
+
+        return ApplyTransition(state, executionUnit, QueueItemState.Review, new RunEvent
+        {
+            Ts = ts,
+            ExecutionUnit = executionUnit,
+            Event = "review-started",
+            By = by,
+            LinkedPr = linkedPr
+        });
+    }
+
+    /// <summary>
+    /// Transition a review item to fixing (repair-in-place).
+    /// </summary>
+    public static QueueTransitionResult RequestFix(
+        QueueState state, string executionUnit, string by, DateTimeOffset ts,
+        string? reason = null)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(by);
+
+        var item = FindItem(state, executionUnit);
+        AssertState(item, QueueItemState.Review, "request-fix");
+
+        return ApplyTransition(state, executionUnit, QueueItemState.Fixing, new RunEvent
+        {
+            Ts = ts,
+            ExecutionUnit = executionUnit,
+            Event = "fix-requested",
+            By = by,
+            Reason = reason
+        });
+    }
+
+    /// <summary>
+    /// Transition a fixing item back to review (repair-in-place cycle).
+    /// </summary>
+    public static QueueTransitionResult ResubmitForReview(
+        QueueState state, string executionUnit, string by, DateTimeOffset ts,
+        string? linkedPr = null)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(by);
+
+        var item = FindItem(state, executionUnit);
+        AssertState(item, QueueItemState.Fixing, "resubmit-for-review");
+
+        return ApplyTransition(state, executionUnit, QueueItemState.Review, new RunEvent
+        {
+            Ts = ts,
+            ExecutionUnit = executionUnit,
+            Event = "review-started",
+            By = by,
+            LinkedPr = linkedPr
+        });
+    }
+
+    /// <summary>
+    /// Transition a review item to clarify-blocked.
+    /// </summary>
+    public static QueueTransitionResult RequestClarification(
+        QueueState state, string executionUnit, string by, DateTimeOffset ts,
+        string? reason = null)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(by);
+
+        var item = FindItem(state, executionUnit);
+        AssertState(item, QueueItemState.Review, "request-clarification");
+
+        return ApplyTransition(state, executionUnit, QueueItemState.ClarifyBlocked, new RunEvent
+        {
+            Ts = ts,
+            ExecutionUnit = executionUnit,
+            Event = "clarify-requested",
+            By = by,
+            Reason = reason
+        });
+    }
+
+    /// <summary>
+    /// Resolve a clarify-blocked item back to active.
+    /// </summary>
+    public static QueueTransitionResult ResolveClarification(
+        QueueState state, string executionUnit, string by, DateTimeOffset ts)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(by);
+
+        var item = FindItem(state, executionUnit);
+        AssertState(item, QueueItemState.ClarifyBlocked, "resolve-clarification");
+
+        return ApplyTransition(state, executionUnit, QueueItemState.Active, new RunEvent
+        {
+            Ts = ts,
+            ExecutionUnit = executionUnit,
+            Event = "clarify-resolved",
+            By = by
+        });
+    }
+
+    /// <summary>
+    /// Complete a reviewed item.
+    /// </summary>
+    public static QueueTransitionResult Complete(
+        QueueState state, string executionUnit, string by, DateTimeOffset ts)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(by);
+
+        var item = FindItem(state, executionUnit);
+        AssertState(item, QueueItemState.Review, "complete");
+
+        var result = ApplyTransition(state, executionUnit, QueueItemState.Completed, new RunEvent
+        {
+            Ts = ts,
+            ExecutionUnit = executionUnit,
+            Event = "completed",
+            By = by
+        });
+
+        // After completion, unblock dependents
+        var unblocked = UnblockDependents(result.UpdatedState, executionUnit, ts);
+        return result with { UpdatedState = unblocked };
+    }
+
+    /// <summary>
+    /// Recalculates blocked/queued states for all items based on current dependency resolution.
+    /// Items whose dependencies are all completed move from blocked to queued.
+    /// </summary>
+    public static QueueState RefreshDependencies(QueueState state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+
+        var completedUnits = state.Items
+            .Where(i => i.State == QueueItemState.Completed)
+            .Select(i => i.ExecutionUnit)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var updatedItems = new QueueItem[state.Items.Count];
+
+        for (var i = 0; i < state.Items.Count; i++)
+        {
+            var item = state.Items[i];
+
+            if (item.State == QueueItemState.Blocked)
+            {
+                var unresolvedDeps = item.Dependencies
+                    .Where(dep => !completedUnits.Contains(dep))
+                    .ToArray();
+
+                if (unresolvedDeps.Length == 0)
+                {
+                    updatedItems[i] = item with
+                    {
+                        State = QueueItemState.Queued,
+                        BlockedBy = []
+                    };
+                    continue;
+                }
+
+                updatedItems[i] = item with
+                {
+                    BlockedBy = unresolvedDeps
+                };
+                continue;
+            }
+
+            updatedItems[i] = item;
+        }
+
+        return state with
+        {
+            Items = updatedItems,
+            UpdatedAt = state.UpdatedAt
+        };
+    }
+
+    private static QueueState UnblockDependents(QueueState state, string completedUnit, DateTimeOffset ts)
+    {
+        return RefreshDependencies(state) with { UpdatedAt = ts };
+    }
+
+    private static QueueItem FindItem(QueueState state, string executionUnit)
+    {
+        for (var i = 0; i < state.Items.Count; i++)
+        {
+            if (string.Equals(state.Items[i].ExecutionUnit, executionUnit, StringComparison.Ordinal))
+            {
+                return state.Items[i];
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Execution unit '{executionUnit}' not found in queue state.");
+    }
+
+    private static void AssertState(QueueItem item, QueueItemState expected, string operation)
+    {
+        if (item.State != expected)
+        {
+            throw new InvalidOperationException(
+                $"Cannot {operation} execution unit '{item.ExecutionUnit}': " +
+                $"expected state '{expected}' but found '{item.State}'.");
+        }
+    }
+
+    private static QueueTransitionResult ApplyTransition(
+        QueueState state, string executionUnit, QueueItemState newState, RunEvent runEvent)
+    {
+        var updatedItems = new QueueItem[state.Items.Count];
+
+        for (var i = 0; i < state.Items.Count; i++)
+        {
+            var item = state.Items[i];
+            if (string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+            {
+                updatedItems[i] = item with { State = newState };
+            }
+            else
+            {
+                updatedItems[i] = item;
+            }
+        }
+
+        var updatedState = state with
+        {
+            Items = updatedItems,
+            UpdatedAt = runEvent.Ts
+        };
+
+        return new QueueTransitionResult
+        {
+            UpdatedState = updatedState,
+            Event = runEvent
+        };
+    }
+}

--- a/src/IntentSystem.Supervisor/QueueTransitionResult.cs
+++ b/src/IntentSystem.Supervisor/QueueTransitionResult.cs
@@ -1,0 +1,13 @@
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Supervisor;
+
+/// <summary>
+/// Represents the result of a queue state transition: a new snapshot and the
+/// corresponding run event to append to the log.
+/// </summary>
+public sealed record QueueTransitionResult
+{
+    public required QueueState UpdatedState { get; init; }
+    public required RunEvent Event { get; init; }
+}

--- a/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
@@ -1,0 +1,274 @@
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Supervisor.Tests;
+
+public sealed class QueueManagerTests
+{
+    private static readonly DateTimeOffset BaseTime = new(2026, 4, 2, 10, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Activate_GivenQueuedItem_TransitionsToActive()
+    {
+        var state = CreateState(QueueItemState.Queued);
+
+        var result = QueueManager.Activate(state, "A1", "worker", BaseTime);
+
+        Assert.Equal(QueueItemState.Active, FindItem(result.UpdatedState, "A1").State);
+        Assert.Equal("activated", result.Event.Event);
+        Assert.Equal("A1", result.Event.ExecutionUnit);
+        Assert.Equal("worker", result.Event.By);
+    }
+
+    [Fact]
+    public void Activate_GivenNonQueuedItem_ThrowsInvalidOperationException()
+    {
+        var state = CreateState(QueueItemState.Active);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => QueueManager.Activate(state, "A1", "worker", BaseTime));
+
+        Assert.Contains("expected state", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SubmitForReview_GivenActiveItem_TransitionsToReview()
+    {
+        var state = CreateState(QueueItemState.Active);
+
+        var result = QueueManager.SubmitForReview(state, "A1", "worker", BaseTime, linkedPr: "https://github.com/org/repo/pull/1");
+
+        Assert.Equal(QueueItemState.Review, FindItem(result.UpdatedState, "A1").State);
+        Assert.Equal("review-started", result.Event.Event);
+        Assert.Equal("https://github.com/org/repo/pull/1", result.Event.LinkedPr);
+    }
+
+    [Fact]
+    public void RequestFix_GivenReviewItem_TransitionsToFixing()
+    {
+        var state = CreateState(QueueItemState.Review);
+
+        var result = QueueManager.RequestFix(state, "A1", "reviewer", BaseTime, reason: "contract mismatch");
+
+        Assert.Equal(QueueItemState.Fixing, FindItem(result.UpdatedState, "A1").State);
+        Assert.Equal("fix-requested", result.Event.Event);
+        Assert.Equal("contract mismatch", result.Event.Reason);
+    }
+
+    [Fact]
+    public void ResubmitForReview_GivenFixingItem_TransitionsBackToReview()
+    {
+        var state = CreateState(QueueItemState.Fixing);
+
+        var result = QueueManager.ResubmitForReview(state, "A1", "worker", BaseTime);
+
+        Assert.Equal(QueueItemState.Review, FindItem(result.UpdatedState, "A1").State);
+        Assert.Equal("review-started", result.Event.Event);
+    }
+
+    [Fact]
+    public void RepairInPlace_GivenReviewFixingReviewCycle_MaintainsSameExecutionUnit()
+    {
+        var state = CreateState(QueueItemState.Review);
+
+        var fixResult = QueueManager.RequestFix(state, "A1", "reviewer", BaseTime, reason: "path mismatch");
+        Assert.Equal(QueueItemState.Fixing, FindItem(fixResult.UpdatedState, "A1").State);
+
+        var resubmitResult = QueueManager.ResubmitForReview(fixResult.UpdatedState, "A1", "worker", BaseTime.AddMinutes(30));
+        Assert.Equal(QueueItemState.Review, FindItem(resubmitResult.UpdatedState, "A1").State);
+
+        Assert.Equal("A1", fixResult.Event.ExecutionUnit);
+        Assert.Equal("A1", resubmitResult.Event.ExecutionUnit);
+    }
+
+    [Fact]
+    public void RequestClarification_GivenReviewItem_TransitionsToClarifyBlocked()
+    {
+        var state = CreateState(QueueItemState.Review);
+
+        var result = QueueManager.RequestClarification(state, "A1", "reviewer", BaseTime, reason: "missing context");
+
+        Assert.Equal(QueueItemState.ClarifyBlocked, FindItem(result.UpdatedState, "A1").State);
+        Assert.Equal("clarify-requested", result.Event.Event);
+        Assert.Equal("missing context", result.Event.Reason);
+    }
+
+    [Fact]
+    public void ResolveClarification_GivenClarifyBlockedItem_TransitionsToActive()
+    {
+        var state = CreateState(QueueItemState.ClarifyBlocked);
+
+        var result = QueueManager.ResolveClarification(state, "A1", "author", BaseTime);
+
+        Assert.Equal(QueueItemState.Active, FindItem(result.UpdatedState, "A1").State);
+        Assert.Equal("clarify-resolved", result.Event.Event);
+    }
+
+    [Fact]
+    public void Complete_GivenReviewItem_TransitionsToCompleted()
+    {
+        var state = CreateState(QueueItemState.Review);
+
+        var result = QueueManager.Complete(state, "A1", "reviewer", BaseTime);
+
+        Assert.Equal(QueueItemState.Completed, FindItem(result.UpdatedState, "A1").State);
+        Assert.Equal("completed", result.Event.Event);
+    }
+
+    [Fact]
+    public void Complete_GivenDependentBlockedItem_UnblocksDependents()
+    {
+        var state = CreateStateWithDependency();
+
+        var result = QueueManager.Complete(state, "A1", "reviewer", BaseTime);
+
+        Assert.Equal(QueueItemState.Completed, FindItem(result.UpdatedState, "A1").State);
+        Assert.Equal(QueueItemState.Queued, FindItem(result.UpdatedState, "B1").State);
+        Assert.Empty(FindItem(result.UpdatedState, "B1").BlockedBy);
+    }
+
+    [Fact]
+    public void Complete_GivenPartialDependency_KeepsItemBlocked()
+    {
+        var a1 = CreateItem("A1", QueueItemState.Review);
+        var a2 = CreateItem("A2", QueueItemState.Active);
+        var b1 = CreateItem("B1", QueueItemState.Blocked) with
+        {
+            Dependencies = ["A1", "A2"],
+            BlockedBy = ["A1", "A2"]
+        };
+
+        var state = CreateState([a1, a2, b1]);
+
+        var result = QueueManager.Complete(state, "A1", "reviewer", BaseTime);
+
+        Assert.Equal(QueueItemState.Blocked, FindItem(result.UpdatedState, "B1").State);
+        Assert.Equal(["A2"], FindItem(result.UpdatedState, "B1").BlockedBy);
+    }
+
+    [Fact]
+    public void RefreshDependencies_GivenAllDepsCompleted_UnblocksItem()
+    {
+        var a1 = CreateItem("A1", QueueItemState.Completed);
+        var b1 = CreateItem("B1", QueueItemState.Blocked) with
+        {
+            Dependencies = ["A1"],
+            BlockedBy = ["A1"]
+        };
+
+        var state = CreateState([a1, b1]);
+
+        var refreshed = QueueManager.RefreshDependencies(state);
+
+        Assert.Equal(QueueItemState.Queued, FindItem(refreshed, "B1").State);
+        Assert.Empty(FindItem(refreshed, "B1").BlockedBy);
+    }
+
+    [Fact]
+    public void RefreshDependencies_GivenUnresolvedDeps_UpdatesBlockedBy()
+    {
+        var a1 = CreateItem("A1", QueueItemState.Completed);
+        var a2 = CreateItem("A2", QueueItemState.Active);
+        var b1 = CreateItem("B1", QueueItemState.Blocked) with
+        {
+            Dependencies = ["A1", "A2"],
+            BlockedBy = ["A1", "A2"]
+        };
+
+        var state = CreateState([a1, a2, b1]);
+
+        var refreshed = QueueManager.RefreshDependencies(state);
+
+        Assert.Equal(QueueItemState.Blocked, FindItem(refreshed, "B1").State);
+        Assert.Equal(["A2"], FindItem(refreshed, "B1").BlockedBy);
+    }
+
+    [Fact]
+    public void TransitionUpdatesTimestamp()
+    {
+        var state = CreateState(QueueItemState.Queued);
+        var newTime = BaseTime.AddHours(1);
+
+        var result = QueueManager.Activate(state, "A1", "worker", newTime);
+
+        Assert.Equal(newTime, result.UpdatedState.UpdatedAt);
+        Assert.Equal(newTime, result.Event.Ts);
+    }
+
+    [Fact]
+    public void FindItem_GivenMissingExecutionUnit_ThrowsInvalidOperationException()
+    {
+        var state = CreateState(QueueItemState.Queued);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => QueueManager.Activate(state, "MISSING", "worker", BaseTime));
+
+        Assert.Contains("not found", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SnapshotAndEventAreSeparate_EventDoesNotMutateSnapshot()
+    {
+        var state = CreateState(QueueItemState.Queued);
+
+        var result = QueueManager.Activate(state, "A1", "worker", BaseTime);
+
+        Assert.Equal(QueueItemState.Queued, FindItem(state, "A1").State);
+        Assert.Equal(QueueItemState.Active, FindItem(result.UpdatedState, "A1").State);
+        Assert.NotNull(result.Event);
+    }
+
+    private static QueueState CreateState(QueueItemState itemState)
+    {
+        return CreateState([CreateItem("A1", itemState)]);
+    }
+
+    private static QueueState CreateStateWithDependency()
+    {
+        var a1 = CreateItem("A1", QueueItemState.Review);
+        var b1 = CreateItem("B1", QueueItemState.Blocked) with
+        {
+            Dependencies = ["A1"],
+            BlockedBy = ["A1"]
+        };
+        return CreateState([a1, b1]);
+    }
+
+    private static QueueState CreateState(QueueItem[] items)
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = BaseTime.AddHours(-1),
+            Items = items
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Test Item",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/rules/issue-template-and-review-context.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit.ToLowerInvariant()}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit.ToLowerInvariant()}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit.ToLowerInvariant()}/packet.yaml"
+            },
+            WorkerRole = "claude",
+            ReviewRole = "human",
+            Priority = "normal"
+        };
+    }
+
+    private static QueueItem FindItem(QueueState state, string executionUnit)
+    {
+        return state.Items.First(i =>
+            string.Equals(i.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Summary

- `QueueManager` を実装：queue item の deterministic な state transition を管理
- `QueueTransitionResult` で snapshot 更新と run log event の責務を分離
- dependency 解決による自動 unblock、repair-in-place cycle、clarify-blocked を含む全 transition をカバー

## State Transition Map

```
queued → active → review → completed
                    ↓  ↑
                  fixing (repair-in-place)
                    ↓
              clarify-blocked → active
blocked → queued (dependency resolution)
```

## Implementation

| Component | File | Purpose |
|---|---|---|
| `QueueManager` | `src/IntentSystem.Supervisor/QueueManager.cs` | Static methods for each state transition (Activate, SubmitForReview, RequestFix, ResubmitForReview, RequestClarification, ResolveClarification, Complete, RefreshDependencies) |
| `QueueTransitionResult` | `src/IntentSystem.Supervisor/QueueTransitionResult.cs` | Immutable result containing updated QueueState + RunEvent to append |

## Acceptance Criteria

- [x] queue item の `queued / active / review / fixing / clarify-blocked / blocked / completed` を deterministic に扱える
- [x] dependency 解決に応じて queue item を `blocked` から `queued` へ戻せる
- [x] `repair-in-place` の fix loop で `review → fixing → review` を同一 execution unit 上で扱える
- [x] queue current snapshot 更新と run log append が責務分離されたまま行える
- [x] 全 transition が immutable snapshot を返し source data を変更しない

## Test plan

- [x] 各 state transition の正常系テスト (Activate, SubmitForReview, RequestFix, etc.)
- [x] 不正な state からの transition で InvalidOperationException
- [x] repair-in-place cycle (review → fixing → review)
- [x] Complete 時の dependency unblock テスト
- [x] 部分的 dependency 解決で blocked を維持するテスト
- [x] RefreshDependencies による BlockedBy 更新テスト
- [x] snapshot immutability テスト
- [x] 全 67 テスト passing (既存 42 + 新規 16 + 既存 Supervisor 9)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)