### PR TITLE
[#37] issue-37-g5-workflow-render-command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -29,6 +29,10 @@ internal static class CommandRouter
                 ["generate"] = ProjectionGenerateCommand.Generate,
                 ["regenerate"] = ProjectionGenerateCommand.Regenerate
             },
+            ["workflow"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["render"] = WorkflowRenderCommand.Execute
+            },
             ["queue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["list"] = QueueListCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/WorkflowRenderCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkflowRenderCommand.cs
@@ -1,0 +1,59 @@
+using IntentSystem.Projection.Serialization;
+using IntentSystem.Workflow;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class WorkflowRenderCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Workflow render command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        var packetYamlPath = Path.Combine(
+            context.RepoRoot,
+            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(packetYamlPath))
+        {
+            writer.WriteLine($"Workflow render packet YAML was not found at {packetYamlPath}");
+            return 1;
+        }
+
+        try
+        {
+            var packetContract = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetYamlPath));
+            var definition = WorkflowDefinitionMapper.Map(queueItem, packetContract);
+            WorkflowArtifactWriter.Write(definition, context.RepoRoot, overwrite: true);
+            writer.WriteLine($"Workflow definition rendered for {executionUnit}.");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+}

--- a/src/IntentSystem.Cli/IntentSystem.Cli.csproj
+++ b/src/IntentSystem.Cli/IntentSystem.Cli.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\IntentSystem.Projection\IntentSystem.Projection.csproj" />
     <ProjectReference Include="..\IntentSystem.Supervisor\IntentSystem.Supervisor.csproj" />
+    <ProjectReference Include="..\IntentSystem.Workflow\IntentSystem.Workflow.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IntentSystem.Workflow/IntentSystem.Workflow.csproj
+++ b/src/IntentSystem.Workflow/IntentSystem.Workflow.csproj
@@ -6,4 +6,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\IntentSystem.Projection\IntentSystem.Projection.csproj" />
+    <ProjectReference Include="..\IntentSystem.Supervisor\IntentSystem.Supervisor.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/IntentSystem.Workflow/WorkflowArtifactPathResolver.cs
+++ b/src/IntentSystem.Workflow/WorkflowArtifactPathResolver.cs
@@ -1,0 +1,13 @@
+namespace IntentSystem.Workflow;
+
+public static class WorkflowArtifactPathResolver
+{
+    private const string WorkflowsDirectory = ".intent-cli/workflows";
+
+    public static string Resolve(string executionUnit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        return $"{WorkflowsDirectory}/{executionUnit.Trim()}.yaml";
+    }
+}

--- a/src/IntentSystem.Workflow/WorkflowArtifactWriter.cs
+++ b/src/IntentSystem.Workflow/WorkflowArtifactWriter.cs
@@ -1,0 +1,27 @@
+using IntentSystem.Workflow.Models;
+using IntentSystem.Workflow.Serialization;
+
+namespace IntentSystem.Workflow;
+
+public static class WorkflowArtifactWriter
+{
+    public static void Write(WorkflowDefinition definition, string repoRoot, bool overwrite)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+
+        var relativePath = WorkflowArtifactPathResolver.Resolve(definition.ExecutionUnit);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+
+        if (!overwrite && File.Exists(absolutePath))
+        {
+            throw new InvalidOperationException($"Workflow artifact already exists at {absolutePath}.");
+        }
+
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException($"Workflow artifact path '{absolutePath}' did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, WorkflowDefinitionSerializer.Serialize(definition));
+    }
+}

