### PR TITLE
[G13] Queue Dispatch Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -46,6 +46,7 @@ internal static class CommandRouter
                 ["list"] = QueueListCommand.Execute,
                 ["show"] = QueueShowCommand.Execute,
                 ["next"] = QueueNextCommand.Execute,
+                ["dispatch"] = QueueDispatchCommand.Execute,
                 ["transition"] = QueueTransitionCommand.Execute
             }
         };

--- a/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
@@ -1,0 +1,122 @@
+using IntentSystem.Projection.Serialization;
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class QueueDispatchCommand
+{
+    private const string TransitionActor = "intent-cli";
+
+    public static Func<IQueueDispatchPublisher> PublisherFactory { get; set; } = () => new GhQueueDispatchPublisher();
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Queue dispatch command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        var packetPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.Yaml);
+        if (!File.Exists(packetPath))
+        {
+            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
+            return 1;
+        }
+
+        var githubBodyPath = ResolveGitHubBodyPath(context.RepoRoot, queueItem.PacketPaths.Yaml);
+        if (!File.Exists(githubBodyPath))
+        {
+            writer.WriteLine($"GitHub issue body artifact was not found at {githubBodyPath}");
+            return 1;
+        }
+
+        try
+        {
+            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+            var targetRepo = packet.ImplementationIssuePacket.TargetRepo;
+            if (string.IsNullOrWhiteSpace(targetRepo))
+            {
+                throw new InvalidOperationException("Projection packet must contain a target repo.");
+            }
+
+            var issueTitle = packet.ImplementationIssuePacket.IssueTitle;
+            if (string.IsNullOrWhiteSpace(issueTitle))
+            {
+                throw new InvalidOperationException("Projection packet must contain a non-empty issue title.");
+            }
+
+            var body = File.ReadAllText(githubBodyPath);
+            var linkedIssue = PublisherFactory().CreateIssue(targetRepo, issueTitle, body);
+            var result = QueueManager.LinkIssue(
+                queueState,
+                executionUnit,
+                linkedIssue,
+                TransitionActor,
+                TimestampFactory());
+
+            PersistDispatch(context, result);
+
+            writer.WriteLine($"Queue item {executionUnit} dispatched to {linkedIssue.Url}.");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static string ResolveArtifactPath(string repoRoot, string artifactRef)
+    {
+        return Path.GetFullPath(Path.Combine(repoRoot, artifactRef.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    internal static string ResolveGitHubBodyPath(string repoRoot, string packetYamlRef)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(packetYamlRef);
+
+        var directoryRef = Path.GetDirectoryName(packetYamlRef.Replace('/', Path.DirectorySeparatorChar))
+            ?? throw new InvalidOperationException("Packet YAML ref did not contain a directory.");
+
+        return Path.GetFullPath(Path.Combine(repoRoot, directoryRef, "github-body.md"));
+    }
+
+    private static void PersistDispatch(CliContext context, QueueTransitionResult result)
+    {
+        var queueStatePath = context.GetQueueStatePath();
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
+
+        var runLogPath = context.GetRunLogPath();
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(
+            runLogPath,
+            RunLogSerializer.SerializeLine(result.Event) + Environment.NewLine);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
@@ -10,6 +10,8 @@ internal static class QueueDispatchCommand
 
     public static Func<IQueueDispatchPublisher> PublisherFactory { get; set; } = () => new GhQueueDispatchPublisher();
 
+    public static Func<IGitRemoteCommandRunner> GitCommandRunnerFactory { get; set; } = () => new GitRemoteCommandRunner();
+
     public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
@@ -57,8 +59,8 @@ internal static class QueueDispatchCommand
         try
         {
             var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
-            var targetRepo = packet.ImplementationIssuePacket.TargetRepo;
-            if (string.IsNullOrWhiteSpace(targetRepo))
+            var packetTargetRepo = packet.ImplementationIssuePacket.TargetRepo;
+            if (string.IsNullOrWhiteSpace(packetTargetRepo))
             {
                 throw new InvalidOperationException("Projection packet must contain a target repo.");
             }
@@ -70,7 +72,11 @@ internal static class QueueDispatchCommand
             }
 
             var body = File.ReadAllText(githubBodyPath);
-            var linkedIssue = PublisherFactory().CreateIssue(targetRepo, issueTitle, body);
+            var githubTargetRepo = GitHubRepositoryTargetResolver.Resolve(
+                context.RepoRoot,
+                packetTargetRepo,
+                GitCommandRunnerFactory());
+            var linkedIssue = PublisherFactory().CreateIssue(githubTargetRepo, issueTitle, body);
             var result = QueueManager.LinkIssue(
                 queueState,
                 executionUnit,

--- a/src/IntentSystem.Cli/GhCommandRunner.cs
+++ b/src/IntentSystem.Cli/GhCommandRunner.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics;
+
+namespace IntentSystem.Cli;
+
+internal sealed class GhCommandRunner : IGitHubCommandRunner
+{
+    public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start gh process.");
+        var stdOut = process.StandardOutput.ReadToEnd();
+        var stdErr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        return new GitHubCommandResult
+        {
+            ExitCode = process.ExitCode,
+            StdOut = stdOut,
+            StdErr = stdErr
+        };
+    }
+}

--- a/src/IntentSystem.Cli/GhQueueDispatchPublisher.cs
+++ b/src/IntentSystem.Cli/GhQueueDispatchPublisher.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Cli;
+
+internal sealed class GhQueueDispatchPublisher : IQueueDispatchPublisher
+{
+    private readonly IGitHubCommandRunner commandRunner;
+
+    public GhQueueDispatchPublisher()
+        : this(new GhCommandRunner())
+    {
+    }
+
+    public GhQueueDispatchPublisher(IGitHubCommandRunner commandRunner)
+    {
+        this.commandRunner = commandRunner ?? throw new ArgumentNullException(nameof(commandRunner));
+    }
+
+    public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetRepo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        ArgumentNullException.ThrowIfNull(body);
+
+        var repoRef = GitHubRepositoryRef.Parse(targetRepo);
+        var payloadPath = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(payloadPath, JsonSerializer.Serialize(new { title, body }));
+
+            var result = commandRunner.Run(
+                [
+                    "api",
+                    $"repos/{repoRef.Owner}/{repoRef.Repo}/issues",
+                    "--method",
+                    "POST",
+                    "--input",
+                    payloadPath
+                ]);
+
+            if (result.ExitCode != 0)
+            {
+                var error = string.IsNullOrWhiteSpace(result.StdErr)
+                    ? "gh api issue create failed."
+                    : result.StdErr.Trim();
+                throw new InvalidOperationException(error);
+            }
+
+            using var document = JsonDocument.Parse(result.StdOut);
+            if (!document.RootElement.TryGetProperty("number", out var numberElement)
+                || !numberElement.TryGetInt32(out var issueNumber))
+            {
+                throw new InvalidOperationException("GitHub issue create response must contain number.");
+            }
+
+            if (!document.RootElement.TryGetProperty("html_url", out var htmlUrlElement)
+                || string.IsNullOrWhiteSpace(htmlUrlElement.GetString()))
+            {
+                throw new InvalidOperationException("GitHub issue create response must contain html_url.");
+            }
+
+            return new LinkedIssue
+            {
+                Repo = targetRepo,
+                Number = issueNumber,
+                Url = htmlUrlElement.GetString()
+                    ?? throw new InvalidOperationException("GitHub issue create response html_url was null.")
+            };
+        }
+        finally
+        {
+            if (File.Exists(payloadPath))
+            {
+                File.Delete(payloadPath);
+            }
+        }
+    }
+
+    private sealed record GitHubRepositoryRef
+    {
+        public required string Owner { get; init; }
+
+        public required string Repo { get; init; }
+
+        public static GitHubRepositoryRef Parse(string targetRepo)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(targetRepo);
+
+            var segments = targetRepo.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (segments.Length != 2)
+            {
+                throw new InvalidOperationException(
+                    $"Target repo '{targetRepo}' must use the GitHub owner/repo shape.");
+            }
+
+            return new GitHubRepositoryRef
+            {
+                Owner = segments[0],
+                Repo = segments[1]
+            };
+        }
+    }
+}

--- a/src/IntentSystem.Cli/GitCommandResult.cs
+++ b/src/IntentSystem.Cli/GitCommandResult.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli;
+
+internal sealed record GitRemoteCommandResult
+{
+    public required int ExitCode { get; init; }
+
+    public required string StdOut { get; init; }
+
+    public required string StdErr { get; init; }
+}

--- a/src/IntentSystem.Cli/GitCommandRunner.cs
+++ b/src/IntentSystem.Cli/GitCommandRunner.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+
+namespace IntentSystem.Cli;
+
+internal sealed class GitRemoteCommandRunner : IGitRemoteCommandRunner
+{
+    public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start git process.");
+        var stdOut = process.StandardOutput.ReadToEnd();
+        var stdErr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        return new GitRemoteCommandResult
+        {
+            ExitCode = process.ExitCode,
+            StdOut = stdOut,
+            StdErr = stdErr
+        };
+    }
+}

