### PR TITLE
[G15] Run Submit Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -31,7 +31,8 @@ internal static class CommandRouter
             },
             ["run"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
-                ["start"] = RunStartCommand.Execute
+                ["start"] = RunStartCommand.Execute,
+                ["submit"] = RunSubmitCommand.Execute
             },
             ["workflow"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/RunSubmitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSubmitCommand.cs
@@ -1,0 +1,224 @@
+using IntentSystem.Projection.Serialization;
+using IntentSystem.Review;
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunSubmitCommand
+{
+    private const string TransitionActor = "intent-cli";
+
+    public static Func<IGitCommandRunner> GitCommandRunnerFactory { get; set; } = () => new GitCommandRunner();
+
+    public static Func<IRunSubmitPublisher> PublisherFactory { get; set; } = () => new GhRunSubmitPublisher();
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Run submit command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        if (queueItem.LinkedIssue is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' must have a linked issue before run submit.");
+            return 1;
+        }
+
+        var packetPath = Path.Combine(
+            context.RepoRoot,
+            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(packetPath))
+        {
+            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
+            return 1;
+        }
+
+        try
+        {
+            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+            var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
+            if (string.IsNullOrWhiteSpace(childRepoRef))
+            {
+                throw new InvalidOperationException("Projection packet must contain a target repo.");
+            }
+
+            var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
+            if (!Directory.Exists(childRepoPath))
+            {
+                throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+            }
+
+            var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
+            if (!Directory.Exists(worktreePath))
+            {
+                throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
+            }
+
+            var branchName = RunStartCommand.ResolveBranchName(executionUnit, queueItem.LinkedIssue);
+            var gitRunner = GitCommandRunnerFactory();
+            EnsureBranchMatches(worktreePath, branchName, gitRunner);
+            PushBranch(worktreePath, branchName, gitRunner);
+
+            var targetRepo = ResolveGitHubTargetRepo(childRepoPath, gitRunner);
+            var pullRequestTitle = ResolvePullRequestTitle(queueItem);
+            var pullRequestBody = ResolvePullRequestBody(queueItem);
+            var linkedPr = PublisherFactory().CreateDraftPullRequest(
+                targetRepo,
+                branchName,
+                pullRequestTitle,
+                pullRequestBody);
+
+            var timestamp = TimestampFactory();
+            var transition = QueueManager.SubmitForReview(
+                queueState,
+                executionUnit,
+                TransitionActor,
+                timestamp,
+                linkedPr);
+            PersistSubmit(context, transition);
+
+            writer.WriteLine($"Run submitted for {executionUnit}.");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static string ResolvePullRequestTitle(QueueItem queueItem)
+    {
+        ArgumentNullException.ThrowIfNull(queueItem);
+        return queueItem.Title;
+    }
+
+    internal static string ResolvePullRequestBody(QueueItem queueItem)
+    {
+        ArgumentNullException.ThrowIfNull(queueItem);
+
+        if (queueItem.LinkedIssue is null)
+        {
+            throw new InvalidOperationException(
+                $"Execution unit '{queueItem.ExecutionUnit}' must have a linked issue before resolving PR body.");
+        }
+
+        return
+            $$"""
+            ## Summary
+
+            - {{queueItem.Title}}
+
+            ## Linked Issue
+
+            - {{queueItem.LinkedIssue.Url}}
+            """;
+    }
+
+    private static string ResolveChildRepoPath(string repoRoot, string childRepoRef)
+    {
+        return Path.IsPathRooted(childRepoRef)
+            ? Path.GetFullPath(childRepoRef)
+            : Path.GetFullPath(Path.Combine(repoRoot, childRepoRef));
+    }
+
+    private static void EnsureBranchMatches(
+        string worktreePath,
+        string expectedBranchName,
+        IGitCommandRunner gitRunner)
+    {
+        var branchResult = RunGit(
+            gitRunner,
+            worktreePath,
+            ["rev-parse", "--abbrev-ref", "HEAD"],
+            "git rev-parse --abbrev-ref HEAD failed.");
+        var currentBranch = branchResult.StdOut.Trim();
+
+        if (!string.Equals(currentBranch, expectedBranchName, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Current worktree branch '{currentBranch}' must match expected branch '{expectedBranchName}'.");
+        }
+    }
+
+    private static void PushBranch(
+        string worktreePath,
+        string branchName,
+        IGitCommandRunner gitRunner)
+    {
+        RunGit(
+            gitRunner,
+            worktreePath,
+            ["push", "-u", "origin", branchName],
+            "git push failed.");
+    }
+
+    private static string ResolveGitHubTargetRepo(string childRepoPath, IGitCommandRunner gitRunner)
+    {
+        var remoteResult = RunGit(
+            gitRunner,
+            childRepoPath,
+            ["remote", "get-url", "origin"],
+            "git remote get-url origin failed.");
+
+        return GitHubRepositoryTargetResolver.ParseRemoteUrl(remoteResult.StdOut.Trim());
+    }
+
+    private static GitCommandResult RunGit(
+        IGitCommandRunner gitRunner,
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        string defaultError)
+    {
+        var result = gitRunner.Run(workingDirectory, arguments);
+        if (result.ExitCode != 0)
+        {
+            var error = string.IsNullOrWhiteSpace(result.StdErr)
+                ? defaultError
+                : result.StdErr.Trim();
+            throw new InvalidOperationException(error);
+        }
+
+        return result;
+    }
+
+    private static void PersistSubmit(CliContext context, QueueTransitionResult result)
+    {
+        var queueStatePath = context.GetQueueStatePath();
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
+
+        var runLogPath = context.GetRunLogPath();
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(
+            runLogPath,
+            RunLogSerializer.SerializeLine(result.Event) + Environment.NewLine);
+    }
+}

--- a/src/IntentSystem.Cli/GhRunSubmitPublisher.cs
+++ b/src/IntentSystem.Cli/GhRunSubmitPublisher.cs
@@ -1,0 +1,71 @@
+namespace IntentSystem.Cli;
+
+internal sealed class GhRunSubmitPublisher : IRunSubmitPublisher
+{
+    private readonly IGitHubCommandRunner commandRunner;
+
+    public GhRunSubmitPublisher()
+        : this(new GhCommandRunner())
+    {
+    }
+
+    public GhRunSubmitPublisher(IGitHubCommandRunner commandRunner)
+    {
+        this.commandRunner = commandRunner ?? throw new ArgumentNullException(nameof(commandRunner));
+    }
+
+    public string CreateDraftPullRequest(string targetRepo, string headBranch, string title, string body)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetRepo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(headBranch);
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        ArgumentNullException.ThrowIfNull(body);
+
+        var bodyPath = Path.GetTempFileName();
+
+        try
+        {
+            File.WriteAllText(bodyPath, body);
+
+            var result = commandRunner.Run(
+                [
+                    "pr",
+                    "create",
+                    "--draft",
+                    "--base",
+                    "main",
+                    "--head",
+                    headBranch,
+                    "--title",
+                    title,
+                    "--body-file",
+                    bodyPath,
+                    "--repo",
+                    targetRepo
+                ]);
+
+            if (result.ExitCode != 0)
+            {
+                var error = string.IsNullOrWhiteSpace(result.StdErr)
+                    ? "gh pr create failed."
+                    : result.StdErr.Trim();
+                throw new InvalidOperationException(error);
+            }
+
+            var pullRequestUrl = result.StdOut.Trim();
+            if (!Uri.TryCreate(pullRequestUrl, UriKind.Absolute, out _))
+            {
+                throw new InvalidOperationException("GitHub PR create response must contain an absolute URL.");
+            }
+
+            return pullRequestUrl;
+        }
+        finally
+        {
+            if (File.Exists(bodyPath))
+            {
+                File.Delete(bodyPath);
+            }
+        }
+    }
+}

--- a/src/IntentSystem.Cli/IRunSubmitPublisher.cs
+++ b/src/IntentSystem.Cli/IRunSubmitPublisher.cs
@@ -1,0 +1,6 @@
+namespace IntentSystem.Cli;
+
+internal interface IRunSubmitPublisher
+{
+    string CreateDraftPullRequest(string targetRepo, string headBranch, string title, string body);
+}

--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -103,7 +103,7 @@ public static class QueueManager
         {
             Ts = ts,
             ExecutionUnit = executionUnit,
-            Event = "review-started",
+            Event = "review",
             By = by,
             LinkedPr = linkedPr
         });

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -181,6 +181,46 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenRunSubmitCommand_DispatchesToRunSubmitRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G14"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateRunSubmitQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreateRunSubmitPacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalGitFactory = RunSubmitCommand.GitCommandRunnerFactory;
+        var originalPublisherFactory = RunSubmitCommand.PublisherFactory;
+        var originalTimestampFactory = RunSubmitCommand.TimestampFactory;
+
+        try
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = () => new FakeRunSubmitGitRunner();
+            RunSubmitCommand.PublisherFactory = () => new FakeRunSubmitPublisher();
+            RunSubmitCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T10:15:00Z");
+
+            var exitCode = CommandRouter.Execute(["run", "submit", "G14"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run submitted for G14", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+            RunSubmitCommand.PublisherFactory = originalPublisherFactory;
+            RunSubmitCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenWorkflowRenderCommand_DispatchesToWorkflowRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -452,6 +492,42 @@ public sealed class CommandRouterTests
         };
     }
 
+    private static QueueState CreateRunSubmitQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G14",
+                    Title = "[G14] Run Start Command",
+                    State = QueueItemState.Active,
+                    Dependencies = [],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G14/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G14/review-context.md",
+                        Yaml = ".intent-cli/issues/G14/packet.yaml"
+                    },
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = 56,
+                        Url = "https://github.com/J-Tech-Japan/intent-system/issues/56"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
     private static QueueState CreateQueueDispatchQueueState()
     {
         return new QueueState
@@ -659,6 +735,56 @@ public sealed class CommandRouterTests
             - "workflow render writes workflow artifact"
           deterministic_review_checks:
             - "definition shape stays canonical"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private static string CreateRunSubmitPacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "G15 Run Submit Command"
+          issue_kind: "feature"
+          source_execution_unit: "G15"
+          goal: "Submit active worktree for review."
+          in_scope:
+            - "run submit command"
+          out_of_scope:
+            - "review execution"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli run submit command"
+          dependencies:
+            - "G14"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "run submit stays thin"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "draft pr created"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+        
+        review_context_packet:
+          source_execution_unit: "G15"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "draft pr created"
+          deterministic_review_checks:
+            - "run submit remains thin"
           clarification_return_path: "intents/intent-cli/clarifications/open.md"
         """;
     }
@@ -987,6 +1113,47 @@ public sealed class CommandRouterTests
                 StdOut = string.Empty,
                 StdErr = string.Empty
             };
+        }
+    }
+
+    private sealed class FakeRunSubmitGitRunner : IGitCommandRunner
+    {
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["rev-parse", "--abbrev-ref", "HEAD"]))
+            {
+                return new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "issue-56-g14" + Environment.NewLine,
+                    StdErr = string.Empty
+                };
+            }
+
+            if (arguments.SequenceEqual(["remote", "get-url", "origin"]))
+            {
+                return new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "git@github.com:J-Tech-Japan/intent-system.git" + Environment.NewLine,
+                    StdErr = string.Empty
+                };
+            }
+
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class FakeRunSubmitPublisher : IRunSubmitPublisher
+    {
+        public string CreateDraftPullRequest(string targetRepo, string headBranch, string title, string body)
+        {
+            return "https://github.com/J-Tech-Japan/intent-system/pull/58";
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -9,6 +9,7 @@ using IntentSystem.WorkerAdapter.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class CommandRouterTests
 {
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/GhRunSubmitPublisherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GhRunSubmitPublisherTests.cs
@@ -1,0 +1,60 @@
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GhRunSubmitPublisherTests
+{
+    [Fact]
+    public void CreateDraftPullRequest_GivenTargetRepoBranchTitleAndBody_CreatesDraftPrAndReturnsUrl()
+    {
+        var runner = new FakeRunner();
+        var publisher = new GhRunSubmitPublisher(runner);
+
+        var linkedPr = publisher.CreateDraftPullRequest(
+            "J-Tech-Japan/intent-system",
+            "issue-56-g14",
+            "[G14] Run Start Command",
+            "Linked issue");
+
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", linkedPr);
+        Assert.Equal(
+            [
+                "pr",
+                "create",
+                "--draft",
+                "--base",
+                "main",
+                "--head",
+                "issue-56-g14",
+                "--title",
+                "[G14] Run Start Command",
+                "--body-file",
+                runner.BodyFilePath,
+                "--repo",
+                "J-Tech-Japan/intent-system"
+            ],
+            runner.Arguments);
+        Assert.Equal("Linked issue", runner.BodyContents);
+    }
+
+    private sealed class FakeRunner : IGitHubCommandRunner
+    {
+        public IReadOnlyList<string> Arguments { get; private set; } = [];
+
+        public string BodyFilePath { get; private set; } = string.Empty;
+
+        public string BodyContents { get; private set; } = string.Empty;
+
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            Arguments = arguments.ToArray();
+            BodyFilePath = Arguments[10];
+            BodyContents = File.ReadAllText(BodyFilePath);
+
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "https://github.com/J-Tech-Japan/intent-system/pull/58" + Environment.NewLine,
+                StdErr = string.Empty
+            };
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/RunSubmitCommandCollection.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSubmitCommandCollection.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace IntentSystem.Cli.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class RunSubmitCommandCollection
+{
+    public const string Name = "RunSubmitCommand";
+}

--- a/tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs
@@ -1,0 +1,522 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Review;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class RunSubmitCommandTests
+{
+    [Fact]
+    public void Execute_GivenActiveItemWithWorktreeAndBranch_PushesCreatesDraftPrAndTransitionsToReview()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var childRepoPath = tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var worktreePath = tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G14"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var gitRunner = new FakeGitRunner(branchName: "issue-56-g14");
+        var publisher = new FakePublisher();
+        var originalGitFactory = RunSubmitCommand.GitCommandRunnerFactory;
+        var originalPublisherFactory = RunSubmitCommand.PublisherFactory;
+        var originalTimestampFactory = RunSubmitCommand.TimestampFactory;
+
+        try
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = () => gitRunner;
+            RunSubmitCommand.PublisherFactory = () => publisher;
+            RunSubmitCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T10:15:00Z");
+
+            var exitCode = RunSubmitCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run submitted for G14", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal("J-Tech-Japan/intent-system", publisher.TargetRepo);
+            Assert.Equal("issue-56-g14", publisher.HeadBranch);
+            Assert.Equal("[G14] Run Start Command", publisher.Title);
+            Assert.Contains("https://github.com/J-Tech-Japan/intent-system/issues/56", publisher.Body, StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Review, queueState.Items.Single(item => item.ExecutionUnit == "G14").State);
+            Assert.Equal(QueueItemState.Blocked, queueState.Items.Single(item => item.ExecutionUnit == "G15").State);
+
+            Assert.Equal(
+                [
+                    $"{worktreePath}::rev-parse --abbrev-ref HEAD",
+                    $"{worktreePath}::push -u origin issue-56-g14",
+                    $"{childRepoPath}::remote get-url origin"
+                ],
+                gitRunner.Calls);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            var reviewEvent = Assert.Single(runEvents);
+            Assert.Equal("review-started", reviewEvent.Event);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", reviewEvent.LinkedPr);
+        }
+        finally
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+            RunSubmitCommand.PublisherFactory = originalPublisherFactory;
+            RunSubmitCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingLinkedIssue_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(withLinkedIssue: false)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = RunSubmitCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must have a linked issue", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = RunSubmitCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Projection packet artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingChildRepoPath_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G14"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = RunSubmitCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Child repo path was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingWorktreePath_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = RunSubmitCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Worktree path was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenBranchMismatch_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G14"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+        var originalGitFactory = RunSubmitCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = () => new FakeGitRunner(branchName: "wrong-branch");
+
+            var originalQueueState = File.ReadAllText(queueStatePath);
+            var exitCode = RunSubmitCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("must match expected branch", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Empty(File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenGitPushFailure_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G14"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+        var originalGitFactory = RunSubmitCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = () => new FakeGitRunner(branchName: "issue-56-g14", failOnPush: true);
+
+            var originalQueueState = File.ReadAllText(queueStatePath);
+            var exitCode = RunSubmitCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("git push failed", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Empty(File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenPrCreateFailure_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G14"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+        var originalGitFactory = RunSubmitCommand.GitCommandRunnerFactory;
+        var originalPublisherFactory = RunSubmitCommand.PublisherFactory;
+
+        try
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = () => new FakeGitRunner(branchName: "issue-56-g14");
+            RunSubmitCommand.PublisherFactory = () => new FailingPublisher();
+
+            var originalQueueState = File.ReadAllText(queueStatePath);
+            var exitCode = RunSubmitCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("gh pr create failed", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Empty(File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+            RunSubmitCommand.PublisherFactory = originalPublisherFactory;
+        }
+    }
+
+    [Fact]
+    public void ResolvePullRequestTitle_GivenQueueItem_UsesQueueTitle()
+    {
+        var title = RunSubmitCommand.ResolvePullRequestTitle(CreateQueueState().Items[0]);
+
+        Assert.Equal("[G14] Run Start Command", title);
+    }
+
+    [Fact]
+    public void ResolvePullRequestBody_GivenQueueItem_UsesMinimalLinkedIssueBody()
+    {
+        var body = RunSubmitCommand.ResolvePullRequestBody(CreateQueueState().Items[0]);
+
+        Assert.Contains("[G14] Run Start Command", body, StringComparison.Ordinal);
+        Assert.Contains("https://github.com/J-Tech-Japan/intent-system/issues/56", body, StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState(bool withLinkedIssue = true)
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                CreateItem("G14", QueueItemState.Active, withLinkedIssue),
+                CreateItem("G15", QueueItemState.Blocked, false) with
+                {
+                    Dependencies = ["G14"],
+                    BlockedBy = ["G14"]
+                }
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state, bool withLinkedIssue)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = "[G14] Run Start Command",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            LinkedIssue = withLinkedIssue
+                ? new LinkedIssue
+                {
+                    Repo = "J-Tech-Japan/intent-system",
+                    Number = 56,
+                    Url = "https://github.com/J-Tech-Japan/intent-system/issues/56"
+                }
+                : null,
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static string CreatePacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "G15 Run Submit Command"
+          issue_kind: "feature"
+          source_execution_unit: "G15"
+          goal: "Submit active worktree for review."
+          in_scope:
+            - "run submit command"
+          out_of_scope:
+            - "review execution"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli run submit command"
+          dependencies:
+            - "G14"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "run submit stays thin"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "draft pr created"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G15"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "draft pr created"
+          deterministic_review_checks:
+            - "run submit remains thin"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private sealed class FakeGitRunner(string branchName, bool failOnPush = false) : IGitCommandRunner
+    {
+        public List<string> Calls { get; } = [];
+
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Calls.Add($"{workingDirectory}::{string.Join(' ', arguments)}");
+
+            if (arguments.Count >= 2
+                && arguments[0] == "push"
+                && arguments[1] == "-u"
+                && failOnPush)
+            {
+                return new GitCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr = "git push failed."
+                };
+            }
+
+            if (arguments.SequenceEqual(["rev-parse", "--abbrev-ref", "HEAD"]))
+            {
+                return new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = branchName + Environment.NewLine,
+                    StdErr = string.Empty
+                };
+            }
+
+            if (arguments.SequenceEqual(["remote", "get-url", "origin"]))
+            {
+                return new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "git@github.com:J-Tech-Japan/intent-system.git" + Environment.NewLine,
+                    StdErr = string.Empty
+                };
+            }
+
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class FakePublisher : IRunSubmitPublisher
+    {
+        public string TargetRepo { get; private set; } = string.Empty;
+        public string HeadBranch { get; private set; } = string.Empty;
+        public string Title { get; private set; } = string.Empty;
+        public string Body { get; private set; } = string.Empty;
+
+        public string CreateDraftPullRequest(string targetRepo, string headBranch, string title, string body)
+        {
+            TargetRepo = targetRepo;
+            HeadBranch = headBranch;
+            Title = title;
+            Body = body;
+
+            return "https://github.com/J-Tech-Japan/intent-system/pull/58";
+        }
+    }
+
+    private sealed class FailingPublisher : IRunSubmitPublisher
+    {
+        public string CreateDraftPullRequest(string targetRepo, string headBranch, string title, string body)
+        {
+            throw new InvalidOperationException("gh pr create failed.");
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-run-submit-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs
@@ -6,6 +6,7 @@ using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class RunSubmitCommandTests
 {
     [Fact]
@@ -62,7 +63,7 @@ public sealed class RunSubmitCommandTests
             var runEvents = RunLogSerializer.DeserializeAll(
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
             var reviewEvent = Assert.Single(runEvents);
-            Assert.Equal("review-started", reviewEvent.Event);
+            Assert.Equal("review", reviewEvent.Event);
             Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", reviewEvent.LinkedPr);
         }
         finally

--- a/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
@@ -39,7 +39,7 @@ public sealed class QueueManagerTests
         var result = QueueManager.SubmitForReview(state, "A1", "worker", BaseTime, linkedPr: "https://github.com/org/repo/pull/1");
 
         Assert.Equal(QueueItemState.Review, FindItem(result.UpdatedState, "A1").State);
-        Assert.Equal("review-started", result.Event.Event);
+        Assert.Equal("review", result.Event.Event);
         Assert.Equal("https://github.com/org/repo/pull/1", result.Event.LinkedPr);
     }
 


### PR DESCRIPTION
## What changed
- add `intent-cli run submit <execution-unit>` to validate the active queue item, resolve the existing deterministic worktree/branch, push it, and open a draft child PR
- resolve the child GitHub repository from the child checkout's `origin` remote and transition the selected queue item to `review` with a linked PR run-log event
- cover success and required reject cases with CLI command, publisher, and router tests

## Why
- issue 58 requires the thin submit path from an already started run into draft review without reimplementing queue dispatch or run start behavior

## Validation
- `dotnet test`
