### PR TITLE
[codex] implement blocking queue transitions

### DIFF
--- a/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
@@ -14,7 +14,7 @@ internal static class QueueTransitionCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
-        if (args.Length != 2
+        if (args.Length < 2
             || string.IsNullOrWhiteSpace(args[0])
             || string.IsNullOrWhiteSpace(args[1]))
         {
@@ -31,18 +31,44 @@ internal static class QueueTransitionCommand
         if (!TryParseTargetState(args[1], out var targetState))
         {
             writer.WriteLine(
-                "Unsupported queue transition target state. Supported states: queued, active, review, fixing, completed.");
+                "Unsupported queue transition target state. Supported states: queued, active, review, fixing, completed, blocked, clarify-blocked.");
+            return 1;
+        }
+
+        if (!TryParseReason(args[2..], out var reason, out var reasonError))
+        {
+            writer.WriteLine(reasonError);
+            return 1;
+        }
+
+        if (IsBlockingTargetState(targetState) && string.IsNullOrWhiteSpace(reason))
+        {
+            writer.WriteLine("Blocking queue transitions require --reason <text>.");
+            return 1;
+        }
+
+        if (!IsBlockingTargetState(targetState) && reason is not null)
+        {
+            writer.WriteLine("Reason is only supported for blocked and clarify-blocked transitions.");
             return 1;
         }
 
         try
         {
-            var result = QueueManager.TransitionNonBlocking(
-                queueState,
-                args[0],
-                targetState,
-                TransitionActor,
-                DateTimeOffset.UtcNow);
+            var result = IsBlockingTargetState(targetState)
+                ? QueueManager.TransitionBlocking(
+                    queueState,
+                    args[0],
+                    targetState,
+                    reason!,
+                    TransitionActor,
+                    DateTimeOffset.UtcNow)
+                : QueueManager.TransitionNonBlocking(
+                    queueState,
+                    args[0],
+                    targetState,
+                    TransitionActor,
+                    DateTimeOffset.UtcNow);
 
             PersistTransition(context, result);
 
@@ -75,10 +101,50 @@ internal static class QueueTransitionCommand
             case "completed":
                 state = QueueItemState.Completed;
                 return true;
+            case "blocked":
+                state = QueueItemState.Blocked;
+                return true;
+            case "clarify-blocked":
+                state = QueueItemState.ClarifyBlocked;
+                return true;
             default:
                 state = default;
                 return false;
         }
+    }
+
+    private static bool TryParseReason(string[] args, out string? reason, out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length == 0)
+        {
+            reason = null;
+            error = null;
+            return true;
+        }
+
+        if (args.Length < 2 || !string.Equals(args[0], "--reason", StringComparison.Ordinal))
+        {
+            reason = null;
+            error = "Queue transition command only supports optional '--reason <text>'.";
+            return false;
+        }
+
+        reason = string.Join(' ', args[1..]).Trim();
+        if (reason.Length == 0)
+        {
+            error = "Queue transition reason must not be empty.";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static bool IsBlockingTargetState(QueueItemState state)
+    {
+        return state is QueueItemState.Blocked or QueueItemState.ClarifyBlocked;
     }
 
     private static void PersistTransition(CliContext context, QueueTransitionResult result)
@@ -97,6 +163,10 @@ internal static class QueueTransitionCommand
 
     private static string FormatState(QueueItemState state)
     {
-        return state.ToString().ToLowerInvariant();
+        return state switch
+        {
+            QueueItemState.ClarifyBlocked => "clarify-blocked",
+            _ => state.ToString().ToLowerInvariant()
+        };
     }
 }

--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -32,6 +32,37 @@ public static class QueueManager
         });
     }
 
+    public static QueueTransitionResult TransitionBlocking(
+        QueueState state,
+        string executionUnit,
+        QueueItemState targetState,
+        string reason,
+        string by,
+        DateTimeOffset ts)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+        ArgumentException.ThrowIfNullOrWhiteSpace(by);
+
+        ValidateBlockingTargetState(targetState);
+        FindItem(state, executionUnit);
+
+        return ApplyTransition(
+            state,
+            executionUnit,
+            targetState,
+            [reason],
+            new RunEvent
+            {
+                Ts = ts,
+                ExecutionUnit = executionUnit,
+                Event = MapBlockingEventName(targetState),
+                By = by,
+                Reason = reason
+            });
+    }
+
     /// <summary>
     /// Transition a queued item to active.
     /// </summary>
@@ -264,6 +295,15 @@ public static class QueueManager
         }
     }
 