--- a/src/IntentSystem.Workflow/WorkflowDefinitionMapper.cs
+++ b/src/IntentSystem.Workflow/WorkflowDefinitionMapper.cs
@@ -1,0 +1,68 @@
+using IntentSystem.Projection.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Workflow.Models;
+
+namespace IntentSystem.Workflow;
+
+public static class WorkflowDefinitionMapper
+{
+    public static WorkflowDefinition Map(QueueItem queueItem, ProjectionPacketContract packetContract)
+    {
+        ArgumentNullException.ThrowIfNull(queueItem);
+        ArgumentNullException.ThrowIfNull(packetContract);
+
+        var implementationPacket = packetContract.ImplementationIssuePacket;
+        var reviewContextPacket = packetContract.ReviewContextPacket;
+
+        if (!string.Equals(queueItem.ExecutionUnit, implementationPacket.SourceExecutionUnit, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Queue item execution unit '{queueItem.ExecutionUnit}' must match packet execution unit '{implementationPacket.SourceExecutionUnit}'.");
+        }
+
+        if (!string.Equals(
+                implementationPacket.SourceExecutionUnit,
+                reviewContextPacket.SourceExecutionUnit,
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Implementation packet execution unit must match review context execution unit.");
+        }
+
+        var workerRoles = new WorkerRoles
+        {
+            Worker = queueItem.WorkerRole,
+            Reviewer = queueItem.ReviewRole
+        };
+
+        return new WorkflowDefinition
+        {
+            ExecutionUnit = queueItem.ExecutionUnit,
+            PacketPaths = new WorkflowPacketPaths
+            {
+                Implementation = queueItem.PacketPaths.Implementation,
+                ReviewContext = queueItem.PacketPaths.ReviewContext,
+                Yaml = queueItem.PacketPaths.Yaml
+            },
+            WorkerRoles = workerRoles,
+            DependencySnapshot = queueItem.Dependencies.ToArray(),
+            EntryConditions = queueItem.Dependencies
+                .Select(dependency => $"{dependency} completed")
+                .ToArray(),
+            Steps = MvpWorkflowTemplate.CreateSteps(workerRoles),
+            SuccessSignal = SelectSuccessSignal(implementationPacket),
+            ReviewMode = implementationPacket.ReviewMode,
+            CompletionAction = implementationPacket.CompletionAction
+        };
+    }
+
+    private static string SelectSuccessSignal(ImplementationIssuePacket implementationPacket)
+    {
+        if (implementationPacket.AcceptanceCriteria.Count > 0)
+        {
+            return implementationPacket.AcceptanceCriteria[0];
+        }
+
+        return implementationPacket.Goal;
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -100,6 +100,25 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenWorkflowRenderCommand_DispatchesToWorkflowRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateWorkflowQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "C2", "packet.yaml"),
+            CreateWorkflowPacketYaml());
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["workflow", "render", "C2"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Workflow definition rendered for C2", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenQueueTransitionCommand_DispatchesToQueueTransitionRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -178,6 +197,91 @@ public sealed class CommandRouterTests
                 }
             ]
         };
