### PR TITLE
[codex] Implement issue 25 private domain binding

### DIFF
--- a/IntentSystem.sln
+++ b/IntentSystem.sln
@@ -31,6 +31,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntentSystem.WorkerAdapter"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntentSystem.WorkerAdapter.Tests", "tests\IntentSystem.WorkerAdapter.Tests\IntentSystem.WorkerAdapter.Tests.csproj", "{4F40F997-2074-443F-909D-2FCB95C397EB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntentSystem.DomainBinding", "src\IntentSystem.DomainBinding\IntentSystem.DomainBinding.csproj", "{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntentSystem.DomainBinding.Tests", "tests\IntentSystem.DomainBinding.Tests\IntentSystem.DomainBinding.Tests.csproj", "{1851D6F9-09DE-449A-8496-73E38D702221}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -185,6 +189,30 @@ Global
 		{4F40F997-2074-443F-909D-2FCB95C397EB}.Release|x64.Build.0 = Release|Any CPU
 		{4F40F997-2074-443F-909D-2FCB95C397EB}.Release|x86.ActiveCfg = Release|Any CPU
 		{4F40F997-2074-443F-909D-2FCB95C397EB}.Release|x86.Build.0 = Release|Any CPU
+		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A}.Debug|x64.Build.0 = Debug|Any CPU
+		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A}.Debug|x86.Build.0 = Debug|Any CPU
+		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A}.Release|x64.ActiveCfg = Release|Any CPU
+		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A}.Release|x64.Build.0 = Release|Any CPU
+		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A}.Release|x86.ActiveCfg = Release|Any CPU
+		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A}.Release|x86.Build.0 = Release|Any CPU
+		{1851D6F9-09DE-449A-8496-73E38D702221}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1851D6F9-09DE-449A-8496-73E38D702221}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1851D6F9-09DE-449A-8496-73E38D702221}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1851D6F9-09DE-449A-8496-73E38D702221}.Debug|x64.Build.0 = Debug|Any CPU
+		{1851D6F9-09DE-449A-8496-73E38D702221}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1851D6F9-09DE-449A-8496-73E38D702221}.Debug|x86.Build.0 = Debug|Any CPU
+		{1851D6F9-09DE-449A-8496-73E38D702221}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1851D6F9-09DE-449A-8496-73E38D702221}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1851D6F9-09DE-449A-8496-73E38D702221}.Release|x64.ActiveCfg = Release|Any CPU
+		{1851D6F9-09DE-449A-8496-73E38D702221}.Release|x64.Build.0 = Release|Any CPU
+		{1851D6F9-09DE-449A-8496-73E38D702221}.Release|x86.ActiveCfg = Release|Any CPU
+		{1851D6F9-09DE-449A-8496-73E38D702221}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -202,5 +230,7 @@ Global
 		{B47E861C-B315-40FD-B0C6-29B7D46E8B0F} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{A0D0CD8C-C11C-41A6-92AE-E6A24227B888} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{4F40F997-2074-443F-909D-2FCB95C397EB} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{1851D6F9-09DE-449A-8496-73E38D702221} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/IntentSystem.DomainBinding/DomainBindingMapper.cs
