### PR TITLE
[codex] Implement issue 27 dogfooding bridge

### DIFF
--- a/IntentSystem.sln
+++ b/IntentSystem.sln
@@ -35,6 +35,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntentSystem.DomainBinding"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntentSystem.DomainBinding.Tests", "tests\IntentSystem.DomainBinding.Tests\IntentSystem.DomainBinding.Tests.csproj", "{1851D6F9-09DE-449A-8496-73E38D702221}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntentSystem.DogfoodingBridge", "src\IntentSystem.DogfoodingBridge\IntentSystem.DogfoodingBridge.csproj", "{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntentSystem.DogfoodingBridge.Tests", "tests\IntentSystem.DogfoodingBridge.Tests\IntentSystem.DogfoodingBridge.Tests.csproj", "{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -213,6 +217,30 @@ Global
 		{1851D6F9-09DE-449A-8496-73E38D702221}.Release|x64.Build.0 = Release|Any CPU
 		{1851D6F9-09DE-449A-8496-73E38D702221}.Release|x86.ActiveCfg = Release|Any CPU
 		{1851D6F9-09DE-449A-8496-73E38D702221}.Release|x86.Build.0 = Release|Any CPU
+		{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D}.Debug|x64.Build.0 = Debug|Any CPU
+		{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D}.Debug|x86.Build.0 = Debug|Any CPU
+		{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D}.Release|x64.ActiveCfg = Release|Any CPU
+		{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D}.Release|x64.Build.0 = Release|Any CPU
+		{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D}.Release|x86.ActiveCfg = Release|Any CPU
+		{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D}.Release|x86.Build.0 = Release|Any CPU
+		{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2}.Debug|x64.Build.0 = Debug|Any CPU
+		{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2}.Debug|x86.Build.0 = Debug|Any CPU
+		{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2}.Release|x64.ActiveCfg = Release|Any CPU
+		{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2}.Release|x64.Build.0 = Release|Any CPU
+		{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2}.Release|x86.ActiveCfg = Release|Any CPU
+		{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -232,5 +260,7 @@ Global
 		{4F40F997-2074-443F-909D-2FCB95C397EB} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{ACE927FA-9305-4C00-86EF-4EDD15B3DC0A} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{1851D6F9-09DE-449A-8496-73E38D702221} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{C4A7AEE7-A61A-4CF5-80E9-A5F5CC1A409D} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{D3FDBB21-3052-4BAF-8C9E-B5EB97D0D1C2} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/src/IntentSystem.DogfoodingBridge/DogfoodingBridgeMapper.cs
+++ b/src/IntentSystem.DogfoodingBridge/DogfoodingBridgeMapper.cs
@@ -1,0 +1,74 @@
+using IntentSystem.ConceptIntake.Models;
+using IntentSystem.DogfoodingBridge.Models;
+using IntentSystem.DomainBinding.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Workflow.Models;
+
+namespace IntentSystem.DogfoodingBridge;
+
+public static class DogfoodingBridgeMapper
+{
+    public static DogfoodingBridgeContract Create(
+        ProjectionReadySlice binding,
+        WorkflowDefinition workflowDefinition,
+        string clarificationReturnPath,
+        IReadOnlyList<InterviewQueueItem> interviewQueueItems)
+    {
+        ArgumentNullException.ThrowIfNull(binding);
+        ArgumentNullException.ThrowIfNull(workflowDefinition);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clarificationReturnPath);
+        ArgumentNullException.ThrowIfNull(interviewQueueItems);
+
+        ValidateExecutionUnit(binding, workflowDefinition);
+
+        var interviewReturnPaths = interviewQueueItems
+            .SelectMany(item => item.ReturnToIntentPaths)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return new DogfoodingBridgeContract
+        {
+            Binding = binding,
+            QueueInput = new QueueReadyDogfoodingInput
+            {
+                ExecutionUnit = binding.ExecutionUnit,
+                PacketPaths = new PacketPaths
+                {
+                    Implementation = workflowDefinition.PacketPaths.Implementation,
+                    ReviewContext = workflowDefinition.PacketPaths.ReviewContext,
+                    Yaml = workflowDefinition.PacketPaths.Yaml
+                },
+                Dependencies = workflowDefinition.DependencySnapshot,
+                ClarificationReturnPath = clarificationReturnPath,
+                WorkerRole = workflowDefinition.WorkerRoles.Worker,
+                ReviewRole = workflowDefinition.WorkerRoles.Reviewer
+            },
+            WorkflowInput = new WorkflowReadyDogfoodingInput
+            {
+                ExecutionUnit = workflowDefinition.ExecutionUnit,
+                PacketPaths = workflowDefinition.PacketPaths,
+                DependencySnapshot = workflowDefinition.DependencySnapshot,
+                WorkerRoles = workflowDefinition.WorkerRoles,
+                EntryConditions = workflowDefinition.EntryConditions,
+                ReviewMode = workflowDefinition.ReviewMode,
+                CompletionAction = workflowDefinition.CompletionAction
+            },
+            ReturnRoutes = new DogfoodingReturnRoutes
+            {
+                ClarificationReturnPath = clarificationReturnPath,
+                InterviewReturnToIntentPaths = interviewReturnPaths
+            }
+        };
+    }
+
+    private static void ValidateExecutionUnit(
+        ProjectionReadySlice binding,
+        WorkflowDefinition workflowDefinition)
+    {
+        if (!string.Equals(binding.ExecutionUnit, workflowDefinition.ExecutionUnit, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Binding execution unit '{binding.ExecutionUnit}' must match workflow execution unit '{workflowDefinition.ExecutionUnit}'.");
+        }
+    }
+}

--- a/src/IntentSystem.DogfoodingBridge/DogfoodingBridgeMapper.cs
+++ b/src/IntentSystem.DogfoodingBridge/DogfoodingBridgeMapper.cs
@@ -23,6 +23,7 @@ public static class DogfoodingBridgeMapper
 
         var interviewReturnPaths = interviewQueueItems
             .SelectMany(item => item.ReturnToIntentPaths)
+            .Select(RedactInterviewReturnPath)
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 
@@ -70,5 +71,19 @@ public static class DogfoodingBridgeMapper
             throw new InvalidOperationException(
                 $"Binding execution unit '{binding.ExecutionUnit}' must match workflow execution unit '{workflowDefinition.ExecutionUnit}'.");
         }
