### PR TITLE
[G16] Run Rereview Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -32,7 +32,8 @@ internal static class CommandRouter
             ["run"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["start"] = RunStartCommand.Execute,
-                ["submit"] = RunSubmitCommand.Execute
+                ["submit"] = RunSubmitCommand.Execute,
+                ["rereview"] = RunRereviewCommand.Execute
             },
             ["workflow"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/RunRereviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunRereviewCommand.cs
@@ -1,0 +1,80 @@
+using IntentSystem.Review;
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunRereviewCommand
+{
+    private const string TransitionActor = "intent-cli";
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Run rereview command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        if (!queueState.Items.Any(item => string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal)))
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            writer.WriteLine($"Run log was not found at {runLogPath}");
+            return 1;
+        }
+
+        try
+        {
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            var linkedPr = LatestLinkedPrResolver.Resolve(runEvents, executionUnit);
+            var transition = QueueManager.ResubmitForReview(
+                queueState,
+                executionUnit,
+                TransitionActor,
+                TimestampFactory(),
+                linkedPr);
+
+            PersistRereview(context, transition);
+            writer.WriteLine($"Run rereviewed for {executionUnit}.");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static void PersistRereview(CliContext context, QueueTransitionResult result)
+    {
+        var queueStatePath = context.GetQueueStatePath();
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
+
+        var runLogPath = context.GetRunLogPath();
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(
+            runLogPath,
+            RunLogSerializer.SerializeLine(result.Event) + Environment.NewLine);
+    }
+}