--- a/src/IntentSystem.Cli/GitHubCommandResult.cs
+++ b/src/IntentSystem.Cli/GitHubCommandResult.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli;
+
+internal sealed record GitHubCommandResult
+{
+    public required int ExitCode { get; init; }
+
+    public required string StdOut { get; init; }
+
+    public required string StdErr { get; init; }
+}

--- a/src/IntentSystem.Cli/GitHubRepositoryTargetResolver.cs
+++ b/src/IntentSystem.Cli/GitHubRepositoryTargetResolver.cs
@@ -1,0 +1,72 @@
+namespace IntentSystem.Cli;
+
+internal static class GitHubRepositoryTargetResolver
+{
+    public static string Resolve(string repoRoot, string packetTargetRepo, IGitRemoteCommandRunner commandRunner)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(packetTargetRepo);
+        ArgumentNullException.ThrowIfNull(commandRunner);
+
+        var childRepoPath = Path.IsPathRooted(packetTargetRepo)
+            ? Path.GetFullPath(packetTargetRepo)
+            : Path.GetFullPath(Path.Combine(repoRoot, packetTargetRepo));
+
+        if (!Directory.Exists(childRepoPath))
+        {
+            throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+        }
+
+        var result = commandRunner.Run(childRepoPath, ["remote", "get-url", "origin"]);
+        if (result.ExitCode != 0)
+        {
+            var error = string.IsNullOrWhiteSpace(result.StdErr)
+                ? "git remote get-url origin failed."
+                : result.StdErr.Trim();
+            throw new InvalidOperationException(error);
+        }
+
+        return ParseRemoteUrl(result.StdOut.Trim());
+    }
+
+    internal static string ParseRemoteUrl(string remoteUrl)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(remoteUrl);
+
+        if (Uri.TryCreate(remoteUrl, UriKind.Absolute, out var absoluteUri))
+        {
+            if (!string.Equals(absoluteUri.Host, "github.com", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException($"Remote URL '{remoteUrl}' must point to github.com.");
+            }
+
+            return NormalizeRepositoryPath(absoluteUri.AbsolutePath);
+        }
+
+        const string sshPrefix = "git@github.com:";
+        if (remoteUrl.StartsWith(sshPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return NormalizeRepositoryPath(remoteUrl[sshPrefix.Length..]);
+        }
+
+        throw new InvalidOperationException($"Remote URL '{remoteUrl}' must use a GitHub remote URL shape.");
+    }
+
+    private static string NormalizeRepositoryPath(string repositoryPath)
+    {
+        var normalized = repositoryPath.Trim().Trim('/');
+        if (normalized.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized[..^4];
+        }
+
+        var segments = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (segments.Length != 2)
+        {
+            throw new InvalidOperationException(
+                $"Remote repository path '{repositoryPath}' must use the GitHub owner/repo shape.");
+        }
+
+        return $"{segments[0]}/{segments[1]}";
+    }
+}