+    }
+
+    private static string RedactInterviewReturnPath(string returnPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(returnPath);
+
+        var token = Path.GetFileNameWithoutExtension(returnPath);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new InvalidOperationException(
+                $"Interview return path '{returnPath}' could not be converted to a public-safe token.");
+        }
+
+        return $"private-intent-ref:{token}";
     }
 }

--- a/src/IntentSystem.DogfoodingBridge/IntentSystem.DogfoodingBridge.csproj
+++ b/src/IntentSystem.DogfoodingBridge/IntentSystem.DogfoodingBridge.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\IntentSystem.Clarify\IntentSystem.Clarify.csproj" />
+    <ProjectReference Include="..\IntentSystem.ConceptIntake\IntentSystem.ConceptIntake.csproj" />
+    <ProjectReference Include="..\IntentSystem.DomainBinding\IntentSystem.DomainBinding.csproj" />
+    <ProjectReference Include="..\IntentSystem.Supervisor\IntentSystem.Supervisor.csproj" />
+    <ProjectReference Include="..\IntentSystem.Workflow\IntentSystem.Workflow.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/IntentSystem.DogfoodingBridge/Models/DogfoodingBridgeContract.cs
+++ b/src/IntentSystem.DogfoodingBridge/Models/DogfoodingBridgeContract.cs
@@ -1,0 +1,18 @@
+using IntentSystem.DomainBinding.Models;
+
+namespace IntentSystem.DogfoodingBridge.Models;
+
+/// <summary>
+/// Aggregates existing binding, queue, workflow, clarify, and interview contracts
+/// into a thin dogfooding bridge boundary.
+/// </summary>
+public sealed record DogfoodingBridgeContract
+{
+    public required ProjectionReadySlice Binding { get; init; }
+
+    public required QueueReadyDogfoodingInput QueueInput { get; init; }
+
+    public required WorkflowReadyDogfoodingInput WorkflowInput { get; init; }
+
+    public required DogfoodingReturnRoutes ReturnRoutes { get; init; }
+}

--- a/src/IntentSystem.DogfoodingBridge/Models/DogfoodingReturnRoutes.cs
+++ b/src/IntentSystem.DogfoodingBridge/Models/DogfoodingReturnRoutes.cs
@@ -1,0 +1,11 @@
+namespace IntentSystem.DogfoodingBridge.Models;
+
+/// <summary>
+/// Distinct return routes for clarify and interview loops.
+/// </summary>
+public sealed record DogfoodingReturnRoutes
+{
+    public required string ClarificationReturnPath { get; init; }
+
+    public required IReadOnlyList<string> InterviewReturnToIntentPaths { get; init; }
+}

--- a/src/IntentSystem.DogfoodingBridge/Models/QueueReadyDogfoodingInput.cs
+++ b/src/IntentSystem.DogfoodingBridge/Models/QueueReadyDogfoodingInput.cs
@@ -1,0 +1,21 @@
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.DogfoodingBridge.Models;
+
+/// <summary>
+/// Thin queue-ready input prepared by the dogfooding bridge without selecting state policy.
+/// </summary>
+public sealed record QueueReadyDogfoodingInput
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required PacketPaths PacketPaths { get; init; }
+
+    public required IReadOnlyList<string> Dependencies { get; init; }
+
+    public required string ClarificationReturnPath { get; init; }
+
+    public required string WorkerRole { get; init; }
+
+    public required string ReviewRole { get; init; }
+}

