### PR TITLE
[#35] issue-35-g4-queue-transition-command

### DIFF
--- a/src/IntentSystem.Cli/CliContext.cs
+++ b/src/IntentSystem.Cli/CliContext.cs
@@ -23,6 +23,11 @@ internal sealed record CliContext
         return CliRuntimeContracts.GetQueueStatePath(RepoRoot);
     }
 
+    public string GetRunLogPath()
+    {
+        return CliRuntimeContracts.GetRunLogPath(RepoRoot);
+    }
+
     public string ResolveArtifactRootPath()
     {
         var artifactRoot = Config.Project.ArtifactRoot;

--- a/src/IntentSystem.Cli/CliRuntimeContracts.cs
+++ b/src/IntentSystem.Cli/CliRuntimeContracts.cs
@@ -5,6 +5,7 @@ internal static class CliRuntimeContracts
     public const string IntentCliDirectoryName = ".intent-cli";
     public const string ConfigFileName = "config.toml";
     public const string QueueStateFileName = "queue-state.json";
+    public const string RunLogFileName = "runs.jsonl";
     public const string ProjectSectionName = "project";
     public const string DefaultDomainKey = "default_domain";
     public const string DomainKey = "domain";
@@ -26,5 +27,10 @@ internal static class CliRuntimeContracts
     public static string GetQueueStatePath(string repoRoot)
     {
         return Path.Combine(GetIntentCliDirectoryPath(repoRoot), QueueStateFileName);
+    }
+
+    public static string GetRunLogPath(string repoRoot)
+    {
+        return Path.Combine(GetIntentCliDirectoryPath(repoRoot), RunLogFileName);
     }
 }

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -33,7 +33,8 @@ internal static class CommandRouter
             {
                 ["list"] = QueueListCommand.Execute,
                 ["show"] = QueueShowCommand.Execute,
-                ["next"] = QueueNextCommand.Execute
+                ["next"] = QueueNextCommand.Execute,
+                ["transition"] = QueueTransitionCommand.Execute
             }
         };
 

