### PR TITLE
[E1] Concept Intake Schema

### DIFF
--- a/IntentSystem.sln
+++ b/IntentSystem.sln
@@ -19,6 +19,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntentSystem.Supervisor", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntentSystem.Supervisor.Tests", "tests\IntentSystem.Supervisor.Tests\IntentSystem.Supervisor.Tests.csproj", "{01886433-4D0F-43EE-B5AD-725971A7246A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntentSystem.ConceptIntake", "src\IntentSystem.ConceptIntake\IntentSystem.ConceptIntake.csproj", "{FC649247-3EDA-4424-9970-C9A12B7145AA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntentSystem.ConceptIntake.Tests", "tests\IntentSystem.ConceptIntake.Tests\IntentSystem.ConceptIntake.Tests.csproj", "{A4C57522-768A-4633-905E-E8639FCE3DB7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +105,30 @@ Global
 		{01886433-4D0F-43EE-B5AD-725971A7246A}.Release|x64.Build.0 = Release|Any CPU
 		{01886433-4D0F-43EE-B5AD-725971A7246A}.Release|x86.ActiveCfg = Release|Any CPU
 		{01886433-4D0F-43EE-B5AD-725971A7246A}.Release|x86.Build.0 = Release|Any CPU
+		{FC649247-3EDA-4424-9970-C9A12B7145AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC649247-3EDA-4424-9970-C9A12B7145AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC649247-3EDA-4424-9970-C9A12B7145AA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FC649247-3EDA-4424-9970-C9A12B7145AA}.Debug|x64.Build.0 = Debug|Any CPU
+		{FC649247-3EDA-4424-9970-C9A12B7145AA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FC649247-3EDA-4424-9970-C9A12B7145AA}.Debug|x86.Build.0 = Debug|Any CPU
+		{FC649247-3EDA-4424-9970-C9A12B7145AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC649247-3EDA-4424-9970-C9A12B7145AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC649247-3EDA-4424-9970-C9A12B7145AA}.Release|x64.ActiveCfg = Release|Any CPU
+		{FC649247-3EDA-4424-9970-C9A12B7145AA}.Release|x64.Build.0 = Release|Any CPU
+		{FC649247-3EDA-4424-9970-C9A12B7145AA}.Release|x86.ActiveCfg = Release|Any CPU
+		{FC649247-3EDA-4424-9970-C9A12B7145AA}.Release|x86.Build.0 = Release|Any CPU
+		{A4C57522-768A-4633-905E-E8639FCE3DB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4C57522-768A-4633-905E-E8639FCE3DB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4C57522-768A-4633-905E-E8639FCE3DB7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A4C57522-768A-4633-905E-E8639FCE3DB7}.Debug|x64.Build.0 = Debug|Any CPU
+		{A4C57522-768A-4633-905E-E8639FCE3DB7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A4C57522-768A-4633-905E-E8639FCE3DB7}.Debug|x86.Build.0 = Debug|Any CPU
+		{A4C57522-768A-4633-905E-E8639FCE3DB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4C57522-768A-4633-905E-E8639FCE3DB7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4C57522-768A-4633-905E-E8639FCE3DB7}.Release|x64.ActiveCfg = Release|Any CPU
+		{A4C57522-768A-4633-905E-E8639FCE3DB7}.Release|x64.Build.0 = Release|Any CPU
+		{A4C57522-768A-4633-905E-E8639FCE3DB7}.Release|x86.ActiveCfg = Release|Any CPU
+		{A4C57522-768A-4633-905E-E8639FCE3DB7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -112,5 +140,7 @@ Global
 		{5ACAE31B-BEC3-4B89-B64C-E4544222A7CC} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{5CD7730B-DB0F-457E-A628-64AA7C35F295} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{01886433-4D0F-43EE-B5AD-725971A7246A} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{FC649247-3EDA-4424-9970-C9A12B7145AA} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{A4C57522-768A-4633-905E-E8639FCE3DB7} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/IntentSystem.ConceptIntake/IntentSystem.ConceptIntake.csproj
+++ b/src/IntentSystem.ConceptIntake/IntentSystem.ConceptIntake.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/IntentSystem.ConceptIntake/Models/ConceptIntakeOutput.cs
+++ b/src/IntentSystem.ConceptIntake/Models/ConceptIntakeOutput.cs
@@ -1,0 +1,17 @@
+namespace IntentSystem.ConceptIntake.Models;
+
+/// <summary>
+/// Represents the output of concept intake processing: intent draft paths,
+/// interview questions to explore unknowns, a clarification return path,
+/// and recommended updates to the parent intent tree.
+/// </summary>
+public sealed record ConceptIntakeOutput
+{
+    public required IReadOnlyList<string> IntentDraftPaths { get; init; }
+
+    public required IReadOnlyList<InterviewQuestion> InterviewQuestions { get; init; }
+
+    public required string ClarificationReturnPath { get; init; }
+
+    public required IReadOnlyList<string> RecommendedUpdates { get; init; }
+}

--- a/src/IntentSystem.ConceptIntake/Models/ConceptIntakePacket.cs
+++ b/src/IntentSystem.ConceptIntake/Models/ConceptIntakePacket.cs
@@ -1,0 +1,22 @@
+namespace IntentSystem.ConceptIntake.Models;
+
+/// <summary>
+/// Represents the input packet for concept intake: a new concept to be
+/// processed into intent drafts and interview questions.
+/// </summary>
+public sealed record ConceptIntakePacket
+{
+    public required string DomainSlug { get; init; }
+
+    public required string ConceptSource { get; init; }
+
+    public required string ConceptText { get; init; }
+
+    public required IReadOnlyList<string> UpstreamPaths { get; init; }
+
+    public required string InitialGoal { get; init; }
+
+    public required IReadOnlyList<string> Constraints { get; init; }
+
+    public required IReadOnlyList<string> KnownUnknowns { get; init; }
+}

--- a/src/IntentSystem.ConceptIntake/Models/InterviewQuestion.cs
+++ b/src/IntentSystem.ConceptIntake/Models/InterviewQuestion.cs
@@ -1,0 +1,19 @@
+namespace IntentSystem.ConceptIntake.Models;
+
+/// <summary>
+/// Represents a single interview question generated during concept intake.
+/// Interview questions explore unknown areas of a new concept, distinct from
+/// clarification artifacts which resolve blockers on existing execution units.
+/// </summary>
+public sealed record InterviewQuestion
+{
+    public required string QuestionId { get; init; }
+
+    public required string QuestionText { get; init; }
+
+    public required string Reason { get; init; }
+
+    public required IReadOnlyList<string> Affects { get; init; }
+
+    public required string BlockingOrNonblocking { get; init; }
+}

--- a/src/IntentSystem.ConceptIntake/Serialization/ConceptIntakeJsonOptions.cs
+++ b/src/IntentSystem.ConceptIntake/Serialization/ConceptIntakeJsonOptions.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.ConceptIntake.Serialization;
+
+internal static class ConceptIntakeJsonOptions
+{
+    public static JsonSerializerOptions Indented { get; } = Create(writeIndented: true);
+
+    public static JsonSerializerOptions Compact { get; } = Create(writeIndented: false);
+
+    private static JsonSerializerOptions Create(bool writeIndented)
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = writeIndented
+        };
+
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.KebabCaseLower));
+
+        return options;
+    }
+}