--- a/src/IntentSystem.DogfoodingBridge/Models/WorkflowReadyDogfoodingInput.cs
+++ b/src/IntentSystem.DogfoodingBridge/Models/WorkflowReadyDogfoodingInput.cs
@@ -1,0 +1,23 @@
+using IntentSystem.Workflow.Models;
+
+namespace IntentSystem.DogfoodingBridge.Models;
+
+/// <summary>
+/// Workflow-ready start input assembled for an execution unit without redefining the workflow artifact.
+/// </summary>
+public sealed record WorkflowReadyDogfoodingInput
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required WorkflowPacketPaths PacketPaths { get; init; }
+
+    public required IReadOnlyList<string> DependencySnapshot { get; init; }
+
+    public required WorkerRoles WorkerRoles { get; init; }
+
+    public required IReadOnlyList<string> EntryConditions { get; init; }
+
+    public required string ReviewMode { get; init; }
+
+    public required string CompletionAction { get; init; }
+}

--- a/src/IntentSystem.DogfoodingBridge/Serialization/DogfoodingBridgeJsonOptions.cs
+++ b/src/IntentSystem.DogfoodingBridge/Serialization/DogfoodingBridgeJsonOptions.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.DogfoodingBridge.Serialization;
+
+internal static class DogfoodingBridgeJsonOptions
+{
+    public static JsonSerializerOptions Indented { get; } = Create(writeIndented: true);
+
+    public static JsonSerializerOptions Compact { get; } = Create(writeIndented: false);
+
+    private static JsonSerializerOptions Create(bool writeIndented)
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = writeIndented
+        };
+
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.KebabCaseLower));
+
+        return options;
+    }
+}

