### PR TITLE
[codex] implement workflow status command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -32,7 +32,8 @@ internal static class CommandRouter
             ["workflow"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["render"] = WorkflowRenderCommand.Execute,
-                ["run"] = WorkflowRunCommand.Execute
+                ["run"] = WorkflowRunCommand.Execute,
+                ["status"] = WorkflowStatusCommand.Execute
             },
             ["queue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/WorkflowStatusCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkflowStatusCommand.cs
@@ -1,0 +1,62 @@
+using IntentSystem.WorkerAdapter;
+using IntentSystem.WorkerAdapter.Serialization;
+using IntentSystem.Workflow;
+using IntentSystem.Workflow.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class WorkflowStatusCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Workflow status command requires an execution unit.");
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var workflowDefinitionRef = WorkflowArtifactPathResolver.Resolve(executionUnit);
+        var workflowDefinitionPath = Path.Combine(
+            context.RepoRoot,
+            workflowDefinitionRef.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(workflowDefinitionPath))
+        {
+            writer.WriteLine($"Workflow definition artifact was not found at {workflowDefinitionPath}");
+            return 1;
+        }
+
+        var runArtifactRef = WorkerAdapterRunArtifactPathResolver.Resolve(executionUnit);
+        var runArtifactPath = Path.Combine(
+            context.RepoRoot,
+            runArtifactRef.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(runArtifactPath))
+        {
+            writer.WriteLine($"Workflow run artifact was not found at {runArtifactPath}");
+            return 1;
+        }
+
+        try
+        {
+            var definition = WorkflowDefinitionSerializer.Deserialize(File.ReadAllText(workflowDefinitionPath));
+            if (!string.Equals(definition.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Workflow definition execution unit '{definition.ExecutionUnit}' must match requested execution unit '{executionUnit}'.");
+            }
+
+            var result = WorkerAdapterSerializer.DeserializeResult(File.ReadAllText(runArtifactPath));
+            WorkflowStatusRenderer.Write(writer, definition, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkflowStatusRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkflowStatusRenderer.cs
@@ -1,0 +1,95 @@
+using IntentSystem.WorkerAdapter.Models;
+using IntentSystem.Workflow.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class WorkflowStatusRenderer
+{
+    public static void Write(TextWriter writer, WorkflowDefinition definition, WorkerAdapterResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(result);
+
+        var statusesByStep = BuildStatusesByStep(definition, result);
+
+        writer.WriteLine($"Execution unit: {definition.ExecutionUnit}");
+        writer.WriteLine($"Run status: {result.RunStatus}");
+        writer.WriteLine($"Result summary: {result.ResultSummary}");
+        writer.WriteLine($"Review disposition: {result.ReviewResult.Disposition}");
+        writer.WriteLine($"Reviewed by: {FormatValue(result.ReviewResult.ReviewedBy)}");
+        writer.WriteLine($"Review comment refs: {FormatList(result.ReviewCommentRefs)}");
+        writer.WriteLine($"Run log refs: {FormatList(result.RunLogRefs)}");
+        writer.WriteLine("Workflow steps:");
+
+        foreach (var step in definition.Steps)
+        {
+            var status = statusesByStep[step.Kind];
+            writer.WriteLine(
+                $"- {step.Kind} | role={step.Role} | status={status.Status} | detail={FormatValue(status.Detail)}");
+        }
+
+        writer.WriteLine("Clarification requests:");
+        if (result.ClarificationRequests.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var clarification in result.ClarificationRequests)
+        {
+            writer.WriteLine(
+                $"- {clarification.QuestionId} | execution_unit={clarification.ExecutionUnit} | status={clarification.Status} | blocking={clarification.BlockingOrNonblocking} | return={clarification.ClarificationReturnPath} | reason={clarification.Reason}");
+        }
+    }
+
+    private static Dictionary<WorkflowStepKind, WorkerAdapterStepStatus> BuildStatusesByStep(
+        WorkflowDefinition definition,
+        WorkerAdapterResult result)
+    {
+        var workflowSteps = definition.Steps
+            .Select(step => step.Kind)
+            .ToHashSet();
+        var statusesByStep = new Dictionary<WorkflowStepKind, WorkerAdapterStepStatus>();
+
+        foreach (var stepStatus in result.StepStatuses)
+        {
+            if (!workflowSteps.Contains(stepStatus.Step))
+            {
+                throw new InvalidOperationException(
+                    $"Workflow run artifact contained status for unknown step '{stepStatus.Step}'.");
+            }
+
+            if (!statusesByStep.TryAdd(stepStatus.Step, stepStatus))
+            {
+                throw new InvalidOperationException(
+                    $"Workflow run artifact contained duplicate status for step '{stepStatus.Step}'.");
+            }
+        }
+
+        foreach (var step in definition.Steps)
+        {
+            if (!statusesByStep.ContainsKey(step.Kind))
+            {
+                throw new InvalidOperationException(
+                    $"Workflow run artifact did not contain status for step '{step.Kind}'.");
+            }
+        }
+
+        return statusesByStep;
+    }
+
+    private static string FormatList(IReadOnlyList<string> values)
+    {
+        return values.Count == 0
+            ? "-"
+            : string.Join(", ", values);
+    }
+
+    private static string FormatValue(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? "-"
+            : value;
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -3,6 +3,7 @@ using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
+using IntentSystem.WorkerAdapter.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -135,6 +136,25 @@ public sealed class CommandRouterTests
 
         Assert.Equal(0, exitCode);
         Assert.Contains("Workflow run artifact generated for C2", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenWorkflowStatusCommand_DispatchesToWorkflowStatusRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.yaml"),
+            CreateWorkflowDefinitionJson());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.run.json"),
+            CreateWorkflowRunArtifactJson());
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["workflow", "status", "C2"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Run status: Running", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -338,6 +358,36 @@ public sealed class CommandRouterTests
           "completion_action": "wait-for-deterministic-review"
         }
         """;
+    }
+
+    private static string CreateWorkflowRunArtifactJson()
+    {
+        return WorkerAdapterSerializer.SerializeResult(
+            new WorkerAdapter.Models.WorkerAdapterResult
+            {
+                RunStatus = WorkerAdapter.Models.WorkerAdapterRunStatus.Running,
+                StepStatuses =
+                [
+                    new WorkerAdapter.Models.WorkerAdapterStepStatus
+                    {
+                        Step = Workflow.Models.WorkflowStepKind.Implement,
+                        Status = WorkerAdapter.Models.WorkerAdapterStepState.Running
+                    },
+                    new WorkerAdapter.Models.WorkerAdapterStepStatus
+                    {
+                        Step = Workflow.Models.WorkflowStepKind.Review,
+                        Status = WorkerAdapter.Models.WorkerAdapterStepState.Pending
+                    }
+                ],
+                ReviewResult = new WorkerAdapter.Models.WorkerReviewResult
+                {
+                    Disposition = WorkerAdapter.Models.WorkerReviewDisposition.Pending
+                },
+                ReviewCommentRefs = [],
+                ClarificationRequests = [],
+                ResultSummary = "Workflow run artifact initialized for C2.",
+                RunLogRefs = [".intent-cli/workflows/C2.run.json"]
+            });
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/tests/IntentSystem.Cli.Tests/WorkflowStatusCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkflowStatusCommandTests.cs
@@ -1,0 +1,292 @@
+using IntentSystem.Clarify.Models;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.WorkerAdapter.Models;
+using IntentSystem.WorkerAdapter.Serialization;
+using IntentSystem.Workflow.Models;
+using IntentSystem.Workflow.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class WorkflowStatusCommandTests
+{
+    [Fact]
+    public void Execute_GivenWorkflowDefinitionAndRunArtifact_WritesHumanFacingStatus()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.yaml"),
+            WorkflowDefinitionSerializer.Serialize(CreateWorkflowDefinition("C2")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.run.json"),
+            WorkerAdapterSerializer.SerializeResult(CreateRunArtifact()));
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowStatusCommand.Execute(CreateContext(repoRoot), ["C2"], writer);
+
+        var output = writer.ToString();
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Execution unit: C2", output, StringComparison.Ordinal);
+        Assert.Contains("Run status: ClarificationRequested", output, StringComparison.Ordinal);
+        Assert.Contains("Result summary: Reviewer requested clarification on the backend contract.", output, StringComparison.Ordinal);
+        Assert.Contains("Review disposition: ClarificationRequested", output, StringComparison.Ordinal);
+        Assert.Contains("Reviewed by: deterministic-reviewer", output, StringComparison.Ordinal);
+        Assert.Contains("Review comment refs: https://github.com/J-Tech-Japan/intent-system/pull/40#discussion_r1", output, StringComparison.Ordinal);
+        Assert.Contains("Run log refs: .intent-cli/workflows/C2.run.json, .intent-cli/logs/C2-run.log", output, StringComparison.Ordinal);
+        Assert.Contains("- Implement | role=coder | status=Completed | detail=Implemented workflow status command", output, StringComparison.Ordinal);
+        Assert.Contains("- Review | role=reviewer | status=Completed | detail=Clarification required before approval", output, StringComparison.Ordinal);
+        Assert.Contains("- Clarify | role=reviewer | status=Running | detail=Waiting for answer on backend ownership", output, StringComparison.Ordinal);
+        Assert.Contains("- Q-1 | execution_unit=C2 | status=Open | blocking=blocking | return=intents/intent-cli/clarifications/open.md | reason=Need backend owner confirmation", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowStatusCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingWorkflowDefinition_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.run.json"),
+            WorkerAdapterSerializer.SerializeResult(CreateRunArtifact()));
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowStatusCommand.Execute(CreateContext(repoRoot), ["C2"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Workflow definition artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingRunArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.yaml"),
+            WorkflowDefinitionSerializer.Serialize(CreateWorkflowDefinition("C2")));
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowStatusCommand.Execute(CreateContext(repoRoot), ["C2"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Workflow run artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMismatchedWorkflowExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.yaml"),
+            WorkflowDefinitionSerializer.Serialize(CreateWorkflowDefinition("C3")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.run.json"),
+            WorkerAdapterSerializer.SerializeResult(CreateRunArtifact()));
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowStatusCommand.Execute(CreateContext(repoRoot), ["C2"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must match requested execution unit", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenRunArtifactMissingStepStatus_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.yaml"),
+            WorkflowDefinitionSerializer.Serialize(CreateWorkflowDefinition("C2")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "workflows", "C2.run.json"),
+            WorkerAdapterSerializer.SerializeResult(CreateRunArtifactWithoutClarifyStep()));
+        using var writer = new StringWriter();
+
+        var exitCode = WorkflowStatusCommand.Execute(CreateContext(repoRoot), ["C2"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("did not contain status for step 'Clarify'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static WorkflowDefinition CreateWorkflowDefinition(string executionUnit)
+    {
+        return new WorkflowDefinition
+        {
+            ExecutionUnit = executionUnit,
+            PacketPaths = new WorkflowPacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            WorkerRoles = new WorkerRoles
+            {
+                Worker = "coder",
+                Reviewer = "reviewer"
+            },
+            DependencySnapshot = ["A1"],
+            EntryConditions = ["A1 completed"],
+            Steps =
+            [
+                new WorkflowStep
+                {
+                    Kind = WorkflowStepKind.Implement,
+                    Role = "coder",
+                    OnSuccess = [WorkflowStepKind.Review],
+                    OnFailure = []
+                },
+                new WorkflowStep
+                {
+                    Kind = WorkflowStepKind.Review,
+                    Role = "reviewer",
+                    OnSuccess = [WorkflowStepKind.Complete],
+                    OnFailure = [WorkflowStepKind.Clarify]
+                },
+                new WorkflowStep
+                {
+                    Kind = WorkflowStepKind.Clarify,
+                    Role = "reviewer",
+                    OnSuccess = [WorkflowStepKind.Review],
+                    OnFailure = []
+                }
+            ],
+            SuccessSignal = "workflow status renders workflow state",
+            ReviewMode = "deterministic-review",
+            CompletionAction = "wait-for-deterministic-review"
+        };
+    }
+
+    private static WorkerAdapterResult CreateRunArtifact()
+    {
+        return new WorkerAdapterResult
+        {
+            RunStatus = WorkerAdapterRunStatus.ClarificationRequested,
+            StepStatuses =
+            [
+                new WorkerAdapterStepStatus
+                {
+                    Step = WorkflowStepKind.Implement,
+                    Status = WorkerAdapterStepState.Completed,
+                    Detail = "Implemented workflow status command"
+                },
+                new WorkerAdapterStepStatus
+                {
+                    Step = WorkflowStepKind.Review,
+                    Status = WorkerAdapterStepState.Completed,
+                    Detail = "Clarification required before approval"
+                },
+                new WorkerAdapterStepStatus
+                {
+                    Step = WorkflowStepKind.Clarify,
+                    Status = WorkerAdapterStepState.Running,
+                    Detail = "Waiting for answer on backend ownership"
+                }
+            ],
+            ReviewResult = new WorkerReviewResult
+            {
+                Disposition = WorkerReviewDisposition.ClarificationRequested,
+                ReviewedBy = "deterministic-reviewer"
+            },
+            ReviewCommentRefs =
+            [
+                "https://github.com/J-Tech-Japan/intent-system/pull/40#discussion_r1"
+            ],
+            ClarificationRequests =
+            [
+                new ClarificationItem
+                {
+                    ClarificationSource = "review",
+                    QuestionId = "Q-1",
+                    ExecutionUnit = "C2",
+                    QuestionText = "Who owns the backend contract?",
+                    Reason = "Need backend owner confirmation",
+                    AffectedIntents = ["ICL.E.SLICES"],
+                    AffectedExecutionUnits = ["C2"],
+                    BlockingOrNonblocking = "blocking",
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    Status = ClarificationStatus.Open,
+                    CreatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z")
+                }
+            ],
+            ResultSummary = "Reviewer requested clarification on the backend contract.",
+            RunLogRefs =
+            [
+                ".intent-cli/workflows/C2.run.json",
+                ".intent-cli/logs/C2-run.log"
+            ]
+        };
+    }
+
+    private static WorkerAdapterResult CreateRunArtifactWithoutClarifyStep()
+    {
+        var result = CreateRunArtifact();
+        return result with
+        {
+            StepStatuses = result.StepStatuses
+                .Where(status => status.Step != WorkflowStepKind.Clarify)
+                .ToArray()
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-workflow-status-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `intent-cli workflow status <execution-unit>` to read the rendered workflow definition and current run artifact and print a deterministic human-facing status view
- add a dedicated workflow status renderer that preserves the current `G6` / `C2` run artifact shape while validating step coverage against the workflow definition
- cover command routing, missing input paths, execution-unit validation, and run-artifact field rendering with focused CLI tests

## Validation
- `dotnet test`

Closes #41
