### PR TITLE
[G14] Run Start Command

### DIFF
--- a/src/IntentSystem.Cli/CliContext.cs
+++ b/src/IntentSystem.Cli/CliContext.cs
@@ -38,4 +38,15 @@ internal sealed record CliContext
 
         return Path.GetFullPath(Path.Combine(RepoRoot, artifactRoot));
     }
+
+    public string ResolveWorktreeRootPath()
+    {
+        var worktreeRoot = Config.Project.WorktreeRoot;
+        if (Path.IsPathRooted(worktreeRoot))
+        {
+            return worktreeRoot;
+        }
+
+        return Path.GetFullPath(Path.Combine(RepoRoot, worktreeRoot));
+    }
 }

--- a/src/IntentSystem.Cli/CliRuntimeContracts.cs
+++ b/src/IntentSystem.Cli/CliRuntimeContracts.cs
@@ -11,6 +11,8 @@ internal static class CliRuntimeContracts
     public const string DomainKey = "domain";
     public const string WorkflowEngineKey = "workflow_engine";
     public const string ArtifactRootKey = "artifact_root";
+    public const string WorktreeRootKey = "worktree_root";
+    public const string DefaultWorktreeRoot = ".intent-cli/worktrees";
 
     public static string GetIntentCliDirectoryPath(string repoRoot)
     {

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -29,6 +29,10 @@ internal static class CommandRouter
                 ["generate"] = ProjectionGenerateCommand.Generate,
                 ["regenerate"] = ProjectionGenerateCommand.Regenerate
             },
+            ["run"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["start"] = RunStartCommand.Execute
+            },
             ["workflow"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["render"] = WorkflowRenderCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/RunStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunStartCommand.cs
@@ -1,0 +1,173 @@
+using IntentSystem.Projection.Serialization;
+using IntentSystem.Review;
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunStartCommand
+{
+    private const string TransitionActor = "intent-cli";
+
+    public static Func<IGitCommandRunner> GitCommandRunnerFactory { get; set; } = () => new GitCommandRunner();
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Run start command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        if (queueItem.LinkedIssue is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' must have a linked issue before run start.");
+            return 1;
+        }
+
+        var packetPath = Path.Combine(
+            context.RepoRoot,
+            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(packetPath))
+        {
+            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
+            return 1;
+        }
+
+        try
+        {
+            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+            var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
+            if (string.IsNullOrWhiteSpace(childRepoRef))
+            {
+                throw new InvalidOperationException("Projection packet must contain a target repo.");
+            }
+
+            var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
+            if (!Directory.Exists(childRepoPath))
+            {
+                throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+            }
+
+            var worktreePath = ResolveWorktreePath(context, executionUnit);
+            if (Directory.Exists(worktreePath))
+            {
+                throw new InvalidOperationException($"Worktree path already exists at {worktreePath}");
+            }
+
+            var branchName = ResolveBranchName(executionUnit, queueItem.LinkedIssue);
+            var gitRunner = GitCommandRunnerFactory();
+            CreateWorktree(childRepoPath, worktreePath, branchName, gitRunner);
+
+            var timestamp = TimestampFactory();
+            var transition = QueueManager.Activate(queueState, executionUnit, TransitionActor, timestamp);
+            PersistStart(context, transition);
+
+            writer.WriteLine($"Run started for {executionUnit}.");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static string ResolveBranchName(string executionUnit, LinkedIssue linkedIssue)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(linkedIssue);
+
+        return $"issue-{linkedIssue.Number}-{executionUnit.ToLowerInvariant()}";
+    }
+
+    internal static string ResolveWorktreePath(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        return Path.GetFullPath(Path.Combine(context.ResolveWorktreeRootPath(), executionUnit));
+    }
+
+    private static string ResolveChildRepoPath(string repoRoot, string childRepoRef)
+    {
+        return Path.IsPathRooted(childRepoRef)
+            ? Path.GetFullPath(childRepoRef)
+            : Path.GetFullPath(Path.Combine(repoRoot, childRepoRef));
+    }
+
+    private static void CreateWorktree(
+        string childRepoPath,
+        string worktreePath,
+        string branchName,
+        IGitCommandRunner gitRunner)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(childRepoPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(branchName);
+        ArgumentNullException.ThrowIfNull(gitRunner);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(worktreePath)
+            ?? throw new InvalidOperationException("Worktree path did not contain a directory."));
+
+        RunGit(gitRunner, childRepoPath, ["fetch", "origin", "main"], "git fetch origin main failed.");
+        RunGit(
+            gitRunner,
+            childRepoPath,
+            ["worktree", "add", "-b", branchName, worktreePath, "origin/main"],
+            "git worktree add failed.");
+    }
+
+    private static void PersistStart(CliContext context, QueueTransitionResult result)
+    {
+        var queueStatePath = context.GetQueueStatePath();
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
+
+        var runLogPath = context.GetRunLogPath();
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(
+            runLogPath,
+            RunLogSerializer.SerializeLine(result.Event) + Environment.NewLine);
+    }
+
+    private static void RunGit(
+        IGitCommandRunner gitRunner,
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        string defaultError)
+    {
+        var result = gitRunner.Run(workingDirectory, arguments);
+        if (result.ExitCode != 0)
+        {
+            var error = string.IsNullOrWhiteSpace(result.StdErr)
+                ? defaultError
+                : result.StdErr.Trim();
+            throw new InvalidOperationException(error);
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
+++ b/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
@@ -49,7 +49,10 @@ internal static class CliConfigLoader
             return false;
         }
 
-        config = CreateConfig(domain, workflowEngine, artifactRoot);
+        var worktreeRoot = TryGetOptionalString(rootTable, CliRuntimeContracts.WorktreeRootKey)
+            ?? CliRuntimeContracts.DefaultWorktreeRoot;
+
+        config = CreateConfig(domain, workflowEngine, artifactRoot, worktreeRoot);
         return true;
     }
 
@@ -72,11 +75,18 @@ internal static class CliConfigLoader
                 $"'{CliRuntimeContracts.WorkflowEngineKey}', and '{CliRuntimeContracts.ArtifactRootKey}'.");
         }
 
