### PR TITLE
[codex] implement workflow run command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -31,7 +31,8 @@ internal static class CommandRouter
             },
             ["workflow"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
-                ["render"] = WorkflowRenderCommand.Execute
+                ["render"] = WorkflowRenderCommand.Execute,
+                ["run"] = WorkflowRunCommand.Execute
             },
             ["queue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/WorkflowRunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkflowRunCommand.cs
@@ -1,0 +1,71 @@
+using IntentSystem.WorkerAdapter;
+using IntentSystem.Workflow.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class WorkflowRunCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Workflow run command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        var workflowDefinitionRef = $".intent-cli/workflows/{executionUnit}.yaml";
+        var workflowDefinitionPath = Path.Combine(
+            context.RepoRoot,
+            workflowDefinitionRef.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(workflowDefinitionPath))
+        {
+            writer.WriteLine($"Workflow definition artifact was not found at {workflowDefinitionPath}");
+            return 1;
+        }
+
+        try
+        {
+            var definition = WorkflowDefinitionSerializer.Deserialize(File.ReadAllText(workflowDefinitionPath));
+            if (!string.Equals(definition.ExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Workflow definition execution unit '{definition.ExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
+            }
+
+            var request = WorkerAdapterRequestFactory.Create(
+                executionUnit,
+                workflowDefinitionRef,
+                context.RepoRoot);
+            var result = WorkerAdapterRunArtifactFactory.CreateInitialResult(request, definition);
+            WorkerAdapterRunArtifactWriter.Write(result, executionUnit, context.RepoRoot, overwrite: true);
+
+            writer.WriteLine($"Workflow run artifact generated for {executionUnit}.");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+}

--- a/src/IntentSystem.Cli/IntentSystem.Cli.csproj
+++ b/src/IntentSystem.Cli/IntentSystem.Cli.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\IntentSystem.Projection\IntentSystem.Projection.csproj" />
     <ProjectReference Include="..\IntentSystem.Supervisor\IntentSystem.Supervisor.csproj" />
+    <ProjectReference Include="..\IntentSystem.WorkerAdapter\IntentSystem.WorkerAdapter.csproj" />
     <ProjectReference Include="..\IntentSystem.Workflow\IntentSystem.Workflow.csproj" />
   </ItemGroup>
 

--- a/src/IntentSystem.WorkerAdapter/WorkerAdapterRequestFactory.cs
+++ b/src/IntentSystem.WorkerAdapter/WorkerAdapterRequestFactory.cs
@@ -1,0 +1,30 @@
+using IntentSystem.WorkerAdapter.Models;
+
+namespace IntentSystem.WorkerAdapter;
+
+public static class WorkerAdapterRequestFactory
+{
+    public static WorkerAdapterRequest Create(string executionUnit, string workflowDefinitionRef, string targetWorktree)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workflowDefinitionRef);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetWorktree);
+
+        return new WorkerAdapterRequest
+        {
+            WorkflowDefinitionRef = workflowDefinitionRef,
+            RunId = $"run-{executionUnit.Trim()}",
+            TargetWorktree = targetWorktree,
+            RuntimeEnv = new AdapterRuntimeEnvironment
+            {
+                Engine = "takt",
+                Arguments = ["run", workflowDefinitionRef]
+            },
+            EventSink = new AdapterEventSink
+            {
+                SinkType = "jsonl-file",
+                SinkRef = WorkerAdapterRunArtifactPathResolver.Resolve(executionUnit)
+            }
+        };
+    }
+}

