### PR TITLE
[G20] Run Fix Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -36,7 +36,8 @@ internal static class CommandRouter
                 ["rereview"] = RunRereviewCommand.Execute,
                 ["resume"] = RunResumeCommand.Execute,
                 ["log"] = RunLogCommand.Execute,
-                ["implement"] = RunImplementCommand.Execute
+                ["implement"] = RunImplementCommand.Execute,
+                ["fix"] = RunFixCommand.Execute
             },
             ["workflow"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/RunFixArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixArtifactPathResolver.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunFixArtifactPathResolver
+{
+    public static string Resolve(string executionUnit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        return $".intent-cli/fix/{executionUnit}.request.md";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunFixArtifactWriter.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixArtifactWriter.cs
@@ -1,0 +1,26 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunFixArtifactWriter
+{
+    public static string Write(string markdown, string executionUnit, string repoRoot, bool overwrite)
+    {
+        ArgumentNullException.ThrowIfNull(markdown);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+
+        var relativePath = RunFixArtifactPathResolver.Resolve(executionUnit);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+
+        if (!overwrite && File.Exists(absolutePath))
+        {
+            throw new InvalidOperationException($"Run fix artifact already exists at {absolutePath}");
+        }
+
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Run fix artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, markdown);
+
+        return absolutePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixCommand.cs
@@ -1,0 +1,214 @@
+using IntentSystem.Projection.Serialization;
+using IntentSystem.Review;
+using IntentSystem.Review.Serialization;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunFixCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Run fix command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        if (queueItem.State is not QueueItemState.Fixing)
+        {
+            writer.WriteLine(
+                $"Execution unit '{executionUnit}' must be fixing before run fix.");
+            return 1;
+        }
+
+        if (queueItem.LinkedIssue is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' must have a linked issue before run fix.");
+            return 1;
+        }
+
+        var packetPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.Yaml);
+        if (!File.Exists(packetPath))
+        {
+            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
+            return 1;
+        }
+
+        var reviewContextPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.ReviewContext);
+        if (!File.Exists(reviewContextPath))
+        {
+            writer.WriteLine($"Review context artifact was not found at {reviewContextPath}");
+            return 1;
+        }
+
+        var reviewCommentArtifactRef = ReviewCommentArtifactPathResolver.Resolve(executionUnit);
+        var reviewCommentArtifactPath = ResolveArtifactPath(context.RepoRoot, reviewCommentArtifactRef);
+        if (!File.Exists(reviewCommentArtifactPath))
+        {
+            writer.WriteLine($"Review comment artifact was not found at {reviewCommentArtifactPath}");
+            return 1;
+        }
+
+        try
+        {
+            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+            var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
+            if (string.IsNullOrWhiteSpace(childRepoRef))
+            {
+                throw new InvalidOperationException("Projection packet must contain a target repo.");
+            }
+
+            var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
+            if (!Directory.Exists(childRepoPath))
+            {
+                throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+            }
+
+            var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
+            if (!Directory.Exists(worktreePath))
+            {
+                throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
+            }
+
+            var reviewContext = ReviewContextMarkdownParser.Parse(File.ReadAllText(reviewContextPath));
+            if (!string.Equals(reviewContext.SourceExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Review context execution unit '{reviewContext.SourceExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
+            }
+
+            var reviewCommentArtifact = ReviewCommentArtifactSerializer.Deserialize(
+                File.ReadAllText(reviewCommentArtifactPath));
+            if (!string.Equals(reviewCommentArtifact.ExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Review comment artifact execution unit '{reviewCommentArtifact.ExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
+            }
+
+            var latestLinkedPr = ResolveLatestLinkedPr(context, executionUnit);
+            if (!string.Equals(reviewCommentArtifact.LinkedPr, latestLinkedPr, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Review comment artifact linked PR '{reviewCommentArtifact.LinkedPr}' must match latest linked PR '{latestLinkedPr}'.");
+            }
+
+            var request = BuildRequest(
+                context,
+                queueItem,
+                packet,
+                reviewContext,
+                reviewCommentArtifactRef,
+                reviewCommentArtifact,
+                worktreePath,
+                childRepoPath,
+                latestLinkedPr);
+            var markdown = RunFixRenderer.RenderMarkdown(request);
+            var artifactPath = RunFixArtifactWriter.Write(markdown, executionUnit, context.RepoRoot, overwrite: true);
+            RunFixRenderer.WriteSummary(writer, request, artifactPath);
+
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static RunFixRequest BuildRequest(
+        CliContext context,
+        QueueItem queueItem,
+        Projection.Models.ProjectionPacketContract packet,
+        Review.Models.ReviewContextSnapshot reviewContext,
+        string reviewCommentArtifactRef,
+        Review.Models.ReviewCommentArtifact reviewCommentArtifact,
+        string worktreePath,
+        string childRepoPath,
+        string latestLinkedPr)
+    {
+        return new RunFixRequest
+        {
+            ExecutionUnit = queueItem.ExecutionUnit,
+            State = FormatState(queueItem.State),
+            ImplementRole = context.Config.Roles.Implement,
+            QueueWorkerRole = queueItem.WorkerRole,
+            QueueReviewRole = queueItem.ReviewRole,
+            WorktreePath = worktreePath,
+            ChildRepoPath = childRepoPath,
+            Branch = RunStartCommand.ResolveBranchName(queueItem.ExecutionUnit, queueItem.LinkedIssue!),
+            LinkedIssue = queueItem.LinkedIssue!.Url,
+            LatestLinkedPr = latestLinkedPr,
+            LatestCommentRef = reviewCommentArtifact.CommentRef,
+            PacketRef = queueItem.PacketPaths.Yaml,
+            ReviewContextRef = queueItem.PacketPaths.ReviewContext,
+            ReviewCommentArtifactRef = reviewCommentArtifactRef,
+            ReviewRequestRef = reviewCommentArtifact.ReviewRequestRef,
+            ReviewCommentBodyPath = reviewCommentArtifact.BodyPath,
+            IssueTitle = packet.ImplementationIssuePacket.IssueTitle,
+            Goal = packet.ImplementationIssuePacket.Goal,
+            TargetPart = packet.ImplementationIssuePacket.TargetPart,
+            TargetRepo = packet.ImplementationIssuePacket.TargetRepo,
+            TargetPath = packet.ImplementationIssuePacket.TargetPath,
+            InScope = packet.ImplementationIssuePacket.InScope,
+            OutOfScope = packet.ImplementationIssuePacket.OutOfScope,
+            AcceptanceCriteria = reviewContext.AcceptanceCriteria,
+            DeterministicReviewChecks = reviewContext.DeterministicReviewChecks,
+            ExpectedEvidence = reviewContext.ExpectedEvidence
+        };
+    }
+
+    private static string ResolveLatestLinkedPr(CliContext context, string executionUnit)
+    {
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            throw new InvalidOperationException($"Run log was not found at {runLogPath}");
+        }
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        return LatestLinkedPrResolver.Resolve(runEvents, executionUnit);
+    }
+
+    private static string ResolveArtifactPath(string repoRoot, string artifactRef)
+    {
+        return Path.GetFullPath(Path.Combine(repoRoot, artifactRef.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static string ResolveChildRepoPath(string repoRoot, string childRepoRef)
+    {
+        return Path.IsPathRooted(childRepoRef)
+            ? Path.GetFullPath(childRepoRef)
+            : Path.GetFullPath(Path.Combine(repoRoot, childRepoRef));
+    }
+
+    private static string FormatState(QueueItemState state)
+    {
+        return state switch
+        {
+            QueueItemState.ClarifyBlocked => "clarify-blocked",
+            _ => state.ToString().ToLowerInvariant()
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunFixRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixRenderer.cs
@@ -1,0 +1,98 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunFixRenderer
+{
+    public static string RenderMarkdown(RunFixRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var lines = new List<string>
+        {
+            "# Repair Worker Handoff",
+            string.Empty,
+            "## Execution Unit",
+            string.Empty,
+            $"`{request.ExecutionUnit}`",
+            string.Empty,
+            "## Role Mapping",
+            string.Empty,
+            $"- implement: {request.ImplementRole}",
+            $"- queue_worker_role: {request.QueueWorkerRole}",
+            $"- queue_review_role: {request.QueueReviewRole}",
+            string.Empty,
+            "## Run Context",
+            string.Empty,
+            $"- state: {request.State}",
+            $"- worktree_path: {request.WorktreePath}",
+            $"- child_repo_path: {request.ChildRepoPath}",
+            $"- branch: {request.Branch}",
+            $"- linked_issue: {request.LinkedIssue}",
+            $"- latest_linked_pr: {request.LatestLinkedPr}",
+            $"- latest_comment_ref: {request.LatestCommentRef}",
+            string.Empty,
+            "## Repair Inputs",
+            string.Empty,
+            $"- packet_ref: {request.PacketRef}",
+            $"- review_context_ref: {request.ReviewContextRef}",
+            $"- review_comment_artifact_ref: {request.ReviewCommentArtifactRef}",
+            $"- review_request_ref: {request.ReviewRequestRef}",
+            $"- review_comment_body_path: {request.ReviewCommentBodyPath}",
+            string.Empty,
+            "## Packet Inputs",
+            string.Empty,
+            $"- issue_title: {request.IssueTitle}",
+            $"- goal: {request.Goal}",
+            $"- target_part: {request.TargetPart}",
+            $"- target_repo: {request.TargetRepo}",
+            $"- target_path: {request.TargetPath}",
+            string.Empty,
+            "## In Scope",
+            string.Empty
+        };
+
+        lines.AddRange(FormatList(request.InScope));
+        lines.Add(string.Empty);
+        lines.Add("## Out Of Scope");
+        lines.Add(string.Empty);
+        lines.AddRange(FormatList(request.OutOfScope));
+        lines.Add(string.Empty);
+        lines.Add("## Acceptance Criteria");
+        lines.Add(string.Empty);
+        lines.AddRange(FormatList(request.AcceptanceCriteria));
+        lines.Add(string.Empty);
+        lines.Add("## Deterministic Review Checks");
+        lines.Add(string.Empty);
+        lines.AddRange(FormatList(request.DeterministicReviewChecks));
+        lines.Add(string.Empty);
+        lines.Add("## Expected Evidence");
+        lines.Add(string.Empty);
+        lines.AddRange(FormatList(request.ExpectedEvidence));
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    public static void WriteSummary(TextWriter writer, RunFixRequest request, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Repair handoff artifact generated for {request.ExecutionUnit}.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Implement role: {request.ImplementRole}");
+        writer.WriteLine($"Worktree path: {request.WorktreePath}");
+        writer.WriteLine($"Branch: {request.Branch}");
+        writer.WriteLine($"Latest linked PR: {request.LatestLinkedPr}");
+        writer.WriteLine($"Latest comment ref: {request.LatestCommentRef}");
+    }
+
+    private static IReadOnlyList<string> FormatList(IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            return ["- none"];
+        }
+
+        return values.Select(value => $"- {value}").ToArray();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunFixRequest.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixRequest.cs
@@ -1,0 +1,56 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record RunFixRequest
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required string State { get; init; }
+
+    public required string ImplementRole { get; init; }
+
+    public required string QueueWorkerRole { get; init; }
+
+    public required string QueueReviewRole { get; init; }
+
+    public required string WorktreePath { get; init; }
+
+    public required string ChildRepoPath { get; init; }
+
+    public required string Branch { get; init; }
+
+    public required string LinkedIssue { get; init; }
+
+    public required string LatestLinkedPr { get; init; }
+
+    public required string LatestCommentRef { get; init; }
+
+    public required string PacketRef { get; init; }
+
+    public required string ReviewContextRef { get; init; }
+
+    public required string ReviewCommentArtifactRef { get; init; }
+
+    public required string ReviewRequestRef { get; init; }
+
+    public required string ReviewCommentBodyPath { get; init; }
+
+    public required string IssueTitle { get; init; }
+
+    public required string Goal { get; init; }
+
+    public required string TargetPart { get; init; }
+
+    public required string TargetRepo { get; init; }
+
+    public required string TargetPath { get; init; }
+
+    public required IReadOnlyList<string> InScope { get; init; }
+
+    public required IReadOnlyList<string> OutOfScope { get; init; }
+
+    public required IReadOnlyList<string> AcceptanceCriteria { get; init; }
+
+    public required IReadOnlyList<string> DeterministicReviewChecks { get; init; }
+
+    public required IReadOnlyList<string> ExpectedEvidence { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -324,6 +324,37 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenRunFixCommand_DispatchesToRunFixRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateRunFixQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunFixRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreateRunFixPacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateRunFixReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateRunFixReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["run", "fix", "G20"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Repair handoff artifact generated for G20", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Latest comment ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenWorkflowRenderCommand_DispatchesToWorkflowRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -799,6 +830,42 @@ public sealed class CommandRouterTests
         };
     }
 
+    private static QueueState CreateRunFixQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-09T09:42:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G20",
+                    Title = "Run fix command",
+                    State = QueueItemState.Fixing,
+                    Dependencies = ["G19"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G20/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G20/review-context.md",
+                        Yaml = ".intent-cli/issues/G20/packet.yaml"
+                    },
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = 68,
+                        Url = "https://github.com/J-Tech-Japan/intent-system/issues/68"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
     private static QueueState CreateReviewQueueState()
     {
         return new QueueState
@@ -1209,6 +1276,58 @@ public sealed class CommandRouterTests
         """;
     }
 
+    private static string CreateRunFixPacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G20] Run Fix Command"
+          issue_kind: "feature"
+          source_execution_unit: "G20"
+          goal: "Generate a repair worker handoff artifact."
+          in_scope:
+            - "run fix command"
+            - "repair handoff artifact generation"
+          out_of_scope:
+            - "queue mutation"
+            - "worker start"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli run fix command"
+          dependencies:
+            - "G19"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "run fix stays handoff-only"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/review-recovery-and-retry.md"
+          acceptance_criteria:
+            - "repair handoff artifact generated"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G20"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/review-recovery-and-retry.md"
+          acceptance_criteria:
+            - "repair handoff artifact generated"
+          deterministic_review_checks:
+            - "run fix command remains handoff-only"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
     private static string CreateRunImplementReviewContextMarkdown()
     {
         return """
@@ -1234,11 +1353,57 @@ public sealed class CommandRouterTests
         """;
     }
 
+    private static string CreateRunFixReviewContextMarkdown()
+    {
+        return """
+        # Execution Unit
+
+        `G20`
+
+        # Goal
+
+        `intent-cli run fix <execution-unit>` を working command にする。
+
+        # Acceptance Criteria
+
+        - repair handoff artifact generated
+
+        # Deterministic Review Checks
+
+        - run fix command remains handoff-only
+
+        # Expected Evidence
+
+        - dotnet test IntentSystem.sln
+        """;
+    }
+
     private static string CreateRunImplementRunLog()
     {
         return """
         {"ts":"2026-04-08T08:00:00Z","execution_unit":"G19","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/66"}
         {"ts":"2026-04-08T08:30:00Z","execution_unit":"G19","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/67"}
+        """ + Environment.NewLine;
+    }
+
+    private static string CreateRunFixReviewCommentArtifactJson()
+    {
+        return """
+        {
+          "execution_unit": "G20",
+          "review_request_ref": ".intent-cli/reviews/G20.request.json",
+          "linked_pr": "https://github.com/J-Tech-Japan/intent-system/pull/69",
+          "comment_ref": "https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2",
+          "body_path": "/repo/prepared-comment.md"
+        }
+        """;
+    }
+
+    private static string CreateRunFixRunLog()
+    {
+        return """
+        {"ts":"2026-04-09T09:00:00Z","execution_unit":"G20","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/69"}
+        {"ts":"2026-04-09T09:20:00Z","execution_unit":"G20","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2"}
         """ + Environment.NewLine;
     }
 

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -1,0 +1,627 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class RunFixCommandTests
+{
+    [Fact]
+    public void Execute_GivenFixingItemWithInputs_GeneratesRepairHandoffArtifactWithoutMutatingStateOrRunLog()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Repair handoff artifact generated for G20", output, StringComparison.Ordinal);
+        Assert.Contains("Implement role: Claude", output, StringComparison.Ordinal);
+        Assert.Contains("Branch: issue-68-g20", output, StringComparison.Ordinal);
+        Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/69", output, StringComparison.Ordinal);
+        Assert.Contains("Latest comment ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", output, StringComparison.Ordinal);
+
+        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "fix", "G20.request.md");
+        Assert.True(File.Exists(artifactPath));
+        var markdown = File.ReadAllText(artifactPath);
+        Assert.Contains("- packet_ref: .intent-cli/issues/G20/packet.yaml", markdown, StringComparison.Ordinal);
+        Assert.Contains("- review_context_ref: .intent-cli/issues/G20/review-context.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("- review_comment_artifact_ref: .intent-cli/reviews/G20.comment.json", markdown, StringComparison.Ordinal);
+        Assert.Contains("- review_request_ref: .intent-cli/reviews/G20.request.json", markdown, StringComparison.Ordinal);
+        Assert.Contains("- latest_linked_pr: https://github.com/J-Tech-Japan/intent-system/pull/69", markdown, StringComparison.Ordinal);
+        Assert.Contains("- latest_comment_ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", markdown, StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = RunFixCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingQueueItem_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G99"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("was not found in queue state", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenInvalidState_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Review)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must be fixing", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingLinkedIssue_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(withLinkedIssue: false)));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must have a linked issue", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+
+        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Projection packet artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingReviewContextArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+
+        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Review context artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingReviewCommentArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+
+        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Review comment artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenReviewContextMismatch_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown("G21"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must match queue item execution unit", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenReviewCommentArtifactMismatch_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson(executionUnit: "G21"));
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Review comment artifact execution unit", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingLatestLinkedPr_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """{"ts":"2026-04-09T09:40:00Z","execution_unit":"G20","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2"}""" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("No linked PR found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenCommentArtifactLinkedPrMismatch_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson(linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/68"));
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must match latest linked PR", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingChildRepoPath_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Child repo path was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingWorktreePath_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+
+        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Worktree path was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                },
+                Roles = new RoleMappings
+                {
+                    Implement = "Claude",
+                    Review = "Codex",
+                    Interview = "Claude",
+                    Clarify = "Codex"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState(
+        QueueItemState selectedState = QueueItemState.Fixing,
+        bool withLinkedIssue = true)
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-09T09:42:34Z"),
+            Items =
+            [
+                CreateItem("G20", selectedState, withLinkedIssue),
+                CreateItem("G21", QueueItemState.Blocked, false) with
+                {
+                    Dependencies = ["G20"],
+                    BlockedBy = ["G20"]
+                }
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state, bool withLinkedIssue)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Run Fix Command",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            LinkedIssue = withLinkedIssue
+                ? new LinkedIssue
+                {
+                    Repo = "J-Tech-Japan/intent-system",
+                    Number = 68,
+                    Url = "https://github.com/J-Tech-Japan/intent-system/issues/68"
+                }
+                : null,
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static string CreatePacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G20] Run Fix Command"
+          issue_kind: "feature"
+          source_execution_unit: "G20"
+          goal: "Generate a repair worker handoff artifact."
+          in_scope:
+            - "run fix command"
+            - "repair handoff artifact generation"
+          out_of_scope:
+            - "queue mutation"
+            - "worker start"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli run fix command"
+          dependencies:
+            - "G19"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "run fix stays handoff-only"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/review-recovery-and-retry.md"
+          acceptance_criteria:
+            - "repair handoff artifact generated"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G20"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/review-recovery-and-retry.md"
+          acceptance_criteria:
+            - "repair handoff artifact generated"
+          deterministic_review_checks:
+            - "run fix command remains handoff-only"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private static string CreateReviewContextMarkdown(string executionUnit = "G20")
+    {
+        return $$"""
+        # Execution Unit
+
+        `{{executionUnit}}`
+
+        # Goal
+
+        `intent-cli run fix <execution-unit>` を working command にする。
+
+        # Acceptance Criteria
+
+        - repair handoff artifact generated
+
+        # Deterministic Review Checks
+
+        - run fix command remains handoff-only
+
+        # Expected Evidence
+
+        - dotnet test IntentSystem.sln
+        """;
+    }
+
+    private static string CreateReviewCommentArtifactJson(
+        string executionUnit = "G20",
+        string linkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/69")
+    {
+        return $$"""
+        {
+          "execution_unit": "{{executionUnit}}",
+          "review_request_ref": ".intent-cli/reviews/G20.request.json",
+          "linked_pr": "{{linkedPr}}",
+          "comment_ref": "https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2",
+          "body_path": "/repo/prepared-comment.md"
+        }
+        """;
+    }
+
+    private static string CreateRunLog()
+    {
+        return """
+        {"ts":"2026-04-09T09:00:00Z","execution_unit":"G20","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/69"}
+        {"ts":"2026-04-09T09:10:00Z","execution_unit":"A1","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/12"}
+        {"ts":"2026-04-09T09:20:00Z","execution_unit":"G20","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2"}
+        """ + Environment.NewLine;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-run-fix-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/RunFixRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixRendererTests.cs
@@ -1,0 +1,67 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class RunFixRendererTests
+{
+    [Fact]
+    public void RenderMarkdown_GivenCompleteRequest_EmitsRepairHandoffShape()
+    {
+        var markdown = RunFixRenderer.RenderMarkdown(CreateRequest());
+
+        Assert.Contains("# Repair Worker Handoff", markdown, StringComparison.Ordinal);
+        Assert.Contains("- latest_linked_pr: https://github.com/J-Tech-Japan/intent-system/pull/69", markdown, StringComparison.Ordinal);
+        Assert.Contains("- latest_comment_ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", markdown, StringComparison.Ordinal);
+        Assert.Contains("- review_comment_artifact_ref: .intent-cli/reviews/G20.comment.json", markdown, StringComparison.Ordinal);
+        Assert.Contains("- review_request_ref: .intent-cli/reviews/G20.request.json", markdown, StringComparison.Ordinal);
+        Assert.Contains("- review_comment_body_path: /repo/prepared-comment.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Deterministic Review Checks", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenRequest_WritesRepairSummary()
+    {
+        using var writer = new StringWriter();
+
+        RunFixRenderer.WriteSummary(writer, CreateRequest(), "/repo/.intent-cli/fix/G20.request.md");
+
+        var output = writer.ToString();
+        Assert.Contains("Repair handoff artifact generated for G20", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: /repo/.intent-cli/fix/G20.request.md", output, StringComparison.Ordinal);
+        Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/69", output, StringComparison.Ordinal);
+        Assert.Contains("Latest comment ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", output, StringComparison.Ordinal);
+    }
+
+    private static RunFixRequest CreateRequest()
+    {
+        return new RunFixRequest
+        {
+            ExecutionUnit = "G20",
+            State = "fixing",
+            ImplementRole = "Claude",
+            QueueWorkerRole = "coder",
+            QueueReviewRole = "reviewer",
+            WorktreePath = "/repo/.intent-cli/worktrees/G20",
+            ChildRepoPath = "/repo/submodules/intent-system",
+            Branch = "issue-68-g20",
+            LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/68",
+            LatestLinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/69",
+            LatestCommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2",
+            PacketRef = ".intent-cli/issues/G20/packet.yaml",
+            ReviewContextRef = ".intent-cli/issues/G20/review-context.md",
+            ReviewCommentArtifactRef = ".intent-cli/reviews/G20.comment.json",
+            ReviewRequestRef = ".intent-cli/reviews/G20.request.json",
+            ReviewCommentBodyPath = "/repo/prepared-comment.md",
+            IssueTitle = "[G20] Run Fix Command",
+            Goal = "Generate a repair worker handoff artifact.",
+            TargetPart = "cli run fix command",
+            TargetRepo = "submodules/intent-system",
+            TargetPath = ".",
+            InScope = ["run fix command", "repair handoff artifact generation"],
+            OutOfScope = ["queue mutation", "worker start"],
+            AcceptanceCriteria = ["repair handoff artifact generated"],
+            DeterministicReviewChecks = ["run fix command remains handoff-only"],
+            ExpectedEvidence = ["dotnet test IntentSystem.sln"]
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add `intent-cli run fix <execution-unit>` to generate a repair worker handoff artifact for the selected fixing item
- include packet, review context, latest review comment artifact, worktree context, latest linked PR, and latest comment ref in the generated handoff markdown
- cover renderer, command runtime behavior, latest linked PR lookup, and CLI routing with tests

## Testing
- dotnet test

Closes #68