### PR TITLE
[G12] Review Accept Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -38,7 +38,8 @@ internal static class CommandRouter
             ["review"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["run"] = ReviewRunCommand.Execute,
-                ["comment"] = ReviewCommentCommand.Execute
+                ["comment"] = ReviewCommentCommand.Execute,
+                ["accept"] = ReviewAcceptCommand.Execute
             },
             ["queue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/ReviewAcceptCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewAcceptCommand.cs
@@ -1,0 +1,151 @@
+using IntentSystem.Projection.Serialization;
+using IntentSystem.Review;
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class ReviewAcceptCommand
+{
+    private const string TransitionActor = "intent-cli";
+
+    public static Func<IReviewAcceptClient> AcceptClientFactory { get; set; } = () => new GhReviewAcceptClient();
+
+    public static Func<IGitCommandRunner> GitCommandRunnerFactory { get; set; } = () => new GitCommandRunner();
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Review accept command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            writer.WriteLine($"Run log was not found at {runLogPath}");
+            return 1;
+        }
+
+        var packetPath = Path.Combine(
+            context.RepoRoot,
+            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(packetPath))
+        {
+            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
+            return 1;
+        }
+
+        try
+        {
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            var linkedPr = LatestLinkedPrResolver.Resolve(runEvents, executionUnit);
+            var linkedIssue = LatestLinkedIssueResolver.Resolve(runEvents, executionUnit);
+            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+            var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
+            if (string.IsNullOrWhiteSpace(childRepoRef))
+            {
+                throw new InvalidOperationException("Projection packet must contain a target repo.");
+            }
+
+            var acceptClient = AcceptClientFactory();
+            var mergedCommitSha = acceptClient.MergePullRequest(linkedPr);
+            acceptClient.CloseIssue(linkedIssue);
+
+            var gitRunner = GitCommandRunnerFactory();
+            ChildRepoMainSynchronizer.Sync(context.RepoRoot, childRepoRef, mergedCommitSha, gitRunner);
+            ParentSubmodulePointerUpdater.Stage(context.RepoRoot, childRepoRef, gitRunner);
+
+            var timestamp = TimestampFactory();
+            var transition = QueueManager.AcceptReview(queueState, executionUnit, TransitionActor, timestamp);
+            PersistCloseout(
+                context,
+                transition.UpdatedState,
+                CreateCloseoutEvents(executionUnit, linkedPr, linkedIssue, timestamp));
+
+            writer.WriteLine($"Review accepted for {executionUnit}.");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static IReadOnlyList<RunEvent> CreateCloseoutEvents(
+        string executionUnit,
+        string linkedPr,
+        string linkedIssue,
+        DateTimeOffset timestamp)
+    {
+        return
+        [
+            new RunEvent
+            {
+                Ts = timestamp,
+                ExecutionUnit = executionUnit,
+                Event = "pr-merged",
+                By = TransitionActor,
+                LinkedPr = linkedPr
+            },
+            new RunEvent
+            {
+                Ts = timestamp,
+                ExecutionUnit = executionUnit,
+                Event = "issue-closed",
+                By = TransitionActor,
+                LinkedIssue = linkedIssue
+            },
+            new RunEvent
+            {
+                Ts = timestamp,
+                ExecutionUnit = executionUnit,
+                Event = "completed",
+                By = TransitionActor
+            }
+        ];
+    }
+
+    private static void PersistCloseout(CliContext context, QueueState updatedState, IReadOnlyList<RunEvent> events)
+    {
+        var queueStatePath = context.GetQueueStatePath();
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+
+        var runLogPath = context.GetRunLogPath();
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+
+        foreach (var runEvent in events)
+        {
+            File.AppendAllText(
+                runLogPath,
+                RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
+        }
+    }
+}

--- a/src/IntentSystem.Review/ChildRepoMainSynchronizer.cs
+++ b/src/IntentSystem.Review/ChildRepoMainSynchronizer.cs
@@ -1,0 +1,55 @@
+namespace IntentSystem.Review;
+
+public static class ChildRepoMainSynchronizer
+{
+    public static void Sync(string parentRepoRoot, string childRepoRef, string mergedCommitSha, IGitCommandRunner commandRunner)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(parentRepoRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(childRepoRef);
+        ArgumentException.ThrowIfNullOrWhiteSpace(mergedCommitSha);
+        ArgumentNullException.ThrowIfNull(commandRunner);
+
+        var childRepoPath = ResolveChildRepoPath(parentRepoRoot, childRepoRef);
+        if (!Directory.Exists(childRepoPath))
+        {
+            throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+        }
+
+        Run(commandRunner, childRepoPath, ["fetch", "origin", "main"], "child repo fetch failed.");
+        Run(commandRunner, childRepoPath, ["switch", "main"], "child repo switch to main failed.");
+        Run(commandRunner, childRepoPath, ["merge", "--ff-only", "origin/main"], "child repo main fast-forward failed.");
+
+        var headResult = Run(commandRunner, childRepoPath, ["rev-parse", "HEAD"], "child repo HEAD resolve failed.");
+        var headCommit = headResult.StdOut.Trim();
+        if (!string.Equals(headCommit, mergedCommitSha, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Child repo main HEAD '{headCommit}' must match merged commit '{mergedCommitSha}'.");
+        }
+    }
+
+    public static string ResolveChildRepoPath(string parentRepoRoot, string childRepoRef)
+    {
+        return Path.IsPathRooted(childRepoRef)
+            ? Path.GetFullPath(childRepoRef)
+            : Path.GetFullPath(Path.Combine(parentRepoRoot, childRepoRef));
+    }
+
+    private static GitCommandResult Run(
+        IGitCommandRunner commandRunner,
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        string defaultError)
+    {
+        var result = commandRunner.Run(workingDirectory, arguments);
+        if (result.ExitCode != 0)
+        {
+            var error = string.IsNullOrWhiteSpace(result.StdErr)
+                ? defaultError
+                : result.StdErr.Trim();
+            throw new InvalidOperationException(error);
+        }
+
+        return result;
+    }
+}

--- a/src/IntentSystem.Review/GhReviewAcceptClient.cs
+++ b/src/IntentSystem.Review/GhReviewAcceptClient.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+
+namespace IntentSystem.Review;
+
+public sealed class GhReviewAcceptClient : IReviewAcceptClient
+{
+    private readonly IReviewCommandRunner commandRunner;
+
+    public GhReviewAcceptClient()
+        : this(new GhReviewCommandRunner())
+    {
+    }
+
+    public GhReviewAcceptClient(IReviewCommandRunner commandRunner)
+    {
+        this.commandRunner = commandRunner ?? throw new ArgumentNullException(nameof(commandRunner));
+    }
+
+    public string MergePullRequest(string linkedPr)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(linkedPr);
+
+        var pullRequest = GitHubPullRequestRef.Parse(linkedPr);
+        var result = commandRunner.Run(
+            [
+                "api",
+                $"repos/{pullRequest.Owner}/{pullRequest.Repo}/pulls/{pullRequest.PullNumber}/merge",
+                "--method",
+                "PUT",
+                "-f",
+                "merge_method=merge"
+            ]);
+
+        if (result.ExitCode != 0)
+        {
+            var error = string.IsNullOrWhiteSpace(result.StdErr)
+                ? "gh api pull request merge failed."
+                : result.StdErr.Trim();
+            throw new InvalidOperationException(error);
+        }
+
+        using var document = JsonDocument.Parse(result.StdOut);
+        if (!document.RootElement.TryGetProperty("sha", out var shaElement)
+            || string.IsNullOrWhiteSpace(shaElement.GetString()))
+        {
+            throw new InvalidOperationException("GitHub pull request merge response must contain sha.");
+        }
+
+        return shaElement.GetString()
+            ?? throw new InvalidOperationException("GitHub pull request merge response sha was null.");
+    }
+
+    public void CloseIssue(string linkedIssue)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(linkedIssue);
+
+        var issue = GitHubIssueRef.Parse(linkedIssue);
+        var result = commandRunner.Run(
+            [
+                "api",
+                $"repos/{issue.Owner}/{issue.Repo}/issues/{issue.IssueNumber}",
+                "--method",
+                "PATCH",
+                "-f",
+                "state=closed"
+            ]);
+
+        if (result.ExitCode != 0)
+        {
+            var error = string.IsNullOrWhiteSpace(result.StdErr)
+                ? "gh api issue close failed."
+                : result.StdErr.Trim();
+            throw new InvalidOperationException(error);
+        }
+    }
+}

--- a/src/IntentSystem.Review/GitCommandResult.cs
+++ b/src/IntentSystem.Review/GitCommandResult.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Review;
+
+public sealed record GitCommandResult
+{
+    public required int ExitCode { get; init; }
+
+    public required string StdOut { get; init; }
+
+    public required string StdErr { get; init; }
+}

--- a/src/IntentSystem.Review/GitCommandRunner.cs
+++ b/src/IntentSystem.Review/GitCommandRunner.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+
+namespace IntentSystem.Review;
+
+public sealed class GitCommandRunner : IGitCommandRunner
+{
+    public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start git process.");
+        var stdOut = process.StandardOutput.ReadToEnd();
+        var stdErr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        return new GitCommandResult
+        {
+            ExitCode = process.ExitCode,
+            StdOut = stdOut,
+            StdErr = stdErr
+        };
+    }
+}