+    private static void ValidateBlockingTargetState(QueueItemState targetState)
+    {
+        if (targetState is not (QueueItemState.Blocked or QueueItemState.ClarifyBlocked))
+        {
+            throw new InvalidOperationException(
+                $"Unsupported blocking queue transition target state '{FormatState(targetState)}'.");
+        }
+    }
+
     private static string MapNonBlockingEventName(QueueItemState targetState)
     {
         return targetState switch
@@ -275,6 +315,17 @@ public static class QueueManager
             QueueItemState.Completed => "completed",
             _ => throw new InvalidOperationException(
                 $"Unsupported queue transition target state '{FormatState(targetState)}'.")
+        };
+    }
+
+    private static string MapBlockingEventName(QueueItemState targetState)
+    {
+        return targetState switch
+        {
+            QueueItemState.Blocked => "blocked",
+            QueueItemState.ClarifyBlocked => "clarify-requested",
+            _ => throw new InvalidOperationException(
+                $"Unsupported blocking queue transition target state '{FormatState(targetState)}'.")
         };
     }
 
@@ -314,6 +365,16 @@ public static class QueueManager
     private static QueueTransitionResult ApplyTransition(
         QueueState state, string executionUnit, QueueItemState newState, RunEvent runEvent)
     {
+        return ApplyTransition(state, executionUnit, newState, blockedBy: null, runEvent);
+    }
+
+    private static QueueTransitionResult ApplyTransition(
+        QueueState state,
+        string executionUnit,
+        QueueItemState newState,
+        IReadOnlyList<string>? blockedBy,
+        RunEvent runEvent)
+    {
         var updatedItems = new QueueItem[state.Items.Count];
 
         for (var i = 0; i < state.Items.Count; i++)
@@ -321,7 +382,9 @@ public static class QueueManager
             var item = state.Items[i];
             if (string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal))
             {
-                updatedItems[i] = item with { State = newState };
+                updatedItems[i] = blockedBy is null
+                    ? item with { State = newState }
+                    : item with { State = newState, BlockedBy = blockedBy };
             }
             else
             {

--- a/tests/IntentSystem.Cli.Tests/QueueTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueTransitionCommandTests.cs
@@ -41,6 +41,75 @@ public sealed class QueueTransitionCommandTests
     }
 
     [Fact]
