### PR TITLE
[G19] Run Implement Command

### DIFF
--- a/src/IntentSystem.Cli/CliRuntimeContracts.cs
+++ b/src/IntentSystem.Cli/CliRuntimeContracts.cs
@@ -12,7 +12,16 @@ internal static class CliRuntimeContracts
     public const string WorkflowEngineKey = "workflow_engine";
     public const string ArtifactRootKey = "artifact_root";
     public const string WorktreeRootKey = "worktree_root";
+    public const string RolesSectionName = "roles";
+    public const string ImplementRoleKey = "implement";
+    public const string ReviewRoleKey = "review";
+    public const string InterviewRoleKey = "interview";
+    public const string ClarifyRoleKey = "clarify";
     public const string DefaultWorktreeRoot = ".intent-cli/worktrees";
+    public const string DefaultImplementRole = "Claude";
+    public const string DefaultReviewRole = "Codex";
+    public const string DefaultInterviewRole = "Claude";
+    public const string DefaultClarifyRole = "Codex";
 
     public static string GetIntentCliDirectoryPath(string repoRoot)
     {

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -35,7 +35,8 @@ internal static class CommandRouter
                 ["submit"] = RunSubmitCommand.Execute,
                 ["rereview"] = RunRereviewCommand.Execute,
                 ["resume"] = RunResumeCommand.Execute,
-                ["log"] = RunLogCommand.Execute
+                ["log"] = RunLogCommand.Execute,
+                ["implement"] = RunImplementCommand.Execute
             },
             ["workflow"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/RunImplementArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementArtifactPathResolver.cs
@@ -1,0 +1,13 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunImplementArtifactPathResolver
+{
+    private const string ImplementDirectory = ".intent-cli/implement";
+
+    public static string Resolve(string executionUnit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        return $"{ImplementDirectory}/{executionUnit.Trim()}.request.md";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunImplementArtifactWriter.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementArtifactWriter.cs
@@ -1,0 +1,26 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunImplementArtifactWriter
+{
+    public static string Write(string markdown, string executionUnit, string repoRoot, bool overwrite)
+    {
+        ArgumentNullException.ThrowIfNull(markdown);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+
+        var relativePath = RunImplementArtifactPathResolver.Resolve(executionUnit);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+
+        if (!overwrite && File.Exists(absolutePath))
+        {
+            throw new InvalidOperationException($"Run implement artifact already exists at {absolutePath}");
+        }
+
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Run implement artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, markdown);
+
+        return absolutePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
@@ -1,0 +1,183 @@
+using IntentSystem.Projection.Serialization;
+using IntentSystem.Review;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunImplementCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Run implement command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        if (queueItem.State is not (QueueItemState.Active or QueueItemState.Fixing))
+        {
+            writer.WriteLine(
+                $"Execution unit '{executionUnit}' must be active or fixing before run implement.");
+            return 1;
+        }
+
+        if (queueItem.LinkedIssue is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' must have a linked issue before run implement.");
+            return 1;
+        }
+
+        var packetPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.Yaml);
+        if (!File.Exists(packetPath))
+        {
+            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
+            return 1;
+        }
+
+        var reviewContextPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.ReviewContext);
+        if (!File.Exists(reviewContextPath))
+        {
+            writer.WriteLine($"Review context artifact was not found at {reviewContextPath}");
+            return 1;
+        }
+
+        try
+        {
+            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+            var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
+            if (string.IsNullOrWhiteSpace(childRepoRef))
+            {
+                throw new InvalidOperationException("Projection packet must contain a target repo.");
+            }
+
+            var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
+            if (!Directory.Exists(childRepoPath))
+            {
+                throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+            }
+
+            var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
+            if (!Directory.Exists(worktreePath))
+            {
+                throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
+            }
+
+            var reviewContext = ReviewContextMarkdownParser.Parse(File.ReadAllText(reviewContextPath));
+            if (!string.Equals(reviewContext.SourceExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Review context execution unit '{reviewContext.SourceExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
+            }
+
+            var latestLinkedPr = ResolveLatestLinkedPr(context, executionUnit);
+            var request = BuildRequest(
+                context,
+                queueItem,
+                packet,
+                reviewContext,
+                worktreePath,
+                childRepoPath,
+                latestLinkedPr);
+            var markdown = RunImplementRenderer.RenderMarkdown(request);
+            var artifactPath = RunImplementArtifactWriter.Write(markdown, executionUnit, context.RepoRoot, overwrite: true);
+            RunImplementRenderer.WriteSummary(writer, request, artifactPath);
+
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static RunImplementRequest BuildRequest(
+        CliContext context,
+        QueueItem queueItem,
+        Projection.Models.ProjectionPacketContract packet,
+        Review.Models.ReviewContextSnapshot reviewContext,
+        string worktreePath,
+        string childRepoPath,
+        string? latestLinkedPr)
+    {
+        return new RunImplementRequest
+        {
+            ExecutionUnit = queueItem.ExecutionUnit,
+            State = FormatState(queueItem.State),
+            ImplementRole = context.Config.Roles.Implement,
+            QueueWorkerRole = queueItem.WorkerRole,
+            QueueReviewRole = queueItem.ReviewRole,
+            WorktreePath = worktreePath,
+            ChildRepoPath = childRepoPath,
+            Branch = RunStartCommand.ResolveBranchName(queueItem.ExecutionUnit, queueItem.LinkedIssue!),
+            LinkedIssue = queueItem.LinkedIssue!.Url,
+            LatestLinkedPr = latestLinkedPr,
+            PacketRef = queueItem.PacketPaths.Yaml,
+            ReviewContextRef = queueItem.PacketPaths.ReviewContext,
+            IssueTitle = packet.ImplementationIssuePacket.IssueTitle,
+            Goal = packet.ImplementationIssuePacket.Goal,
+            TargetPart = packet.ImplementationIssuePacket.TargetPart,
+            TargetRepo = packet.ImplementationIssuePacket.TargetRepo,
+            TargetPath = packet.ImplementationIssuePacket.TargetPath,
+            InScope = packet.ImplementationIssuePacket.InScope,
+            OutOfScope = packet.ImplementationIssuePacket.OutOfScope,
+            AcceptanceCriteria = reviewContext.AcceptanceCriteria,
+            DeterministicReviewChecks = reviewContext.DeterministicReviewChecks,
+            ExpectedEvidence = reviewContext.ExpectedEvidence
+        };
+    }
+
+    private static string? ResolveLatestLinkedPr(CliContext context, string executionUnit)
+    {
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            return null;
+        }
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        return LatestLinkedPrResolver.TryResolve(runEvents, executionUnit);
+    }
+
+    private static string ResolveArtifactPath(string repoRoot, string artifactRef)
+    {
+        return Path.GetFullPath(Path.Combine(repoRoot, artifactRef.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static string ResolveChildRepoPath(string repoRoot, string childRepoRef)
+    {
+        return Path.IsPathRooted(childRepoRef)
+            ? Path.GetFullPath(childRepoRef)
+            : Path.GetFullPath(Path.Combine(repoRoot, childRepoRef));
+    }
+
+    private static string FormatState(QueueItemState state)
+    {
+        return state switch
+        {
+            QueueItemState.ClarifyBlocked => "clarify-blocked",
+            _ => state.ToString().ToLowerInvariant()
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunImplementRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementRenderer.cs
@@ -1,0 +1,101 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunImplementRenderer
+{
+    public static string RenderMarkdown(RunImplementRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var lines = new List<string>
+        {
+            "# Execution Worker Handoff",
+            string.Empty,
+            "## Execution Unit",
+            string.Empty,
+            $"`{request.ExecutionUnit}`",
+            string.Empty,
+            "## Role Mapping",
+            string.Empty,
+            $"- implement: {request.ImplementRole}",
+            $"- queue_worker_role: {request.QueueWorkerRole}",
+            $"- queue_review_role: {request.QueueReviewRole}",
+            string.Empty,
+            "## Run Context",
+            string.Empty,
+            $"- state: {request.State}",
+            $"- worktree_path: {request.WorktreePath}",
+            $"- child_repo_path: {request.ChildRepoPath}",
+            $"- branch: {request.Branch}",
+            $"- linked_issue: {request.LinkedIssue}"
+        };
+
+        if (!string.IsNullOrWhiteSpace(request.LatestLinkedPr))
+        {
+            lines.Add($"- latest_linked_pr: {request.LatestLinkedPr}");
+        }
+
+        lines.AddRange(
+        [
+            string.Empty,
+            "## Packet Inputs",
+            string.Empty,
+            $"- packet_ref: {request.PacketRef}",
+            $"- review_context_ref: {request.ReviewContextRef}",
+            $"- issue_title: {request.IssueTitle}",
+            $"- goal: {request.Goal}",
+            $"- target_part: {request.TargetPart}",
+            $"- target_repo: {request.TargetRepo}",
+            $"- target_path: {request.TargetPath}",
+            string.Empty,
+            "## In Scope",
+            string.Empty
+        ]);
+        lines.AddRange(FormatList(request.InScope));
+        lines.Add(string.Empty);
+        lines.Add("## Out Of Scope");
+        lines.Add(string.Empty);
+        lines.AddRange(FormatList(request.OutOfScope));
+        lines.Add(string.Empty);
+        lines.Add("## Acceptance Criteria");
+        lines.Add(string.Empty);
+        lines.AddRange(FormatList(request.AcceptanceCriteria));
+        lines.Add(string.Empty);
+        lines.Add("## Deterministic Review Checks");
+        lines.Add(string.Empty);
+        lines.AddRange(FormatList(request.DeterministicReviewChecks));
+        lines.Add(string.Empty);
+        lines.Add("## Expected Evidence");
+        lines.Add(string.Empty);
+        lines.AddRange(FormatList(request.ExpectedEvidence));
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    public static void WriteSummary(TextWriter writer, RunImplementRequest request, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Implementation handoff artifact generated for {request.ExecutionUnit}.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Implement role: {request.ImplementRole}");
+        writer.WriteLine($"Worktree path: {request.WorktreePath}");
+        writer.WriteLine($"Branch: {request.Branch}");
+
+        if (!string.IsNullOrWhiteSpace(request.LatestLinkedPr))
+        {
+            writer.WriteLine($"Latest linked PR: {request.LatestLinkedPr}");
+        }
+    }
+
+    private static IReadOnlyList<string> FormatList(IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            return ["- none"];
+        }
+
+        return values.Select(value => $"- {value}").ToArray();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunImplementRequest.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementRequest.cs
@@ -1,0 +1,48 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record RunImplementRequest
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required string State { get; init; }
+
+    public required string ImplementRole { get; init; }
+
+    public required string QueueWorkerRole { get; init; }
+
+    public required string QueueReviewRole { get; init; }
+
+    public required string WorktreePath { get; init; }
+
+    public required string ChildRepoPath { get; init; }
+
+    public required string Branch { get; init; }
+
+    public required string LinkedIssue { get; init; }
+
+    public string? LatestLinkedPr { get; init; }
+
+    public required string PacketRef { get; init; }
+
+    public required string ReviewContextRef { get; init; }
+
+    public required string IssueTitle { get; init; }
+
+    public required string Goal { get; init; }
+
+    public required string TargetPart { get; init; }
+
+    public required string TargetRepo { get; init; }
+
+    public required string TargetPath { get; init; }
+
+    public required IReadOnlyList<string> InScope { get; init; }
+
+    public required IReadOnlyList<string> OutOfScope { get; init; }
+
+    public required IReadOnlyList<string> AcceptanceCriteria { get; init; }
+
+    public required IReadOnlyList<string> DeterministicReviewChecks { get; init; }
+
+    public required IReadOnlyList<string> ExpectedEvidence { get; init; }
+}

--- a/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
+++ b/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
@@ -51,8 +51,9 @@ internal static class CliConfigLoader
 
         var worktreeRoot = TryGetOptionalString(rootTable, CliRuntimeContracts.WorktreeRootKey)
             ?? CliRuntimeContracts.DefaultWorktreeRoot;
+        var roles = ReadRoles(rootTable);
 
-        config = CreateConfig(domain, workflowEngine, artifactRoot, worktreeRoot);
+        config = CreateConfig(domain, workflowEngine, artifactRoot, worktreeRoot, roles);
         return true;
     }
 
@@ -77,8 +78,9 @@ internal static class CliConfigLoader
 
         var worktreeRoot = TryGetOptionalString(projectTable, CliRuntimeContracts.WorktreeRootKey)
             ?? CliRuntimeContracts.DefaultWorktreeRoot;
+        var roles = ReadRoles(rootTable);
 
-        config = CreateConfig(domain, workflowEngine, artifactRoot, worktreeRoot);
+        config = CreateConfig(domain, workflowEngine, artifactRoot, worktreeRoot, roles);
         return true;
     }
 
@@ -86,7 +88,8 @@ internal static class CliConfigLoader
         string domain,
         string workflowEngine,
         string artifactRoot,
-        string worktreeRoot)
+        string worktreeRoot,
+        RoleMappings roles)
     {
         return new CliConfig
         {
@@ -96,7 +99,31 @@ internal static class CliConfigLoader
                 WorkflowEngine = workflowEngine,
                 ArtifactRoot = artifactRoot,
                 WorktreeRoot = worktreeRoot
-            }
+            },
+            Roles = roles
+        };
+    }
+
+    private static RoleMappings ReadRoles(TomlTable rootTable)
+    {
+        ArgumentNullException.ThrowIfNull(rootTable);
+
+        if (!rootTable.TryGetValue(CliRuntimeContracts.RolesSectionName, out var section)
+            || section is not TomlTable rolesTable)
+        {
+            return new RoleMappings();
+        }
+
+        return new RoleMappings
+        {
+            Implement = TryGetOptionalString(rolesTable, CliRuntimeContracts.ImplementRoleKey)
+                ?? CliRuntimeContracts.DefaultImplementRole,
+            Review = TryGetOptionalString(rolesTable, CliRuntimeContracts.ReviewRoleKey)
+                ?? CliRuntimeContracts.DefaultReviewRole,
+            Interview = TryGetOptionalString(rolesTable, CliRuntimeContracts.InterviewRoleKey)
+                ?? CliRuntimeContracts.DefaultInterviewRole,
+            Clarify = TryGetOptionalString(rolesTable, CliRuntimeContracts.ClarifyRoleKey)
+                ?? CliRuntimeContracts.DefaultClarifyRole
         };
     }
 

--- a/src/IntentSystem.Cli/Models/CliConfig.cs
+++ b/src/IntentSystem.Cli/Models/CliConfig.cs
@@ -3,6 +3,8 @@ namespace IntentSystem.Cli.Models;
 internal sealed record CliConfig
 {
     public required ProjectConfig Project { get; init; }
+
+    public RoleMappings Roles { get; init; } = new();
 }
 
 internal sealed record ProjectConfig
@@ -14,4 +16,15 @@ internal sealed record ProjectConfig
     public required string ArtifactRoot { get; init; }
 
     public string WorktreeRoot { get; init; } = ".intent-cli/worktrees";
+}
+
+internal sealed record RoleMappings
+{
+    public string Implement { get; init; } = CliRuntimeContracts.DefaultImplementRole;
+
+    public string Review { get; init; } = CliRuntimeContracts.DefaultReviewRole;
+
+    public string Interview { get; init; } = CliRuntimeContracts.DefaultInterviewRole;
+
+    public string Clarify { get; init; } = CliRuntimeContracts.DefaultClarifyRole;
 }

--- a/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
@@ -20,6 +20,8 @@ public sealed class CliConfigLoaderTests
         Assert.Equal("takt", config.Project.WorkflowEngine);
         Assert.Equal(".intent-cli", config.Project.ArtifactRoot);
         Assert.Equal(".intent-cli/worktrees", config.Project.WorktreeRoot);
+        Assert.Equal("Claude", config.Roles.Implement);
+        Assert.Equal("Codex", config.Roles.Review);
     }
 
     [Fact]
@@ -41,6 +43,7 @@ public sealed class CliConfigLoaderTests
         Assert.Equal("takt", config.Project.WorkflowEngine);
         Assert.Equal(".intent-cli", config.Project.ArtifactRoot);
         Assert.Equal(".intent-cli/worktrees", config.Project.WorktreeRoot);
+        Assert.Equal("Claude", config.Roles.Implement);
     }
 
     [Fact]
