### PR TITLE
[codex] implement review comment command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -37,7 +37,8 @@ internal static class CommandRouter
             },
             ["review"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
-                ["run"] = ReviewRunCommand.Execute
+                ["run"] = ReviewRunCommand.Execute,
+                ["comment"] = ReviewCommentCommand.Execute
             },
             ["queue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/ReviewCommentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCommentCommand.cs
@@ -1,0 +1,148 @@
+using IntentSystem.Review;
+using IntentSystem.Review.Models;
+using IntentSystem.Review.Serialization;
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class ReviewCommentCommand
+{
+    private const string TransitionActor = "intent-cli";
+
+    public static Func<IReviewCommentPublisher> PublisherFactory { get; set; } = () => new GhReviewCommentPublisher();
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 3
+            || string.IsNullOrWhiteSpace(args[0])
+            || !string.Equals(args[1], "--from-file", StringComparison.Ordinal)
+            || string.IsNullOrWhiteSpace(args[2]))
+        {
+            writer.WriteLine("Review comment command requires an execution unit and '--from-file <path>'.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        var reviewRequestRef = ReviewArtifactPathResolver.Resolve(executionUnit);
+        var reviewRequestPath = Path.Combine(
+            context.RepoRoot,
+            reviewRequestRef.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(reviewRequestPath))
+        {
+            writer.WriteLine($"Review request artifact was not found at {reviewRequestPath}");
+            return 1;
+        }
+
+        var bodyPath = ResolveBodyPath(context.RepoRoot, args[2]);
+        if (!File.Exists(bodyPath))
+        {
+            writer.WriteLine($"Review comment body file was not found at {bodyPath}");
+            return 1;
+        }
+
+        var body = File.ReadAllText(bodyPath);
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            writer.WriteLine("Review comment body file must not be empty.");
+            return 1;
+        }
+
+        try
+        {
+            var request = ReviewRequestSerializer.Deserialize(File.ReadAllText(reviewRequestPath));
+            if (!string.Equals(request.ExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Review request execution unit '{request.ExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
+            }
+
+            if (string.IsNullOrWhiteSpace(request.LinkedPr))
+            {
+                throw new InvalidOperationException("Review request must contain a linked PR.");
+            }
+
+            var commentRef = PublisherFactory().PostComment(request.LinkedPr, body);
+            var artifact = new ReviewCommentArtifact
+            {
+                ExecutionUnit = executionUnit,
+                ReviewRequestRef = reviewRequestRef,
+                LinkedPr = request.LinkedPr,
+                CommentRef = commentRef,
+                BodyPath = bodyPath
+            };
+
+            ReviewCommentArtifactWriter.Write(artifact, executionUnit, context.RepoRoot, overwrite: true);
+
+            var transition = QueueManager.RequestFix(
+                queueState,
+                executionUnit,
+                TransitionActor,
+                TimestampFactory());
+
+            PersistTransition(
+                context,
+                transition with
+                {
+                    Event = transition.Event with
+                    {
+                        LinkedPr = request.LinkedPr,
+                        CommentRef = commentRef
+                    }
+                });
+
+            writer.WriteLine($"Review comment posted for {executionUnit}.");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static string ResolveBodyPath(string repoRoot, string rawPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(rawPath);
+
+        return Path.IsPathRooted(rawPath)
+            ? Path.GetFullPath(rawPath)
+            : Path.GetFullPath(Path.Combine(repoRoot, rawPath));
+    }
+
+    private static void PersistTransition(CliContext context, QueueTransitionResult result)
+    {
+        var queueStatePath = context.GetQueueStatePath();
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
+
+        var runLogPath = context.GetRunLogPath();
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(
+            runLogPath,
+            RunLogSerializer.SerializeLine(result.Event) + Environment.NewLine);
+    }
+}

--- a/src/IntentSystem.Review/GhReviewCommandRunner.cs
+++ b/src/IntentSystem.Review/GhReviewCommandRunner.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics;
+
+namespace IntentSystem.Review;
+
+public sealed class GhReviewCommandRunner : IReviewCommandRunner
+{
+    public ReviewCommandResult Run(IReadOnlyList<string> arguments)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start gh process.");
+        var stdOut = process.StandardOutput.ReadToEnd();
+        var stdErr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        return new ReviewCommandResult
+        {
+            ExitCode = process.ExitCode,
+            StdOut = stdOut,
+            StdErr = stdErr
+        };
+    }
+}

--- a/src/IntentSystem.Review/GhReviewCommentPublisher.cs
+++ b/src/IntentSystem.Review/GhReviewCommentPublisher.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+
+namespace IntentSystem.Review;
+
+public sealed class GhReviewCommentPublisher : IReviewCommentPublisher
+{
+    private readonly IReviewCommandRunner commandRunner;
+
+    public GhReviewCommentPublisher()
+        : this(new GhReviewCommandRunner())
+    {
+    }
+
+    public GhReviewCommentPublisher(IReviewCommandRunner commandRunner)
+    {
+        this.commandRunner = commandRunner ?? throw new ArgumentNullException(nameof(commandRunner));
+    }
+
+    public string PostComment(string linkedPr, string body)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(linkedPr);
+        ArgumentException.ThrowIfNullOrWhiteSpace(body);
+
+        var pullRequest = GitHubPullRequestRef.Parse(linkedPr);
+        var payloadPath = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(payloadPath, JsonSerializer.Serialize(new { body }));
+
+            var result = commandRunner.Run(
+                [
+                    "api",
+                    $"repos/{pullRequest.Owner}/{pullRequest.Repo}/issues/{pullRequest.PullNumber}/comments",
+                    "--method",
+                    "POST",
+                    "--input",
+                    payloadPath
+                ]);
+
+            if (result.ExitCode != 0)
+            {
+                var error = string.IsNullOrWhiteSpace(result.StdErr)
+                    ? "gh api comment post failed."
+                    : result.StdErr.Trim();
+                throw new InvalidOperationException(error);
+            }
+
+            using var document = JsonDocument.Parse(result.StdOut);
+            if (!document.RootElement.TryGetProperty("html_url", out var htmlUrlElement)
+                || string.IsNullOrWhiteSpace(htmlUrlElement.GetString()))
+            {
+                throw new InvalidOperationException("GitHub comment post response must contain html_url.");
+            }
+
+            return htmlUrlElement.GetString()
+                ?? throw new InvalidOperationException("GitHub comment post response html_url was null.");
+        }
+        finally
+        {
+            if (File.Exists(payloadPath))
+            {
+                File.Delete(payloadPath);
+            }
+        }
+    }
+}