-        config = CreateConfig(domain, workflowEngine, artifactRoot);
+        var worktreeRoot = TryGetOptionalString(projectTable, CliRuntimeContracts.WorktreeRootKey)
+            ?? CliRuntimeContracts.DefaultWorktreeRoot;
+
+        config = CreateConfig(domain, workflowEngine, artifactRoot, worktreeRoot);
         return true;
     }
 
-    private static CliConfig CreateConfig(string domain, string workflowEngine, string artifactRoot)
+    private static CliConfig CreateConfig(
+        string domain,
+        string workflowEngine,
+        string artifactRoot,
+        string worktreeRoot)
     {
         return new CliConfig
         {
@@ -84,7 +94,8 @@ internal static class CliConfigLoader
             {
                 Domain = domain,
                 WorkflowEngine = workflowEngine,
-                ArtifactRoot = artifactRoot
+                ArtifactRoot = artifactRoot,
+                WorktreeRoot = worktreeRoot
             }
         };
     }
@@ -106,5 +117,24 @@ internal static class CliConfigLoader
 
         value = textValue;
         return true;
+    }
+
+    private static string? TryGetOptionalString(TomlTable table, string key)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        if (!table.TryGetValue(key, out var rawValue))
+        {
+            return null;
+        }
+
+        if (rawValue is not string textValue || string.IsNullOrWhiteSpace(textValue))
+        {
+            throw new InvalidOperationException(
+                $"CLI config value '{key}' must be a non-empty string.");
+        }
+
+        return textValue;
     }
 }

--- a/src/IntentSystem.Cli/Models/CliConfig.cs
+++ b/src/IntentSystem.Cli/Models/CliConfig.cs
@@ -12,4 +12,6 @@ internal sealed record ProjectConfig
     public required string WorkflowEngine { get; init; }
 
     public required string ArtifactRoot { get; init; }
+
+    public string WorktreeRoot { get; init; } = ".intent-cli/worktrees";
 }

--- a/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
@@ -11,6 +11,7 @@ public sealed class CliConfigLoaderTests
         default_domain = "intent-cli"
         workflow_engine = "takt"
         artifact_root = ".intent-cli"
+        worktree_root = ".intent-cli/worktrees"
         """;
 
         var config = CliConfigLoader.Load(toml);
@@ -18,6 +19,7 @@ public sealed class CliConfigLoaderTests
         Assert.Equal("intent-cli", config.Project.Domain);
         Assert.Equal("takt", config.Project.WorkflowEngine);
         Assert.Equal(".intent-cli", config.Project.ArtifactRoot);
+        Assert.Equal(".intent-cli/worktrees", config.Project.WorktreeRoot);
     }
 
     [Fact]
@@ -30,6 +32,7 @@ public sealed class CliConfigLoaderTests
             default_domain = "intent-cli"
             workflow_engine = "takt"
             artifact_root = ".intent-cli"
+            worktree_root = ".intent-cli/worktrees"
             """);
 
         var config = CliConfigLoader.LoadFromFile(configPath);
