### PR TITLE
[G17] Run Resume Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -33,7 +33,8 @@ internal static class CommandRouter
             {
                 ["start"] = RunStartCommand.Execute,
                 ["submit"] = RunSubmitCommand.Execute,
-                ["rereview"] = RunRereviewCommand.Execute
+                ["rereview"] = RunRereviewCommand.Execute,
+                ["resume"] = RunResumeCommand.Execute
             },
             ["workflow"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/RunResumeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunResumeCommand.cs
@@ -1,0 +1,149 @@
+using IntentSystem.Projection.Serialization;
+using IntentSystem.Review;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunResumeCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Run resume command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        if (queueItem.State is not (QueueItemState.Active or QueueItemState.Fixing))
+        {
+            writer.WriteLine(
+                $"Execution unit '{executionUnit}' must be active or fixing before run resume.");
+            return 1;
+        }
+
+        if (queueItem.LinkedIssue is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' must have a linked issue before run resume.");
+            return 1;
+        }
+
+        var packetPath = Path.Combine(
+            context.RepoRoot,
+            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(packetPath))
+        {
+            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
+            return 1;
+        }
+
+        try
+        {
+            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+            var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
+            if (string.IsNullOrWhiteSpace(childRepoRef))
+            {
+                throw new InvalidOperationException("Projection packet must contain a target repo.");
+            }
+
+            var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
+            if (!Directory.Exists(childRepoPath))
+            {
+                throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+            }
+
+            var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
+            if (!Directory.Exists(worktreePath))
+            {
+                throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
+            }
+
+            var branchName = RunStartCommand.ResolveBranchName(executionUnit, queueItem.LinkedIssue);
+            var latestLinkedPr = ResolveLatestLinkedPr(context, executionUnit);
+
+            WriteContext(
+                writer,
+                queueItem,
+                worktreePath,
+                childRepoPath,
+                branchName,
+                latestLinkedPr);
+
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static void WriteContext(
+        TextWriter writer,
+        QueueItem queueItem,
+        string worktreePath,
+        string childRepoPath,
+        string branchName,
+        string? latestLinkedPr)
+    {
+        writer.WriteLine($"Execution unit: {queueItem.ExecutionUnit}");
+        writer.WriteLine($"State: {FormatState(queueItem.State)}");
+        writer.WriteLine($"Worktree path: {worktreePath}");
+        writer.WriteLine($"Child repo path: {childRepoPath}");
+        writer.WriteLine($"Branch: {branchName}");
+        writer.WriteLine($"Linked issue: {queueItem.LinkedIssue!.Url}");
+
+        if (!string.IsNullOrWhiteSpace(latestLinkedPr))
+        {
+            writer.WriteLine($"Latest linked PR: {latestLinkedPr}");
+        }
+    }
+
+    private static string? ResolveLatestLinkedPr(CliContext context, string executionUnit)
+    {
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            return null;
+        }
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        return LatestLinkedPrResolver.TryResolve(runEvents, executionUnit);
+    }
+
+    private static string ResolveChildRepoPath(string repoRoot, string childRepoRef)
+    {
+        return Path.IsPathRooted(childRepoRef)
+            ? Path.GetFullPath(childRepoRef)
+            : Path.GetFullPath(Path.Combine(repoRoot, childRepoRef));
+    }
+
+    private static string FormatState(QueueItemState state)
+    {
+        return state switch
+        {
+            QueueItemState.ClarifyBlocked => "clarify-blocked",
+            _ => state.ToString().ToLowerInvariant()
+        };
+    }
+}

--- a/src/IntentSystem.Review/LatestLinkedPrResolver.cs
+++ b/src/IntentSystem.Review/LatestLinkedPrResolver.cs
@@ -6,6 +6,13 @@ public static class LatestLinkedPrResolver
 {
     public static string Resolve(IReadOnlyList<RunEvent> runEvents, string executionUnit)
     {
+        return TryResolve(runEvents, executionUnit)
+            ?? throw new InvalidOperationException(
+                $"No linked PR found for execution unit '{executionUnit}' in run log.");
+    }
+
+    public static string? TryResolve(IReadOnlyList<RunEvent> runEvents, string executionUnit)
+    {
         ArgumentNullException.ThrowIfNull(runEvents);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
 
@@ -24,8 +31,6 @@ public static class LatestLinkedPrResolver
             }
         }
 