--- a/src/IntentSystem.Review/GitHubPullRequestRef.cs
+++ b/src/IntentSystem.Review/GitHubPullRequestRef.cs
@@ -1,0 +1,38 @@
+namespace IntentSystem.Review;
+
+public sealed record GitHubPullRequestRef
+{
+    public required string Owner { get; init; }
+
+    public required string Repo { get; init; }
+
+    public required int PullNumber { get; init; }
+
+    public static GitHubPullRequestRef Parse(string linkedPr)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(linkedPr);
+
+        if (!Uri.TryCreate(linkedPr, UriKind.Absolute, out var uri))
+        {
+            throw new InvalidOperationException($"Linked PR '{linkedPr}' must be an absolute URL.");
+        }
+
+        var segments = uri.AbsolutePath
+            .Trim('/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        if (segments.Length != 4
+            || !string.Equals(segments[2], "pull", StringComparison.Ordinal)
+            || !int.TryParse(segments[3], out var pullNumber))
+        {
+            throw new InvalidOperationException($"Linked PR '{linkedPr}' must use the GitHub pull request URL shape.");
+        }
+
+        return new GitHubPullRequestRef
+        {
+            Owner = segments[0],
+            Repo = segments[1],
+            PullNumber = pullNumber
+        };
+    }
+}

--- a/src/IntentSystem.Review/IReviewCommandRunner.cs
+++ b/src/IntentSystem.Review/IReviewCommandRunner.cs
@@ -1,0 +1,6 @@
+namespace IntentSystem.Review;
+
+public interface IReviewCommandRunner
+{
+    ReviewCommandResult Run(IReadOnlyList<string> arguments);
+}

