### PR TITLE
[G18] Run Log Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -34,7 +34,8 @@ internal static class CommandRouter
                 ["start"] = RunStartCommand.Execute,
                 ["submit"] = RunSubmitCommand.Execute,
                 ["rereview"] = RunRereviewCommand.Execute,
-                ["resume"] = RunResumeCommand.Execute
+                ["resume"] = RunResumeCommand.Execute,
+                ["log"] = RunLogCommand.Execute
             },
             ["workflow"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/RunLogCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunLogCommand.cs
@@ -1,0 +1,49 @@
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunLogCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Run log command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            writer.WriteLine($"Run log was not found at {runLogPath}");
+            return 1;
+        }
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath))
+            .Where(runEvent => string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+            .ToArray();
+
+        RunLogRenderer.Write(writer, queueItem, runEvents);
+        return 0;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunLogRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/RunLogRenderer.cs
@@ -1,0 +1,65 @@
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunLogRenderer
+{
+    public static void Write(TextWriter writer, QueueItem queueItem, IReadOnlyList<RunEvent> runEvents)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(queueItem);
+        ArgumentNullException.ThrowIfNull(runEvents);
+
+        writer.WriteLine($"Execution unit: {queueItem.ExecutionUnit}");
+        writer.WriteLine($"Current state: {FormatState(queueItem.State)}");
+        writer.WriteLine($"Linked issue: {FormatValue(queueItem.LinkedIssue?.Url)}");
+        writer.WriteLine("Run history:");
+
+        if (runEvents.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var runEvent in runEvents)
+        {
+            var parts = new List<string>
+            {
+                runEvent.Ts.ToString("O"),
+                $"event={runEvent.Event}",
+                $"by={runEvent.By}"
+            };
+
+            AppendOptionalPart(parts, "linked_issue", runEvent.LinkedIssue);
+            AppendOptionalPart(parts, "linked_pr", runEvent.LinkedPr);
+            AppendOptionalPart(parts, "comment_ref", runEvent.CommentRef);
+            AppendOptionalPart(parts, "reason", runEvent.Reason);
+
+            writer.WriteLine($"- {string.Join(" | ", parts)}");
+        }
+    }
+
+    private static void AppendOptionalPart(List<string> parts, string label, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            parts.Add($"{label}={value}");
+        }
+    }
+
+    private static string FormatState(QueueItemState state)
+    {
+        return state switch
+        {
+            QueueItemState.ClarifyBlocked => "clarify-blocked",
+            _ => state.ToString().ToLowerInvariant()
+        };
+    }
+
+    private static string FormatValue(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? "-"
+            : value;
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -276,6 +276,26 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenRunLogCommand_DispatchesToRunLogRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateRunLogQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLogCommandRunLog());
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["run", "log", "G18"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Execution unit: G18", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("event=review", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenWorkflowRenderCommand_DispatchesToWorkflowRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -679,6 +699,42 @@ public sealed class CommandRouterTests
         };
     }
 