@@ -37,6 +40,7 @@ public sealed class CliConfigLoaderTests
         Assert.Equal("intent-cli", config.Project.Domain);
         Assert.Equal("takt", config.Project.WorkflowEngine);
         Assert.Equal(".intent-cli", config.Project.ArtifactRoot);
+        Assert.Equal(".intent-cli/worktrees", config.Project.WorktreeRoot);
     }
 
     [Fact]
@@ -47,6 +51,7 @@ public sealed class CliConfigLoaderTests
         domain = "intent-cli"
         workflow_engine = "takt"
         artifact_root = ".intent-cli"
+        worktree_root = ".intent-cli/worktrees"
         """;
 
         var config = CliConfigLoader.Load(toml);
@@ -54,6 +59,7 @@ public sealed class CliConfigLoaderTests
         Assert.Equal("intent-cli", config.Project.Domain);
         Assert.Equal("takt", config.Project.WorkflowEngine);
         Assert.Equal(".intent-cli", config.Project.ArtifactRoot);
+        Assert.Equal(".intent-cli/worktrees", config.Project.WorktreeRoot);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -145,6 +145,42 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenRunStartCommand_DispatchesToRunStartRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateRunStartQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreateRunStartPacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = RunStartCommand.TimestampFactory;
+
+        try
+        {
+            RunStartCommand.GitCommandRunnerFactory = () => new FakeRunStartGitRunner();
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T09:30:00Z");
+
+            var exitCode = CommandRouter.Execute(["run", "start", "G14"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run started for G14", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunStartCommand.GitCommandRunnerFactory = originalGitFactory;
+            RunStartCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenWorkflowRenderCommand_DispatchesToWorkflowRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -476,6 +512,42 @@ public sealed class CommandRouterTests
         };
     }
 
+    private static QueueState CreateRunStartQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G14",
+                    Title = "Run start command",
+                    State = QueueItemState.Queued,
+                    Dependencies = [],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G14/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G14/review-context.md",
+                        Yaml = ".intent-cli/issues/G14/packet.yaml"
+                    },
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = 56,
+                        Url = "https://github.com/J-Tech-Japan/intent-system/issues/56"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
     private static QueueState CreateReviewCommentQueueState()
     {
         return new QueueState
@@ -737,6 +809,56 @@ public sealed class CommandRouterTests
         """;
     }
 
+    private static string CreateRunStartPacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G14] Run Start Command"
+          issue_kind: "feature"
+          source_execution_unit: "G14"
+          goal: "Create isolated worktree and activate queue item."
+          in_scope:
+            - "run start command"
+          out_of_scope:
+            - "worker start"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli run start command"
+          dependencies:
+            - "G13"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "run start stays thin"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "isolated worktree created"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+        
+        review_context_packet:
+          source_execution_unit: "G14"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "isolated worktree created"
+          deterministic_review_checks:
+            - "run start remains thin"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
     private static string CreateReviewRunLog()
     {
         return """
@@ -850,6 +972,19 @@ public sealed class CommandRouterTests
             {
                 ExitCode = 0,
                 StdOut = "git@github.com:J-Tech-Japan/intent-system.git" + Environment.NewLine,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class FakeRunStartGitRunner : IGitCommandRunner
+    {
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
                 StdErr = string.Empty
             };
         }

--- a/tests/IntentSystem.Cli.Tests/ProgramTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ProgramTests.cs
@@ -20,6 +20,7 @@ public sealed class ProgramTests
                 default_domain = "intent-cli"
                 workflow_engine = "takt"
                 artifact_root = ".intent-cli"
+                worktree_root = ".intent-cli/worktrees"
                 """);
             var workingDirectory = tempDirectory.CreateDirectory(Path.Combine("repo", "src", "feature"));
             using var consoleScope = new ConsoleScope();