+++ b/src/IntentSystem.DomainBinding/DomainBindingMapper.cs
@@ -1,0 +1,58 @@
+using IntentSystem.DomainBinding.Models;
+using IntentSystem.Projection.Models;
+
+namespace IntentSystem.DomainBinding;
+
+public static class DomainBindingMapper
+{
+    public static ProjectionReadySlice ToProjectionReadySlice(DomainExecutionSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        return new ProjectionReadySlice
+        {
+            ExecutionUnit = source.ExecutionUnit,
+            Goal = source.Goal,
+            TargetRepo = source.TargetRepo,
+            TargetPath = source.TargetPath,
+            TargetPart = source.TargetPart,
+            Dependencies = source.Dependencies,
+            SuccessSignal = source.SuccessSignal,
+            ReviewMode = source.ReviewMode,
+            CompletionAction = source.CompletionAction,
+            LandingPolicy = source.LandingPolicy,
+            DogfoodingTrack = source.DogfoodingTrack,
+            EmbeddedCanonicalSummary = source.EmbeddedCanonicalSummary
+        };
+    }
+
+    public static SubSliceRow ToSubSliceRow(DomainExecutionSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var projectionReady = ToProjectionReadySlice(source);
+        return ToSubSliceRow(projectionReady);
+    }
+
+    public static SubSliceRow ToSubSliceRow(ProjectionReadySlice projectionReady)
+    {
+        ArgumentNullException.ThrowIfNull(projectionReady);
+
+        return new SubSliceRow
+        {
+            SourceExecutionUnit = projectionReady.ExecutionUnit,
+            Goal = projectionReady.Goal,
+            TargetRepo = projectionReady.TargetRepo,
+            TargetPath = projectionReady.TargetPath,
+            TargetPart = projectionReady.TargetPart,
+            DependsOnSubslices = projectionReady.Dependencies,
+            DependsOn = projectionReady.Dependencies,
+            RelatedIntents = [],
+            SourceConcepts = [],
+            SuccessSignal = projectionReady.SuccessSignal,
+            ReviewMode = projectionReady.ReviewMode,
+            CompletionAction = projectionReady.CompletionAction,
+            LandingPolicy = projectionReady.LandingPolicy
+        };
+    }
+}

--- a/src/IntentSystem.DomainBinding/IntentSystem.DomainBinding.csproj
+++ b/src/IntentSystem.DomainBinding/IntentSystem.DomainBinding.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\IntentSystem.Projection\IntentSystem.Projection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/IntentSystem.DomainBinding/Models/DogfoodingTrack.cs
+++ b/src/IntentSystem.DomainBinding/Models/DogfoodingTrack.cs
@@ -1,0 +1,11 @@
+namespace IntentSystem.DomainBinding.Models;
+
+/// <summary>
+/// Delivery track carried through the binding contract.
+/// </summary>
+public enum DogfoodingTrack
+{
+    BackendFirst,
+    FullStack,
+    General
+}

--- a/src/IntentSystem.DomainBinding/Models/DomainExecutionSource.cs
+++ b/src/IntentSystem.DomainBinding/Models/DomainExecutionSource.cs
@@ -1,0 +1,34 @@
+namespace IntentSystem.DomainBinding.Models;
+
+/// <summary>
+/// Canonical, repo-local summary of a private execution source that can be
+/// embedded in fixtures without exposing private paths or URLs.
+/// </summary>
+public sealed record DomainExecutionSource
+{
+    public required DomainExecutionSourceKind SourceKind { get; init; }
+
+    public required DogfoodingTrack DogfoodingTrack { get; init; }
+
+    public required string ExecutionUnit { get; init; }
+
+    public required string Goal { get; init; }
+
+    public required string TargetRepo { get; init; }
+
+    public required string TargetPath { get; init; }
+
+    public required string TargetPart { get; init; }
+
+    public required IReadOnlyList<string> Dependencies { get; init; }
+
+    public required string SuccessSignal { get; init; }
+
+    public required string ReviewMode { get; init; }
+
+    public required string CompletionAction { get; init; }
+
+    public required string LandingPolicy { get; init; }
+
+    public required string EmbeddedCanonicalSummary { get; init; }
+}

--- a/src/IntentSystem.DomainBinding/Models/DomainExecutionSourceKind.cs
+++ b/src/IntentSystem.DomainBinding/Models/DomainExecutionSourceKind.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.DomainBinding.Models;
+
+/// <summary>
+/// Current execution source kinds supported by the dogfooding binding.
+/// </summary>
+public enum DomainExecutionSourceKind
+{
+    IssueReadySlice,
+    IssueReadySubSlice
+}