--- a/src/IntentSystem.WorkerAdapter/WorkerAdapterRunArtifactFactory.cs
+++ b/src/IntentSystem.WorkerAdapter/WorkerAdapterRunArtifactFactory.cs
@@ -1,0 +1,48 @@
+using IntentSystem.WorkerAdapter.Models;
+using IntentSystem.Workflow.Models;
+
+namespace IntentSystem.WorkerAdapter;
+
+public static class WorkerAdapterRunArtifactFactory
+{
+    public static WorkerAdapterResult CreateInitialResult(
+        WorkerAdapterRequest request,
+        WorkflowDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(definition);
+
+        var expectedWorkflowRef = $".intent-cli/workflows/{definition.ExecutionUnit}.yaml";
+        if (!string.Equals(request.WorkflowDefinitionRef, expectedWorkflowRef, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Worker adapter request workflow definition ref '{request.WorkflowDefinitionRef}' must match execution unit '{definition.ExecutionUnit}'.");
+        }
+
+        var stepStatuses = new WorkerAdapterStepStatus[definition.Steps.Count];
+        for (var index = 0; index < definition.Steps.Count; index++)
+        {
+            stepStatuses[index] = new WorkerAdapterStepStatus
+            {
+                Step = definition.Steps[index].Kind,
+                Status = index == 0
+                    ? WorkerAdapterStepState.Running
+                    : WorkerAdapterStepState.Pending
+            };
+        }
+
+        return new WorkerAdapterResult
+        {
+            RunStatus = WorkerAdapterRunStatus.Running,
+            StepStatuses = stepStatuses,
+            ReviewResult = new WorkerReviewResult
+            {
+                Disposition = WorkerReviewDisposition.Pending
+            },
+            ReviewCommentRefs = [],
+            ClarificationRequests = [],
+            ResultSummary = $"Workflow run artifact initialized for {definition.ExecutionUnit}.",
+            RunLogRefs = [request.EventSink.SinkRef]
+        };
+    }
+}

--- a/src/IntentSystem.WorkerAdapter/WorkerAdapterRunArtifactPathResolver.cs
+++ b/src/IntentSystem.WorkerAdapter/WorkerAdapterRunArtifactPathResolver.cs
@@ -1,0 +1,13 @@
+namespace IntentSystem.WorkerAdapter;
+
+public static class WorkerAdapterRunArtifactPathResolver
+{
+    private const string WorkflowsDirectory = ".intent-cli/workflows";
+
+    public static string Resolve(string executionUnit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        return $"{WorkflowsDirectory}/{executionUnit.Trim()}.run.json";
+    }
+}

--- a/src/IntentSystem.WorkerAdapter/WorkerAdapterRunArtifactWriter.cs
+++ b/src/IntentSystem.WorkerAdapter/WorkerAdapterRunArtifactWriter.cs
@@ -1,0 +1,28 @@
+using IntentSystem.WorkerAdapter.Models;
+using IntentSystem.WorkerAdapter.Serialization;
+
+namespace IntentSystem.WorkerAdapter;
+
+public static class WorkerAdapterRunArtifactWriter
+{
+    public static void Write(WorkerAdapterResult result, string executionUnit, string repoRoot, bool overwrite)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+
+        var relativePath = WorkerAdapterRunArtifactPathResolver.Resolve(executionUnit);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+
+        if (!overwrite && File.Exists(absolutePath))
+        {
+            throw new InvalidOperationException($"Workflow run artifact already exists at {absolutePath}.");
+        }
+
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException($"Workflow run artifact path '{absolutePath}' did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, WorkerAdapterSerializer.SerializeResult(result));
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -119,6 +119,25 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenWorkflowRunCommand_DispatchesToWorkflowRunRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateWorkflowQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.yaml"),
+            CreateWorkflowDefinitionJson());
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["workflow", "run", "C2"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Workflow run artifact generated for C2", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenQueueTransitionCommand_DispatchesToQueueTransitionRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -281,6 +300,43 @@ public sealed class CommandRouterTests
           deterministic_review_checks:
             - "definition shape stays canonical"
           clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private static string CreateWorkflowDefinitionJson()
+    {
+        return """
+        {
+          "execution_unit": "C2",
+          "packet_paths": {
+            "implementation": ".intent-cli/issues/C2/implementation.md",
+            "review_context": ".intent-cli/issues/C2/review-context.md",
+            "yaml": ".intent-cli/issues/C2/packet.yaml"
+          },
+          "worker_roles": {
+            "worker": "coder",
+            "reviewer": "reviewer"
+          },
+          "dependency_snapshot": ["A1"],
+          "entry_conditions": ["A1 completed"],
+          "steps": [
+            {
+              "kind": "implement",
+              "role": "coder",
+              "on_success": ["review"],
+              "on_failure": []
+            },
+            {
+              "kind": "review",
+              "role": "reviewer",
+              "on_success": ["complete"],
+              "on_failure": ["comment-findings"]
+            }
+          ],
+          "success_signal": "workflow render writes workflow artifact",
+          "review_mode": "deterministic-review",
+          "completion_action": "wait-for-deterministic-review"
+        }
         """;
     }
 

--- a/tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj
+++ b/tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\IntentSystem.Cli\IntentSystem.Cli.csproj" />
     <ProjectReference Include="..\..\src\IntentSystem.Supervisor\IntentSystem.Supervisor.csproj" />
+    <ProjectReference Include="..\..\src\IntentSystem.WorkerAdapter\IntentSystem.WorkerAdapter.csproj" />
     <ProjectReference Include="..\..\src\IntentSystem.Workflow\IntentSystem.Workflow.csproj" />
   </ItemGroup>
 

--- a/tests/IntentSystem.Cli.Tests/WorkflowRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkflowRunCommandTests.cs
@@ -1,0 +1,193 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+using IntentSystem.WorkerAdapter.Serialization;
+using IntentSystem.Workflow.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class WorkflowRunCommandTests
+{
+    [Fact]
+    public void Execute_GivenQueueItemAndRenderedWorkflow_WritesRunArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.yaml"),
+            WorkflowDefinitionSerializer.Serialize(CreateWorkflowDefinition("C2")));
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowRunCommand.Execute(CreateContext(repoRoot), ["C2"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Workflow run artifact generated for C2", writer.ToString(), StringComparison.Ordinal);
+
+        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "workflows", "C2.run.json");
+        Assert.True(File.Exists(artifactPath));
+        var result = WorkerAdapterSerializer.DeserializeResult(File.ReadAllText(artifactPath));
+        Assert.Equal(WorkerAdapter.Models.WorkerAdapterRunStatus.Running, result.RunStatus);
+        Assert.Equal(Workflow.Models.WorkflowStepKind.Implement, result.StepStatuses[0].Step);
+        Assert.Equal(WorkerAdapter.Models.WorkerAdapterStepState.Running, result.StepStatuses[0].Status);
+        Assert.Equal(WorkerAdapter.Models.WorkerReviewDisposition.Pending, result.ReviewResult.Disposition);
+        Assert.Empty(result.ReviewCommentRefs);
+        Assert.Empty(result.ClarificationRequests);
+        Assert.Equal([".intent-cli/workflows/C2.run.json"], result.RunLogRefs);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowRunCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingWorkflowDefinition_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowRunCommand.Execute(CreateContext(repoRoot), ["C2"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Workflow definition artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMismatchedWorkflowExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.yaml"),
+            WorkflowDefinitionSerializer.Serialize(CreateWorkflowDefinition("C3")));
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowRunCommand.Execute(CreateContext(repoRoot), ["C2"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must match queue item execution unit", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "C2",
+                    Title = "Workflow run command",
+                    State = QueueItemState.Queued,
+                    Dependencies = ["A1"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/C2/implementation.md",
+                        ReviewContext = ".intent-cli/issues/C2/review-context.md",
+                        Yaml = ".intent-cli/issues/C2/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
+    private static Workflow.Models.WorkflowDefinition CreateWorkflowDefinition(string executionUnit)
+    {
+        var roles = new Workflow.Models.WorkerRoles
+        {
+            Worker = "coder",
+            Reviewer = "reviewer"
+        };
+
+        return new Workflow.Models.WorkflowDefinition
+        {
+            ExecutionUnit = executionUnit,
+            PacketPaths = new Workflow.Models.WorkflowPacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            WorkerRoles = roles,
+            DependencySnapshot = ["A1"],
+            EntryConditions = ["A1 completed"],
+            Steps = Workflow.MvpWorkflowTemplate.CreateSteps(roles),
+            SuccessSignal = "workflow render writes workflow artifact",
+            ReviewMode = "deterministic-review",
+            CompletionAction = "wait-for-deterministic-review"
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-workflow-run-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.WorkerAdapter.Tests/IntentSystem.WorkerAdapter.Tests.csproj
+++ b/tests/IntentSystem.WorkerAdapter.Tests/IntentSystem.WorkerAdapter.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\IntentSystem.WorkerAdapter\IntentSystem.WorkerAdapter.csproj" />
+    <ProjectReference Include="..\..\src\IntentSystem.Workflow\IntentSystem.Workflow.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/IntentSystem.WorkerAdapter.Tests/WorkerAdapterRunArtifactFactoryTests.cs
+++ b/tests/IntentSystem.WorkerAdapter.Tests/WorkerAdapterRunArtifactFactoryTests.cs
@@ -1,0 +1,73 @@
+using IntentSystem.WorkerAdapter.Models;
+using IntentSystem.Workflow;
+using IntentSystem.Workflow.Models;
+
+namespace IntentSystem.WorkerAdapter.Tests;
+
+public sealed class WorkerAdapterRunArtifactFactoryTests
+{
+    [Fact]
+    public void CreateInitialResult_GivenRequestAndDefinition_ProducesCanonicalRunArtifactShape()
+    {
+        var definition = CreateDefinition();
+        var request = WorkerAdapterRequestFactory.Create(
+            "C2",
+            ".intent-cli/workflows/C2.yaml",
+            "/worktrees/intent-system");
+
+        var result = WorkerAdapterRunArtifactFactory.CreateInitialResult(request, definition);
+
+        Assert.Equal(WorkerAdapterRunStatus.Running, result.RunStatus);
+        Assert.Equal(definition.Steps.Count, result.StepStatuses.Count);
+        Assert.Equal(WorkflowStepKind.Implement, result.StepStatuses[0].Step);
+        Assert.Equal(WorkerAdapterStepState.Running, result.StepStatuses[0].Status);
+        Assert.All(result.StepStatuses.Skip(1), step => Assert.Equal(WorkerAdapterStepState.Pending, step.Status));
+        Assert.Equal(WorkerReviewDisposition.Pending, result.ReviewResult.Disposition);
+        Assert.Empty(result.ReviewCommentRefs);
+        Assert.Empty(result.ClarificationRequests);
+        Assert.Equal("Workflow run artifact initialized for C2.", result.ResultSummary);
+        Assert.Equal([".intent-cli/workflows/C2.run.json"], result.RunLogRefs);
+    }
+
+    [Fact]
+    public void CreateInitialResult_GivenMismatchedWorkflowDefinitionRef_ThrowsInvalidOperationException()
+    {
+        var definition = CreateDefinition();
+        var request = WorkerAdapterRequestFactory.Create(
+            "C2",
+            ".intent-cli/workflows/C3.yaml",
+            "/worktrees/intent-system");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => WorkerAdapterRunArtifactFactory.CreateInitialResult(request, definition));
+
+        Assert.Contains("must match execution unit", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static WorkflowDefinition CreateDefinition()
+    {
+        var roles = new WorkerRoles
+        {
+            Worker = "coder",
+            Reviewer = "reviewer"
+        };
+
+        return new WorkflowDefinition
+        {
+            ExecutionUnit = "C2",
+            PacketPaths = new WorkflowPacketPaths
+            {
+                Implementation = ".intent-cli/issues/C2/implementation.md",
+                ReviewContext = ".intent-cli/issues/C2/review-context.md",
+                Yaml = ".intent-cli/issues/C2/packet.yaml"
+            },
+            WorkerRoles = roles,
+            DependencySnapshot = ["A1"],
+            EntryConditions = ["A1 completed"],
+            Steps = MvpWorkflowTemplate.CreateSteps(roles),
+            SuccessSignal = "workflow render writes workflow artifact",
+            ReviewMode = "deterministic-review",
+            CompletionAction = "wait-for-deterministic-review"
+        };
+    }
+}

--- a/tests/IntentSystem.WorkerAdapter.Tests/WorkerAdapterRunArtifactWriterTests.cs
+++ b/tests/IntentSystem.WorkerAdapter.Tests/WorkerAdapterRunArtifactWriterTests.cs
@@ -1,0 +1,102 @@
+using IntentSystem.WorkerAdapter.Models;
+using IntentSystem.WorkerAdapter.Serialization;
+
+namespace IntentSystem.WorkerAdapter.Tests;
+
+public sealed class WorkerAdapterRunArtifactWriterTests
+{
+    [Fact]
+    public void Resolve_GivenExecutionUnit_UsesRunJsonBaselinePath()
+    {
+        var path = WorkerAdapterRunArtifactPathResolver.Resolve("C2");
+
+        Assert.Equal(".intent-cli/workflows/C2.run.json", path);
+    }
+
+    [Fact]
+    public void Write_GivenResult_WritesSerializedArtifactUnderRepoRoot()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var result = CreateResult();
+
+        WorkerAdapterRunArtifactWriter.Write(result, "C2", repoRoot, overwrite: false);
+
+        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "workflows", "C2.run.json");
+        Assert.True(File.Exists(artifactPath));
+        Assert.Equal(
+            WorkerAdapterSerializer.SerializeResult(result),
+            File.ReadAllText(artifactPath));
+    }
+
+    [Fact]
+    public void Write_GivenExistingArtifactAndOverwriteFalse_ThrowsInvalidOperationException()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var artifactPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.run.json"),
+            "existing run artifact");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => WorkerAdapterRunArtifactWriter.Write(CreateResult(), "C2", repoRoot, overwrite: false));
+
+        Assert.Contains("already exists", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("existing run artifact", File.ReadAllText(artifactPath));
+    }
+
+    private static WorkerAdapterResult CreateResult()
+    {
+        return new WorkerAdapterResult
+        {
+            RunStatus = WorkerAdapterRunStatus.Running,
+            StepStatuses =
+            [
+                new WorkerAdapterStepStatus
+                {
+                    Step = Workflow.Models.WorkflowStepKind.Implement,
+                    Status = WorkerAdapterStepState.Running
+                }
+            ],
+            ReviewResult = new WorkerReviewResult
+            {
+                Disposition = WorkerReviewDisposition.Pending
+            },
+            ReviewCommentRefs = [],
+            ClarificationRequests = [],
+            ResultSummary = "Workflow run artifact initialized for C2.",
+            RunLogRefs = [".intent-cli/workflows/C2.run.json"]
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-worker-adapter-writer-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `intent-cli workflow run <execution-unit>` to generate deterministic `.intent-cli/workflows/<execution-unit>.run.json` artifacts from the current queue item and rendered workflow definition
- add worker-adapter request/result helpers and run-artifact writer utilities so the generated run artifact stays aligned with the C2 adapter output contract
- cover CLI routing, run artifact generation, path resolution, and overwrite behavior with focused CLI and worker-adapter tests

## Validation
- `dotnet test`

Closes #39