--- a/tests/IntentSystem.Cli.Tests/RunStartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunStartCommandTests.cs
@@ -1,0 +1,397 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Review;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class RunStartCommandTests
+{
+    [Fact]
+    public void Execute_GivenQueuedItemWithLinkedIssue_CreatesWorktreeAndActivatesItem()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var gitRunner = new FakeGitRunner();
+        var originalGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = RunStartCommand.TimestampFactory;
+
+        try
+        {
+            RunStartCommand.GitCommandRunnerFactory = () => gitRunner;
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T09:30:00Z");
+
+            var exitCode = RunStartCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run started for G14", writer.ToString(), StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Active, queueState.Items.Single(item => item.ExecutionUnit == "G14").State);
+            Assert.Equal(QueueItemState.Blocked, queueState.Items.Single(item => item.ExecutionUnit == "G15").State);
+
+            var worktreePath = Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "worktrees", "G14"));
+            var childRepoPath = Path.Combine(repoRoot, "submodules", "intent-system");
+            Assert.Equal(
+                [
+                    $"{childRepoPath}::fetch origin main",
+                    $"{childRepoPath}::worktree add -b issue-56-g14 {worktreePath} origin/main"
+                ],
+                gitRunner.Calls);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            var activated = Assert.Single(runEvents);
+            Assert.Equal("activated", activated.Event);
+            Assert.Equal("G14", activated.ExecutionUnit);
+        }
+        finally
+        {
+            RunStartCommand.GitCommandRunnerFactory = originalGitFactory;
+            RunStartCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingLinkedIssue_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(withLinkedIssue: false)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = RunStartCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must have a linked issue", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = RunStartCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Projection packet artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingChildRepoPath_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = RunStartCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Child repo path was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenExistingWorktreePath_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G14"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = RunStartCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Worktree path already exists", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenGitWorktreeFailure_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+        var originalGitFactory = RunStartCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunStartCommand.GitCommandRunnerFactory = () => new FakeGitRunner(failOnWorktreeAdd: true);
+
+            var originalQueueState = File.ReadAllText(queueStatePath);
+            var exitCode = RunStartCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("git worktree add failed", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Empty(File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            RunStartCommand.GitCommandRunnerFactory = originalGitFactory;
+        }
+    }
+
+    [Fact]
+    public void ResolveBranchName_GivenExecutionUnitAndLinkedIssue_UsesDeterministicShape()
+    {
+        var linkedIssue = new LinkedIssue
+        {
+            Repo = "J-Tech-Japan/intent-system",
+            Number = 56,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/56"
+        };
+
+        var branchName = RunStartCommand.ResolveBranchName("G14", linkedIssue);
+
+        Assert.Equal("issue-56-g14", branchName);
+    }
+
+    [Fact]
+    public void ResolveWorktreePath_GivenRelativeConfiguredRoot_UsesConfiguredWorktreeRoot()
+    {
+        var context = CreateContext("/tmp/repo");
+
+        var worktreePath = RunStartCommand.ResolveWorktreePath(context, "G14");
+
+        Assert.Equal(
+            Path.GetFullPath("/tmp/repo/.intent-cli/worktrees/G14"),
+            worktreePath);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState(bool withLinkedIssue = true)
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                CreateItem("G14", QueueItemState.Queued, withLinkedIssue),
+                CreateItem("G15", QueueItemState.Blocked, false) with
+                {
+                    Dependencies = ["G14"],
+                    BlockedBy = ["G14"]
+                }
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state, bool withLinkedIssue)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Run Start",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            LinkedIssue = withLinkedIssue
+                ? new LinkedIssue
+                {
+                    Repo = "J-Tech-Japan/intent-system",
+                    Number = 56,
+                    Url = "https://github.com/J-Tech-Japan/intent-system/issues/56"
+                }
+                : null,
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static string CreatePacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G14] Run Start Command"
+          issue_kind: "feature"
+          source_execution_unit: "G14"
+          goal: "Create isolated worktree and activate queue item."
+          in_scope:
+            - "run start command"
+          out_of_scope:
+            - "worker start"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli run start command"
+          dependencies:
+            - "G13"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "run start stays thin"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "isolated worktree created"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G14"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "isolated worktree created"
+          deterministic_review_checks:
+            - "run start remains thin"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private sealed class FakeGitRunner(bool failOnWorktreeAdd = false) : IGitCommandRunner
+    {
+        public List<string> Calls { get; } = [];
+
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Calls.Add($"{workingDirectory}::{string.Join(' ', arguments)}");
+
+            if (failOnWorktreeAdd && arguments.Count >= 2 && arguments[0] == "worktree" && arguments[1] == "add")
+            {
+                return new GitCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr = "git worktree add failed."
+                };
+            }
+
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-run-start-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `intent-cli run start <execution-unit>` to create an isolated child-repo worktree from `origin/main` and move the selected queued item to `active`
- read `worktree_root` from CLI config and resolve deterministic branch/worktree paths from the selected execution unit and linked issue
- add tests for worktree path resolution, branch naming, queue update, run-log append, router dispatch, and git worktree failure paths

Closes #56