--- a/src/IntentSystem.Review/GitHubIssueRef.cs
+++ b/src/IntentSystem.Review/GitHubIssueRef.cs
@@ -1,0 +1,38 @@
+namespace IntentSystem.Review;
+
+public sealed record GitHubIssueRef
+{
+    public required string Owner { get; init; }
+
+    public required string Repo { get; init; }
+
+    public required int IssueNumber { get; init; }
+
+    public static GitHubIssueRef Parse(string linkedIssue)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(linkedIssue);
+
+        if (!Uri.TryCreate(linkedIssue, UriKind.Absolute, out var uri))
+        {
+            throw new InvalidOperationException($"Linked issue '{linkedIssue}' must be an absolute URL.");
+        }
+
+        var segments = uri.AbsolutePath
+            .Trim('/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        if (segments.Length != 4
+            || !string.Equals(segments[2], "issues", StringComparison.Ordinal)
+            || !int.TryParse(segments[3], out var issueNumber))
+        {
+            throw new InvalidOperationException($"Linked issue '{linkedIssue}' must use the GitHub issue URL shape.");
+        }
+
+        return new GitHubIssueRef
+        {
+            Owner = segments[0],
+            Repo = segments[1],
+            IssueNumber = issueNumber
+        };
+    }
+}

--- a/src/IntentSystem.Review/IGitCommandRunner.cs
+++ b/src/IntentSystem.Review/IGitCommandRunner.cs
@@ -1,0 +1,6 @@
+namespace IntentSystem.Review;
+
+public interface IGitCommandRunner
+{
+    GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments);
+}