-        return latestLinkedPr
-            ?? throw new InvalidOperationException(
-                $"No linked PR found for execution unit '{executionUnit}' in run log.");
+        return latestLinkedPr;
     }
 }

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -251,6 +251,31 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenRunResumeCommand_DispatchesToRunResumeRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G17"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateRunResumeQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G17", "packet.yaml"),
+            CreateRunResumePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunResumeRunLog());
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["run", "resume", "G17"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Execution unit: G17", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/63", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenWorkflowRenderCommand_DispatchesToWorkflowRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -618,6 +643,42 @@ public sealed class CommandRouterTests
         };
     }
 
+    private static QueueState CreateRunResumeQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-06T08:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G17",
+                    Title = "Run resume command",
+                    State = QueueItemState.Active,
+                    Dependencies = ["G16"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G17/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G17/review-context.md",
+                        Yaml = ".intent-cli/issues/G17/packet.yaml"
+                    },
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = 62,
+                        Url = "https://github.com/J-Tech-Japan/intent-system/issues/62"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
     private static QueueState CreateReviewQueueState()
     {
         return new QueueState
@@ -905,6 +966,65 @@ public sealed class CommandRouterTests
         {"ts":"2026-04-05T09:00:00Z","execution_unit":"G16","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/60"}
         {"ts":"2026-04-05T09:10:00Z","execution_unit":"G16","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/60#issuecomment-1"}
         {"ts":"2026-04-05T09:30:00Z","execution_unit":"G16","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/61"}
+        """ + Environment.NewLine;
+    }
+
+    private static string CreateRunResumePacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "G17 Run Resume Command"
+          issue_kind: "feature"
+          source_execution_unit: "G17"
+          goal: "Render resumable context for an existing run."
+          in_scope:
+            - "run resume command"
+          out_of_scope:
+            - "queue mutation"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli run resume command"
+          dependencies:
+            - "G16"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "run resume stays read-only"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "resumable context displayed"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G17"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "resumable context displayed"
+          deterministic_review_checks:
+            - "run resume remains read-only"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private static string CreateRunResumeRunLog()
+    {
+        return """
+        {"ts":"2026-04-06T08:00:00Z","execution_unit":"G17","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/62"}
+        {"ts":"2026-04-06T08:20:00Z","execution_unit":"G17","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/62#issuecomment-1"}
+        {"ts":"2026-04-06T08:30:00Z","execution_unit":"G17","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/63"}
         """ + Environment.NewLine;
     }
 

--- a/tests/IntentSystem.Cli.Tests/RunResumeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunResumeCommandTests.cs
@@ -1,0 +1,373 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Review;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class RunResumeCommandTests
+{
+    [Fact]
+    public void Execute_GivenActiveItemWithExistingContext_WritesDeterministicResumeContext()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var childRepoPath = tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var worktreePath = tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G17"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G17", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+        var exitCode = RunResumeCommand.Execute(CreateContext(repoRoot), ["G17"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Execution unit: G17", output, StringComparison.Ordinal);
+        Assert.Contains("State: active", output, StringComparison.Ordinal);
+        Assert.Contains($"Worktree path: {worktreePath}", output, StringComparison.Ordinal);
+        Assert.Contains($"Child repo path: {childRepoPath}", output, StringComparison.Ordinal);
+        Assert.Contains("Branch: issue-62-g17", output, StringComparison.Ordinal);
+        Assert.Contains("Linked issue: https://github.com/J-Tech-Japan/intent-system/issues/62", output, StringComparison.Ordinal);
+        Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/63", output, StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenFixingItemWithoutLinkedPr_WritesResumeContextWithoutLatestLinkedPr()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G17"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G17", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """{"ts":"2026-04-06T08:00:00Z","execution_unit":"G17","event":"fix-requested","by":"intent-cli"}""" + Environment.NewLine);
+        using var writer = new StringWriter();
+
+        var exitCode = RunResumeCommand.Execute(CreateContext(repoRoot), ["G17"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain("Latest linked PR:", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("State: fixing", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = RunResumeCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingQueueItem_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = RunResumeCommand.Execute(CreateContext(repoRoot), ["G99"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("was not found in queue state", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenInvalidState_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Review)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G17", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+        var exitCode = RunResumeCommand.Execute(CreateContext(repoRoot), ["G17"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must be active or fixing", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingLinkedIssue_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(withLinkedIssue: false)));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G17", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = RunResumeCommand.Execute(CreateContext(repoRoot), ["G17"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must have a linked issue", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = RunResumeCommand.Execute(CreateContext(repoRoot), ["G17"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Projection packet artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingChildRepoPath_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G17"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G17", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+        var exitCode = RunResumeCommand.Execute(CreateContext(repoRoot), ["G17"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Child repo path was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingWorktreePath_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G17", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+        var exitCode = RunResumeCommand.Execute(CreateContext(repoRoot), ["G17"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Worktree path was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState(
+        QueueItemState selectedState = QueueItemState.Active,
+        bool withLinkedIssue = true)
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-06T08:12:34Z"),
+            Items =
+            [
+                CreateItem("G17", selectedState, withLinkedIssue),
+                CreateItem("G18", QueueItemState.Blocked, false) with
+                {
+                    Dependencies = ["G17"],
+                    BlockedBy = ["G17"]
+                }
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state, bool withLinkedIssue)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Run Resume Command",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            LinkedIssue = withLinkedIssue
+                ? new LinkedIssue
+                {
+                    Repo = "J-Tech-Japan/intent-system",
+                    Number = 62,
+                    Url = "https://github.com/J-Tech-Japan/intent-system/issues/62"
+                }
+                : null,
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static string CreatePacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G17] Run Resume Command"
+          issue_kind: "feature"
+          source_execution_unit: "G17"
+          goal: "Render resumable context for an existing run."
+          in_scope:
+            - "run resume command"
+          out_of_scope:
+            - "queue mutation"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli run resume command"
+          dependencies:
+            - "G16"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "run resume stays read-only"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "resumable context displayed"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G17"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "resumable context displayed"
+          deterministic_review_checks:
+            - "run resume remains read-only"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private static string CreateRunLog()
+    {
+        return """
+        {"ts":"2026-04-06T08:00:00Z","execution_unit":"G17","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/62"}
+        {"ts":"2026-04-06T08:10:00Z","execution_unit":"A1","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/12"}
+        {"ts":"2026-04-06T08:20:00Z","execution_unit":"G17","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/62#issuecomment-1"}
+        {"ts":"2026-04-06T08:30:00Z","execution_unit":"G17","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/63"}
+        """ + Environment.NewLine;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-run-resume-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Review.Tests/LatestLinkedPrResolverTests.cs
+++ b/tests/IntentSystem.Review.Tests/LatestLinkedPrResolverTests.cs
@@ -57,4 +57,22 @@ public sealed class LatestLinkedPrResolverTests
 
         Assert.Contains("No linked PR found", exception.Message, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void TryResolve_GivenNoLinkedPrForExecutionUnit_ReturnsNull()
+    {
+        var linkedPr = LatestLinkedPrResolver.TryResolve(
+            [
+                new RunEvent
+                {
+                    Ts = DateTimeOffset.Parse("2026-04-03T10:00:00Z"),
+                    ExecutionUnit = "G9",
+                    Event = "queued",
+                    By = "intent-cli"
+                }
+            ],
+            "G9");
+
+        Assert.Null(linkedPr);
+    }
 }


### PR DESCRIPTION
## What changed
- add `intent-cli run resume <execution-unit>` to render deterministic resumable context for an existing `active` or `fixing` item
- resolve the existing worktree path, child repo path, deterministic branch, linked issue, and optional latest linked PR without mutating queue state or appending run events
- add `LatestLinkedPrResolver.TryResolve` so read-only command paths can show PR context when available and omit it when absent

## Why
- issue 62 requires a read-only resume entry that reconnects a human to the current run context without broadening into queue mutation, git push, or review execution

## Validation
- `dotnet test`