--- a/src/IntentSystem.Review/IReviewCommentPublisher.cs
+++ b/src/IntentSystem.Review/IReviewCommentPublisher.cs
@@ -1,0 +1,6 @@
+namespace IntentSystem.Review;
+
+public interface IReviewCommentPublisher
+{
+    string PostComment(string linkedPr, string body);
+}

--- a/src/IntentSystem.Review/Models/ReviewCommentArtifact.cs
+++ b/src/IntentSystem.Review/Models/ReviewCommentArtifact.cs
@@ -1,0 +1,14 @@
+namespace IntentSystem.Review.Models;
+
+public sealed record ReviewCommentArtifact
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required string ReviewRequestRef { get; init; }
+
+    public required string LinkedPr { get; init; }
+
+    public required string CommentRef { get; init; }
+
+    public required string BodyPath { get; init; }
+}

--- a/src/IntentSystem.Review/ReviewCommandResult.cs
+++ b/src/IntentSystem.Review/ReviewCommandResult.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Review;
+
+public sealed record ReviewCommandResult
+{
+    public required int ExitCode { get; init; }
+
+    public required string StdOut { get; init; }
+
+    public required string StdErr { get; init; }
+}

--- a/src/IntentSystem.Review/ReviewCommentArtifactPathResolver.cs
+++ b/src/IntentSystem.Review/ReviewCommentArtifactPathResolver.cs
@@ -1,0 +1,13 @@
+namespace IntentSystem.Review;
+
+public static class ReviewCommentArtifactPathResolver
+{
+    private const string ReviewsDirectory = ".intent-cli/reviews";
+
+    public static string Resolve(string executionUnit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        return $"{ReviewsDirectory}/{executionUnit.Trim()}.comment.json";
+    }
+}

--- a/src/IntentSystem.Review/ReviewCommentArtifactWriter.cs
+++ b/src/IntentSystem.Review/ReviewCommentArtifactWriter.cs
@@ -1,0 +1,28 @@
+using IntentSystem.Review.Models;
+using IntentSystem.Review.Serialization;
+
+namespace IntentSystem.Review;
+
+public static class ReviewCommentArtifactWriter
+{
+    public static void Write(ReviewCommentArtifact artifact, string executionUnit, string repoRoot, bool overwrite)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+
+        var relativePath = ReviewCommentArtifactPathResolver.Resolve(executionUnit);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+
+        if (!overwrite && File.Exists(absolutePath))
+        {
+            throw new InvalidOperationException($"Review comment artifact already exists at {absolutePath}.");
+        }
+
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException($"Review comment artifact path '{absolutePath}' did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, ReviewCommentArtifactSerializer.Serialize(artifact));
+    }
+}

--- a/src/IntentSystem.Review/Serialization/ReviewCommentArtifactSerializer.cs
+++ b/src/IntentSystem.Review/Serialization/ReviewCommentArtifactSerializer.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using IntentSystem.Review.Models;
+
+namespace IntentSystem.Review.Serialization;
+
+public static class ReviewCommentArtifactSerializer
+{
+    private static readonly string[] RequiredFields =
+    [
+        "execution_unit",
+        "review_request_ref",
+        "linked_pr",
+        "comment_ref",
+        "body_path"
+    ];
+
+    public static string Serialize(ReviewCommentArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+        return JsonSerializer.Serialize(artifact, ReviewJsonOptions.Indented);
+    }
+
+    public static ReviewCommentArtifact Deserialize(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        using var document = JsonDocument.Parse(json);
+        ValidateRequiredFields(document.RootElement);
+
+        return JsonSerializer.Deserialize<ReviewCommentArtifact>(json, ReviewJsonOptions.Compact)
+            ?? throw new InvalidOperationException("Review comment artifact payload deserialized to null.");
+    }
+
+    private static void ValidateRequiredFields(JsonElement element)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!element.TryGetProperty(field, out _))
+            {
+                throw new InvalidOperationException(
+                    $"Review comment artifact must contain required field '{field}'.");
+            }
+        }
+    }
+}