--- a/src/IntentSystem.DogfoodingBridge/Serialization/DogfoodingBridgeSerializer.cs
+++ b/src/IntentSystem.DogfoodingBridge/Serialization/DogfoodingBridgeSerializer.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using IntentSystem.DogfoodingBridge.Models;
+
+namespace IntentSystem.DogfoodingBridge.Serialization;
+
+public static class DogfoodingBridgeSerializer
+{
+    public static string Serialize(DogfoodingBridgeContract contract)
+    {
+        ArgumentNullException.ThrowIfNull(contract);
+        return JsonSerializer.Serialize(contract, DogfoodingBridgeJsonOptions.Indented);
+    }
+
+    public static DogfoodingBridgeContract Deserialize(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        using var document = JsonDocument.Parse(json);
+        ValidateRequiredFields(document.RootElement);
+
+        return JsonSerializer.Deserialize<DogfoodingBridgeContract>(json, DogfoodingBridgeJsonOptions.Compact)
+            ?? throw new InvalidOperationException(
+                "Dogfooding bridge payload deserialized to null.");
+    }
+
+    private static readonly string[] RequiredFields =
+    [
+        "binding",
+        "queue_input",
+        "workflow_input",
+        "return_routes"
+    ];
+
+    private static readonly string[] RequiredQueueInputFields =
+    [
+        "execution_unit",
+        "packet_paths",
+        "dependencies",
+        "clarification_return_path",
+        "worker_role",
+        "review_role"
+    ];
+
+    private static readonly string[] RequiredWorkflowInputFields =
+    [
+        "execution_unit",
+        "packet_paths",
+        "dependency_snapshot",
+        "worker_roles",
+        "entry_conditions",
+        "review_mode",
+        "completion_action"
+    ];
+
+    private static readonly string[] RequiredReturnRouteFields =
+    [
+        "clarification_return_path",
+        "interview_return_to_intent_paths"
+    ];
+
+    private static void ValidateRequiredFields(JsonElement root)
+    {
+        ValidateRequiredFields(root, RequiredFields, "Dogfooding bridge");
+        ValidateRequiredFields(root.GetProperty("queue_input"), RequiredQueueInputFields, "Dogfooding bridge queue_input");
+        ValidateRequiredFields(root.GetProperty("workflow_input"), RequiredWorkflowInputFields, "Dogfooding bridge workflow_input");
+        ValidateRequiredFields(root.GetProperty("return_routes"), RequiredReturnRouteFields, "Dogfooding bridge return_routes");
+    }
+
+    private static void ValidateRequiredFields(
+        JsonElement element,
+        IReadOnlyList<string> requiredFields,
+        string contractName)
+    {
+        foreach (var field in requiredFields)
+        {
+            if (!element.TryGetProperty(field, out _))
+            {
+                throw new InvalidOperationException(
+                    $"{contractName} must contain required field '{field}'.");
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeArchitectureTests.cs
+++ b/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeArchitectureTests.cs
@@ -1,0 +1,44 @@
+using IntentSystem.DogfoodingBridge.Serialization;
+
+namespace IntentSystem.DogfoodingBridge.Tests;
+
+public sealed class DogfoodingBridgeArchitectureTests
+{
+    [Fact]
+    public void SerializationInfrastructure_DoesNotExposeDogfoodingBridgeJsonOptionsAsPublicApi()
+    {
+        var optionsType = typeof(DogfoodingBridgeSerializer).Assembly
+            .GetType("IntentSystem.DogfoodingBridge.Serialization.DogfoodingBridgeJsonOptions");
+
+        Assert.NotNull(optionsType);
+        Assert.False(optionsType!.IsPublic);
+    }
+
+    [Fact]
+    public void TestSources_DoNotUseGivenWhenThenComments()
+    {
+        var testSourceDirectory = GetTestSourceDirectory();
+        var sourceFiles = Directory.GetFiles(testSourceDirectory, "*.cs", SearchOption.TopDirectoryOnly);
+        var bannedMarkers = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "// Given",
+            "// When",
+            "// Then"
+        };
+
+        var violations = sourceFiles
+            .SelectMany(file => File.ReadLines(file)
+                .Select((line, index) => new { file, line, lineNumber = index + 1 }))
+            .Where(entry => bannedMarkers.Contains(entry.line.Trim()))
+            .Select(entry => $"{Path.GetFileName(entry.file)}:{entry.lineNumber}")
+            .ToArray();
+
+        Assert.Empty(violations);
+    }
+
+    private static string GetTestSourceDirectory()
+    {
+        var projectDirectory = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
+        return new DirectoryInfo(projectDirectory).FullName;
+    }
+}

--- a/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeMapperTests.cs
+++ b/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeMapperTests.cs
@@ -47,10 +47,13 @@ public sealed class DogfoodingBridgeMapperTests
             bridge.ReturnRoutes.ClarificationReturnPath);
         Assert.Equal(
             [
-                "intents/private-domain/intent-tree/backend.md",
-                "intents/private-domain/intent-tree/shared.md"
+                "private-intent-ref:backend",
+                "private-intent-ref:shared"
             ],
             bridge.ReturnRoutes.InterviewReturnToIntentPaths);
+        Assert.DoesNotContain(
+            bridge.ReturnRoutes.InterviewReturnToIntentPaths,
+            value => value.Contains("intents/private-domain/", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeMapperTests.cs
+++ b/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeMapperTests.cs
@@ -1,0 +1,144 @@
+using IntentSystem.ConceptIntake.Models;
+using IntentSystem.DogfoodingBridge.Models;
+using IntentSystem.DomainBinding.Models;
+using IntentSystem.Workflow;
+using IntentSystem.Workflow.Models;
+
+namespace IntentSystem.DogfoodingBridge.Tests;
+
+public sealed class DogfoodingBridgeMapperTests
+{
+    [Fact]
+    public void Create_GivenBindingAndWorkflow_BuildsQueueAndWorkflowReadyInputs()
+    {
+        var binding = CreateBinding();
+        var workflow = CreateWorkflowDefinition();
+        var interviewItems = CreateInterviewItems();
+
+        var bridge = DogfoodingBridgeMapper.Create(
+            binding,
+            workflow,
+            "intents/rules/issue-template-and-review-context.md",
+            interviewItems);
+
+        Assert.Equal("F2", bridge.QueueInput.ExecutionUnit);
+        Assert.Equal(".intent-cli/packets/F2/implementation.md", bridge.QueueInput.PacketPaths.Implementation);
+        Assert.Equal(["C1", "D2", "E2", "F1"], bridge.QueueInput.Dependencies);
+        Assert.Equal("coder", bridge.QueueInput.WorkerRole);
+        Assert.Equal("reviewer", bridge.QueueInput.ReviewRole);
+
+        Assert.Equal("F2", bridge.WorkflowInput.ExecutionUnit);
+        Assert.Equal(["dependency snapshot captured"], bridge.WorkflowInput.EntryConditions);
+        Assert.Equal("manual-review", bridge.WorkflowInput.ReviewMode);
+        Assert.Equal("open-pr", bridge.WorkflowInput.CompletionAction);
+    }
+
+    [Fact]
+    public void Create_GivenClarifyAndInterviewRoutes_DoesNotMixTheirReturnTargets()
+    {
+        var bridge = DogfoodingBridgeMapper.Create(
+            CreateBinding(),
+            CreateWorkflowDefinition(),
+            "intents/rules/issue-template-and-review-context.md",
+            CreateInterviewItems());
+
+        Assert.Equal(
+            "intents/rules/issue-template-and-review-context.md",
+            bridge.ReturnRoutes.ClarificationReturnPath);
+        Assert.Equal(
+            [
+                "intents/private-domain/intent-tree/backend.md",
+                "intents/private-domain/intent-tree/shared.md"
+            ],
+            bridge.ReturnRoutes.InterviewReturnToIntentPaths);
+    }
+
+    [Fact]
+    public void Create_GivenExecutionUnitMismatch_ThrowsInvalidOperationException()
+    {
+        var binding = CreateBinding();
+        var workflow = CreateWorkflowDefinition() with
+        {
+            ExecutionUnit = "X9"
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => DogfoodingBridgeMapper.Create(
+                binding,
+                workflow,
+                "intents/rules/issue-template-and-review-context.md",
+                []));
+
+        Assert.Contains("must match workflow execution unit", ex.Message, StringComparison.Ordinal);
+    }
+
+    private static ProjectionReadySlice CreateBinding()
+    {
+        return new ProjectionReadySlice
+        {
+            ExecutionUnit = "F2",
+            Goal = "Bridge a bound private execution unit into queue-ready and workflow-ready input.",
+            TargetRepo = "J-Tech-Japan/intent-system",
+            TargetPath = ".",
+            TargetPart = "dogfooding bridge",
+            Dependencies = ["C1", "D2", "E2", "F1"],
+            SuccessSignal = "dogfooding run can be reconstructed from bridge input",
+            ReviewMode = "manual-review",
+            CompletionAction = "open-pr",
+            LandingPolicy = "squash",
+            DogfoodingTrack = DogfoodingTrack.BackendFirst,
+            EmbeddedCanonicalSummary = "Backend-first private domain summary embedded for child-repo tests."
+        };
+    }
+
+    private static WorkflowDefinition CreateWorkflowDefinition()
+    {
+        var roles = new WorkerRoles
+        {
+            Worker = "coder",
+            Reviewer = "reviewer"
+        };
+
+        return new WorkflowDefinition
+        {
+            ExecutionUnit = "F2",
+            PacketPaths = new WorkflowPacketPaths
+            {
+                Implementation = ".intent-cli/packets/F2/implementation.md",
+                ReviewContext = ".intent-cli/packets/F2/review-context.md",
+                Yaml = ".intent-cli/packets/F2/packet.yaml"
+            },
+            WorkerRoles = roles,
+            DependencySnapshot = ["C1", "D2", "E2", "F1"],
+            EntryConditions = ["dependency snapshot captured"],
+            Steps = MvpWorkflowTemplate.CreateSteps(roles),
+            SuccessSignal = "dogfooding run can be reconstructed from bridge input",
+            ReviewMode = "manual-review",
+            CompletionAction = "open-pr"
+        };
+    }
+
+    private static IReadOnlyList<InterviewQueueItem> CreateInterviewItems()
+    {
+        return
+        [
+            new InterviewQueueItem
+            {
+                DomainSlug = "private-domain",
+                SourceConceptRef = "embedded-summary",
+                QuestionId = "iq-1",
+                QuestionText = "What backend boundary should be dogfooded first?",
+                Reason = "Need first trial path.",
+                Affects = ["backend"],
+                BlockingOrNonblocking = "blocking",
+                Status = InterviewQueueItemStatus.Open,
+                ReturnToIntentPaths =
+                [
+                    "intents/private-domain/intent-tree/backend.md",
+                    "intents/private-domain/intent-tree/shared.md"
+                ],
+                CreatedAt = DateTimeOffset.Parse("2026-04-03T12:00:00Z")
+            }
+        ];
+    }
+}

--- a/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeMapperTests.cs
+++ b/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeMapperTests.cs
@@ -22,7 +22,7 @@ public sealed class DogfoodingBridgeMapperTests
             interviewItems);
 
         Assert.Equal("F2", bridge.QueueInput.ExecutionUnit);
-        Assert.Equal(".intent-cli/packets/F2/implementation.md", bridge.QueueInput.PacketPaths.Implementation);
+        Assert.Equal(".intent-cli/issues/F2/implementation.md", bridge.QueueInput.PacketPaths.Implementation);
         Assert.Equal(["C1", "D2", "E2", "F1"], bridge.QueueInput.Dependencies);
         Assert.Equal("coder", bridge.QueueInput.WorkerRole);
         Assert.Equal("reviewer", bridge.QueueInput.ReviewRole);
@@ -104,9 +104,9 @@ public sealed class DogfoodingBridgeMapperTests
             ExecutionUnit = "F2",
             PacketPaths = new WorkflowPacketPaths
             {
-                Implementation = ".intent-cli/packets/F2/implementation.md",
-                ReviewContext = ".intent-cli/packets/F2/review-context.md",
-                Yaml = ".intent-cli/packets/F2/packet.yaml"
+                Implementation = ".intent-cli/issues/F2/implementation.md",
+                ReviewContext = ".intent-cli/issues/F2/review-context.md",
+                Yaml = ".intent-cli/issues/F2/packet.yaml"
             },
             WorkerRoles = roles,
             DependencySnapshot = ["C1", "D2", "E2", "F1"],

--- a/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeSerializerTests.cs
+++ b/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeSerializerTests.cs
@@ -36,6 +36,8 @@ public sealed class DogfoodingBridgeSerializerTests
         Assert.DoesNotContain("\"source_path\"", serialized, StringComparison.Ordinal);
         Assert.DoesNotContain("\"state\"", serialized, StringComparison.Ordinal);
         Assert.DoesNotContain("\"blocked_by\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("intents/private-domain/", serialized, StringComparison.Ordinal);
+        Assert.Contains("private-intent-ref:backend", serialized, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -88,8 +90,8 @@ public sealed class DogfoodingBridgeSerializerTests
           "return_routes": {
             "clarification_return_path": "intents/rules/issue-template-and-review-context.md",
             "interview_return_to_intent_paths": [
-              "intents/private-domain/intent-tree/backend.md",
-              "intents/private-domain/intent-tree/shared.md"
+              "private-intent-ref:backend",
+              "private-intent-ref:shared"
             ]
           }
         }
@@ -103,8 +105,8 @@ public sealed class DogfoodingBridgeSerializerTests
         Assert.Equal("coder", contract.WorkflowInput.WorkerRoles.Worker);
         Assert.Equal(
             [
-                "intents/private-domain/intent-tree/backend.md",
-                "intents/private-domain/intent-tree/shared.md"
+                "private-intent-ref:backend",
+                "private-intent-ref:shared"
             ],
             contract.ReturnRoutes.InterviewReturnToIntentPaths);
     }
@@ -210,8 +212,8 @@ public sealed class DogfoodingBridgeSerializerTests
                 ClarificationReturnPath = "intents/rules/issue-template-and-review-context.md",
                 InterviewReturnToIntentPaths =
                 [
-                    "intents/private-domain/intent-tree/backend.md",
-                    "intents/private-domain/intent-tree/shared.md"
+                    "private-intent-ref:backend",
+                    "private-intent-ref:shared"
                 ]
             }
         };

--- a/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeSerializerTests.cs
+++ b/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeSerializerTests.cs
@@ -1,0 +1,219 @@
+using System.Text.Json;
+using IntentSystem.DogfoodingBridge.Models;
+using IntentSystem.DogfoodingBridge.Serialization;
+
+namespace IntentSystem.DogfoodingBridge.Tests;
+
+public sealed class DogfoodingBridgeSerializerTests
+{
+    [Fact]
+    public void Serialize_GivenCompleteContract_ContainsQueueAndWorkflowReadyFields()
+    {
+        var contract = CreateBridgeContract();
+
+        var serialized = DogfoodingBridgeSerializer.Serialize(contract);
+        using var document = JsonDocument.Parse(serialized);
+        var root = document.RootElement;
+
+        Assert.Equal("F2", root.GetProperty("queue_input").GetProperty("execution_unit").GetString());
+        Assert.Equal("F2", root.GetProperty("workflow_input").GetProperty("execution_unit").GetString());
+        Assert.Equal("manual-review", root.GetProperty("workflow_input").GetProperty("review_mode").GetString());
+        Assert.Equal("open-pr", root.GetProperty("workflow_input").GetProperty("completion_action").GetString());
+        Assert.Equal(
+            "intents/rules/issue-template-and-review-context.md",
+            root.GetProperty("return_routes").GetProperty("clarification_return_path").GetString());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("return_routes").GetProperty("interview_return_to_intent_paths").ValueKind);
+    }
+
+    [Fact]
+    public void Serialize_GivenCompleteContract_DoesNotLeakPrivateSourceDetailsOrQueuePolicyFields()
+    {
+        var contract = CreateBridgeContract();
+
+        var serialized = DogfoodingBridgeSerializer.Serialize(contract);
+
+        Assert.DoesNotContain("\"source_url\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"source_path\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"state\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"blocked_by\"", serialized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Deserialize_GivenCompleteJson_RestoresAllRequiredFields()
+    {
+        var json = """
+        {
+          "binding": {
+            "execution_unit": "F2",
+            "goal": "Bridge a bound private execution unit into queue-ready and workflow-ready input.",
+            "target_repo": "J-Tech-Japan/intent-system",
+            "target_path": ".",
+            "target_part": "dogfooding bridge",
+            "dependencies": ["C1", "D2", "E2", "F1"],
+            "success_signal": "dogfooding run can be reconstructed from bridge input",
+            "review_mode": "manual-review",
+            "completion_action": "open-pr",
+            "landing_policy": "squash",
+            "dogfooding_track": "backend-first",
+            "embedded_canonical_summary": "Backend-first private domain summary embedded for child-repo tests."
+          },
+          "queue_input": {
+            "execution_unit": "F2",
+            "packet_paths": {
+              "implementation": ".intent-cli/packets/F2/implementation.md",
+              "review_context": ".intent-cli/packets/F2/review-context.md",
+              "yaml": ".intent-cli/packets/F2/packet.yaml"
+            },
+            "dependencies": ["C1", "D2", "E2", "F1"],
+            "clarification_return_path": "intents/rules/issue-template-and-review-context.md",
+            "worker_role": "coder",
+            "review_role": "reviewer"
+          },
+          "workflow_input": {
+            "execution_unit": "F2",
+            "packet_paths": {
+              "implementation": ".intent-cli/packets/F2/implementation.md",
+              "review_context": ".intent-cli/packets/F2/review-context.md",
+              "yaml": ".intent-cli/packets/F2/packet.yaml"
+            },
+            "dependency_snapshot": ["C1", "D2", "E2", "F1"],
+            "worker_roles": {
+              "worker": "coder",
+              "reviewer": "reviewer"
+            },
+            "entry_conditions": ["dependency snapshot captured"],
+            "review_mode": "manual-review",
+            "completion_action": "open-pr"
+          },
+          "return_routes": {
+            "clarification_return_path": "intents/rules/issue-template-and-review-context.md",
+            "interview_return_to_intent_paths": [
+              "intents/private-domain/intent-tree/backend.md",
+              "intents/private-domain/intent-tree/shared.md"
+            ]
+          }
+        }
+        """;
+
+        var contract = DogfoodingBridgeSerializer.Deserialize(json);
+
+        Assert.Equal("F2", contract.Binding.ExecutionUnit);
+        Assert.Equal("F2", contract.QueueInput.ExecutionUnit);
+        Assert.Equal(["C1", "D2", "E2", "F1"], contract.WorkflowInput.DependencySnapshot);
+        Assert.Equal("coder", contract.WorkflowInput.WorkerRoles.Worker);
+        Assert.Equal(
+            [
+                "intents/private-domain/intent-tree/backend.md",
+                "intents/private-domain/intent-tree/shared.md"
+            ],
+            contract.ReturnRoutes.InterviewReturnToIntentPaths);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingWorkflowField_ThrowsInvalidOperationException()
+    {
+        var json = """
+        {
+          "binding": {},
+          "queue_input": {
+            "execution_unit": "F2",
+            "packet_paths": {},
+            "dependencies": [],
+            "clarification_return_path": "path.md",
+            "worker_role": "coder",
+            "review_role": "reviewer"
+          },
+          "workflow_input": {
+            "execution_unit": "F2"
+          },
+          "return_routes": {
+            "clarification_return_path": "path.md",
+            "interview_return_to_intent_paths": []
+          }
+        }
+        """;
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => DogfoodingBridgeSerializer.Deserialize(json));
+
+        Assert.Contains("workflow_input", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SerializeAndDeserialize_RoundTrips()
+    {
+        var contract = CreateBridgeContract();
+
+        var serialized = DogfoodingBridgeSerializer.Serialize(contract);
+        var deserialized = DogfoodingBridgeSerializer.Deserialize(serialized);
+
+        Assert.Equal(contract.Binding.ExecutionUnit, deserialized.Binding.ExecutionUnit);
+        Assert.Equal(contract.QueueInput.PacketPaths.ReviewContext, deserialized.QueueInput.PacketPaths.ReviewContext);
+        Assert.Equal(contract.WorkflowInput.ReviewMode, deserialized.WorkflowInput.ReviewMode);
+        Assert.Equal(contract.ReturnRoutes.ClarificationReturnPath, deserialized.ReturnRoutes.ClarificationReturnPath);
+    }
+
+    private static DogfoodingBridgeContract CreateBridgeContract()
+    {
+        return new DogfoodingBridgeContract
+        {
+            Binding = new IntentSystem.DomainBinding.Models.ProjectionReadySlice
+            {
+                ExecutionUnit = "F2",
+                Goal = "Bridge a bound private execution unit into queue-ready and workflow-ready input.",
+                TargetRepo = "J-Tech-Japan/intent-system",
+                TargetPath = ".",
+                TargetPart = "dogfooding bridge",
+                Dependencies = ["C1", "D2", "E2", "F1"],
+                SuccessSignal = "dogfooding run can be reconstructed from bridge input",
+                ReviewMode = "manual-review",
+                CompletionAction = "open-pr",
+                LandingPolicy = "squash",
+                DogfoodingTrack = IntentSystem.DomainBinding.Models.DogfoodingTrack.BackendFirst,
+                EmbeddedCanonicalSummary = "Backend-first private domain summary embedded for child-repo tests."
+            },
+            QueueInput = new QueueReadyDogfoodingInput
+            {
+                ExecutionUnit = "F2",
+                PacketPaths = new IntentSystem.Supervisor.Models.PacketPaths
+                {
+                    Implementation = ".intent-cli/packets/F2/implementation.md",
+                    ReviewContext = ".intent-cli/packets/F2/review-context.md",
+                    Yaml = ".intent-cli/packets/F2/packet.yaml"
+                },
+                Dependencies = ["C1", "D2", "E2", "F1"],
+                ClarificationReturnPath = "intents/rules/issue-template-and-review-context.md",
+                WorkerRole = "coder",
+                ReviewRole = "reviewer"
+            },
+            WorkflowInput = new WorkflowReadyDogfoodingInput
+            {
+                ExecutionUnit = "F2",
+                PacketPaths = new IntentSystem.Workflow.Models.WorkflowPacketPaths
+                {
+                    Implementation = ".intent-cli/packets/F2/implementation.md",
+                    ReviewContext = ".intent-cli/packets/F2/review-context.md",
+                    Yaml = ".intent-cli/packets/F2/packet.yaml"
+                },
+                DependencySnapshot = ["C1", "D2", "E2", "F1"],
+                WorkerRoles = new IntentSystem.Workflow.Models.WorkerRoles
+                {
+                    Worker = "coder",
+                    Reviewer = "reviewer"
+                },
+                EntryConditions = ["dependency snapshot captured"],
+                ReviewMode = "manual-review",
+                CompletionAction = "open-pr"
+            },
+            ReturnRoutes = new DogfoodingReturnRoutes
+            {
+                ClarificationReturnPath = "intents/rules/issue-template-and-review-context.md",
+                InterviewReturnToIntentPaths =
+                [
+                    "intents/private-domain/intent-tree/backend.md",
+                    "intents/private-domain/intent-tree/shared.md"
+                ]
+            }
+        };
+    }
+}

--- a/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeSerializerTests.cs
+++ b/tests/IntentSystem.DogfoodingBridge.Tests/DogfoodingBridgeSerializerTests.cs
@@ -60,9 +60,9 @@ public sealed class DogfoodingBridgeSerializerTests
           "queue_input": {
             "execution_unit": "F2",
             "packet_paths": {
-              "implementation": ".intent-cli/packets/F2/implementation.md",
-              "review_context": ".intent-cli/packets/F2/review-context.md",
-              "yaml": ".intent-cli/packets/F2/packet.yaml"
+              "implementation": ".intent-cli/issues/F2/implementation.md",
+              "review_context": ".intent-cli/issues/F2/review-context.md",
+              "yaml": ".intent-cli/issues/F2/packet.yaml"
             },
             "dependencies": ["C1", "D2", "E2", "F1"],
             "clarification_return_path": "intents/rules/issue-template-and-review-context.md",
@@ -72,9 +72,9 @@ public sealed class DogfoodingBridgeSerializerTests
           "workflow_input": {
             "execution_unit": "F2",
             "packet_paths": {
-              "implementation": ".intent-cli/packets/F2/implementation.md",
-              "review_context": ".intent-cli/packets/F2/review-context.md",
-              "yaml": ".intent-cli/packets/F2/packet.yaml"
+              "implementation": ".intent-cli/issues/F2/implementation.md",
+              "review_context": ".intent-cli/issues/F2/review-context.md",
+              "yaml": ".intent-cli/issues/F2/packet.yaml"
             },
             "dependency_snapshot": ["C1", "D2", "E2", "F1"],
             "worker_roles": {
@@ -177,9 +177,9 @@ public sealed class DogfoodingBridgeSerializerTests
                 ExecutionUnit = "F2",
                 PacketPaths = new IntentSystem.Supervisor.Models.PacketPaths
                 {
-                    Implementation = ".intent-cli/packets/F2/implementation.md",
-                    ReviewContext = ".intent-cli/packets/F2/review-context.md",
-                    Yaml = ".intent-cli/packets/F2/packet.yaml"
+                    Implementation = ".intent-cli/issues/F2/implementation.md",
+                    ReviewContext = ".intent-cli/issues/F2/review-context.md",
+                    Yaml = ".intent-cli/issues/F2/packet.yaml"
                 },
                 Dependencies = ["C1", "D2", "E2", "F1"],
                 ClarificationReturnPath = "intents/rules/issue-template-and-review-context.md",
@@ -191,9 +191,9 @@ public sealed class DogfoodingBridgeSerializerTests
                 ExecutionUnit = "F2",
                 PacketPaths = new IntentSystem.Workflow.Models.WorkflowPacketPaths
                 {
-                    Implementation = ".intent-cli/packets/F2/implementation.md",
-                    ReviewContext = ".intent-cli/packets/F2/review-context.md",
-                    Yaml = ".intent-cli/packets/F2/packet.yaml"
+                    Implementation = ".intent-cli/issues/F2/implementation.md",
+                    ReviewContext = ".intent-cli/issues/F2/review-context.md",
+                    Yaml = ".intent-cli/issues/F2/packet.yaml"
                 },
                 DependencySnapshot = ["C1", "D2", "E2", "F1"],
                 WorkerRoles = new IntentSystem.Workflow.Models.WorkerRoles

--- a/tests/IntentSystem.DogfoodingBridge.Tests/IntentSystem.DogfoodingBridge.Tests.csproj
+++ b/tests/IntentSystem.DogfoodingBridge.Tests/IntentSystem.DogfoodingBridge.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\IntentSystem.DogfoodingBridge\IntentSystem.DogfoodingBridge.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add a new `IntentSystem.DogfoodingBridge` module for the thin bridge from projection-ready private execution bindings into queue-ready and workflow-ready run input
- define queue-ready, workflow-ready, and return-route contracts that aggregate existing binding, workflow, clarify, and interview contracts without reimplementing their source artifacts
- add mapper and serializer coverage to keep clarify and interview return loops distinct on the same execution unit

## Why
Issue #27 needs a deterministic dogfooding bridge that can take a bound private execution unit and prepare the public child repo's queue/workflow inputs without dragging queue manager policy, workflow definition ownership, or worker execution into the bridge layer.

## Impact
- a bound execution unit can now be mapped into queue-ready and workflow-ready bridge input from existing contracts
- clarify and interview return targets are carried separately so the bridge does not mix those loops
- child-repo tests can exercise the bridge contract using embedded summaries and fixtures without reading a parent checkout or leaking private domain details

## Validation
- `dotnet test`

Closes #27
