### PR TITLE
[#33] issue-33-g3-queue-show-and-next

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -31,7 +31,9 @@ internal static class CommandRouter
             },
             ["queue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
-                ["list"] = QueueListCommand.Execute
+                ["list"] = QueueListCommand.Execute,
+                ["show"] = QueueShowCommand.Execute,
+                ["next"] = QueueNextCommand.Execute
             }
         };
 

--- a/src/IntentSystem.Cli/Commands/QueueCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/QueueCommandSupport.cs
@@ -1,0 +1,60 @@
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class QueueCommandSupport
+{
+    public static QueueState? LoadQueueState(CliContext context, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        var queueStatePath = context.GetQueueStatePath();
+        if (!File.Exists(queueStatePath))
+        {
+            writer.WriteLine($"No queue state found at {queueStatePath}");
+            return null;
+        }
+
+        return QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+    }
+
+    public static void WriteItemDetails(TextWriter writer, QueueItem item)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(item);
+
+        writer.WriteLine($"Execution unit: {item.ExecutionUnit}");
+        writer.WriteLine($"Title: {item.Title}");
+        writer.WriteLine($"State: {item.State}");
+        writer.WriteLine($"Priority: {item.Priority}");
+        writer.WriteLine($"Dependencies: {FormatList(item.Dependencies)}");
+        writer.WriteLine($"Blocked by: {FormatList(item.BlockedBy)}");
+        writer.WriteLine($"Clarification return path: {item.ClarificationReturnPath}");
+        writer.WriteLine($"Packet implementation: {item.PacketPaths.Implementation}");
+        writer.WriteLine($"Packet review context: {item.PacketPaths.ReviewContext}");
+        writer.WriteLine($"Packet yaml: {item.PacketPaths.Yaml}");
+
+        if (item.LinkedIssue is null)
+        {
+            writer.WriteLine("Linked issue: -");
+        }
+        else
+        {
+            writer.WriteLine($"Linked issue repo: {item.LinkedIssue.Repo}");
+            writer.WriteLine($"Linked issue number: {item.LinkedIssue.Number}");
+            writer.WriteLine($"Linked issue url: {item.LinkedIssue.Url}");
+        }
+
+        writer.WriteLine($"Worker role: {item.WorkerRole}");
+        writer.WriteLine($"Review role: {item.ReviewRole}");
+    }
+
+    private static string FormatList(IReadOnlyList<string> values)
+    {
+        return values.Count == 0
+            ? "-"
+            : string.Join(", ", values);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/QueueListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueListCommand.cs
@@ -1,5 +1,3 @@
-using IntentSystem.Supervisor.Serialization;
-
 namespace IntentSystem.Cli.Commands;
 
 internal static class QueueListCommand
@@ -10,14 +8,11 @@ internal static class QueueListCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
-        var queueStatePath = context.GetQueueStatePath();
-        if (!File.Exists(queueStatePath))
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
         {
-            writer.WriteLine($"No queue state found at {queueStatePath}");
             return 0;
         }
-
-        var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
 
         writer.WriteLine("Execution Unit | State | Priority | Dependencies | Title");
         foreach (var item in queueState.Items)

--- a/src/IntentSystem.Cli/Commands/QueueNextCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueNextCommand.cs
@@ -1,0 +1,36 @@
+using IntentSystem.Supervisor;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class QueueNextCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 0)
+        {
+            writer.WriteLine("Queue next command does not accept arguments.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 0;
+        }
+
+        var nextItem = QueueSelection.SelectNext(queueState);
+        if (nextItem is null)
+        {
+            writer.WriteLine("No eligible queued item found.");
+            return 0;
+        }
+
+        writer.WriteLine("Next candidate");
+        QueueCommandSupport.WriteItemDetails(writer, nextItem);
+        return 0;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/QueueShowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueShowCommand.cs
@@ -1,0 +1,36 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class QueueShowCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Queue show command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 0;
+        }
+
+        var executionUnit = args[0];
+        var item = queueState.Items.FirstOrDefault(queueItem =>
+            string.Equals(queueItem.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (item is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        QueueCommandSupport.WriteItemDetails(writer, item);
+        return 0;
+    }
+}

--- a/src/IntentSystem.Supervisor/QueueSelection.cs
+++ b/src/IntentSystem.Supervisor/QueueSelection.cs
@@ -1,0 +1,38 @@
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Supervisor;
+
+public static class QueueSelection
+{
+    public static QueueItem? SelectNext(QueueState state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+
+        var completedUnits = state.Items
+            .Where(item => item.State == QueueItemState.Completed)
+            .Select(item => item.ExecutionUnit)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var item in state.Items)
+        {
+            if (item.State != QueueItemState.Queued)
+            {
+                continue;
+            }
+
+            if (item.BlockedBy.Count > 0)
+            {
+                continue;
+            }
+
+            if (item.Dependencies.Any(dependency => !completedUnits.Contains(dependency)))
+            {
+                continue;
+            }
+
+            return item;
+        }
+
+        return null;
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -67,6 +67,38 @@ public sealed class CommandRouterTests
         Assert.Contains("A2", writer.ToString(), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Execute_GivenQueueShowCommand_DispatchesToQueueShowRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["queue", "show", "A2"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Execution unit: A2", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenQueueNextCommand_DispatchesToQueueNextRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["queue", "next"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Next candidate", writer.ToString(), StringComparison.Ordinal);
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext
@@ -109,6 +141,24 @@ public sealed class CommandRouterTests
                     WorkerRole = "coder",
                     ReviewRole = "reviewer",
                     Priority = "high"
+                },
+                new QueueItem
+                {
+                    ExecutionUnit = "A3",
+                    Title = "Queue read commands",
+                    State = QueueItemState.Queued,
+                    Dependencies = [],
+                    BlockedBy = [],
+                    ClarificationReturnPath = ".takt/runs/20260403-101234-issue-33-g3-queue-show-and-next/context/task/order.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/A3/implementation.md",
+                        ReviewContext = ".intent-cli/issues/A3/review-context.md",
+                        Yaml = ".intent-cli/issues/A3/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "normal"
                 }
             ]
         };