--- a/src/IntentSystem.Supervisor/Models/RunEvent.cs
+++ b/src/IntentSystem.Supervisor/Models/RunEvent.cs
@@ -14,5 +14,7 @@ public sealed record RunEvent
 
     public string? LinkedPr { get; init; }
 
+    public string? CommentRef { get; init; }
+
     public string? Reason { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1,6 +1,7 @@
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Review;
 using IntentSystem.Review.Serialization;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
@@ -200,6 +201,45 @@ public sealed class CommandRouterTests
         Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/45", artifact.LinkedPr);
     }
 
+    [Fact]
+    public void Execute_GivenReviewCommentCommand_DispatchesToReviewCommentRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateReviewCommentQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G10.request.json"),
+            CreateReviewCommentRequestJson());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "prepared-comment.md"),
+            "repair in place");
+        using var writer = new StringWriter();
+        var originalFactory = ReviewCommentCommand.PublisherFactory;
+        var originalTimestampFactory = ReviewCommentCommand.TimestampFactory;
+
+        try
+        {
+            ReviewCommentCommand.PublisherFactory = () => new FakeReviewCommentPublisher();
+            ReviewCommentCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-04T04:40:00Z");
+
+            var exitCode = CommandRouter.Execute(
+                ["review", "comment", "G10", "--from-file", "prepared-comment.md"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Review comment posted for G10", writer.ToString(), StringComparison.Ordinal);
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "reviews", "G10.comment.json")));
+        }
+        finally
+        {
+            ReviewCommentCommand.PublisherFactory = originalFactory;
+            ReviewCommentCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext
@@ -316,6 +356,36 @@ public sealed class CommandRouterTests
                         Implementation = ".intent-cli/issues/G9/implementation.md",
                         ReviewContext = ".intent-cli/issues/G9/review-context.md",
                         Yaml = ".intent-cli/issues/G9/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
+    private static QueueState CreateReviewCommentQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G10",
+                    Title = "Review comment command",
+                    State = QueueItemState.Review,
+                    Dependencies = ["G9"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G10/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G10/review-context.md",
+                        Yaml = ".intent-cli/issues/G10/packet.yaml"
                     },
                     WorkerRole = "coder",
                     ReviewRole = "reviewer",
@@ -482,6 +552,32 @@ public sealed class CommandRouterTests
         {"ts":"2026-04-03T10:00:00Z","execution_unit":"G9","event":"review-started","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/44"}
         {"ts":"2026-04-03T10:20:00Z","execution_unit":"G9","event":"review-started","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/45"}
         """ + Environment.NewLine;
+    }
+
+    private static string CreateReviewCommentRequestJson()
+    {
+        return """
+        {
+          "execution_unit": "G10",
+          "review_context_ref": ".intent-cli/issues/G10/review-context.md",
+          "linked_pr": "https://github.com/J-Tech-Japan/intent-system/pull/46",
+          "deterministic_review_checks": [
+            "review comment command が deterministic diff review の実行, merge, closeout の責務へ広がっていない"
+          ],
+          "acceptance_criteria": [],
+          "expected_evidence": [
+            "dotnet test IntentSystem.sln"
+          ]
+        }
+        """;
+    }
+
+    private sealed class FakeReviewCommentPublisher : IReviewCommentPublisher
+    {
+        public string PostComment(string linkedPr, string body)
+        {
+            return "https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1";
+        }
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/tests/IntentSystem.Cli.Tests/ReviewCommentCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewCommentCommandTests.cs
@@ -1,0 +1,273 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Review;
+using IntentSystem.Review.Serialization;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ReviewCommentCommandTests
+{
+    [Fact]
+    public void Execute_GivenRequestAndBody_PostsCommentWritesArtifactAndTransitionsToFixing()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var bodyPath = tempDirectory.CreateFile(Path.Combine("repo", "prepared-comment.md"), "repair in place");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G10.request.json"),
+            CreateReviewRequestJson());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """{"ts":"2026-04-03T10:00:00Z","execution_unit":"G10","event":"review-started","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/46"}""" + Environment.NewLine);
+        using var writer = new StringWriter();
+        var publisher = new FakePublisher();
+
+        var originalFactory = ReviewCommentCommand.PublisherFactory;
+        var originalTimestampFactory = ReviewCommentCommand.TimestampFactory;
+
+        try
+        {
+            ReviewCommentCommand.PublisherFactory = () => publisher;
+            ReviewCommentCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-04T04:40:00Z");
+
+            var exitCode = ReviewCommentCommand.Execute(
+                CreateContext(repoRoot),
+                ["G10", "--from-file", "prepared-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/46", publisher.LinkedPr);
+            Assert.Equal("repair in place", publisher.Body);
+            Assert.Contains("Review comment posted for G10", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = ReviewCommentArtifactSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "reviews", "G10.comment.json")));
+            Assert.Equal("G10", artifact.ExecutionUnit);
+            Assert.Equal(".intent-cli/reviews/G10.request.json", artifact.ReviewRequestRef);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/46", artifact.LinkedPr);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1", artifact.CommentRef);
+            Assert.Equal(Path.GetFullPath(bodyPath), artifact.BodyPath);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Fixing, queueState.Items.Single(item => item.ExecutionUnit == "G10").State);
+            Assert.Equal(QueueItemState.Blocked, queueState.Items.Single(item => item.ExecutionUnit == "B1").State);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal(2, runEvents.Count);
+            Assert.Equal("fix-requested", runEvents[^1].Event);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/46", runEvents[^1].LinkedPr);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1", runEvents[^1].CommentRef);
+        }
+        finally
+        {
+            ReviewCommentCommand.PublisherFactory = originalFactory;
+            ReviewCommentCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingRequestArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(Path.Combine("repo", "prepared-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+
+        var exitCode = ReviewCommentCommand.Execute(
+            CreateContext(repoRoot),
+            ["G10", "--from-file", "prepared-comment.md"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Review request artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenEmptyBodyFile_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G10.request.json"),
+            CreateReviewRequestJson());
+        tempDirectory.CreateFile(Path.Combine("repo", "prepared-comment.md"), "   ");
+        using var writer = new StringWriter();
+
+        var exitCode = ReviewCommentCommand.Execute(
+            CreateContext(repoRoot),
+            ["G10", "--from-file", "prepared-comment.md"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must not be empty", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingLinkedPrInRequest_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var queueStateContents = QueueStateSerializer.Serialize(CreateQueueState());
+        tempDirectory.CreateFile(queueStatePath, queueStateContents);
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(runLogPath, string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G10.request.json"),
+            """
+            {
+              "execution_unit": "G10",
+              "review_context_ref": ".intent-cli/issues/G10/review-context.md",
+              "deterministic_review_checks": [],
+              "acceptance_criteria": [],
+              "expected_evidence": []
+            }
+            """);
+        tempDirectory.CreateFile(Path.Combine("repo", "prepared-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+
+        var exitCode = ReviewCommentCommand.Execute(
+            CreateContext(repoRoot),
+            ["G10", "--from-file", "prepared-comment.md"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("linked_pr", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(queueStateContents, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                CreateItem("G10", QueueItemState.Review),
+                CreateItem("B1", QueueItemState.Blocked) with
+                {
+                    Dependencies = ["G10"],
+                    BlockedBy = ["G10"]
+                }
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Review Item",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static string CreateReviewRequestJson()
+    {
+        return """
+        {
+          "execution_unit": "G10",
+          "review_context_ref": ".intent-cli/issues/G10/review-context.md",
+          "linked_pr": "https://github.com/J-Tech-Japan/intent-system/pull/46",
+          "deterministic_review_checks": [
+            "review comment command が deterministic diff review の実行, merge, closeout の責務へ広がっていない"
+          ],
+          "acceptance_criteria": [],
+          "expected_evidence": [
+            "dotnet test IntentSystem.sln"
+          ]
+        }
+        """;
+    }
+
+    private sealed class FakePublisher : IReviewCommentPublisher
+    {
+        public string LinkedPr { get; private set; } = string.Empty;
+
+        public string Body { get; private set; } = string.Empty;
+
+        public string PostComment(string linkedPr, string body)
+        {
+            LinkedPr = linkedPr;
+            Body = body;
+            return "https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1";
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-review-comment-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Review.Tests/GhReviewCommentPublisherTests.cs
+++ b/tests/IntentSystem.Review.Tests/GhReviewCommentPublisherTests.cs
@@ -1,0 +1,55 @@
+namespace IntentSystem.Review.Tests;
+
+public sealed class GhReviewCommentPublisherTests
+{
+    [Fact]
+    public void PostComment_GivenLinkedPrAndBody_PostsViaGhApiAndReturnsHtmlUrl()
+    {
+        var runner = new FakeRunner();
+        var publisher = new GhReviewCommentPublisher(runner);
+
+        var commentRef = publisher.PostComment(
+            "https://github.com/J-Tech-Japan/intent-system/pull/46",
+            "repair in place");
+
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1", commentRef);
+        Assert.Equal(
+            "repos/J-Tech-Japan/intent-system/issues/46/comments",
+            runner.Arguments[1]);
+        Assert.Equal("POST", runner.Arguments[3]);
+        Assert.Contains("\"body\":\"repair in place\"", runner.PayloadJson, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_GivenInvalidPullRequestUrl_ThrowsInvalidOperationException()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => GitHubPullRequestRef.Parse("https://github.com/J-Tech-Japan/intent-system/issues/46"));
+
+        Assert.Contains("pull request URL shape", exception.Message, StringComparison.Ordinal);
+    }
+
+    private sealed class FakeRunner : IReviewCommandRunner
+    {
+        public IReadOnlyList<string> Arguments { get; private set; } = [];
+
+        public string PayloadJson { get; private set; } = string.Empty;
+
+        public ReviewCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            Arguments = arguments.ToArray();
+            var payloadIndex = Arguments
+                .Select((argument, index) => (argument, index))
+                .First(item => string.Equals(item.argument, "--input", StringComparison.Ordinal))
+                .index + 1;
+            PayloadJson = File.ReadAllText(Arguments[payloadIndex]);
+
+            return new ReviewCommandResult
+            {
+                ExitCode = 0,
+                StdOut = """{"html_url":"https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1"}""",
+                StdErr = string.Empty
+            };
+        }
+    }
+}

--- a/tests/IntentSystem.Review.Tests/ReviewCommentArtifactSerializerTests.cs
+++ b/tests/IntentSystem.Review.Tests/ReviewCommentArtifactSerializerTests.cs
@@ -1,0 +1,48 @@
+using IntentSystem.Review.Models;
+using IntentSystem.Review.Serialization;
+
+namespace IntentSystem.Review.Tests;
+
+public sealed class ReviewCommentArtifactSerializerTests
+{
+    [Fact]
+    public void Serialize_GivenArtifact_WritesCurrentFieldShape()
+    {
+        var serialized = ReviewCommentArtifactSerializer.Serialize(CreateArtifact());
+
+        Assert.Contains("\"execution_unit\": \"G10\"", serialized, StringComparison.Ordinal);
+        Assert.Contains("\"review_request_ref\": \".intent-cli/reviews/G10.request.json\"", serialized, StringComparison.Ordinal);
+        Assert.Contains("\"linked_pr\": \"https://github.com/J-Tech-Japan/intent-system/pull/46\"", serialized, StringComparison.Ordinal);
+        Assert.Contains("\"comment_ref\": \"https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1\"", serialized, StringComparison.Ordinal);
+        Assert.Contains("\"body_path\": \"/tmp/G10-comment.md\"", serialized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_ThrowsInvalidOperationException()
+    {
+        var json = """
+        {
+          "execution_unit": "G10",
+          "review_request_ref": ".intent-cli/reviews/G10.request.json",
+          "linked_pr": "https://github.com/J-Tech-Japan/intent-system/pull/46",
+          "comment_ref": "https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1"
+        }
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => ReviewCommentArtifactSerializer.Deserialize(json));
+
+        Assert.Contains("body_path", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static ReviewCommentArtifact CreateArtifact()
+    {
+        return new ReviewCommentArtifact
+        {
+            ExecutionUnit = "G10",
+            ReviewRequestRef = ".intent-cli/reviews/G10.request.json",
+            LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/46",
+            CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1",
+            BodyPath = "/tmp/G10-comment.md"
+        };
+    }
+}