--- a/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
@@ -1,0 +1,102 @@
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class QueueTransitionCommand
+{
+    private const string TransitionActor = "intent-cli";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 2
+            || string.IsNullOrWhiteSpace(args[0])
+            || string.IsNullOrWhiteSpace(args[1]))
+        {
+            writer.WriteLine("Queue transition command requires an execution unit and target state.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        if (!TryParseTargetState(args[1], out var targetState))
+        {
+            writer.WriteLine(
+                "Unsupported queue transition target state. Supported states: queued, active, review, fixing, completed.");
+            return 1;
+        }
+
+        try
+        {
+            var result = QueueManager.TransitionNonBlocking(
+                queueState,
+                args[0],
+                targetState,
+                TransitionActor,
+                DateTimeOffset.UtcNow);
+
+            PersistTransition(context, result);
+
+            writer.WriteLine($"Transitioned {args[0]} to {FormatState(targetState)}.");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static bool TryParseTargetState(string rawState, out QueueItemState state)
+    {
+        switch (rawState.Trim().ToLowerInvariant())
+        {
+            case "queued":
+                state = QueueItemState.Queued;
+                return true;
+            case "active":
+                state = QueueItemState.Active;
+                return true;
+            case "review":
+                state = QueueItemState.Review;
+                return true;
+            case "fixing":
+                state = QueueItemState.Fixing;
+                return true;
+            case "completed":
+                state = QueueItemState.Completed;
+                return true;
+            default:
+                state = default;
+                return false;
+        }
+    }
+
+    private static void PersistTransition(CliContext context, QueueTransitionResult result)
+    {
+        var queueStatePath = context.GetQueueStatePath();
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
+
+        var runLogPath = context.GetRunLogPath();
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(
+            runLogPath,
+            RunLogSerializer.SerializeLine(result.Event) + Environment.NewLine);
+    }
+
+    private static string FormatState(QueueItemState state)
+    {
+        return state.ToString().ToLowerInvariant();
+    }
+}

--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -9,6 +9,29 @@ namespace IntentSystem.Supervisor;
 /// </summary>
 public static class QueueManager
 {
+    public static QueueTransitionResult TransitionNonBlocking(
+        QueueState state,
+        string executionUnit,
+        QueueItemState targetState,
+        string by,
+        DateTimeOffset ts)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(by);
+
+        ValidateNonBlockingTargetState(targetState);
+        FindItem(state, executionUnit);
+
+        return ApplyTransition(state, executionUnit, targetState, new RunEvent
+        {
+            Ts = ts,
+            ExecutionUnit = executionUnit,
+            Event = MapNonBlockingEventName(targetState),
+            By = by
+        });
+    }
+
     /// <summary>
     /// Transition a queued item to active.
     /// </summary>
@@ -230,6 +253,38 @@ public static class QueueManager
     private static QueueState UnblockDependents(QueueState state, string completedUnit, DateTimeOffset ts)
     {
         return RefreshDependencies(state) with { UpdatedAt = ts };
+    }
+
+    private static void ValidateNonBlockingTargetState(QueueItemState targetState)
+    {
+        if (targetState is QueueItemState.Blocked or QueueItemState.ClarifyBlocked)
+        {
+            throw new InvalidOperationException(
+                $"Unsupported queue transition target state '{FormatState(targetState)}'.");
+        }
+    }
+
+    private static string MapNonBlockingEventName(QueueItemState targetState)
+    {
+        return targetState switch
+        {
+            QueueItemState.Queued => "queued",
+            QueueItemState.Active => "activated",
+            QueueItemState.Review => "review-started",
+            QueueItemState.Fixing => "fix-requested",
+            QueueItemState.Completed => "completed",
+            _ => throw new InvalidOperationException(
+                $"Unsupported queue transition target state '{FormatState(targetState)}'.")
+        };
+    }
+
+    private static string FormatState(QueueItemState state)
+    {
+        return state switch
+        {
+            QueueItemState.ClarifyBlocked => "clarify-blocked",
+            _ => state.ToString().ToLowerInvariant()
+        };
     }
 
     private static QueueItem FindItem(QueueState state, string executionUnit)

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -99,6 +99,22 @@ public sealed class CommandRouterTests
         Assert.Contains("Next candidate", writer.ToString(), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Execute_GivenQueueTransitionCommand_DispatchesToQueueTransitionRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["queue", "transition", "A2", "completed"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Transitioned A2 to completed", writer.ToString(), StringComparison.Ordinal);
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/QueueTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueTransitionCommandTests.cs
@@ -1,0 +1,200 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class QueueTransitionCommandTests
+{
+    [Fact]
+    public void Execute_GivenValidTransition_UpdatesSelectedItemAndAppendsRunLog()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """{"ts":"2026-04-03T10:00:00Z","execution_unit":"A1","event":"queued","by":"supervisor"}""" + Environment.NewLine);
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "completed"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Transitioned A2 to completed", writer.ToString(), StringComparison.Ordinal);
+
+        var updatedState = QueueStateSerializer.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+        Assert.Equal(QueueItemState.Completed, updatedState.Items.Single(item => item.ExecutionUnit == "A2").State);
+        Assert.Equal(QueueItemState.Blocked, updatedState.Items.Single(item => item.ExecutionUnit == "B1").State);
+        Assert.Equal(["A2"], updatedState.Items.Single(item => item.ExecutionUnit == "B1").BlockedBy);
+
+        var runEvents = RunLogSerializer.DeserializeAll(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+        Assert.Equal(2, runEvents.Count);
+        Assert.Equal("completed", runEvents[^1].Event);
+        Assert.Equal("A2", runEvents[^1].ExecutionUnit);
+        Assert.Equal("intent-cli", runEvents[^1].By);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingRunLog_CreatesRunLogFile()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "active"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+
+        var runEvents = RunLogSerializer.DeserializeAll(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+        Assert.Single(runEvents);
+        Assert.Equal("activated", runEvents[0].Event);
+    }
+
+    [Fact]
+    public void Execute_GivenInvalidState_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "blocked"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Supported states", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownExecutionUnit_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var queueStateContents = QueueStateSerializer.Serialize(CreateQueueState());
+        tempDirectory.CreateFile(queueStatePath, queueStateContents);
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            runLogPath,
+            """{"ts":"2026-04-03T10:00:00Z","execution_unit":"A1","event":"queued","by":"supervisor"}""" + Environment.NewLine);
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["MISSING", "active"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("not found in queue state", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(queueStateContents, File.ReadAllText(queueStatePath));
+        Assert.Single(RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath)));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingArguments_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext("/tmp/intent-system"), ["A2"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit and target state", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                CreateItem("A2", QueueItemState.Review),
+                CreateItem("B1", QueueItemState.Blocked) with
+                {
+                    Dependencies = ["A2"],
+                    BlockedBy = ["A2"]
+                }
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Queue Item",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "normal"
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-queue-transition-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
@@ -218,6 +218,47 @@ public sealed class QueueManagerTests
         Assert.NotNull(result.Event);
     }
 
+    [Fact]
+    public void TransitionNonBlocking_GivenCompletedTarget_UpdatesSelectedItemOnly()
+    {
+        var selectedItem = CreateItem("A1", QueueItemState.Active);
+        var otherItem = CreateItem("B1", QueueItemState.Blocked) with
+        {
+            Dependencies = ["A1"],
+            BlockedBy = ["A1"]
+        };
+        var state = CreateState([selectedItem, otherItem]);
+
+        var result = QueueManager.TransitionNonBlocking(
+            state,
+            "A1",
+            QueueItemState.Completed,
+            "intent-cli",
+            BaseTime);
+
+        Assert.Equal(QueueItemState.Completed, FindItem(result.UpdatedState, "A1").State);
+        Assert.Equal(QueueItemState.Blocked, FindItem(result.UpdatedState, "B1").State);
+        Assert.Equal(["A1"], FindItem(result.UpdatedState, "B1").BlockedBy);
+        Assert.Equal("completed", result.Event.Event);
+        Assert.Equal("intent-cli", result.Event.By);
+    }
+
+    [Fact]
+    public void TransitionNonBlocking_GivenBlockedTarget_ThrowsInvalidOperationException()
+    {
+        var state = CreateState(QueueItemState.Active);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => QueueManager.TransitionNonBlocking(
+                state,
+                "A1",
+                QueueItemState.Blocked,
+                "intent-cli",
+                BaseTime));
+
+        Assert.Contains("Unsupported queue transition target state 'blocked'", exception.Message, StringComparison.Ordinal);
+    }
+
     private static QueueState CreateState(QueueItemState itemState)
     {
         return CreateState([CreateItem("A1", itemState)]);


### PR DESCRIPTION
## Summary

- add `intent-cli queue transition <execution-unit> <state>` for deterministic queue snapshot updates and run-log appends
- add a supervisor-side non-blocking transition helper that only mutates the selected queue item and maps supported target states to run events
- cover CLI validation, single-item update behavior, invalid unit/state rejection, and append-only `runs.jsonl` writes with tests

## Why

Issue 35 requires the first queue write command to update the canonical `.intent-cli/queue-state.json` snapshot and append a transition event to `.intent-cli/runs.jsonl` without widening into workflow execution, GitHub mutation, or hidden state contracts.

## Impact

- users can transition one execution unit into `queued`, `active`, `review`, `fixing`, or `completed`
- queue snapshot writes stay scoped to the selected item; other queue items are not implicitly updated
- `runs.jsonl` is treated as append-only, and the command creates the log file when it does not exist yet

## Validation

- `dotnet test`

Closes #35