--- a/src/IntentSystem.Cli/IGitCommandRunner.cs
+++ b/src/IntentSystem.Cli/IGitCommandRunner.cs
@@ -1,0 +1,6 @@
+namespace IntentSystem.Cli;
+
+internal interface IGitRemoteCommandRunner
+{
+    GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments);
+}

--- a/src/IntentSystem.Cli/IGitHubCommandRunner.cs
+++ b/src/IntentSystem.Cli/IGitHubCommandRunner.cs
@@ -1,0 +1,6 @@
+namespace IntentSystem.Cli;
+
+internal interface IGitHubCommandRunner
+{
+    GitHubCommandResult Run(IReadOnlyList<string> arguments);
+}

--- a/src/IntentSystem.Cli/IQueueDispatchPublisher.cs
+++ b/src/IntentSystem.Cli/IQueueDispatchPublisher.cs
@@ -1,0 +1,8 @@
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Cli;
+
+internal interface IQueueDispatchPublisher
+{
+    LinkedIssue CreateIssue(string targetRepo, string title, string body);
+}

--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -251,6 +251,49 @@ public static class QueueManager
         });
     }
 
+    public static QueueTransitionResult LinkIssue(
+        QueueState state,
+        string executionUnit,
+        LinkedIssue linkedIssue,
+        string by,
+        DateTimeOffset ts)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(linkedIssue);
+        ArgumentException.ThrowIfNullOrWhiteSpace(by);
+
+        var item = FindItem(state, executionUnit);
+        AssertState(item, QueueItemState.Queued, "link-issue");
+
+        var updatedItems = new QueueItem[state.Items.Count];
+
+        for (var i = 0; i < state.Items.Count; i++)
+        {
+            var currentItem = state.Items[i];
+            updatedItems[i] = string.Equals(currentItem.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                ? currentItem with { LinkedIssue = linkedIssue }
+                : currentItem;
+        }
+
+        return new QueueTransitionResult
+        {
+            UpdatedState = state with
+            {
+                Items = updatedItems,
+                UpdatedAt = ts
+            },
+            Event = new RunEvent
+            {
+                Ts = ts,
+                ExecutionUnit = executionUnit,
+                Event = "issue-created",
+                By = by,
+                LinkedIssue = linkedIssue.Url
+            }
+        };
+    }
+
     /// <summary>
     /// Recalculates blocked/queued states for all items based on current dependency resolution.
     /// Items whose dependencies are all completed move from blocked to queued.

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -103,6 +103,44 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenQueueDispatchCommand_DispatchesToQueueDispatchRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueDispatchQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreateQueueDispatchPacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalTimestampFactory = QueueDispatchCommand.TimestampFactory;
+
+        try
+        {
+            QueueDispatchCommand.PublisherFactory = () => new FakeQueueDispatchPublisher();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T06:00:00Z");
+
+            var exitCode = CommandRouter.Execute(["queue", "dispatch", "G13"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Queue item G13 dispatched", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenWorkflowRenderCommand_DispatchesToWorkflowRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -374,6 +412,36 @@ public sealed class CommandRouterTests
         };
     }
 
+    private static QueueState CreateQueueDispatchQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G13",
+                    Title = "Queue dispatch command",
+                    State = QueueItemState.Queued,
+                    Dependencies = [],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G13/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G13/review-context.md",
+                        Yaml = ".intent-cli/issues/G13/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
     private static QueueState CreateReviewQueueState()
     {
         return new QueueState
@@ -515,6 +583,56 @@ public sealed class CommandRouterTests
             - "workflow render writes workflow artifact"
           deterministic_review_checks:
             - "definition shape stays canonical"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private static string CreateQueueDispatchPacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G13] Queue Dispatch Command"
+          issue_kind: "feature"
+          source_execution_unit: "G13"
+          goal: "Dispatch queue item into GitHub issue."
+          in_scope:
+            - "queue dispatch command"
+          out_of_scope:
+            - "branch creation"
+          target_repo: "J-Tech-Japan/intent-system"
+          target_path: "."
+          target_part: "cli queue dispatch command"
+          dependencies:
+            - "G3"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "dispatch stays thin"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/issue-lifecycle-and-landing.md"
+          acceptance_criteria:
+            - "issue created"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+        
+        review_context_packet:
+          source_execution_unit: "G13"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/issue-lifecycle-and-landing.md"
+          acceptance_criteria:
+            - "issue created"
+          deterministic_review_checks:
+            - "dispatch remains thin"
           clarification_return_path: "intents/intent-cli/clarifications/open.md"
         """;
     }
@@ -704,6 +822,19 @@ public sealed class CommandRouterTests
         public string PostComment(string linkedPr, string body)
         {
             return "https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1";
+        }
+    }
+
+    private sealed class FakeQueueDispatchPublisher : IQueueDispatchPublisher
+    {
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            return new LinkedIssue
+            {
+                Repo = targetRepo,
+                Number = 53,
+                Url = "https://github.com/J-Tech-Japan/intent-system/issues/53"
+            };
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -116,16 +116,19 @@ public sealed class CommandRouterTests
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
             "# Goal");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "runs.jsonl"),
             string.Empty);
         using var writer = new StringWriter();
         var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalGitFactory = QueueDispatchCommand.GitCommandRunnerFactory;
         var originalTimestampFactory = QueueDispatchCommand.TimestampFactory;
 
         try
         {
             QueueDispatchCommand.PublisherFactory = () => new FakeQueueDispatchPublisher();
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeQueueDispatchGitRunner();
             QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T06:00:00Z");
 
             var exitCode = CommandRouter.Execute(["queue", "dispatch", "G13"], CreateContext(repoRoot), writer);
@@ -136,6 +139,7 @@ public sealed class CommandRouterTests
         finally
         {
             QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalGitFactory;
             QueueDispatchCommand.TimestampFactory = originalTimestampFactory;
         }
     }
@@ -544,7 +548,7 @@ public sealed class CommandRouterTests
             - "cli workflow render command"
           out_of_scope:
             - "workflow execution"
-          target_repo: "J-Tech-Japan/intent-system"
+          target_repo: "submodules/intent-system"
           target_path: "."
           target_part: "cli workflow render command"
           dependencies:
@@ -599,7 +603,7 @@ public sealed class CommandRouterTests
             - "queue dispatch command"
           out_of_scope:
             - "branch creation"
-          target_repo: "J-Tech-Japan/intent-system"
+          target_repo: "submodules/intent-system"
           target_path: "."
           target_part: "cli queue dispatch command"
           dependencies:
@@ -834,6 +838,19 @@ public sealed class CommandRouterTests
                 Repo = targetRepo,
                 Number = 53,
                 Url = "https://github.com/J-Tech-Japan/intent-system/issues/53"
+            };
+        }
+    }
+
+    private sealed class FakeQueueDispatchGitRunner : IGitRemoteCommandRunner
+    {
+        public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            return new GitRemoteCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "git@github.com:J-Tech-Japan/intent-system.git" + Environment.NewLine,
+                StdErr = string.Empty
             };
         }
     }

--- a/tests/IntentSystem.Cli.Tests/GhQueueDispatchPublisherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GhQueueDispatchPublisherTests.cs
@@ -1,0 +1,67 @@
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GhQueueDispatchPublisherTests
+{
+    [Fact]
+    public void CreateIssue_GivenTargetRepoTitleAndBody_PostsViaGhApiAndReturnsLinkedIssue()
+    {
+        var runner = new FakeRunner();
+        var publisher = new GhQueueDispatchPublisher(runner);
+
+        var linkedIssue = publisher.CreateIssue(
+            "J-Tech-Japan/intent-system",
+            "[G13] Queue Dispatch Command",
+            "# Goal");
+
+        Assert.Equal(
+            new LinkedIssue
+            {
+                Repo = "J-Tech-Japan/intent-system",
+                Number = 53,
+                Url = "https://github.com/J-Tech-Japan/intent-system/issues/53"
+            },
+            linkedIssue);
+        Assert.Equal(
+            "repos/J-Tech-Japan/intent-system/issues",
+            runner.Arguments[1]);
+        Assert.Contains("\"title\":\"[G13] Queue Dispatch Command\"", runner.PayloadJson, StringComparison.Ordinal);
+        Assert.Contains("\"body\":\"# Goal\"", runner.PayloadJson, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateIssue_GivenInvalidTargetRepo_ThrowsInvalidOperationException()
+    {
+        var publisher = new GhQueueDispatchPublisher(new FakeRunner());
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => publisher.CreateIssue("intent-system", "title", "body"));
+
+        Assert.Contains("owner/repo shape", exception.Message, StringComparison.Ordinal);
+    }
+
+    private sealed class FakeRunner : IGitHubCommandRunner
+    {
+        public IReadOnlyList<string> Arguments { get; private set; } = [];
+
+        public string PayloadJson { get; private set; } = string.Empty;
+
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            Arguments = arguments.ToArray();
+            var payloadIndex = Arguments
+                .Select((argument, index) => (argument, index))
+                .First(item => string.Equals(item.argument, "--input", StringComparison.Ordinal))
+                .index + 1;
+            PayloadJson = File.ReadAllText(Arguments[payloadIndex]);
+
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = """{"number":53,"html_url":"https://github.com/J-Tech-Japan/intent-system/issues/53"}""",
+                StdErr = string.Empty
+            };
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/QueueDispatchCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueDispatchCommandTests.cs
@@ -1,0 +1,319 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class QueueDispatchCommandTests
+{
+    [Fact]
+    public void Execute_GivenPacketAndGitHubBody_CreatesIssueUpdatesQueueAndAppendsRunLog()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalTimestampFactory = QueueDispatchCommand.TimestampFactory;
+
+        try
+        {
+            QueueDispatchCommand.PublisherFactory = () => new FakePublisher();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T06:00:00Z");
+
+            var exitCode = QueueDispatchCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Queue item G13 dispatched", writer.ToString(), StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            var selectedItem = queueState.Items.Single(item => item.ExecutionUnit == "G13");
+            Assert.NotNull(selectedItem.LinkedIssue);
+            Assert.Equal("J-Tech-Japan/intent-system", selectedItem.LinkedIssue!.Repo);
+            Assert.Equal(53, selectedItem.LinkedIssue.Number);
+            Assert.Equal(
+                "https://github.com/J-Tech-Japan/intent-system/issues/53",
+                selectedItem.LinkedIssue.Url);
+            Assert.Null(queueState.Items.Single(item => item.ExecutionUnit == "G14").LinkedIssue);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            var issueCreated = Assert.Single(runEvents);
+            Assert.Equal("issue-created", issueCreated.Event);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/53", issueCreated.LinkedIssue);
+        }
+        finally
+        {
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        using var writer = new StringWriter();
+
+        var exitCode = QueueDispatchCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Projection packet artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingGitHubBodyArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var exitCode = QueueDispatchCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("GitHub issue body artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingTargetRepo_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreatePacketYaml(targetRepo: ""));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = QueueDispatchCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("target repo", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenEmptyIssueTitle_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreatePacketYaml(issueTitle: ""));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = QueueDispatchCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("issue title", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_ResolveGitHubBodyPath_UsesPacketDirectory()
+    {
+        var bodyPath = QueueDispatchCommand.ResolveGitHubBodyPath(
+            "/tmp/repo",
+            ".intent-cli/issues/G13/packet.yaml");
+
+        Assert.Equal(
+            Path.GetFullPath("/tmp/repo/.intent-cli/issues/G13/github-body.md"),
+            bodyPath);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                CreateItem("G13", QueueItemState.Queued),
+                CreateItem("G14", QueueItemState.Queued)
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Queue Dispatch",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static string CreatePacketYaml(
+        string targetRepo = "J-Tech-Japan/intent-system",
+        string issueTitle = "[G13] Queue Dispatch Command")
+    {
+        return $"""
+        implementation_issue_packet:
+          issue_title: "{issueTitle}"
+          issue_kind: "feature"
+          source_execution_unit: "G13"
+          goal: "Create linked child issue from prepared artifacts."
+          in_scope:
+            - "queue dispatch command"
+          out_of_scope:
+            - "worker execution"
+          target_repo: "{targetRepo}"
+          target_path: "."
+          target_part: "cli queue dispatch command"
+          dependencies:
+            - "G3"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "dispatch stays thin"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/issue-lifecycle-and-landing.md"
+          acceptance_criteria:
+            - "issue created"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+        
+        review_context_packet:
+          source_execution_unit: "G13"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/issue-lifecycle-and-landing.md"
+          acceptance_criteria:
+            - "issue created"
+          deterministic_review_checks:
+            - "dispatch remains thin"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private sealed class FakePublisher : IQueueDispatchPublisher
+    {
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            return new LinkedIssue
+            {
+                Repo = targetRepo,
+                Number = 53,
+                Url = "https://github.com/J-Tech-Japan/intent-system/issues/53"
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-queue-dispatch-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/QueueDispatchCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueDispatchCommandTests.cs
@@ -21,16 +21,19 @@ public sealed class QueueDispatchCommandTests
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
             "# Goal");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "runs.jsonl"),
             string.Empty);
         using var writer = new StringWriter();
         var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalGitCommandRunnerFactory = QueueDispatchCommand.GitCommandRunnerFactory;
         var originalTimestampFactory = QueueDispatchCommand.TimestampFactory;
 
         try
         {
             QueueDispatchCommand.PublisherFactory = () => new FakePublisher();
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeGitCommandRunner();
             QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T06:00:00Z");
 
             var exitCode = QueueDispatchCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
@@ -58,6 +61,7 @@ public sealed class QueueDispatchCommandTests
         finally
         {
             QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
             QueueDispatchCommand.TimestampFactory = originalTimestampFactory;
         }
     }