--- a/tests/IntentSystem.Review.Tests/ReviewCommentArtifactWriterTests.cs
+++ b/tests/IntentSystem.Review.Tests/ReviewCommentArtifactWriterTests.cs
@@ -1,0 +1,59 @@
+using IntentSystem.Review.Models;
+using IntentSystem.Review.Serialization;
+
+namespace IntentSystem.Review.Tests;
+
+public sealed class ReviewCommentArtifactWriterTests
+{
+    [Fact]
+    public void Resolve_GivenExecutionUnit_UsesCommentJsonBaselinePath()
+    {
+        Assert.Equal(".intent-cli/reviews/G10.comment.json", ReviewCommentArtifactPathResolver.Resolve("G10"));
+    }
+
+    [Fact]
+    public void Write_GivenArtifact_WritesSerializedArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var artifact = CreateArtifact();
+
+        ReviewCommentArtifactWriter.Write(artifact, "G10", repoRoot, overwrite: false);
+
+        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "reviews", "G10.comment.json");
+        Assert.True(File.Exists(artifactPath));
+        Assert.Equal(ReviewCommentArtifactSerializer.Serialize(artifact), File.ReadAllText(artifactPath));
+    }
+
+    private static ReviewCommentArtifact CreateArtifact()
+    {
+        return new ReviewCommentArtifact
+        {
+            ExecutionUnit = "G10",
+            ReviewRequestRef = ".intent-cli/reviews/G10.request.json",
+            LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/46",
+            CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1",
+            BodyPath = "/tmp/G10-comment.md"
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-review-comment-writer-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Supervisor.Tests/RunLogSerializerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/RunLogSerializerTests.cs
@@ -20,6 +20,7 @@ public sealed class RunLogSerializerTests
         Assert.Equal("supervisor", runEvent.By);
         Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/7", runEvent.LinkedIssue);
         Assert.Null(runEvent.LinkedPr);
+        Assert.Null(runEvent.CommentRef);
         Assert.Null(runEvent.Reason);
     }
 
@@ -59,6 +60,19 @@ public sealed class RunLogSerializerTests
     }
 
     [Fact]