--- a/src/IntentSystem.DomainBinding/Models/ProjectionReadySlice.cs
+++ b/src/IntentSystem.DomainBinding/Models/ProjectionReadySlice.cs
@@ -1,0 +1,32 @@
+namespace IntentSystem.DomainBinding.Models;
+
+/// <summary>
+/// Generic projection-ready binding output that preserves the execution fields
+/// needed by projection and queue layers while staying thin.
+/// </summary>
+public sealed record ProjectionReadySlice
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required string Goal { get; init; }
+
+    public required string TargetRepo { get; init; }
+
+    public required string TargetPath { get; init; }
+
+    public required string TargetPart { get; init; }
+
+    public required IReadOnlyList<string> Dependencies { get; init; }
+
+    public required string SuccessSignal { get; init; }
+
+    public required string ReviewMode { get; init; }
+
+    public required string CompletionAction { get; init; }
+
+    public required string LandingPolicy { get; init; }
+
+    public required DogfoodingTrack DogfoodingTrack { get; init; }
+
+    public required string EmbeddedCanonicalSummary { get; init; }
+}

--- a/src/IntentSystem.DomainBinding/Serialization/DomainBindingJsonOptions.cs
+++ b/src/IntentSystem.DomainBinding/Serialization/DomainBindingJsonOptions.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.DomainBinding.Serialization;
+
+internal static class DomainBindingJsonOptions
+{
+    public static JsonSerializerOptions Indented { get; } = Create(writeIndented: true);
+
+    public static JsonSerializerOptions Compact { get; } = Create(writeIndented: false);
+
+    private static JsonSerializerOptions Create(bool writeIndented)
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = writeIndented
+        };
+
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.KebabCaseLower));
+
+        return options;
+    }
+}