+    public void Execute_GivenBlockedTransitionWithReason_UpdatesBlockedByAndAppendsReasonedRunLog()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """{"ts":"2026-04-03T10:00:00Z","execution_unit":"A1","event":"queued","by":"supervisor"}""" + Environment.NewLine);
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(
+            CreateContext(repoRoot),
+            ["A2", "blocked", "--reason", "waiting on infra approval"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Transitioned A2 to blocked", writer.ToString(), StringComparison.Ordinal);
+
+        var updatedState = QueueStateSerializer.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+        var selectedItem = updatedState.Items.Single(item => item.ExecutionUnit == "A2");
+        Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+        Assert.Equal(["waiting on infra approval"], selectedItem.BlockedBy);
+        Assert.Equal(QueueItemState.Blocked, updatedState.Items.Single(item => item.ExecutionUnit == "B1").State);
+        Assert.Equal(["A2"], updatedState.Items.Single(item => item.ExecutionUnit == "B1").BlockedBy);
+
+        var runEvents = RunLogSerializer.DeserializeAll(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+        Assert.Equal(2, runEvents.Count);
+        Assert.Equal("blocked", runEvents[^1].Event);
+        Assert.Equal("waiting on infra approval", runEvents[^1].Reason);
+    }
+
+    [Fact]
+    public void Execute_GivenClarifyBlockedTransitionWithReason_UpdatesBlockedByAndAppendsReasonedRunLog()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """{"ts":"2026-04-03T10:00:00Z","execution_unit":"A1","event":"queued","by":"supervisor"}""" + Environment.NewLine);
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(
+            CreateContext(repoRoot),
+            ["A2", "clarify-blocked", "--reason", "need product clarification"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Transitioned A2 to clarify-blocked", writer.ToString(), StringComparison.Ordinal);
+
+        var updatedState = QueueStateSerializer.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+        var selectedItem = updatedState.Items.Single(item => item.ExecutionUnit == "A2");
+        Assert.Equal(QueueItemState.ClarifyBlocked, selectedItem.State);
+        Assert.Equal(["need product clarification"], selectedItem.BlockedBy);
+
+        var runEvents = RunLogSerializer.DeserializeAll(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+        Assert.Equal("clarify-requested", runEvents[^1].Event);
+        Assert.Equal("need product clarification", runEvents[^1].Reason);
+    }
+
+    [Fact]
     public void Execute_GivenMissingRunLog_CreatesRunLogFile()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -71,10 +140,69 @@ public sealed class QueueTransitionCommandTests
             QueueStateSerializer.Serialize(CreateQueueState()));
         using var writer = new StringWriter();
 
-        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "blocked"], writer);
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "paused"], writer);
 
         Assert.Equal(1, exitCode);
         Assert.Contains("Supported states", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenBlockingStateWithoutReason_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var queueStateContents = QueueStateSerializer.Serialize(CreateQueueState());
+        tempDirectory.CreateFile(queueStatePath, queueStateContents);
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(runLogPath, string.Empty);
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "blocked"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("require --reason", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(queueStateContents, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenReasonForNonBlockingState_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var queueStateContents = QueueStateSerializer.Serialize(CreateQueueState());
+        tempDirectory.CreateFile(queueStatePath, queueStateContents);
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(runLogPath, string.Empty);
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(
+            CreateContext(repoRoot),
+            ["A2", "completed", "--reason", "not allowed here"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("only supported for blocked and clarify-blocked", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(queueStateContents, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedReasonFlag_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "blocked", "--why", "missing"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("only supports optional '--reason <text>'", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
@@ -259,6 +259,83 @@ public sealed class QueueManagerTests
         Assert.Contains("Unsupported queue transition target state 'blocked'", exception.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void TransitionBlocking_GivenBlockedTarget_UpdatesSelectedItemOnlyAndStoresReason()
+    {
+        var selectedItem = CreateItem("A1", QueueItemState.Active);
+        var otherItem = CreateItem("B1", QueueItemState.Blocked) with
+        {
+            Dependencies = ["A1"],
+            BlockedBy = ["A1"]
+        };
+        var state = CreateState([selectedItem, otherItem]);
+
+        var result = QueueManager.TransitionBlocking(
+            state,
+            "A1",
+            QueueItemState.Blocked,
+            "waiting on infra approval",
+            "intent-cli",
+            BaseTime);
+
+        Assert.Equal(QueueItemState.Blocked, FindItem(result.UpdatedState, "A1").State);
+        Assert.Equal(["waiting on infra approval"], FindItem(result.UpdatedState, "A1").BlockedBy);
+        Assert.Equal(QueueItemState.Blocked, FindItem(result.UpdatedState, "B1").State);
+        Assert.Equal(["A1"], FindItem(result.UpdatedState, "B1").BlockedBy);
+        Assert.Equal("blocked", result.Event.Event);
+        Assert.Equal("waiting on infra approval", result.Event.Reason);
+    }
+
+    [Fact]
+    public void TransitionBlocking_GivenClarifyBlockedTarget_UsesClarifyRequestedEvent()
+    {
+        var state = CreateState(QueueItemState.Review);
+
+        var result = QueueManager.TransitionBlocking(
+            state,
+            "A1",
+            QueueItemState.ClarifyBlocked,
+            "need product clarification",
+            "intent-cli",
+            BaseTime);
+
+        Assert.Equal(QueueItemState.ClarifyBlocked, FindItem(result.UpdatedState, "A1").State);
+        Assert.Equal(["need product clarification"], FindItem(result.UpdatedState, "A1").BlockedBy);
+        Assert.Equal("clarify-requested", result.Event.Event);
+    }
+
+    [Fact]
+    public void TransitionBlocking_GivenNonBlockingTarget_ThrowsInvalidOperationException()
+    {
+        var state = CreateState(QueueItemState.Active);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => QueueManager.TransitionBlocking(
+                state,
+                "A1",
+                QueueItemState.Completed,
+                "reason",
+                "intent-cli",
+                BaseTime));
+
+        Assert.Contains("Unsupported blocking queue transition target state 'completed'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TransitionBlocking_GivenEmptyReason_ThrowsArgumentException()
+    {
+        var state = CreateState(QueueItemState.Active);
+
+        Assert.Throws<ArgumentException>(
+            () => QueueManager.TransitionBlocking(
+                state,
+                "A1",
+                QueueItemState.Blocked,
+                "",
+                "intent-cli",
+                BaseTime));
+    }
+
     private static QueueState CreateState(QueueItemState itemState)
     {
         return CreateState([CreateItem("A1", itemState)]);


### PR DESCRIPTION
## Summary
- extend `intent-cli queue transition` to support `blocked` and `clarify-blocked` targets with mandatory `--reason <text>` validation
- add supervisor-level blocking transition handling that updates only the selected queue item, persists the reason through `blocked_by`, and appends reasoned JSONL run events
- cover CLI validation, selected-item updates, `blocked_by` persistence, and append-only run log behavior with focused CLI and supervisor tests

## Validation
- `dotnet test`

Closes #43