--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -151,7 +151,7 @@ public static class QueueManager
         {
             Ts = ts,
             ExecutionUnit = executionUnit,
-            Event = "review-started",
+            Event = "review",
             By = by,
             LinkedPr = linkedPr
         });

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -222,6 +222,35 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenRunRereviewCommand_DispatchesToRunRereviewRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateRunRereviewQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunRereviewRunLog());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunRereviewCommand.TimestampFactory;
+
+        try
+        {
+            RunRereviewCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T08:30:00Z");
+
+            var exitCode = CommandRouter.Execute(["run", "rereview", "G16"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run rereviewed for G16", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunRereviewCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenWorkflowRenderCommand_DispatchesToWorkflowRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -559,6 +588,36 @@ public sealed class CommandRouterTests
         };
     }
 
+    private static QueueState CreateRunRereviewQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-05T09:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G16",
+                    Title = "Run rereview command",
+                    State = QueueItemState.Fixing,
+                    Dependencies = ["G15"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G16/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G16/review-context.md",
+                        Yaml = ".intent-cli/issues/G16/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
     private static QueueState CreateReviewQueueState()
     {
         return new QueueState
@@ -838,6 +897,15 @@ public sealed class CommandRouterTests
             - "dispatch remains thin"
           clarification_return_path: "intents/intent-cli/clarifications/open.md"
         """;
+    }
+
+    private static string CreateRunRereviewRunLog()
+    {
+        return """
+        {"ts":"2026-04-05T09:00:00Z","execution_unit":"G16","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/60"}
+        {"ts":"2026-04-05T09:10:00Z","execution_unit":"G16","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/60#issuecomment-1"}
+        {"ts":"2026-04-05T09:30:00Z","execution_unit":"G16","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/61"}
+        """ + Environment.NewLine;
     }
 
     private static string CreateWorkflowDefinitionJson()

--- a/tests/IntentSystem.Cli.Tests/RunRereviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunRereviewCommandTests.cs
@@ -1,0 +1,251 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class RunRereviewCommandTests
+{
+    [Fact]
+    public void Execute_GivenFixingItemAndLatestLinkedPr_ReturnsItemToReviewAndAppendsReviewEvent()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunRereviewCommand.TimestampFactory;
+
+        try
+        {
+            RunRereviewCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T08:30:00Z");
+
+            var exitCode = RunRereviewCommand.Execute(CreateContext(repoRoot), ["G16"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run rereviewed for G16", writer.ToString(), StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Review, queueState.Items.Single(item => item.ExecutionUnit == "G16").State);
+            Assert.Equal(QueueItemState.Blocked, queueState.Items.Single(item => item.ExecutionUnit == "G17").State);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            var appendedEvent = runEvents[^1];
+            Assert.Equal("review", appendedEvent.Event);
+            Assert.Equal("G16", appendedEvent.ExecutionUnit);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/61", appendedEvent.LinkedPr);
+        }
+        finally
+        {
+            RunRereviewCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = RunRereviewCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingQueueItem_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+
+        var exitCode = RunRereviewCommand.Execute(CreateContext(repoRoot), ["G99"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("was not found in queue state", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingRunLog_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = RunRereviewCommand.Execute(CreateContext(repoRoot), ["G16"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Run log was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingLinkedPr_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """{"ts":"2026-04-05T09:00:00Z","execution_unit":"G16","event":"fix-requested","by":"intent-cli"}""" + Environment.NewLine);
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunRereviewCommand.Execute(CreateContext(repoRoot), ["G16"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("No linked PR found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenNonFixingState_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Review)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunRereviewCommand.Execute(CreateContext(repoRoot), ["G16"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("expected state 'Fixing'", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState(QueueItemState selectedState = QueueItemState.Fixing)
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-05T09:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G16",
+                    Title = "Run rereview command",
+                    State = selectedState,
+                    Dependencies = ["G15"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G16/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G16/review-context.md",
+                        Yaml = ".intent-cli/issues/G16/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                },
+                new QueueItem
+                {
+                    ExecutionUnit = "G17",
+                    Title = "Unrelated blocked item",
+                    State = QueueItemState.Blocked,
+                    Dependencies = ["G16"],
+                    BlockedBy = ["G16"],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G17/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G17/review-context.md",
+                        Yaml = ".intent-cli/issues/G17/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "normal"
+                }
+            ]
+        };
+    }
+
+    private static string CreateRunLog()
+    {
+        return """
+        {"ts":"2026-04-05T09:00:00Z","execution_unit":"G16","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/60"}
+        {"ts":"2026-04-05T09:10:00Z","execution_unit":"G16","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/60#issuecomment-1"}
+        {"ts":"2026-04-05T09:20:00Z","execution_unit":"A1","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/12"}
+        {"ts":"2026-04-05T09:30:00Z","execution_unit":"G16","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/61"}
+        """ + Environment.NewLine;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-run-rereview-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
@@ -60,10 +60,16 @@ public sealed class QueueManagerTests
     {
         var state = CreateState(QueueItemState.Fixing);
 
-        var result = QueueManager.ResubmitForReview(state, "A1", "worker", BaseTime);
+        var result = QueueManager.ResubmitForReview(
+            state,
+            "A1",
+            "worker",
+            BaseTime,
+            linkedPr: "https://github.com/org/repo/pull/2");
 
         Assert.Equal(QueueItemState.Review, FindItem(result.UpdatedState, "A1").State);
-        Assert.Equal("review-started", result.Event.Event);
+        Assert.Equal("review", result.Event.Event);
+        Assert.Equal("https://github.com/org/repo/pull/2", result.Event.LinkedPr);
     }
 
     [Fact]


### PR DESCRIPTION
## What changed
- add `intent-cli run rereview <execution-unit>` to move a fixing item back to `review` using the latest linked PR from the current `.intent-cli/runs.jsonl`
- append the linked PR ref back into `.intent-cli/runs.jsonl` while keeping the queue mutation limited to the selected execution unit
- align the fixing -> review queue transition contract with the canonical `review` event and cover the new flow in CLI and supervisor tests

## Why
- issue 60 requires a deterministic rereview entry after repair-in-place without reintroducing git, review execution, or workflow responsibilities into the command

## Validation
- `dotnet test`