@@ -73,6 +77,7 @@ public sealed class QueueDispatchCommandTests
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
             "# Goal");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
         using var writer = new StringWriter();
 
         var exitCode = QueueDispatchCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
@@ -117,6 +122,7 @@ public sealed class QueueDispatchCommandTests
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
             "# Goal");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
         using var writer = new StringWriter();
 
         var originalQueueState = File.ReadAllText(queueStatePath);
@@ -166,6 +172,59 @@ public sealed class QueueDispatchCommandTests
         Assert.Equal(
             Path.GetFullPath("/tmp/repo/.intent-cli/issues/G13/github-body.md"),
             bodyPath);
+    }
+
+    [Fact]
+    public void Execute_GivenCanonicalPacketTargetRepo_ResolvesGitHubTargetFromChildOriginRemote()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreatePacketYaml(targetRepo: "submodules/intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var publisher = new CapturingPublisher();
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalGitCommandRunnerFactory = QueueDispatchCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = QueueDispatchCommand.TimestampFactory;
+
+        try
+        {
+            QueueDispatchCommand.PublisherFactory = () => publisher;
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeGitCommandRunner();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T06:00:00Z");
+
+            var exitCode = QueueDispatchCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal("J-Tech-Japan/intent-system", publisher.TargetRepo);
+        }
+        finally
+        {
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+            QueueDispatchCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Theory]
+    [InlineData("https://github.com/J-Tech-Japan/intent-system.git", "J-Tech-Japan/intent-system")]
+    [InlineData("git@github.com:J-Tech-Japan/intent-system.git", "J-Tech-Japan/intent-system")]
+    public void ParseRemoteUrl_GivenGitHubRemote_ShapesOwnerRepo(string remoteUrl, string expected)
+    {
+        var actual = GitHubRepositoryTargetResolver.ParseRemoteUrl(remoteUrl);
+
+        Assert.Equal(expected, actual);
     }
 
     private static CliContext CreateContext(string repoRoot)
@@ -222,7 +281,7 @@ public sealed class QueueDispatchCommandTests
     }
 
     private static string CreatePacketYaml(
-        string targetRepo = "J-Tech-Japan/intent-system",
+        string targetRepo = "submodules/intent-system",
         string issueTitle = "[G13] Queue Dispatch Command")
     {
         return $"""
@@ -282,6 +341,36 @@ public sealed class QueueDispatchCommandTests
                 Repo = targetRepo,
                 Number = 53,
                 Url = "https://github.com/J-Tech-Japan/intent-system/issues/53"
+            };
+        }
+    }
+
+    private sealed class CapturingPublisher : IQueueDispatchPublisher
+    {
+        public string TargetRepo { get; private set; } = string.Empty;
+
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            TargetRepo = targetRepo;
+
+            return new LinkedIssue
+            {
+                Repo = targetRepo,
+                Number = 53,
+                Url = "https://github.com/J-Tech-Japan/intent-system/issues/53"
+            };
+        }
+    }
+
+    private sealed class FakeGitCommandRunner : IGitRemoteCommandRunner
+    {
+        public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            return new GitRemoteCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "git@github.com:J-Tech-Japan/intent-system.git" + Environment.NewLine,
+                StdErr = string.Empty
             };
         }
     }

--- a/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
@@ -160,6 +160,28 @@ public sealed class QueueManagerTests
     }
 
     [Fact]
+    public void LinkIssue_GivenQueuedItem_UpdatesOnlySelectedItemAndEmitsIssueCreatedEvent()
+    {
+        var selectedItem = CreateItem("A1", QueueItemState.Queued);
+        var otherItem = CreateItem("B1", QueueItemState.Blocked);
+        var state = CreateState([selectedItem, otherItem]);
+        var linkedIssue = new LinkedIssue
+        {
+            Repo = "J-Tech-Japan/intent-system",
+            Number = 53,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/53"
+        };
+
+        var result = QueueManager.LinkIssue(state, "A1", linkedIssue, "intent-cli", BaseTime);
+
+        Assert.Equal(linkedIssue, FindItem(result.UpdatedState, "A1").LinkedIssue);
+        Assert.Null(FindItem(result.UpdatedState, "B1").LinkedIssue);
+        Assert.Equal(QueueItemState.Queued, FindItem(result.UpdatedState, "A1").State);
+        Assert.Equal("issue-created", result.Event.Event);
+        Assert.Equal(linkedIssue.Url, result.Event.LinkedIssue);
+    }
+
+    [Fact]
     public void RefreshDependencies_GivenAllDepsCompleted_UnblocksItem()
     {
         var a1 = CreateItem("A1", QueueItemState.Completed);


### PR DESCRIPTION
## Summary
- add `intent-cli queue dispatch <execution-unit>` to create a linked GitHub issue from the current packet and prepared `github-body.md`
- update only the selected queued item `linked_issue` fields and append an `issue-created` event to `.intent-cli/runs.jsonl`
- add tests for GitHub issue creation boundary, packet/body path resolution, queue update, and failure paths for missing artifacts or invalid packet fields

Closes #53