+    }
+
+    private static QueueState CreateWorkflowQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "C2",
+                    Title = "Workflow render command",
+                    State = QueueItemState.Queued,
+                    Dependencies = ["A1"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/C2/implementation.md",
+                        ReviewContext = ".intent-cli/issues/C2/review-context.md",
+                        Yaml = ".intent-cli/issues/C2/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
+    private static string CreateWorkflowPacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[C2] Workflow Render Command"
+          issue_kind: "feature"
+          source_execution_unit: "C2"
+          goal: "Render workflow definition artifact from queue and packet sources."
+          in_scope:
+            - "cli workflow render command"
+          out_of_scope:
+            - "workflow execution"
+          target_repo: "J-Tech-Japan/intent-system"
+          target_path: "."
+          target_part: "cli workflow render command"
+          dependencies:
+            - "G1"
+            - "B2"
+            - "C1"
+            - "C2"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "C1 and C2 are fixed baselines"
+          intent_references:
+            - "ICL.E.SLICES"
+          rules_and_specs:
+            - "intents/intent-cli/specs/07-workflow-definition-and-takt-adapter.md"
+          acceptance_criteria:
+            - "workflow render writes workflow artifact"
+          verification_evidence:
+            - "contract-reviewed"
+            - "tests-passing"
+            - "acceptance-criteria-checked"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+        
+        review_context_packet:
+          source_execution_unit: "C2"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.E.SLICES"
+          rules_and_specs:
+            - "intents/intent-cli/specs/07-workflow-definition-and-takt-adapter.md"
+          acceptance_criteria:
+            - "workflow render writes workflow artifact"
+          deterministic_review_checks:
+            - "definition shape stays canonical"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj
+++ b/tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\IntentSystem.Cli\IntentSystem.Cli.csproj" />
     <ProjectReference Include="..\..\src\IntentSystem.Supervisor\IntentSystem.Supervisor.csproj" />
+    <ProjectReference Include="..\..\src\IntentSystem.Workflow\IntentSystem.Workflow.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/IntentSystem.Cli.Tests/WorkflowRenderCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkflowRenderCommandTests.cs
@@ -1,0 +1,236 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+using IntentSystem.Workflow.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class WorkflowRenderCommandTests
+{
+    [Fact]
+    public void Execute_GivenQueueItemAndPacketYaml_WritesWorkflowArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "C2", "packet.yaml"),
+            CreatePacketYaml("C2"));
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowRenderCommand.Execute(CreateContext(repoRoot), ["C2"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Workflow definition rendered for C2", writer.ToString(), StringComparison.Ordinal);
+
+        var workflowPath = Path.Combine(repoRoot, ".intent-cli", "workflows", "C2.yaml");
+        Assert.True(File.Exists(workflowPath));
+
+        var definition = WorkflowDefinitionSerializer.Deserialize(File.ReadAllText(workflowPath));
+        Assert.Equal("C2", definition.ExecutionUnit);
+        Assert.Equal(".intent-cli/issues/C2/packet.yaml", definition.PacketPaths.Yaml);
+        Assert.Equal("coder", definition.WorkerRoles.Worker);
+        Assert.Equal(["A1"], definition.DependencySnapshot);
+        Assert.Equal(["A1 completed"], definition.EntryConditions);
+        Assert.Equal("workflow render writes workflow artifact", definition.SuccessSignal);
+        Assert.Equal("deterministic-review", definition.ReviewMode);
+        Assert.Equal("wait-for-deterministic-review", definition.CompletionAction);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowRenderCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingQueueState_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowRenderCommand.Execute(CreateContext(repoRoot), ["C2"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("No queue state found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketYaml_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowRenderCommand.Execute(CreateContext(repoRoot), ["C2"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("packet YAML was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMismatchedPacketExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "C2", "packet.yaml"),
+            CreatePacketYaml("C3"));
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowRenderCommand.Execute(CreateContext(repoRoot), ["C2"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must match packet execution unit", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "C2",
+                    Title = "Workflow render command",
+                    State = QueueItemState.Queued,
+                    Dependencies = ["A1"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/C2/implementation.md",
+                        ReviewContext = ".intent-cli/issues/C2/review-context.md",
+                        Yaml = ".intent-cli/issues/C2/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
+    private static string CreatePacketYaml(string executionUnit)
+    {
+        return $$"""
+        implementation_issue_packet:
+          issue_title: "[{{executionUnit}}] Workflow Render Command"
+          issue_kind: "feature"
+          source_execution_unit: "{{executionUnit}}"
+          goal: "Render workflow definition artifact from queue and packet sources."
+          in_scope:
+            - "cli workflow render command"
+          out_of_scope:
+            - "workflow execution"
+          target_repo: "J-Tech-Japan/intent-system"
+          target_path: "."
+          target_part: "cli workflow render command"
+          dependencies:
+            - "G1"
+            - "B2"
+            - "C1"
+            - "C2"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "C1 and C2 are fixed baselines"
+          intent_references:
+            - "ICL.E.SLICES"
+          rules_and_specs:
+            - "intents/intent-cli/specs/07-workflow-definition-and-takt-adapter.md"
+          acceptance_criteria:
+            - "workflow render writes workflow artifact"
+            - "generated workflow artifact follows current definition contract"
+          verification_evidence:
+            - "contract-reviewed"
+            - "tests-passing"
+            - "acceptance-criteria-checked"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+        
+        review_context_packet:
+          source_execution_unit: "{{executionUnit}}"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.E.SLICES"
+          rules_and_specs:
+            - "intents/intent-cli/specs/07-workflow-definition-and-takt-adapter.md"
+          acceptance_criteria:
+            - "workflow render writes workflow artifact"
+          deterministic_review_checks:
+            - "definition shape stays canonical"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-workflow-render-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Workflow.Tests/WorkflowArtifactWriterTests.cs
+++ b/tests/IntentSystem.Workflow.Tests/WorkflowArtifactWriterTests.cs
@@ -1,0 +1,105 @@
+using IntentSystem.Workflow.Models;
+using IntentSystem.Workflow.Serialization;
+
+namespace IntentSystem.Workflow.Tests;
+
+public sealed class WorkflowArtifactWriterTests
+{
+    [Fact]
+    public void Resolve_GivenExecutionUnit_UsesWorkflowYamlBaselinePath()
+    {
+        var path = WorkflowArtifactPathResolver.Resolve("C2");
+
+        Assert.Equal(".intent-cli/workflows/C2.yaml", path);
+    }
+
+    [Fact]
+    public void Write_GivenDefinition_WritesSerializedArtifactUnderRepoRoot()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var definition = CreateDefinition();
+
+        WorkflowArtifactWriter.Write(definition, repoRoot, overwrite: false);
+
+        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "workflows", "C2.yaml");
+        Assert.True(File.Exists(artifactPath));
+        Assert.Equal(
+            WorkflowDefinitionSerializer.Serialize(definition),
+            File.ReadAllText(artifactPath));
+    }
+
+    [Fact]
+    public void Write_GivenExistingArtifactAndOverwriteFalse_ThrowsInvalidOperationException()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var artifactPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.yaml"),
+            "existing artifact");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => WorkflowArtifactWriter.Write(CreateDefinition(), repoRoot, overwrite: false));
+
+        Assert.Contains("already exists", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("existing artifact", File.ReadAllText(artifactPath));
+    }
+
+    private static WorkflowDefinition CreateDefinition()
+    {
+        var roles = new WorkerRoles
+        {
+            Worker = "coder",
+            Reviewer = "reviewer"
+        };
+
+        return new WorkflowDefinition
+        {
+            ExecutionUnit = "C2",
+            PacketPaths = new WorkflowPacketPaths
+            {
+                Implementation = ".intent-cli/issues/C2/implementation.md",
+                ReviewContext = ".intent-cli/issues/C2/review-context.md",
+                Yaml = ".intent-cli/issues/C2/packet.yaml"
+            },
+            WorkerRoles = roles,
+            DependencySnapshot = ["A1"],
+            EntryConditions = ["A1 completed"],
+            Steps = MvpWorkflowTemplate.CreateSteps(roles),
+            SuccessSignal = "workflow render writes workflow artifact",
+            ReviewMode = "deterministic-review",
+            CompletionAction = "wait-for-deterministic-review"
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-workflow-writer-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Workflow.Tests/WorkflowDefinitionMapperTests.cs
+++ b/tests/IntentSystem.Workflow.Tests/WorkflowDefinitionMapperTests.cs
@@ -1,0 +1,100 @@
+using IntentSystem.Projection.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Workflow.Models;
+
+namespace IntentSystem.Workflow.Tests;
+
+public sealed class WorkflowDefinitionMapperTests
+{
+    [Fact]
+    public void Map_GivenQueueItemAndPacketContract_ProducesDefinitionUsingCurrentBaselineShape()
+    {
+        var definition = WorkflowDefinitionMapper.Map(CreateQueueItem(), CreatePacketContract("C2"));
+
+        Assert.Equal("C2", definition.ExecutionUnit);
+        Assert.Equal(".intent-cli/issues/C2/implementation.md", definition.PacketPaths.Implementation);
+        Assert.Equal("coder", definition.WorkerRoles.Worker);
+        Assert.Equal("reviewer", definition.WorkerRoles.Reviewer);
+        Assert.Equal(["A1", "B1"], definition.DependencySnapshot);
+        Assert.Equal(["A1 completed", "B1 completed"], definition.EntryConditions);
+        Assert.Equal(7, definition.Steps.Count);
+        Assert.Equal("workflow render writes workflow artifact", definition.SuccessSignal);
+        Assert.Equal("deterministic-review", definition.ReviewMode);
+        Assert.Equal("wait-for-deterministic-review", definition.CompletionAction);
+    }
+
+    [Fact]
+    public void Map_GivenMismatchedExecutionUnit_ThrowsInvalidOperationException()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => WorkflowDefinitionMapper.Map(CreateQueueItem(), CreatePacketContract("C3")));
+
+        Assert.Contains("must match packet execution unit", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static QueueItem CreateQueueItem()
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = "C2",
+            Title = "Workflow render command",
+            State = QueueItemState.Queued,
+            Dependencies = ["A1", "B1"],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = ".intent-cli/issues/C2/implementation.md",
+                ReviewContext = ".intent-cli/issues/C2/review-context.md",
+                Yaml = ".intent-cli/issues/C2/packet.yaml"
+            },
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static ProjectionPacketContract CreatePacketContract(string executionUnit)
+    {
+        return new ProjectionPacketContract
+        {
+            ImplementationIssuePacket = new ImplementationIssuePacket
+            {
+                IssueTitle = $"[{executionUnit}] Workflow Render Command",
+                IssueKind = IssueKind.Feature,
+                SourceExecutionUnit = executionUnit,
+                Goal = "Render workflow definition artifact from queue and packet sources.",
+                InScope = ["cli workflow render command"],
+                OutOfScope = ["workflow execution"],
+                TargetRepo = "J-Tech-Japan/intent-system",
+                TargetPath = ".",
+                TargetPart = "cli workflow render command",
+                Dependencies = ["G1", "B2", "C1", "C2"],
+                TechnicalBaseline = ["C# / .NET"],
+                ProjectLocalGuide = ["AGENTS.md"],
+                IntentBaseline = ["C1 and C2 are fixed baselines"],
+                IntentReferences = ["ICL.E.SLICES"],
+                RulesAndSpecs = ["intents/intent-cli/specs/07-workflow-definition-and-takt-adapter.md"],
+                AcceptanceCriteria =
+                [
+                    "workflow render writes workflow artifact",
+                    "generated workflow artifact follows current definition contract"
+                ],
+                VerificationEvidence = ["contract-reviewed", "tests-passing", "acceptance-criteria-checked"],
+                ReviewMode = "deterministic-review",
+                CompletionAction = "wait-for-deterministic-review",
+                LandingPolicy = "merge-after-review"
+            },
+            ReviewContextPacket = new ReviewContextPacket
+            {
+                SourceExecutionUnit = executionUnit,
+                ParentIntentRoot = "intents/intent-cli/intent-tree/00-map.md",
+                IntentReferences = ["ICL.E.SLICES"],
+                RulesAndSpecs = ["intents/intent-cli/specs/07-workflow-definition-and-takt-adapter.md"],
+                AcceptanceCriteria = ["workflow render writes workflow artifact"],
+                DeterministicReviewChecks = ["definition shape stays canonical"],
+                ClarificationReturnPath = "intents/intent-cli/clarifications/open.md"
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- add `intent-cli workflow render <execution-unit>` to build the workflow definition artifact from the current queue snapshot and packet contract
- add workflow-side mapping, path resolution, and artifact writing helpers so the CLI command stays focused on runtime input resolution
- cover mapper behavior, workflow artifact path/output, and CLI render entry/error cases with tests

## Why

Issue 37 requires a working workflow render command that regenerates `.intent-cli/workflows/<execution-unit>.yaml` from the canonical queue item and packet sources without widening into workflow execution, adapter launch, or GitHub mutation.

## Impact

- users can render a workflow definition artifact for a selected execution unit using current `.intent-cli/queue-state.json` and `.intent-cli/issues/<execution-unit>/packet.yaml`
- generated workflow artifacts follow the existing `C1` field shape and `C2` step/role baseline
- render output is fixed to `.intent-cli/workflows/<execution-unit>.yaml`, while file contents remain on the current serializer baseline

## Validation

- `dotnet test`

Closes #37