+    public void DeserializeLine_GivenCommentRef_ReadsCommentRef()
+    {
+        var line =
+            """{"ts":"2026-04-02T10:00:13Z","execution_unit":"B1","event":"fix-requested","by":"reviewer","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1"}""";
+
+        var runEvent = RunLogSerializer.DeserializeLine(line);
+
+        Assert.Equal(
+            "https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1",
+            runEvent.CommentRef);
+    }
+
+    [Fact]
     public void SerializeLine_GivenNullOptionalFields_OmitsThemFromCompactJson()
     {
         var runEvent = new RunEvent
@@ -78,6 +92,7 @@ public sealed class RunLogSerializerTests
         Assert.True(document.RootElement.TryGetProperty("by", out _));
         Assert.False(document.RootElement.TryGetProperty("linked_issue", out _));
         Assert.False(document.RootElement.TryGetProperty("linked_pr", out _));
+        Assert.False(document.RootElement.TryGetProperty("comment_ref", out _));
         Assert.False(document.RootElement.TryGetProperty("reason", out _));
         Assert.DoesNotContain("\n", serialized, StringComparison.Ordinal);
     }


### PR DESCRIPTION
## Summary
- add `intent-cli review comment <execution-unit> --from-file <path>` to read the current review request artifact and prepared body file, post a repair-in-place PR comment, and write `.intent-cli/reviews/<execution-unit>.comment.json`
- extend the review module with GitHub PR comment posting, comment artifact serialization/writing, and pull-request URL parsing while keeping deterministic review execution out of scope
- update the successful path to move only the selected queue item back to `fixing` and append a `fix-requested` run-log event carrying the posted `comment_ref`

## Validation
- `dotnet test`

Closes #47