--- a/src/IntentSystem.ConceptIntake/Serialization/ConceptIntakeSerializer.cs
+++ b/src/IntentSystem.ConceptIntake/Serialization/ConceptIntakeSerializer.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.ConceptIntake.Serialization;
+
+public static class ConceptIntakeSerializer
+{
+    public static string SerializePacket(ConceptIntakePacket packet)
+    {
+        ArgumentNullException.ThrowIfNull(packet);
+        return JsonSerializer.Serialize(packet, ConceptIntakeJsonOptions.Indented);
+    }
+
+    public static ConceptIntakePacket DeserializePacket(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        using var document = JsonDocument.Parse(json);
+        ValidateRequiredPacketFields(document.RootElement);
+
+        return JsonSerializer.Deserialize<ConceptIntakePacket>(json, ConceptIntakeJsonOptions.Compact)
+            ?? throw new InvalidOperationException(
+                "Concept intake packet payload deserialized to null.");
+    }
+
+    public static string SerializeOutput(ConceptIntakeOutput output)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+        ValidateInterviewQuestions(output.InterviewQuestions);
+        return JsonSerializer.Serialize(output, ConceptIntakeJsonOptions.Indented);
+    }
+
+    public static ConceptIntakeOutput DeserializeOutput(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        using var document = JsonDocument.Parse(json);
+        ValidateRequiredOutputFields(document.RootElement);
+        ValidateInterviewQuestionFields(document.RootElement);
+
+        var output = JsonSerializer.Deserialize<ConceptIntakeOutput>(json, ConceptIntakeJsonOptions.Compact)
+            ?? throw new InvalidOperationException(
+                "Concept intake output payload deserialized to null.");
+
+        ValidateInterviewQuestions(output.InterviewQuestions);
+        return output;
+    }
+
+    private static readonly string[] RequiredPacketFields =
+    [
+        "domain_slug",
+        "concept_source",
+        "concept_text",
+        "upstream_paths",
+        "initial_goal",
+        "constraints",
+        "known_unknowns"
+    ];
+
+    private static readonly string[] RequiredOutputFields =
+    [
+        "intent_draft_paths",
+        "interview_questions",
+        "clarification_return_path",
+        "recommended_updates"
+    ];
+
+    private static readonly string[] RequiredInterviewQuestionFields =
+    [
+        "question_id",
+        "question_text",
+        "reason",
+        "affects",
+        "blocking_or_nonblocking"
+    ];
+
+    private static void ValidateRequiredPacketFields(JsonElement element)
+    {
+        foreach (var field in RequiredPacketFields)
+        {
+            if (!element.TryGetProperty(field, out _))
+            {
+                throw new InvalidOperationException(
+                    $"Concept intake packet must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static void ValidateRequiredOutputFields(JsonElement element)
+    {
+        foreach (var field in RequiredOutputFields)
+        {
+            if (!element.TryGetProperty(field, out _))
+            {
+                throw new InvalidOperationException(
+                    $"Concept intake output must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static void ValidateInterviewQuestionFields(JsonElement element)
+    {
+        if (!element.TryGetProperty("interview_questions", out var questionsElement))
+        {
+            return;
+        }
+
+        if (questionsElement.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        var index = 0;
+        foreach (var question in questionsElement.EnumerateArray())
+        {
+            foreach (var field in RequiredInterviewQuestionFields)
+            {
+                if (!question.TryGetProperty(field, out _))
+                {
+                    throw new InvalidOperationException(
+                        $"Interview question at index {index} must contain required field '{field}'.");
+                }
+            }
+
+            index++;
+        }
+    }
+
+    private static void ValidateInterviewQuestions(IReadOnlyList<InterviewQuestion> questions)
+    {
+        for (var i = 0; i < questions.Count; i++)
+        {
+            var q = questions[i];
+            if (string.IsNullOrWhiteSpace(q.QuestionId))
+            {
+                throw new InvalidOperationException(
+                    $"Interview question at index {i} must have a non-empty question_id.");
+            }
+
+            if (string.IsNullOrWhiteSpace(q.QuestionText))
+            {
+                throw new InvalidOperationException(
+                    $"Interview question at index {i} must have a non-empty question_text.");
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.ConceptIntake.Tests/ConceptIntakeArchitectureTests.cs
+++ b/tests/IntentSystem.ConceptIntake.Tests/ConceptIntakeArchitectureTests.cs
@@ -1,0 +1,52 @@
+using IntentSystem.ConceptIntake.Serialization;
+
+namespace IntentSystem.ConceptIntake.Tests;
+
+public sealed class ConceptIntakeArchitectureTests
+{
+    [Fact]
+    public void SerializationInfrastructure_DoesNotExposeConceptIntakeJsonOptionsAsPublicApi()
+    {
+        var optionsType = typeof(ConceptIntakeSerializer).Assembly
+            .GetType("IntentSystem.ConceptIntake.Serialization.ConceptIntakeJsonOptions");
+
+        Assert.NotNull(optionsType);
+        Assert.False(optionsType!.IsPublic);
+    }
+
+    [Fact]
+    public void TestSources_DoNotUseGivenWhenThenComments()
+    {
+        var testSourceDirectory = GetTestSourceDirectory();
+        var sourceFiles = Directory.GetFiles(testSourceDirectory, "*.cs", SearchOption.TopDirectoryOnly);
+        var bannedMarkers = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "// Given",
+            "// When",
+            "// Then"
+        };
+
+        var violations = sourceFiles
+            .SelectMany(file => File.ReadLines(file)
+                .Select((line, index) => new { file, line, lineNumber = index + 1 }))
+            .Where(entry => bannedMarkers.Contains(entry.line.Trim()))
+            .Select(entry => $"{Path.GetFileName(entry.file)}:{entry.lineNumber}")
+            .ToArray();
+
+        Assert.Empty(violations);
+    }
+
+    private static string GetTestSourceDirectory()
+    {
+        var projectDirectory = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
+        var directoryInfo = new DirectoryInfo(projectDirectory);
+        var sourceDirectory = directoryInfo.FullName;
+
+        if (!Directory.Exists(sourceDirectory))
+        {
+            throw new DirectoryNotFoundException($"Test source directory not found: {sourceDirectory}");
+        }
+
+        return sourceDirectory;
+    }
+}

--- a/tests/IntentSystem.ConceptIntake.Tests/ConceptIntakeSerializerTests.cs
+++ b/tests/IntentSystem.ConceptIntake.Tests/ConceptIntakeSerializerTests.cs
@@ -1,0 +1,254 @@
+using System.Text.Json;
+using IntentSystem.ConceptIntake.Models;
+using IntentSystem.ConceptIntake.Serialization;
+
+namespace IntentSystem.ConceptIntake.Tests;
+
+public sealed class ConceptIntakeSerializerTests
+{
+    [Fact]
+    public void SerializePacket_GivenCompletePacket_ContainsAllRequiredFields()
+    {
+        var packet = CreatePacket();
+
+        var serialized = ConceptIntakeSerializer.SerializePacket(packet);
+        using var document = JsonDocument.Parse(serialized);
+        var root = document.RootElement;
+
+        Assert.Equal("auth", root.GetProperty("domain_slug").GetString());
+        Assert.Equal("feature-request", root.GetProperty("concept_source").GetString());
+        Assert.Equal("Add OAuth2 provider support.", root.GetProperty("concept_text").GetString());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("upstream_paths").ValueKind);
+        Assert.Equal("Enable third-party authentication.", root.GetProperty("initial_goal").GetString());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("constraints").ValueKind);
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("known_unknowns").ValueKind);
+    }
+
+    [Fact]
+    public void SerializePacket_GivenCompletePacket_UsesSnakeCaseProperties()
+    {
+        var packet = CreatePacket();
+
+        var serialized = ConceptIntakeSerializer.SerializePacket(packet);
+
+        Assert.DoesNotContain("\"domainSlug\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"conceptSource\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"conceptText\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"upstreamPaths\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"initialGoal\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"knownUnknowns\"", serialized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeserializePacket_GivenCompleteJson_RestoresAllFields()
+    {
+        var json = """
+        {
+          "domain_slug": "auth",
+          "concept_source": "feature-request",
+          "concept_text": "Add OAuth2 provider support.",
+          "upstream_paths": ["intents/intent-cli/intent-tree/means/04-worker-interface-strategy.md"],
+          "initial_goal": "Enable third-party authentication.",
+          "constraints": ["Must not break existing session flow"],
+          "known_unknowns": ["Which OAuth providers to support?"]
+        }
+        """;
+
+        var packet = ConceptIntakeSerializer.DeserializePacket(json);
+
+        Assert.Equal("auth", packet.DomainSlug);
+        Assert.Equal("feature-request", packet.ConceptSource);
+        Assert.Equal("Add OAuth2 provider support.", packet.ConceptText);
+        Assert.Single(packet.UpstreamPaths);
+        Assert.Equal("Enable third-party authentication.", packet.InitialGoal);
+        Assert.Single(packet.Constraints);
+        Assert.Single(packet.KnownUnknowns);
+    }
+
+    [Fact]
+    public void DeserializePacket_GivenMissingRequiredField_ThrowsInvalidOperationException()
+    {
+        var json = """
+        {
+          "domain_slug": "auth",
+          "concept_source": "feature-request"
+        }
+        """;
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ConceptIntakeSerializer.DeserializePacket(json));
+
+        Assert.Contains("required field", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SerializePacketAndDeserializePacket_RoundTrips()
+    {
+        var packet = CreatePacket();
+
+        var serialized = ConceptIntakeSerializer.SerializePacket(packet);
+        var deserialized = ConceptIntakeSerializer.DeserializePacket(serialized);
+
+        Assert.Equal(packet.DomainSlug, deserialized.DomainSlug);
+        Assert.Equal(packet.ConceptSource, deserialized.ConceptSource);
+        Assert.Equal(packet.ConceptText, deserialized.ConceptText);
+        Assert.Equal(packet.UpstreamPaths, deserialized.UpstreamPaths);
+        Assert.Equal(packet.InitialGoal, deserialized.InitialGoal);
+        Assert.Equal(packet.Constraints, deserialized.Constraints);
+        Assert.Equal(packet.KnownUnknowns, deserialized.KnownUnknowns);
+    }
+
+    [Fact]
+    public void SerializeOutput_GivenCompleteOutput_ContainsAllRequiredFields()
+    {
+        var output = CreateOutput();
+
+        var serialized = ConceptIntakeSerializer.SerializeOutput(output);
+        using var document = JsonDocument.Parse(serialized);
+        var root = document.RootElement;
+
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("intent_draft_paths").ValueKind);
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("interview_questions").ValueKind);
+        Assert.Equal("intents/rules/issue-template-and-review-context.md",
+            root.GetProperty("clarification_return_path").GetString());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("recommended_updates").ValueKind);
+    }
+
+    [Fact]
+    public void SerializeOutput_GivenInterviewQuestions_ContainsAllRequiredQuestionFields()
+    {
+        var output = CreateOutput();
+
+        var serialized = ConceptIntakeSerializer.SerializeOutput(output);
+        using var document = JsonDocument.Parse(serialized);
+        var question = document.RootElement
+            .GetProperty("interview_questions")[0];
+
+        Assert.Equal("iq-1", question.GetProperty("question_id").GetString());
+        Assert.Equal("Which OAuth providers should be supported?",
+            question.GetProperty("question_text").GetString());
+        Assert.Equal("Provider selection impacts architecture.",
+            question.GetProperty("reason").GetString());
+        Assert.Equal(JsonValueKind.Array, question.GetProperty("affects").ValueKind);
+        Assert.Equal("blocking", question.GetProperty("blocking_or_nonblocking").GetString());
+    }
+
+    [Fact]
+    public void DeserializeOutput_GivenCompleteJson_RestoresAllFields()
+    {
+        var json = """
+        {
+          "intent_draft_paths": ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+          "interview_questions": [
+            {
+              "question_id": "iq-1",
+              "question_text": "Which OAuth providers should be supported?",
+              "reason": "Provider selection impacts architecture.",
+              "affects": ["auth-oauth2"],
+              "blocking_or_nonblocking": "blocking"
+            }
+          ],
+          "clarification_return_path": "intents/rules/issue-template-and-review-context.md",
+          "recommended_updates": ["Update auth strategy document"]
+        }
+        """;
+
+        var output = ConceptIntakeSerializer.DeserializeOutput(json);
+
+        Assert.Single(output.IntentDraftPaths);
+        Assert.Single(output.InterviewQuestions);
+        Assert.Equal("iq-1", output.InterviewQuestions[0].QuestionId);
+        Assert.Equal("blocking", output.InterviewQuestions[0].BlockingOrNonblocking);
+        Assert.Equal("intents/rules/issue-template-and-review-context.md", output.ClarificationReturnPath);
+        Assert.Single(output.RecommendedUpdates);
+    }
+
+    [Fact]
+    public void DeserializeOutput_GivenMissingRequiredOutputField_ThrowsInvalidOperationException()
+    {
+        var json = """
+        {
+          "intent_draft_paths": []
+        }
+        """;
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ConceptIntakeSerializer.DeserializeOutput(json));
+
+        Assert.Contains("required field", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeserializeOutput_GivenInterviewQuestionMissingRequiredField_ThrowsInvalidOperationException()
+    {
+        var json = """
+        {
+          "intent_draft_paths": [],
+          "interview_questions": [
+            {
+              "question_id": "iq-1",
+              "question_text": "Missing reason and affects"
+            }
+          ],
+          "clarification_return_path": "path.md",
+          "recommended_updates": []
+        }
+        """;
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ConceptIntakeSerializer.DeserializeOutput(json));
+
+        Assert.Contains("Interview question at index 0", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SerializeOutputAndDeserializeOutput_RoundTrips()
+    {
+        var output = CreateOutput();
+
+        var serialized = ConceptIntakeSerializer.SerializeOutput(output);
+        var deserialized = ConceptIntakeSerializer.DeserializeOutput(serialized);
+
+        Assert.Equal(output.IntentDraftPaths, deserialized.IntentDraftPaths);
+        Assert.Equal(output.InterviewQuestions.Count, deserialized.InterviewQuestions.Count);
+        Assert.Equal(output.InterviewQuestions[0].QuestionId, deserialized.InterviewQuestions[0].QuestionId);
+        Assert.Equal(output.InterviewQuestions[0].BlockingOrNonblocking, deserialized.InterviewQuestions[0].BlockingOrNonblocking);
+        Assert.Equal(output.ClarificationReturnPath, deserialized.ClarificationReturnPath);
+        Assert.Equal(output.RecommendedUpdates, deserialized.RecommendedUpdates);
+    }
+
+    private static ConceptIntakePacket CreatePacket()
+    {
+        return new ConceptIntakePacket
+        {
+            DomainSlug = "auth",
+            ConceptSource = "feature-request",
+            ConceptText = "Add OAuth2 provider support.",
+            UpstreamPaths = ["intents/intent-cli/intent-tree/means/04-worker-interface-strategy.md"],
+            InitialGoal = "Enable third-party authentication.",
+            Constraints = ["Must not break existing session flow"],
+            KnownUnknowns = ["Which OAuth providers to support?"]
+        };
+    }
+
+    private static ConceptIntakeOutput CreateOutput()
+    {
+        return new ConceptIntakeOutput
+        {
+            IntentDraftPaths = ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+            InterviewQuestions =
+            [
+                new InterviewQuestion
+                {
+                    QuestionId = "iq-1",
+                    QuestionText = "Which OAuth providers should be supported?",
+                    Reason = "Provider selection impacts architecture.",
+                    Affects = ["auth-oauth2"],
+                    BlockingOrNonblocking = "blocking"
+                }
+            ],
+            ClarificationReturnPath = "intents/rules/issue-template-and-review-context.md",
+            RecommendedUpdates = ["Update auth strategy document"]
+        };
+    }
+}

--- a/tests/IntentSystem.ConceptIntake.Tests/IntentSystem.ConceptIntake.Tests.csproj
+++ b/tests/IntentSystem.ConceptIntake.Tests/IntentSystem.ConceptIntake.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\IntentSystem.ConceptIntake\IntentSystem.ConceptIntake.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- `ConceptIntakePacket`, `ConceptIntakeOutput`, `InterviewQuestion` の canonical model を実装
- `ConceptIntakeSerializer` で packet / output の serialize / deserialize + field validation
- interview と clarification の責務境界を崩さない schema 設計

## Models

| Model | Fields |
|---|---|
| `ConceptIntakePacket` | `domain_slug`, `concept_source`, `concept_text`, `upstream_paths`, `initial_goal`, `constraints`, `known_unknowns` |
| `ConceptIntakeOutput` | `intent_draft_paths`, `interview_questions`, `clarification_return_path`, `recommended_updates` |
| `InterviewQuestion` | `question_id`, `question_text`, `reason`, `affects`, `blocking_or_nonblocking` |

## Acceptance Criteria

- [x] `concept_intake_packet` が `domain_slug`, `concept_source`, `concept_text`, `upstream_paths`, `initial_goal`, `constraints`, `known_unknowns` を表現できる
- [x] intake output が `intent_draft_paths`, `interview_questions`, `clarification_return_path`, `recommended_updates` を表現できる
- [x] `interview_questions` が `question_id`, `question_text`, `reason`, `affects`, `blocking_or_nonblocking` を required field として持つ
- [x] concept intake contract が `interview` と `clarification` の境界を崩さない
- [x] serializer / tests が current canonical contract を固定できる

## Test plan

- [x] Packet serialize: 全 required field の snake_case 出力
- [x] Packet deserialize: 全 field の復元
- [x] Packet deserialize: required field 不足でエラー
- [x] Packet round-trip
- [x] Output serialize: 全 required field + interview question fields
- [x] Output deserialize: 全 field の復元
- [x] Output deserialize: required output field 不足でエラー
- [x] Output deserialize: interview question の required field 不足でエラー
- [x] Output round-trip
- [x] Architecture: JSON options は internal
- [x] Architecture: Given/When/Then コメント禁止
- [x] 全 126 テスト passing

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)