--- a/src/IntentSystem.DomainBinding/Serialization/DomainBindingSerializer.cs
+++ b/src/IntentSystem.DomainBinding/Serialization/DomainBindingSerializer.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using IntentSystem.DomainBinding.Models;
+
+namespace IntentSystem.DomainBinding.Serialization;
+
+public static class DomainBindingSerializer
+{
+    public static string SerializeSource(DomainExecutionSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        return JsonSerializer.Serialize(source, DomainBindingJsonOptions.Indented);
+    }
+
+    public static DomainExecutionSource DeserializeSource(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        using var document = JsonDocument.Parse(json);
+        ValidateRequiredFields(document.RootElement, RequiredSourceFields, "Domain execution source");
+
+        return JsonSerializer.Deserialize<DomainExecutionSource>(json, DomainBindingJsonOptions.Compact)
+            ?? throw new InvalidOperationException(
+                "Domain execution source payload deserialized to null.");
+    }
+
+    public static string SerializeProjectionReadySlice(ProjectionReadySlice projectionReady)
+    {
+        ArgumentNullException.ThrowIfNull(projectionReady);
+        return JsonSerializer.Serialize(projectionReady, DomainBindingJsonOptions.Indented);
+    }
+
+    public static ProjectionReadySlice DeserializeProjectionReadySlice(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        using var document = JsonDocument.Parse(json);
+        ValidateRequiredFields(document.RootElement, RequiredProjectionReadyFields, "Projection-ready slice");
+
+        return JsonSerializer.Deserialize<ProjectionReadySlice>(json, DomainBindingJsonOptions.Compact)
+            ?? throw new InvalidOperationException(
+                "Projection-ready slice payload deserialized to null.");
+    }
+
+    private static readonly string[] RequiredSourceFields =
+    [
+        "source_kind",
+        "dogfooding_track",
+        "execution_unit",
+        "goal",
+        "target_repo",
+        "target_path",
+        "target_part",
+        "dependencies",
+        "success_signal",
+        "review_mode",
+        "completion_action",
+        "landing_policy",
+        "embedded_canonical_summary"
+    ];
+
+    private static readonly string[] RequiredProjectionReadyFields =
+    [
+        "execution_unit",
+        "goal",
+        "target_repo",
+        "target_path",
+        "target_part",
+        "dependencies",
+        "success_signal",
+        "review_mode",
+        "completion_action",
+        "landing_policy",
+        "dogfooding_track",
+        "embedded_canonical_summary"
+    ];
+
+    private static void ValidateRequiredFields(
+        JsonElement element,
+        IReadOnlyList<string> requiredFields,
+        string contractName)
+    {
+        foreach (var field in requiredFields)
+        {
+            if (!element.TryGetProperty(field, out _))
+            {
+                throw new InvalidOperationException(
+                    $"{contractName} must contain required field '{field}'.");
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.DomainBinding.Tests/DomainBindingArchitectureTests.cs
+++ b/tests/IntentSystem.DomainBinding.Tests/DomainBindingArchitectureTests.cs
@@ -1,0 +1,44 @@
+using IntentSystem.DomainBinding.Serialization;
+
+namespace IntentSystem.DomainBinding.Tests;
+
+public sealed class DomainBindingArchitectureTests
+{
+    [Fact]
+    public void SerializationInfrastructure_DoesNotExposeDomainBindingJsonOptionsAsPublicApi()
+    {
+        var optionsType = typeof(DomainBindingSerializer).Assembly
+            .GetType("IntentSystem.DomainBinding.Serialization.DomainBindingJsonOptions");
+
+        Assert.NotNull(optionsType);
+        Assert.False(optionsType!.IsPublic);
+    }
+
+    [Fact]
+    public void TestSources_DoNotUseGivenWhenThenComments()
+    {
+        var testSourceDirectory = GetTestSourceDirectory();
+        var sourceFiles = Directory.GetFiles(testSourceDirectory, "*.cs", SearchOption.TopDirectoryOnly);
+        var bannedMarkers = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "// Given",
+            "// When",
+            "// Then"
+        };
+
+        var violations = sourceFiles
+            .SelectMany(file => File.ReadLines(file)
+                .Select((line, index) => new { file, line, lineNumber = index + 1 }))
+            .Where(entry => bannedMarkers.Contains(entry.line.Trim()))
+            .Select(entry => $"{Path.GetFileName(entry.file)}:{entry.lineNumber}")
+            .ToArray();
+
+        Assert.Empty(violations);
+    }
+
+    private static string GetTestSourceDirectory()
+    {
+        var projectDirectory = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
+        return new DirectoryInfo(projectDirectory).FullName;
+    }
+}

--- a/tests/IntentSystem.DomainBinding.Tests/DomainBindingMapperTests.cs
+++ b/tests/IntentSystem.DomainBinding.Tests/DomainBindingMapperTests.cs
@@ -1,0 +1,77 @@
+using IntentSystem.DomainBinding.Models;
+
+namespace IntentSystem.DomainBinding.Tests;
+
+public sealed class DomainBindingMapperTests
+{
+    [Fact]
+    public void ToProjectionReadySlice_GivenBackendFirstSource_PreservesAllProjectionContractFields()
+    {
+        var source = CreateSource();
+
+        var projectionReady = DomainBindingMapper.ToProjectionReadySlice(source);
+
+        Assert.Equal(source.ExecutionUnit, projectionReady.ExecutionUnit);
+        Assert.Equal(source.Goal, projectionReady.Goal);
+        Assert.Equal(source.TargetRepo, projectionReady.TargetRepo);
+        Assert.Equal(source.TargetPath, projectionReady.TargetPath);
+        Assert.Equal(source.TargetPart, projectionReady.TargetPart);
+        Assert.Equal(source.Dependencies, projectionReady.Dependencies);
+        Assert.Equal(source.SuccessSignal, projectionReady.SuccessSignal);
+        Assert.Equal(source.ReviewMode, projectionReady.ReviewMode);
+        Assert.Equal(source.CompletionAction, projectionReady.CompletionAction);
+        Assert.Equal(source.DogfoodingTrack, projectionReady.DogfoodingTrack);
+        Assert.Equal(source.EmbeddedCanonicalSummary, projectionReady.EmbeddedCanonicalSummary);
+    }
+
+    [Fact]
+    public void ToSubSliceRow_GivenProjectionReadySlice_MapsToGenericProjectionInput()
+    {
+        var source = CreateSource();
+
+        var row = DomainBindingMapper.ToSubSliceRow(source);
+
+        Assert.Equal("F1", row.SourceExecutionUnit);
+        Assert.Equal("Create a projection-ready binding for the backend execution slice.", row.Goal);
+        Assert.Equal("J-Tech-Japan/intent-system", row.TargetRepo);
+        Assert.Equal(".", row.TargetPath);
+        Assert.Equal("domain binding", row.TargetPart);
+        Assert.Equal(["A2", "B2"], row.DependsOnSubslices);
+        Assert.Equal(["A2", "B2"], row.DependsOn);
+        Assert.Equal("backend sub-slice can be reconstructed as projection-ready input", row.SuccessSignal);
+        Assert.Equal("manual-review", row.ReviewMode);
+        Assert.Equal("open-pr", row.CompletionAction);
+        Assert.Equal("squash", row.LandingPolicy);
+    }
+
+    [Fact]
+    public void ToSubSliceRow_GivenDomainSource_DoesNotInjectPrivateSummaryIntoGenericProjectionFields()
+    {
+        var source = CreateSource();
+
+        var row = DomainBindingMapper.ToSubSliceRow(source);
+
+        Assert.Empty(row.RelatedIntents);
+        Assert.Empty(row.SourceConcepts);
+    }
+
+    private static DomainExecutionSource CreateSource()
+    {
+        return new DomainExecutionSource
+        {
+            SourceKind = DomainExecutionSourceKind.IssueReadySubSlice,
+            DogfoodingTrack = DogfoodingTrack.BackendFirst,
+            ExecutionUnit = "F1",
+            Goal = "Create a projection-ready binding for the backend execution slice.",
+            TargetRepo = "J-Tech-Japan/intent-system",
+            TargetPath = ".",
+            TargetPart = "domain binding",
+            Dependencies = ["A2", "B2"],
+            SuccessSignal = "backend sub-slice can be reconstructed as projection-ready input",
+            ReviewMode = "manual-review",
+            CompletionAction = "open-pr",
+            LandingPolicy = "squash",
+            EmbeddedCanonicalSummary = "Backend execution slice summary embedded for child-repo contract tests."
+        };
+    }
+}

--- a/tests/IntentSystem.DomainBinding.Tests/DomainBindingSerializerTests.cs
+++ b/tests/IntentSystem.DomainBinding.Tests/DomainBindingSerializerTests.cs
@@ -1,0 +1,197 @@
+using System.Text.Json;
+using IntentSystem.DomainBinding.Models;
+using IntentSystem.DomainBinding.Serialization;
+
+namespace IntentSystem.DomainBinding.Tests;
+
+public sealed class DomainBindingSerializerTests
+{
+    [Fact]
+    public void SerializeSource_GivenCompleteContract_ContainsAllRequiredFields()
+    {
+        var source = CreateSource();
+
+        var serialized = DomainBindingSerializer.SerializeSource(source);
+        using var document = JsonDocument.Parse(serialized);
+        var root = document.RootElement;
+
+        Assert.Equal("issue-ready-sub-slice", root.GetProperty("source_kind").GetString());
+        Assert.Equal("backend-first", root.GetProperty("dogfooding_track").GetString());
+        Assert.Equal("F1", root.GetProperty("execution_unit").GetString());
+        Assert.Equal("Create a projection-ready binding for the backend execution slice.", root.GetProperty("goal").GetString());
+        Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("target_repo").GetString());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("dependencies").ValueKind);
+        Assert.Equal(JsonValueKind.String, root.GetProperty("embedded_canonical_summary").ValueKind);
+    }
+
+    [Fact]
+    public void SerializeSource_GivenCompleteContract_DoesNotExposePrivatePathOrUrlFields()
+    {
+        var source = CreateSource();
+
+        var serialized = DomainBindingSerializer.SerializeSource(source);
+
+        Assert.DoesNotContain("\"source_url\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"source_path\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"private_repo\"", serialized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeserializeSource_GivenCompleteJson_RestoresAllFields()
+    {
+        var json = """
+        {
+          "source_kind": "issue-ready-sub-slice",
+          "dogfooding_track": "backend-first",
+          "execution_unit": "F1",
+          "goal": "Create a projection-ready binding for the backend execution slice.",
+          "target_repo": "J-Tech-Japan/intent-system",
+          "target_path": ".",
+          "target_part": "domain binding",
+          "dependencies": ["A2", "B2"],
+          "success_signal": "backend sub-slice can be reconstructed as projection-ready input",
+          "review_mode": "manual-review",
+          "completion_action": "open-pr",
+          "landing_policy": "squash",
+          "embedded_canonical_summary": "Backend execution slice summary embedded for child-repo contract tests."
+        }
+        """;
+
+        var source = DomainBindingSerializer.DeserializeSource(json);
+
+        Assert.Equal(DomainExecutionSourceKind.IssueReadySubSlice, source.SourceKind);
+        Assert.Equal(DogfoodingTrack.BackendFirst, source.DogfoodingTrack);
+        Assert.Equal("F1", source.ExecutionUnit);
+        Assert.Equal(["A2", "B2"], source.Dependencies);
+        Assert.Equal("squash", source.LandingPolicy);
+        Assert.Equal(
+            "Backend execution slice summary embedded for child-repo contract tests.",
+            source.EmbeddedCanonicalSummary);
+    }
+
+    [Fact]
+    public void DeserializeSource_GivenMissingRequiredField_ThrowsInvalidOperationException()
+    {
+        var json = """
+        {
+          "source_kind": "issue-ready-sub-slice",
+          "execution_unit": "F1"
+        }
+        """;
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => DomainBindingSerializer.DeserializeSource(json));
+
+        Assert.Contains("required field", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SerializeProjectionReadySlice_GivenCompleteContract_ContainsAllGenericProjectionFields()
+    {
+        var projectionReady = CreateProjectionReadySlice();
+
+        var serialized = DomainBindingSerializer.SerializeProjectionReadySlice(projectionReady);
+        using var document = JsonDocument.Parse(serialized);
+        var root = document.RootElement;
+
+        Assert.Equal("F1", root.GetProperty("execution_unit").GetString());
+        Assert.Equal("domain binding", root.GetProperty("target_part").GetString());
+        Assert.Equal("manual-review", root.GetProperty("review_mode").GetString());
+        Assert.Equal("open-pr", root.GetProperty("completion_action").GetString());
+        Assert.Equal("backend-first", root.GetProperty("dogfooding_track").GetString());
+    }
+
+    [Fact]
+    public void SerializeProjectionReadySlice_GivenCompleteContract_DoesNotContainRendererQueueOrWorkflowFields()
+    {
+        var projectionReady = CreateProjectionReadySlice();
+
+        var serialized = DomainBindingSerializer.SerializeProjectionReadySlice(projectionReady);
+
+        Assert.DoesNotContain("\"packet_paths\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"queue_state\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"run_status\"", serialized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeserializeProjectionReadySlice_GivenCompleteJson_RestoresAllFields()
+    {
+        var json = """
+        {
+          "execution_unit": "F1",
+          "goal": "Create a projection-ready binding for the backend execution slice.",
+          "target_repo": "J-Tech-Japan/intent-system",
+          "target_path": ".",
+          "target_part": "domain binding",
+          "dependencies": ["A2", "B2"],
+          "success_signal": "backend sub-slice can be reconstructed as projection-ready input",
+          "review_mode": "manual-review",
+          "completion_action": "open-pr",
+          "landing_policy": "squash",
+          "dogfooding_track": "backend-first",
+          "embedded_canonical_summary": "Backend execution slice summary embedded for child-repo contract tests."
+        }
+        """;
+
+        var projectionReady = DomainBindingSerializer.DeserializeProjectionReadySlice(json);
+
+        Assert.Equal("F1", projectionReady.ExecutionUnit);
+        Assert.Equal(["A2", "B2"], projectionReady.Dependencies);
+        Assert.Equal(DogfoodingTrack.BackendFirst, projectionReady.DogfoodingTrack);
+        Assert.Equal("manual-review", projectionReady.ReviewMode);
+    }
+
+    [Fact]
+    public void SerializeSourceAndDeserializeSource_RoundTrips()
+    {
+        var source = CreateSource();
+
+        var serialized = DomainBindingSerializer.SerializeSource(source);
+        var deserialized = DomainBindingSerializer.DeserializeSource(serialized);
+
+        Assert.Equal(source.SourceKind, deserialized.SourceKind);
+        Assert.Equal(source.DogfoodingTrack, deserialized.DogfoodingTrack);
+        Assert.Equal(source.ExecutionUnit, deserialized.ExecutionUnit);
+        Assert.Equal(source.Dependencies, deserialized.Dependencies);
+        Assert.Equal(source.EmbeddedCanonicalSummary, deserialized.EmbeddedCanonicalSummary);
+    }
+
+    private static DomainExecutionSource CreateSource()
+    {
+        return new DomainExecutionSource
+        {
+            SourceKind = DomainExecutionSourceKind.IssueReadySubSlice,
+            DogfoodingTrack = DogfoodingTrack.BackendFirst,
+            ExecutionUnit = "F1",
+            Goal = "Create a projection-ready binding for the backend execution slice.",
+            TargetRepo = "J-Tech-Japan/intent-system",
+            TargetPath = ".",
+            TargetPart = "domain binding",
+            Dependencies = ["A2", "B2"],
+            SuccessSignal = "backend sub-slice can be reconstructed as projection-ready input",
+            ReviewMode = "manual-review",
+            CompletionAction = "open-pr",
+            LandingPolicy = "squash",
+            EmbeddedCanonicalSummary = "Backend execution slice summary embedded for child-repo contract tests."
+        };
+    }
+
+    private static ProjectionReadySlice CreateProjectionReadySlice()
+    {
+        return new ProjectionReadySlice
+        {
+            ExecutionUnit = "F1",
+            Goal = "Create a projection-ready binding for the backend execution slice.",
+            TargetRepo = "J-Tech-Japan/intent-system",
+            TargetPath = ".",
+            TargetPart = "domain binding",
+            Dependencies = ["A2", "B2"],
+            SuccessSignal = "backend sub-slice can be reconstructed as projection-ready input",
+            ReviewMode = "manual-review",
+            CompletionAction = "open-pr",
+            LandingPolicy = "squash",
+            DogfoodingTrack = DogfoodingTrack.BackendFirst,
+            EmbeddedCanonicalSummary = "Backend execution slice summary embedded for child-repo contract tests."
+        };
+    }
+}

--- a/tests/IntentSystem.DomainBinding.Tests/IntentSystem.DomainBinding.Tests.csproj
+++ b/tests/IntentSystem.DomainBinding.Tests/IntentSystem.DomainBinding.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\IntentSystem.DomainBinding\IntentSystem.DomainBinding.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add a new `IntentSystem.DomainBinding` module for the thin private execution source -> projection-ready binding contract
- define source and projection-ready models, serializers, and a mapper to generic `SubSliceRow` input
- keep backend-first dogfooding metadata and embedded canonical summary in the binding layer without introducing private paths or URLs into the contract

## Why
Issue #25 needs a deterministic bridge from a private execution source-of-truth into the public child repo's generic projection input without reimplementing packet rendering, queue policy, or workflow execution.

## Impact
- child-repo contract tests can run from embedded summary fixtures without reading a parent checkout
- the binding preserves `execution_unit`, `goal`, `target_repo`, `target_path`, `target_part`, `dependencies`, `success_signal`, `review_mode`, and `completion_action`
- the mapper can reconstruct a backend-first dogfooding sub-slice as generic projection input while keeping private-source details out of the public contract

## Validation
- `dotnet test`

Closes #25