--- a/tests/IntentSystem.Cli.Tests/QueueNextCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueNextCommandTests.cs
@@ -1,0 +1,208 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class QueueNextCommandTests
+{
+    [Fact]
+    public void Execute_GivenEligibleQueuedItem_WritesNextCandidateDetails()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = QueueNextCommand.Execute(CreateContext(repoRoot), [], writer);
+
+        var output = writer.ToString();
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Next candidate", output, StringComparison.Ordinal);
+        Assert.Contains("Execution unit: B1", output, StringComparison.Ordinal);
+        Assert.Contains("Priority: high", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Execution unit: C1", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenBlockedAndUnresolvedQueuedItems_SkipsIneligibleCandidates()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueStateWithIneligibleItemsAhead()));
+        using var writer = new StringWriter();
+
+        var exitCode = QueueNextCommand.Execute(CreateContext(repoRoot), [], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Execution unit: D1", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNoEligibleQueuedItems_WritesNoEligibleMessage()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueStateWithoutEligibleItem()));
+        using var writer = new StringWriter();
+
+        var exitCode = QueueNextCommand.Execute(CreateContext(repoRoot), [], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("No eligible queued item found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnexpectedArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = QueueNextCommand.Execute(CreateContext("/tmp/intent-system"), ["A1"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("does not accept arguments", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return CreateState(
+        [
+            CreateItem("A1", QueueItemState.Completed),
+            CreateItem("B1", QueueItemState.Queued) with
+            {
+                Dependencies = ["A1"],
+                Priority = "high"
+            },
+            CreateItem("C1", QueueItemState.Queued) with
+            {
+                Priority = "low"
+            }
+        ]);
+    }
+
+    private static QueueState CreateQueueStateWithIneligibleItemsAhead()
+    {
+        return CreateState(
+        [
+            CreateItem("A1", QueueItemState.Active),
+            CreateItem("B1", QueueItemState.Queued) with
+            {
+                Dependencies = ["A1"],
+                Priority = "high"
+            },
+            CreateItem("C1", QueueItemState.Queued) with
+            {
+                BlockedBy = ["manual-hold"],
+                Priority = "high"
+            },
+            CreateItem("D1", QueueItemState.Queued) with
+            {
+                Priority = "normal"
+            }
+        ]);
+    }
+
+    private static QueueState CreateQueueStateWithoutEligibleItem()
+    {
+        return CreateState(
+        [
+            CreateItem("A1", QueueItemState.Active),
+            CreateItem("B1", QueueItemState.Queued) with
+            {
+                Dependencies = ["A1"]
+            },
+            CreateItem("C1", QueueItemState.Blocked) with
+            {
+                Dependencies = ["A1"],
+                BlockedBy = ["A1"]
+            }
+        ]);
+    }
+
+    private static QueueState CreateState(QueueItem[] items)
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items = items
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Queue Item",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "normal"
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-queue-next-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/QueueShowCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueShowCommandTests.cs
@@ -1,0 +1,145 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class QueueShowCommandTests
+{
+    [Fact]
+    public void Execute_GivenExecutionUnit_WritesQueueItemDetails()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = QueueShowCommand.Execute(CreateContext(repoRoot), ["A2"], writer);
+
+        var output = writer.ToString();
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Execution unit: A2", output, StringComparison.Ordinal);
+        Assert.Contains("State: Review", output, StringComparison.Ordinal);
+        Assert.Contains("Dependencies: A1", output, StringComparison.Ordinal);
+        Assert.Contains("Blocked by: -", output, StringComparison.Ordinal);
+        Assert.Contains("Linked issue repo: J-Tech-Japan/intent-system", output, StringComparison.Ordinal);
+        Assert.Contains("Linked issue number: 33", output, StringComparison.Ordinal);
+        Assert.Contains("Packet yaml: .intent-cli/issues/A2/packet.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Worker role: coder", output, StringComparison.Ordinal);
+        Assert.Contains("Review role: reviewer", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = QueueShowCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = QueueShowCommand.Execute(CreateContext(repoRoot), ["MISSING"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("was not found in queue state", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "A2",
+                    Title = "CLI shell baseline",
+                    State = QueueItemState.Review,
+                    Dependencies = ["A1"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = ".takt/runs/20260403-101234-issue-29-g1-cli-shell-and-root/context/task/order.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/A2/implementation.md",
+                        ReviewContext = ".intent-cli/issues/A2/review-context.md",
+                        Yaml = ".intent-cli/issues/A2/packet.yaml"
+                    },
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = 33,
+                        Url = "https://github.com/J-Tech-Japan/intent-system/issues/33"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-queue-show-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Supervisor.Tests/QueueSelectionTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueSelectionTests.cs
@@ -1,0 +1,109 @@
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Supervisor.Tests;
+
+public sealed class QueueSelectionTests
+{
+    [Fact]
+    public void SelectNext_GivenEligibleQueuedItem_ReturnsFirstEligibleSnapshotItem()
+    {
+        var state = CreateState(
+        [
+            CreateItem("A1", QueueItemState.Completed),
+            CreateItem("B1", QueueItemState.Queued) with { Dependencies = ["A1"] },
+            CreateItem("C1", QueueItemState.Queued)
+        ]);
+
+        var nextItem = QueueSelection.SelectNext(state);
+
+        Assert.NotNull(nextItem);
+        Assert.Equal("B1", nextItem!.ExecutionUnit);
+    }
+
+    [Fact]
+    public void SelectNext_GivenQueuedItemWithBlockedBy_SkipsBlockedCandidate()
+    {
+        var state = CreateState(
+        [
+            CreateItem("A1", QueueItemState.Completed),
+            CreateItem("B1", QueueItemState.Queued) with
+            {
+                Dependencies = ["A1"],
+                BlockedBy = ["manual-hold"]
+            },
+            CreateItem("C1", QueueItemState.Queued)
+        ]);
+
+        var nextItem = QueueSelection.SelectNext(state);
+
+        Assert.NotNull(nextItem);
+        Assert.Equal("C1", nextItem!.ExecutionUnit);
+    }
+
+    [Fact]
+    public void SelectNext_GivenQueuedItemWithUnresolvedDependency_SkipsIneligibleCandidate()
+    {
+        var state = CreateState(
+        [
+            CreateItem("A1", QueueItemState.Active),
+            CreateItem("B1", QueueItemState.Queued) with { Dependencies = ["A1"] },
+            CreateItem("C1", QueueItemState.Queued)
+        ]);
+
+        var nextItem = QueueSelection.SelectNext(state);
+
+        Assert.NotNull(nextItem);
+        Assert.Equal("C1", nextItem!.ExecutionUnit);
+    }
+
+    [Fact]
+    public void SelectNext_GivenNoEligibleQueuedItems_ReturnsNull()
+    {
+        var state = CreateState(
+        [
+            CreateItem("A1", QueueItemState.Active),
+            CreateItem("B1", QueueItemState.Blocked) with
+            {
+                Dependencies = ["A1"],
+                BlockedBy = ["A1"]
+            },
+            CreateItem("C1", QueueItemState.Review)
+        ]);
+
+        var nextItem = QueueSelection.SelectNext(state);
+
+        Assert.Null(nextItem);
+    }
+
+    private static QueueState CreateState(QueueItem[] items)
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items = items
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Queue Item",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "normal"
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- add `intent-cli queue show <execution-unit>` to render queue item details from the current `.intent-cli/queue-state.json`
- add `intent-cli queue next` to deterministically select the first eligible queued item from the current queue snapshot
- keep queue read commands read-only by pushing eligibility logic into a small supervisor-side selector and covering it with CLI/runtime tests

## Why

Issue 33 requires working queue read commands that resolve item details and the next candidate from the canonical `queue-state.json` snapshot without mutating state or consulting `runs.jsonl`.

## Impact

- users can inspect a single execution unit including packet paths, linked issue metadata, and worker/review roles
- users can ask for the next candidate and get a deterministic answer based on snapshot order, queued state, `blocked_by`, and completed dependencies
- queue command wiring stays inside read-only CLI behavior; no queue write or workflow execution behavior was added

## Validation

- `dotnet test`

Closes #33