@@ -60,6 +63,30 @@ public sealed class CliConfigLoaderTests
         Assert.Equal("takt", config.Project.WorkflowEngine);
         Assert.Equal(".intent-cli", config.Project.ArtifactRoot);
         Assert.Equal(".intent-cli/worktrees", config.Project.WorktreeRoot);
+        Assert.Equal("Claude", config.Roles.Implement);
+    }
+
+    [Fact]
+    public void Load_GivenRolesSection_RestoresRoleMappings()
+    {
+        var toml = """
+        default_domain = "intent-cli"
+        workflow_engine = "takt"
+        artifact_root = ".intent-cli"
+
+        [roles]
+        implement = "Codex"
+        review = "Claude"
+        interview = "Codex"
+        clarify = "Claude"
+        """;
+
+        var config = CliConfigLoader.Load(toml);
+
+        Assert.Equal("Codex", config.Roles.Implement);
+        Assert.Equal("Claude", config.Roles.Review);
+        Assert.Equal("Codex", config.Roles.Interview);
+        Assert.Equal("Claude", config.Roles.Clarify);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -296,6 +296,34 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenRunImplementCommand_DispatchesToRunImplementRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G19"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateRunImplementQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunImplementRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreateRunImplementPacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateRunImplementReviewContextMarkdown());
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["run", "implement", "G19"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Implementation handoff artifact generated for G19", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Implement role: Claude", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenWorkflowRenderCommand_DispatchesToWorkflowRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -735,6 +763,42 @@ public sealed class CommandRouterTests
         };
     }
 