--- a/src/IntentSystem.Review/IReviewAcceptClient.cs
+++ b/src/IntentSystem.Review/IReviewAcceptClient.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Review;
+
+public interface IReviewAcceptClient
+{
+    string MergePullRequest(string linkedPr);
+
+    void CloseIssue(string linkedIssue);
+}

--- a/src/IntentSystem.Review/LatestLinkedIssueResolver.cs
+++ b/src/IntentSystem.Review/LatestLinkedIssueResolver.cs
@@ -1,0 +1,31 @@
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Review;
+
+public static class LatestLinkedIssueResolver
+{
+    public static string Resolve(IReadOnlyList<RunEvent> runEvents, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(runEvents);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        string? latestLinkedIssue = null;
+
+        foreach (var runEvent in runEvents)
+        {
+            if (!string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(runEvent.LinkedIssue))
+            {
+                latestLinkedIssue = runEvent.LinkedIssue;
+            }
+        }
+
+        return latestLinkedIssue
+            ?? throw new InvalidOperationException(
+                $"No linked issue found for execution unit '{executionUnit}' in run log.");
+    }
+}

--- a/src/IntentSystem.Review/ParentSubmodulePointerUpdater.cs
+++ b/src/IntentSystem.Review/ParentSubmodulePointerUpdater.cs
@@ -1,0 +1,26 @@
+namespace IntentSystem.Review;
+
+public static class ParentSubmodulePointerUpdater
+{
+    public static void Stage(string parentRepoRoot, string childRepoRef, IGitCommandRunner commandRunner)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(parentRepoRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(childRepoRef);
+        ArgumentNullException.ThrowIfNull(commandRunner);
+
+        var childRepoPath = ChildRepoMainSynchronizer.ResolveChildRepoPath(parentRepoRoot, childRepoRef);
+        if (!Directory.Exists(childRepoPath))
+        {
+            throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+        }
+
+        var result = commandRunner.Run(parentRepoRoot, ["add", childRepoRef]);
+        if (result.ExitCode != 0)
+        {
+            var error = string.IsNullOrWhiteSpace(result.StdErr)
+                ? "parent submodule pointer stage failed."
+                : result.StdErr.Trim();
+            throw new InvalidOperationException(error);
+        }
+    }
+}