+    private static QueueState CreateRunLogQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-07T08:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G18",
+                    Title = "Run log command",
+                    State = QueueItemState.Fixing,
+                    Dependencies = ["G17"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G18/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G18/review-context.md",
+                        Yaml = ".intent-cli/issues/G18/packet.yaml"
+                    },
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = 64,
+                        Url = "https://github.com/J-Tech-Japan/intent-system/issues/64"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
     private static QueueState CreateReviewQueueState()
     {
         return new QueueState
@@ -1025,6 +1081,15 @@ public sealed class CommandRouterTests
         {"ts":"2026-04-06T08:00:00Z","execution_unit":"G17","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/62"}
         {"ts":"2026-04-06T08:20:00Z","execution_unit":"G17","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/62#issuecomment-1"}
         {"ts":"2026-04-06T08:30:00Z","execution_unit":"G17","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/63"}
+        """ + Environment.NewLine;
+    }
+
+    private static string CreateRunLogCommandRunLog()
+    {
+        return """
+        {"ts":"2026-04-07T08:00:00Z","execution_unit":"G18","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/64"}
+        {"ts":"2026-04-07T08:10:00Z","execution_unit":"G18","event":"activated","by":"intent-cli"}
+        {"ts":"2026-04-07T08:20:00Z","execution_unit":"G18","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/65"}
         """ + Environment.NewLine;
     }
 

--- a/tests/IntentSystem.Cli.Tests/RunLogCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunLogCommandTests.cs
@@ -1,0 +1,224 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class RunLogCommandTests
+{
+    [Fact]
+    public void Execute_GivenQueueItemAndRunLog_WritesSelectedExecutionUnitHistoryWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunLogCommand.Execute(CreateContext(repoRoot), ["G18"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Execution unit: G18", output, StringComparison.Ordinal);
+        Assert.Contains("Current state: fixing", output, StringComparison.Ordinal);
+        Assert.Contains("event=issue-created", output, StringComparison.Ordinal);
+        Assert.Contains("event=activated", output, StringComparison.Ordinal);
+        Assert.Contains("event=review", output, StringComparison.Ordinal);
+        Assert.Contains("event=fix-requested", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Execution unit: A1", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("https://github.com/J-Tech-Japan/intent-system/pull/12", output, StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenNoMatchingRunEvents_WritesNoneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """{"ts":"2026-04-07T08:00:00Z","execution_unit":"A1","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/12"}""" + Environment.NewLine);
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunLogCommand.Execute(CreateContext(repoRoot), ["G18"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("- none", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = RunLogCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingQueueItem_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+
+        var exitCode = RunLogCommand.Execute(CreateContext(repoRoot), ["G99"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("was not found in queue state", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingRunLog_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = RunLogCommand.Execute(CreateContext(repoRoot), ["G18"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Run log was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-07T08:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G18",
+                    Title = "Run log command",
+                    State = QueueItemState.Fixing,
+                    Dependencies = ["G17"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G18/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G18/review-context.md",
+                        Yaml = ".intent-cli/issues/G18/packet.yaml"
+                    },
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = 64,
+                        Url = "https://github.com/J-Tech-Japan/intent-system/issues/64"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                },
+                new QueueItem
+                {
+                    ExecutionUnit = "A1",
+                    Title = "Unrelated execution unit",
+                    State = QueueItemState.Completed,
+                    Dependencies = [],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/A1/implementation.md",
+                        ReviewContext = ".intent-cli/issues/A1/review-context.md",
+                        Yaml = ".intent-cli/issues/A1/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "normal"
+                }
+            ]
+        };
+    }
+
+    private static string CreateRunLog()
+    {
+        return """
+        {"ts":"2026-04-07T08:00:00Z","execution_unit":"G18","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/64"}
+        {"ts":"2026-04-07T08:05:00Z","execution_unit":"A1","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/12"}
+        {"ts":"2026-04-07T08:10:00Z","execution_unit":"G18","event":"activated","by":"intent-cli"}
+        {"ts":"2026-04-07T08:20:00Z","execution_unit":"G18","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/65"}
+        {"ts":"2026-04-07T08:30:00Z","execution_unit":"G18","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/65#issuecomment-1","reason":"contract mismatch"}
+        """ + Environment.NewLine;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-run-log-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/RunLogRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunLogRendererTests.cs
@@ -1,0 +1,103 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class RunLogRendererTests
+{
+    [Fact]
+    public void Write_GivenRunEventsWithOptionalRefs_RendersDeterministicHistory()
+    {
+        using var writer = new StringWriter();
+
+        RunLogRenderer.Write(writer, CreateQueueItem(), CreateRunEvents());
+
+        var output = writer.ToString();
+        Assert.Contains("Execution unit: G18", output, StringComparison.Ordinal);
+        Assert.Contains("Current state: fixing", output, StringComparison.Ordinal);
+        Assert.Contains("Linked issue: https://github.com/J-Tech-Japan/intent-system/issues/64", output, StringComparison.Ordinal);
+        Assert.Contains("event=issue-created", output, StringComparison.Ordinal);
+        Assert.Contains("linked_issue=https://github.com/J-Tech-Japan/intent-system/issues/64", output, StringComparison.Ordinal);
+        Assert.Contains("linked_pr=https://github.com/J-Tech-Japan/intent-system/pull/65", output, StringComparison.Ordinal);
+        Assert.Contains("comment_ref=https://github.com/J-Tech-Japan/intent-system/pull/65#issuecomment-1", output, StringComparison.Ordinal);
+        Assert.Contains("reason=contract mismatch", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Write_GivenNoRunEvents_RendersNone()
+    {
+        using var writer = new StringWriter();
+
+        RunLogRenderer.Write(writer, CreateQueueItem(), []);
+
+        Assert.Contains("Run history:", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("- none", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static QueueItem CreateQueueItem()
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = "G18",
+            Title = "[G18] Run Log Command",
+            State = QueueItemState.Fixing,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = ".intent-cli/issues/G18/implementation.md",
+                ReviewContext = ".intent-cli/issues/G18/review-context.md",
+                Yaml = ".intent-cli/issues/G18/packet.yaml"
+            },
+            LinkedIssue = new LinkedIssue
+            {
+                Repo = "J-Tech-Japan/intent-system",
+                Number = 64,
+                Url = "https://github.com/J-Tech-Japan/intent-system/issues/64"
+            },
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static IReadOnlyList<RunEvent> CreateRunEvents()
+    {
+        return
+        [
+            new RunEvent
+            {
+                Ts = DateTimeOffset.Parse("2026-04-07T08:00:00Z"),
+                ExecutionUnit = "G18",
+                Event = "issue-created",
+                By = "intent-cli",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/64"
+            },
+            new RunEvent
+            {
+                Ts = DateTimeOffset.Parse("2026-04-07T08:10:00Z"),
+                ExecutionUnit = "G18",
+                Event = "activated",
+                By = "intent-cli"
+            },
+            new RunEvent
+            {
+                Ts = DateTimeOffset.Parse("2026-04-07T08:20:00Z"),
+                ExecutionUnit = "G18",
+                Event = "review",
+                By = "intent-cli",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/65"
+            },
+            new RunEvent
+            {
+                Ts = DateTimeOffset.Parse("2026-04-07T08:30:00Z"),
+                ExecutionUnit = "G18",
+                Event = "fix-requested",
+                By = "intent-cli",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/65#issuecomment-1",
+                Reason = "contract mismatch"
+            }
+        ];
+    }
+}


### PR DESCRIPTION
## What changed
- add `intent-cli run log <execution-unit>` to render the selected execution unit's current queue state and append-only run history from `.intent-cli/runs.jsonl`
- add a dedicated run log renderer that deterministically includes optional linked issue, linked PR, comment ref, and reason fields only when present
- cover command routing, selected-item-only history filtering, no-history rendering, and read-only behavior with CLI tests

## Why
- issue 64 requires a human-facing run history reader without broadening into queue mutation, run-log writes, git operations, or review execution

## Validation
- `dotnet test`