+    private static QueueState CreateRunImplementQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-08T08:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G19",
+                    Title = "Run implement command",
+                    State = QueueItemState.Active,
+                    Dependencies = ["G18"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G19/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G19/review-context.md",
+                        Yaml = ".intent-cli/issues/G19/packet.yaml"
+                    },
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = 66,
+                        Url = "https://github.com/J-Tech-Japan/intent-system/issues/66"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
     private static QueueState CreateReviewQueueState()
     {
         return new QueueState
@@ -1090,6 +1154,91 @@ public sealed class CommandRouterTests
         {"ts":"2026-04-07T08:00:00Z","execution_unit":"G18","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/64"}
         {"ts":"2026-04-07T08:10:00Z","execution_unit":"G18","event":"activated","by":"intent-cli"}
         {"ts":"2026-04-07T08:20:00Z","execution_unit":"G18","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/65"}
+        """ + Environment.NewLine;
+    }
+
+    private static string CreateRunImplementPacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G19] Run Implement Command"
+          issue_kind: "feature"
+          source_execution_unit: "G19"
+          goal: "Generate an execution worker handoff artifact."
+          in_scope:
+            - "run implement command"
+            - "handoff artifact generation"
+          out_of_scope:
+            - "queue mutation"
+            - "worker start"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli run implement command"
+          dependencies:
+            - "G18"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "run implement stays handoff-only"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "handoff artifact generated"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G19"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "handoff artifact generated"
+          deterministic_review_checks:
+            - "run implement command remains handoff-only"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private static string CreateRunImplementReviewContextMarkdown()
+    {
+        return """
+        # Execution Unit
+
+        `G19`
+
+        # Goal
+
+        `intent-cli run implement <execution-unit>` を working command にする。
+
+        # Acceptance Criteria
+
+        - handoff artifact generated
+
+        # Deterministic Review Checks
+
+        - run implement command remains handoff-only
+
+        # Expected Evidence
+
+        - dotnet test IntentSystem.sln
+        """;
+    }
+
+    private static string CreateRunImplementRunLog()
+    {
+        return """
+        {"ts":"2026-04-08T08:00:00Z","execution_unit":"G19","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/66"}
+        {"ts":"2026-04-08T08:30:00Z","execution_unit":"G19","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/67"}
         """ + Environment.NewLine;
     }
 

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -1,0 +1,487 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class RunImplementCommandTests
+{
+    [Fact]
+    public void Execute_GivenActiveItemWithInputs_GeneratesHandoffArtifactWithoutMutatingStateOrRunLog()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G19"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Implementation handoff artifact generated for G19", output, StringComparison.Ordinal);
+        Assert.Contains("Implement role: Claude", output, StringComparison.Ordinal);
+        Assert.Contains("Branch: issue-66-g19", output, StringComparison.Ordinal);
+        Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/67", output, StringComparison.Ordinal);
+
+        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "implement", "G19.request.md");
+        Assert.True(File.Exists(artifactPath));
+        var markdown = File.ReadAllText(artifactPath);
+        Assert.Contains("- packet_ref: .intent-cli/issues/G19/packet.yaml", markdown, StringComparison.Ordinal);
+        Assert.Contains("- review_context_ref: .intent-cli/issues/G19/review-context.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("- latest_linked_pr: https://github.com/J-Tech-Japan/intent-system/pull/67", markdown, StringComparison.Ordinal);
+        Assert.Contains("- implement: Claude", markdown, StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenFixingItemWithoutLatestPr_GeneratesArtifactWithoutLatestPr()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G19"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """{"ts":"2026-04-08T08:00:00Z","execution_unit":"G19","event":"fix-requested","by":"intent-cli"}""" + Environment.NewLine);
+        using var writer = new StringWriter();
+
+        var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain("Latest linked PR:", writer.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("latest_linked_pr", File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "implement", "G19.request.md")), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = RunImplementCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingQueueItem_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G99"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("was not found in queue state", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenInvalidState_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Review)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must be active or fixing", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingLinkedIssue_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(withLinkedIssue: false)));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must have a linked issue", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+
+        var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Projection packet artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingReviewContextArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Review context artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenReviewContextMismatch_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G19"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown("G20"));
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must match queue item execution unit", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingChildRepoPath_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G19"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Child repo path was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingWorktreePath_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Worktree path was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                },
+                Roles = new RoleMappings
+                {
+                    Implement = "Claude",
+                    Review = "Codex",
+                    Interview = "Claude",
+                    Clarify = "Codex"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState(
+        QueueItemState selectedState = QueueItemState.Active,
+        bool withLinkedIssue = true)
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-08T08:12:34Z"),
+            Items =
+            [
+                CreateItem("G19", selectedState, withLinkedIssue),
+                CreateItem("G20", QueueItemState.Blocked, false) with
+                {
+                    Dependencies = ["G19"],
+                    BlockedBy = ["G19"]
+                }
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state, bool withLinkedIssue)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Run Implement Command",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            LinkedIssue = withLinkedIssue
+                ? new LinkedIssue
+                {
+                    Repo = "J-Tech-Japan/intent-system",
+                    Number = 66,
+                    Url = "https://github.com/J-Tech-Japan/intent-system/issues/66"
+                }
+                : null,
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static string CreatePacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G19] Run Implement Command"
+          issue_kind: "feature"
+          source_execution_unit: "G19"
+          goal: "Generate an execution worker handoff artifact."
+          in_scope:
+            - "run implement command"
+            - "handoff artifact generation"
+          out_of_scope:
+            - "queue mutation"
+            - "worker start"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli run implement command"
+          dependencies:
+            - "G18"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "run implement stays handoff-only"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "handoff artifact generated"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G19"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "handoff artifact generated"
+          deterministic_review_checks:
+            - "run implement command remains handoff-only"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private static string CreateReviewContextMarkdown(string executionUnit = "G19")
+    {
+        return $$"""
+        # Execution Unit
+
+        `{{executionUnit}}`
+
+        # Goal
+
+        `intent-cli run implement <execution-unit>` を working command にする。
+
+        # Acceptance Criteria
+
+        - handoff artifact generated
+
+        # Deterministic Review Checks
+
+        - run implement command remains handoff-only
+
+        # Expected Evidence
+
+        - dotnet test IntentSystem.sln
+        """;
+    }
+
+    private static string CreateRunLog()
+    {
+        return """
+        {"ts":"2026-04-08T08:00:00Z","execution_unit":"G19","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/66"}
+        {"ts":"2026-04-08T08:10:00Z","execution_unit":"A1","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/12"}
+        {"ts":"2026-04-08T08:20:00Z","execution_unit":"G19","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/66#issuecomment-1"}
+        {"ts":"2026-04-08T08:30:00Z","execution_unit":"G19","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/67"}
+        """ + Environment.NewLine;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-run-implement-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/RunImplementRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementRendererTests.cs
@@ -1,0 +1,67 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class RunImplementRendererTests
+{
+    [Fact]
+    public void RenderMarkdown_GivenImplementRequest_RendersDeterministicHandoffArtifact()
+    {
+        var markdown = RunImplementRenderer.RenderMarkdown(CreateRequest());
+
+        Assert.Contains("# Execution Worker Handoff", markdown, StringComparison.Ordinal);
+        Assert.Contains("`G19`", markdown, StringComparison.Ordinal);
+        Assert.Contains("- implement: Claude", markdown, StringComparison.Ordinal);
+        Assert.Contains("- queue_worker_role: coder", markdown, StringComparison.Ordinal);
+        Assert.Contains("- queue_review_role: reviewer", markdown, StringComparison.Ordinal);
+        Assert.Contains("- worktree_path: /repo/.intent-cli/worktrees/G19", markdown, StringComparison.Ordinal);
+        Assert.Contains("- latest_linked_pr: https://github.com/J-Tech-Japan/intent-system/pull/67", markdown, StringComparison.Ordinal);
+        Assert.Contains("- packet_ref: .intent-cli/issues/G19/packet.yaml", markdown, StringComparison.Ordinal);
+        Assert.Contains("- review_context_ref: .intent-cli/issues/G19/review-context.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Deterministic Review Checks", markdown, StringComparison.Ordinal);
+        Assert.Contains("- command remains read/write only for handoff artifact generation", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderMarkdown_GivenNoLatestLinkedPrOrEvidence_OmitsLatestPrAndRendersNoneEvidence()
+    {
+        var markdown = RunImplementRenderer.RenderMarkdown(CreateRequest() with
+        {
+            LatestLinkedPr = null,
+            ExpectedEvidence = []
+        });
+
+        Assert.DoesNotContain("latest_linked_pr", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Expected Evidence", markdown, StringComparison.Ordinal);
+        Assert.Contains("- none", markdown, StringComparison.Ordinal);
+    }
+
+    private static RunImplementRequest CreateRequest()
+    {
+        return new RunImplementRequest
+        {
+            ExecutionUnit = "G19",
+            State = "active",
+            ImplementRole = "Claude",
+            QueueWorkerRole = "coder",
+            QueueReviewRole = "reviewer",
+            WorktreePath = "/repo/.intent-cli/worktrees/G19",
+            ChildRepoPath = "/repo/submodules/intent-system",
+            Branch = "issue-66-g19",
+            LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/66",
+            LatestLinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/67",
+            PacketRef = ".intent-cli/issues/G19/packet.yaml",
+            ReviewContextRef = ".intent-cli/issues/G19/review-context.md",
+            IssueTitle = "[G19] Run Implement Command",
+            Goal = "Generate an execution worker handoff artifact.",
+            TargetPart = "cli run implement command",
+            TargetRepo = "submodules/intent-system",
+            TargetPath = ".",
+            InScope = ["run implement command", "handoff artifact generation"],
+            OutOfScope = ["queue mutation"],
+            AcceptanceCriteria = ["handoff artifact generated"],
+            DeterministicReviewChecks = ["command remains read/write only for handoff artifact generation"],
+            ExpectedEvidence = ["dotnet test"]
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add `intent-cli run implement <execution-unit>` to generate the execution worker handoff artifact
- load implement/review/interview/clarify role mappings from `.intent-cli/config.toml` with canonical defaults
- cover artifact rendering, latest linked PR lookup, and CLI routing/config behavior with tests

## Testing
- dotnet test

Closes #66