--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -230,6 +230,28 @@ public static class QueueManager
     }
 
     /// <summary>
+    /// Accept a reviewed item as completed without mutating dependent items.
+    /// </summary>
+    public static QueueTransitionResult AcceptReview(
+        QueueState state, string executionUnit, string by, DateTimeOffset ts)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(by);
+
+        var item = FindItem(state, executionUnit);
+        AssertState(item, QueueItemState.Review, "accept-review");
+
+        return ApplyTransition(state, executionUnit, QueueItemState.Completed, new RunEvent
+        {
+            Ts = ts,
+            ExecutionUnit = executionUnit,
+            Event = "completed",
+            By = by
+        });
+    }
+
+    /// <summary>
     /// Recalculates blocked/queued states for all items based on current dependency resolution.
     /// Items whose dependencies are all completed move from blocked to queued.
     /// </summary>

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -240,6 +240,45 @@ public sealed class CommandRouterTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenReviewAcceptCommand_DispatchesToReviewAcceptRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateReviewAcceptQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G12", "packet.yaml"),
+            CreateReviewAcceptPacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateReviewAcceptRunLog());
+        using var writer = new StringWriter();
+        var originalClientFactory = ReviewAcceptCommand.AcceptClientFactory;
+        var originalGitFactory = ReviewAcceptCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = ReviewAcceptCommand.TimestampFactory;
+
+        try
+        {
+            ReviewAcceptCommand.AcceptClientFactory = () => new FakeReviewAcceptClient();
+            ReviewAcceptCommand.GitCommandRunnerFactory = () => new FakeReviewAcceptGitRunner();
+            ReviewAcceptCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T01:02:03Z");
+
+            var exitCode = CommandRouter.Execute(["review", "accept", "G12"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Review accepted for G12", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            ReviewAcceptCommand.AcceptClientFactory = originalClientFactory;
+            ReviewAcceptCommand.GitCommandRunnerFactory = originalGitFactory;
+            ReviewAcceptCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext
@@ -386,6 +425,36 @@ public sealed class CommandRouterTests
                         Implementation = ".intent-cli/issues/G10/implementation.md",
                         ReviewContext = ".intent-cli/issues/G10/review-context.md",
                         Yaml = ".intent-cli/issues/G10/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
+    private static QueueState CreateReviewAcceptQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G12",
+                    Title = "Review accept command",
+                    State = QueueItemState.Review,
+                    Dependencies = ["G10"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G12/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G12/review-context.md",
+                        Yaml = ".intent-cli/issues/G12/packet.yaml"
                     },
                     WorkerRole = "coder",
                     ReviewRole = "reviewer",
@@ -572,11 +641,96 @@ public sealed class CommandRouterTests
         """;
     }
 
+    private static string CreateReviewAcceptPacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G12] Review Accept Command"
+          issue_kind: "feature"
+          source_execution_unit: "G12"
+          goal: "Close out accepted review."
+          in_scope:
+            - "review accept command"
+          out_of_scope:
+            - "review comment"
+          target_repo: "submodules/child-repo"
+          target_path: "."
+          target_part: "cli review accept command"
+          dependencies:
+            - "G10"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "closeout stays thin"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/issue-lifecycle-and-landing.md"
+          acceptance_criteria:
+            - "review accept merges and closes"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+        
+        review_context_packet:
+          source_execution_unit: "G12"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/issue-lifecycle-and-landing.md"
+          acceptance_criteria:
+            - "review accept merges and closes"
+          deterministic_review_checks:
+            - "selected item only"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private static string CreateReviewAcceptRunLog()
+    {
+        return """
+        {"ts":"2026-04-03T10:00:00Z","execution_unit":"G12","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/51"}
+        {"ts":"2026-04-03T10:10:00Z","execution_unit":"G12","event":"review-started","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/52"}
+        """ + Environment.NewLine;
+    }
+
     private sealed class FakeReviewCommentPublisher : IReviewCommentPublisher
     {
         public string PostComment(string linkedPr, string body)
         {
             return "https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1";
+        }
+    }
+
+    private sealed class FakeReviewAcceptClient : IReviewAcceptClient
+    {
+        public string MergePullRequest(string linkedPr)
+        {
+            return "abc123";
+        }
+
+        public void CloseIssue(string linkedIssue)
+        {
+        }
+    }
+
+    private sealed class FakeReviewAcceptGitRunner : IGitCommandRunner
+    {
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = arguments.SequenceEqual(["rev-parse", "HEAD"])
+                    ? "abc123" + Environment.NewLine
+                    : string.Empty,
+                StdErr = string.Empty
+            };
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/ReviewAcceptCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewAcceptCommandTests.cs
@@ -1,0 +1,410 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Review;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ReviewAcceptCommandTests
+{
+    [Fact]
+    public void Execute_GivenCloseoutInputs_MergesClosesSyncsStagesAndCompletesSelectedItem()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G12", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+        var client = new FakeAcceptClient();
+        var gitRunner = new FakeGitRunner(headCommit: "abc123");
+
+        var originalClientFactory = ReviewAcceptCommand.AcceptClientFactory;
+        var originalGitFactory = ReviewAcceptCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = ReviewAcceptCommand.TimestampFactory;
+
+        try
+        {
+            ReviewAcceptCommand.AcceptClientFactory = () => client;
+            ReviewAcceptCommand.GitCommandRunnerFactory = () => gitRunner;
+            ReviewAcceptCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T01:02:03Z");
+
+            var exitCode = ReviewAcceptCommand.Execute(CreateContext(repoRoot), ["G12"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Review accepted for G12", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/52", client.LinkedPr);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/51", client.LinkedIssue);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Completed, queueState.Items.Single(item => item.ExecutionUnit == "G12").State);
+            Assert.Equal(QueueItemState.Blocked, queueState.Items.Single(item => item.ExecutionUnit == "B1").State);
+            Assert.Equal(["G12"], queueState.Items.Single(item => item.ExecutionUnit == "B1").BlockedBy);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal(5, runEvents.Count);
+            Assert.Equal("pr-merged", runEvents[^3].Event);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/52", runEvents[^3].LinkedPr);
+            Assert.Equal("issue-closed", runEvents[^2].Event);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/51", runEvents[^2].LinkedIssue);
+            Assert.Equal("completed", runEvents[^1].Event);
+
+            var childRepoPath = Path.Combine(repoRoot, "submodules", "child-repo");
+            Assert.Equal(
+                [
+                    $"{childRepoPath}::fetch origin main",
+                    $"{childRepoPath}::switch main",
+                    $"{childRepoPath}::merge --ff-only origin/main",
+                    $"{childRepoPath}::rev-parse HEAD",
+                    $"{repoRoot}::add submodules/child-repo"
+                ],
+                gitRunner.Calls);
+        }
+        finally
+        {
+            ReviewAcceptCommand.AcceptClientFactory = originalClientFactory;
+            ReviewAcceptCommand.GitCommandRunnerFactory = originalGitFactory;
+            ReviewAcceptCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingLinkedIssue_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-03T10:00:00Z","execution_unit":"G12","event":"review-started","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/52"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G12", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = ReviewAcceptCommand.Execute(CreateContext(repoRoot), ["G12"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("No linked issue found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingLinkedPr_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-03T10:00:00Z","execution_unit":"G12","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/51"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G12", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = ReviewAcceptCommand.Execute(CreateContext(repoRoot), ["G12"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("No linked PR found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMergeFailure_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G12", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalClientFactory = ReviewAcceptCommand.AcceptClientFactory;
+
+        try
+        {
+            ReviewAcceptCommand.AcceptClientFactory = () => new FakeAcceptClient
+            {
+                MergeException = new InvalidOperationException("merge failed")
+            };
+
+            var originalQueueState = File.ReadAllText(queueStatePath);
+            var originalRunLog = File.ReadAllText(runLogPath);
+            var exitCode = ReviewAcceptCommand.Execute(CreateContext(repoRoot), ["G12"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("merge failed", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            ReviewAcceptCommand.AcceptClientFactory = originalClientFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenChildSyncFailure_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G12", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalClientFactory = ReviewAcceptCommand.AcceptClientFactory;
+        var originalGitFactory = ReviewAcceptCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            ReviewAcceptCommand.AcceptClientFactory = () => new FakeAcceptClient();
+            ReviewAcceptCommand.GitCommandRunnerFactory = () => new FakeGitRunner(headCommit: "def456");
+
+            var originalQueueState = File.ReadAllText(queueStatePath);
+            var originalRunLog = File.ReadAllText(runLogPath);
+            var exitCode = ReviewAcceptCommand.Execute(CreateContext(repoRoot), ["G12"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("must match merged commit", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            ReviewAcceptCommand.AcceptClientFactory = originalClientFactory;
+            ReviewAcceptCommand.GitCommandRunnerFactory = originalGitFactory;
+        }
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                CreateItem("G12", QueueItemState.Review),
+                CreateItem("B1", QueueItemState.Blocked) with
+                {
+                    Dependencies = ["G12"],
+                    BlockedBy = ["G12"]
+                }
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Review Accept",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static string CreateRunLog()
+    {
+        return """
+        {"ts":"2026-04-03T10:00:00Z","execution_unit":"G12","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/51"}
+        {"ts":"2026-04-03T10:10:00Z","execution_unit":"G12","event":"review-started","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/52"}
+        """ + Environment.NewLine;
+    }
+
+    private static string CreatePacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G12] Review Accept Command"
+          issue_kind: "feature"
+          source_execution_unit: "G12"
+          goal: "Close out accepted review."
+          in_scope:
+            - "review accept command"
+          out_of_scope:
+            - "review comment"
+          target_repo: "submodules/child-repo"
+          target_path: "."
+          target_part: "cli review accept command"
+          dependencies:
+            - "G10"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "closeout stays thin"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/issue-lifecycle-and-landing.md"
+          acceptance_criteria:
+            - "review accept merges and closes"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+        
+        review_context_packet:
+          source_execution_unit: "G12"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/issue-lifecycle-and-landing.md"
+          acceptance_criteria:
+            - "review accept merges and closes"
+          deterministic_review_checks:
+            - "selected item only"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private sealed class FakeAcceptClient : IReviewAcceptClient
+    {
+        public string LinkedPr { get; private set; } = string.Empty;
+
+        public string LinkedIssue { get; private set; } = string.Empty;
+
+        public Exception? MergeException { get; init; }
+
+        public string MergePullRequest(string linkedPr)
+        {
+            if (MergeException is not null)
+            {
+                throw MergeException;
+            }
+
+            LinkedPr = linkedPr;
+            return "abc123";
+        }
+
+        public void CloseIssue(string linkedIssue)
+        {
+            LinkedIssue = linkedIssue;
+        }
+    }
+
+    private sealed class FakeGitRunner(string headCommit) : IGitCommandRunner
+    {
+        public List<string> Calls { get; } = [];
+
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Calls.Add($"{workingDirectory}::{string.Join(' ', arguments)}");
+
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = arguments.SequenceEqual(["rev-parse", "HEAD"])
+                    ? headCommit + Environment.NewLine
+                    : string.Empty,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-review-accept-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Review.Tests/ChildRepoMainSynchronizerTests.cs
+++ b/tests/IntentSystem.Review.Tests/ChildRepoMainSynchronizerTests.cs
@@ -1,0 +1,93 @@
+namespace IntentSystem.Review.Tests;
+
+public sealed class ChildRepoMainSynchronizerTests
+{
+    [Fact]
+    public void Sync_GivenMergedCommit_RunsFetchSwitchFastForwardAndHeadCheck()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var parentRepoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        var runner = new FakeGitRunner(headCommit: "abc123");
+
+        ChildRepoMainSynchronizer.Sync(parentRepoRoot, "submodules/child-repo", "abc123", runner);
+
+        var childRepoPath = Path.Combine(parentRepoRoot, "submodules", "child-repo");
+        Assert.Equal(
+            [
+                $"{childRepoPath}::fetch origin main",
+                $"{childRepoPath}::switch main",
+                $"{childRepoPath}::merge --ff-only origin/main",
+                $"{childRepoPath}::rev-parse HEAD"
+            ],
+            runner.Calls);
+    }
+
+    [Fact]
+    public void Sync_GivenHeadMismatch_ThrowsInvalidOperationException()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var parentRepoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        var runner = new FakeGitRunner(headCommit: "def456");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ChildRepoMainSynchronizer.Sync(parentRepoRoot, "submodules/child-repo", "abc123", runner));
+
+        Assert.Contains("must match merged commit", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Stage_GivenChildRepoRef_StagesParentSubmodulePointer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var parentRepoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        var runner = new FakeGitRunner(headCommit: "abc123");
+
+        ParentSubmodulePointerUpdater.Stage(parentRepoRoot, "submodules/child-repo", runner);
+
+        Assert.Equal(
+            [$"{parentRepoRoot}::add submodules/child-repo"],
+            runner.Calls);
+    }
+
+    private sealed class FakeGitRunner(string headCommit) : IGitCommandRunner
+    {
+        public List<string> Calls { get; } = [];
+
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Calls.Add($"{workingDirectory}::{string.Join(' ', arguments)}");
+
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = arguments.SequenceEqual(["rev-parse", "HEAD"])
+                    ? headCommit + Environment.NewLine
+                    : string.Empty,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-review-sync-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Review.Tests/GhReviewAcceptClientTests.cs
+++ b/tests/IntentSystem.Review.Tests/GhReviewAcceptClientTests.cs
@@ -1,0 +1,73 @@
+namespace IntentSystem.Review.Tests;
+
+public sealed class GhReviewAcceptClientTests
+{
+    [Fact]
+    public void MergePullRequest_GivenLinkedPr_MergesViaGhApiAndReturnsMergedSha()
+    {
+        var runner = new FakeRunner(
+            """{"sha":"abc123"}""",
+            string.Empty);
+        var client = new GhReviewAcceptClient(runner);
+
+        var mergedSha = client.MergePullRequest("https://github.com/J-Tech-Japan/intent-system/pull/46");
+
+        Assert.Equal("abc123", mergedSha);
+        Assert.Equal(
+            [
+                "api",
+                "repos/J-Tech-Japan/intent-system/pulls/46/merge",
+                "--method",
+                "PUT",
+                "-f",
+                "merge_method=merge"
+            ],
+            runner.Arguments);
+    }
+
+    [Fact]
+    public void CloseIssue_GivenLinkedIssue_ClosesViaGhApi()
+    {
+        var runner = new FakeRunner("""{"state":"closed"}""", string.Empty);
+        var client = new GhReviewAcceptClient(runner);
+
+        client.CloseIssue("https://github.com/J-Tech-Japan/intent-system/issues/51");
+
+        Assert.Equal(
+            [
+                "api",
+                "repos/J-Tech-Japan/intent-system/issues/51",
+                "--method",
+                "PATCH",
+                "-f",
+                "state=closed"
+            ],
+            runner.Arguments);
+    }
+
+    [Fact]
+    public void Parse_GivenInvalidIssueUrl_ThrowsInvalidOperationException()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => GitHubIssueRef.Parse("https://github.com/J-Tech-Japan/intent-system/pull/51"));
+
+        Assert.Contains("issue URL shape", exception.Message, StringComparison.Ordinal);
+    }
+
+    private sealed class FakeRunner(string stdOut, string stdErr, int exitCode = 0) : IReviewCommandRunner
+    {
+        public IReadOnlyList<string> Arguments { get; private set; } = [];
+
+        public ReviewCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            Arguments = arguments.ToArray();
+
+            return new ReviewCommandResult
+            {
+                ExitCode = exitCode,
+                StdOut = stdOut,
+                StdErr = stdErr
+            };
+        }
+    }
+}

--- a/tests/IntentSystem.Review.Tests/LatestLinkedIssueResolverTests.cs
+++ b/tests/IntentSystem.Review.Tests/LatestLinkedIssueResolverTests.cs
@@ -1,0 +1,60 @@
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Review.Tests;
+
+public sealed class LatestLinkedIssueResolverTests
+{
+    [Fact]
+    public void Resolve_GivenMultipleEvents_ReturnsLatestLinkedIssueForExecutionUnit()
+    {
+        var linkedIssue = LatestLinkedIssueResolver.Resolve(
+            [
+                new RunEvent
+                {
+                    Ts = DateTimeOffset.Parse("2026-04-03T10:00:00Z"),
+                    ExecutionUnit = "G12",
+                    Event = "issue-created",
+                    By = "intent-cli",
+                    LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/49"
+                },
+                new RunEvent
+                {
+                    Ts = DateTimeOffset.Parse("2026-04-03T10:10:00Z"),
+                    ExecutionUnit = "A1",
+                    Event = "issue-created",
+                    By = "intent-cli",
+                    LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/1"
+                },
+                new RunEvent
+                {
+                    Ts = DateTimeOffset.Parse("2026-04-03T10:20:00Z"),
+                    ExecutionUnit = "G12",
+                    Event = "issue-linked",
+                    By = "intent-cli",
+                    LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/51"
+                }
+            ],
+            "G12");
+
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/51", linkedIssue);
+    }
+
+    [Fact]
+    public void Resolve_GivenMissingLinkedIssue_ThrowsInvalidOperationException()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => LatestLinkedIssueResolver.Resolve(
+                [
+                    new RunEvent
+                    {
+                        Ts = DateTimeOffset.Parse("2026-04-03T10:00:00Z"),
+                        ExecutionUnit = "G12",
+                        Event = "queued",
+                        By = "intent-cli"
+                    }
+                ],
+                "G12"));
+
+        Assert.Contains("No linked issue found", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
@@ -147,6 +147,19 @@ public sealed class QueueManagerTests
     }
 
     [Fact]
+    public void AcceptReview_GivenReviewItem_TransitionsToCompletedWithoutUnblockingDependents()
+    {
+        var state = CreateStateWithDependency();
+
+        var result = QueueManager.AcceptReview(state, "A1", "reviewer", BaseTime);
+
+        Assert.Equal(QueueItemState.Completed, FindItem(result.UpdatedState, "A1").State);
+        Assert.Equal(QueueItemState.Blocked, FindItem(result.UpdatedState, "B1").State);
+        Assert.Equal(["A1"], FindItem(result.UpdatedState, "B1").BlockedBy);
+        Assert.Equal("completed", result.Event.Event);
+    }
+
+    [Fact]
     public void RefreshDependencies_GivenAllDepsCompleted_UnblocksItem()
     {
         var a1 = CreateItem("A1", QueueItemState.Completed);


### PR DESCRIPTION
## Summary
- add `intent-cli review accept <execution-unit>` as the closeout entrypoint for review-approved items
- merge the linked child PR, close the linked child issue, sync child `main`, and stage the parent submodule pointer before marking the selected queue item completed
- append `pr-merged`, `issue-closed`, and `completed` events to `.intent-cli/runs.jsonl` and add runtime tests for failure paths and closeout boundaries

Closes #51