### PR TITLE
[G21] Run Resubmit Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -33,6 +33,7 @@ internal static class CommandRouter
             {
                 ["start"] = RunStartCommand.Execute,
                 ["submit"] = RunSubmitCommand.Execute,
+                ["resubmit"] = RunResubmitCommand.Execute,
                 ["rereview"] = RunRereviewCommand.Execute,
                 ["resume"] = RunResumeCommand.Execute,
                 ["log"] = RunLogCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/RunResubmitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunResubmitCommand.cs
@@ -1,0 +1,190 @@
+using IntentSystem.Projection.Serialization;
+using IntentSystem.Review;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunResubmitCommand
+{
+    private const string EventActor = "intent-cli";
+
+    public static Func<IGitCommandRunner> GitCommandRunnerFactory { get; set; } = () => new GitCommandRunner();
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Run resubmit command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        if (queueItem.State is not QueueItemState.Fixing)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' must be fixing before run resubmit.");
+            return 1;
+        }
+
+        if (queueItem.LinkedIssue is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' must have a linked issue before run resubmit.");
+            return 1;
+        }
+
+        var packetPath = Path.Combine(
+            context.RepoRoot,
+            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(packetPath))
+        {
+            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
+            return 1;
+        }
+
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            writer.WriteLine($"Run log was not found at {runLogPath}");
+            return 1;
+        }
+
+        try
+        {
+            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+            var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
+            if (string.IsNullOrWhiteSpace(childRepoRef))
+            {
+                throw new InvalidOperationException("Projection packet must contain a target repo.");
+            }
+
+            var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
+            if (!Directory.Exists(childRepoPath))
+            {
+                throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+            }
+
+            var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
+            if (!Directory.Exists(worktreePath))
+            {
+                throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
+            }
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            var linkedPr = LatestLinkedPrResolver.Resolve(runEvents, executionUnit);
+
+            var branchName = RunStartCommand.ResolveBranchName(executionUnit, queueItem.LinkedIssue);
+            var gitRunner = GitCommandRunnerFactory();
+            EnsureBranchMatches(worktreePath, branchName, gitRunner);
+            PushBranch(worktreePath, branchName, gitRunner);
+
+            PersistRunEvent(
+                runLogPath,
+                new RunEvent
+                {
+                    Ts = TimestampFactory(),
+                    ExecutionUnit = executionUnit,
+                    Event = "resubmitted",
+                    By = EventActor,
+                    LinkedPr = linkedPr
+                });
+
+            writer.WriteLine($"Run resubmitted for {executionUnit}.");
+            writer.WriteLine($"Branch: {branchName}");
+            writer.WriteLine($"Worktree path: {worktreePath}");
+            writer.WriteLine($"Latest linked PR: {linkedPr}");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static string ResolveChildRepoPath(string repoRoot, string childRepoRef)
+    {
+        return Path.IsPathRooted(childRepoRef)
+            ? Path.GetFullPath(childRepoRef)
+            : Path.GetFullPath(Path.Combine(repoRoot, childRepoRef));
+    }
+
+    private static void EnsureBranchMatches(
+        string worktreePath,
+        string expectedBranchName,
+        IGitCommandRunner gitRunner)
+    {
+        var branchResult = RunGit(
+            gitRunner,
+            worktreePath,
+            ["rev-parse", "--abbrev-ref", "HEAD"],
+            "git rev-parse --abbrev-ref HEAD failed.");
+        var currentBranch = branchResult.StdOut.Trim();
+
+        if (!string.Equals(currentBranch, expectedBranchName, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Current worktree branch '{currentBranch}' must match expected branch '{expectedBranchName}'.");
+        }
+    }
+
+    private static void PushBranch(
+        string worktreePath,
+        string branchName,
+        IGitCommandRunner gitRunner)
+    {
+        RunGit(
+            gitRunner,
+            worktreePath,
+            ["push", "-u", "origin", branchName],
+            "git push failed.");
+    }
+
+    private static GitCommandResult RunGit(
+        IGitCommandRunner gitRunner,
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        string defaultError)
+    {
+        var result = gitRunner.Run(workingDirectory, arguments);
+        if (result.ExitCode != 0)
+        {
+            var error = string.IsNullOrWhiteSpace(result.StdErr)
+                ? defaultError
+                : result.StdErr.Trim();
+            throw new InvalidOperationException(error);
+        }
+
+        return result;
+    }
+
+    private static void PersistRunEvent(string runLogPath, RunEvent runEvent)
+    {
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(
+            runLogPath,
+            RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -222,6 +222,44 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenRunResubmitCommand_DispatchesToRunResubmitRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G21"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateRunResubmitQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G21", "packet.yaml"),
+            CreateRunResubmitPacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunResubmitRunLog());
+        using var writer = new StringWriter();
+        var originalGitFactory = RunResubmitCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = RunResubmitCommand.TimestampFactory;
+
+        try
+        {
+            RunResubmitCommand.GitCommandRunnerFactory = () => new FakeRunResubmitGitRunner();
+            RunResubmitCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-10T07:15:00Z");
+
+            var exitCode = CommandRouter.Execute(["run", "resubmit", "G21"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run resubmitted for G21", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/71", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunResubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+            RunResubmitCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenRunRereviewCommand_DispatchesToRunRereviewRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -866,6 +904,42 @@ public sealed class CommandRouterTests
         };
     }
 
+    private static QueueState CreateRunResubmitQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-10T07:12:34Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G21",
+                    Title = "Run resubmit command",
+                    State = QueueItemState.Fixing,
+                    Dependencies = ["G20"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G21/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G21/review-context.md",
+                        Yaml = ".intent-cli/issues/G21/packet.yaml"
+                    },
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = 70,
+                        Url = "https://github.com/J-Tech-Japan/intent-system/issues/70"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
     private static QueueState CreateReviewQueueState()
     {
         return new QueueState
@@ -1328,6 +1402,58 @@ public sealed class CommandRouterTests
         """;
     }
 
+    private static string CreateRunResubmitPacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G21] Run Resubmit Command"
+          issue_kind: "feature"
+          source_execution_unit: "G21"
+          goal: "Push the repair branch and append a resubmitted event."
+          in_scope:
+            - "run resubmit command"
+            - "repair branch push"
+          out_of_scope:
+            - "queue state mutation"
+            - "PR creation"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli run resubmit command"
+          dependencies:
+            - "G20"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "run resubmit stays push-only"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/05-intent-cli-surface.md"
+          acceptance_criteria:
+            - "resubmitted event appended"
+          verification_evidence:
+            - "dotnet test IntentSystem.sln"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G21"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/05-intent-cli-surface.md"
+          acceptance_criteria:
+            - "resubmitted event appended"
+          deterministic_review_checks:
+            - "run resubmit remains push-only"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
     private static string CreateRunImplementReviewContextMarkdown()
     {
         return """
@@ -1404,6 +1530,14 @@ public sealed class CommandRouterTests
         return """
         {"ts":"2026-04-09T09:00:00Z","execution_unit":"G20","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/69"}
         {"ts":"2026-04-09T09:20:00Z","execution_unit":"G20","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2"}
+        """ + Environment.NewLine;
+    }
+
+    private static string CreateRunResubmitRunLog()
+    {
+        return """
+        {"ts":"2026-04-10T07:00:00Z","execution_unit":"G21","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/71"}
+        {"ts":"2026-04-10T07:10:00Z","execution_unit":"G21","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/71#issuecomment-3"}
         """ + Environment.NewLine;
     }
 
@@ -1704,6 +1838,29 @@ public sealed class CommandRouterTests
                 {
                     ExitCode = 0,
                     StdOut = "git@github.com:J-Tech-Japan/intent-system.git" + Environment.NewLine,
+                    StdErr = string.Empty
+                };
+            }
+
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class FakeRunResubmitGitRunner : IGitCommandRunner
+    {
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["rev-parse", "--abbrev-ref", "HEAD"]))
+            {
+                return new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "issue-70-g21" + Environment.NewLine,
                     StdErr = string.Empty
                 };
             }

--- a/tests/IntentSystem.Cli.Tests/RunResubmitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunResubmitCommandTests.cs
@@ -1,0 +1,540 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Review;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class RunResubmitCommandTests
+{
+    [Fact]
+    public void Execute_GivenFixingItemWithWorktreeAndLatestLinkedPr_PushesAndAppendsResubmittedEventWithoutMutatingQueue()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var worktreePath = tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G21"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G21", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+        var gitRunner = new FakeGitRunner(branchName: "issue-70-g21");
+        var originalGitFactory = RunResubmitCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = RunResubmitCommand.TimestampFactory;
+
+        try
+        {
+            RunResubmitCommand.GitCommandRunnerFactory = () => gitRunner;
+            RunResubmitCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-10T07:15:00Z");
+
+            var originalQueueState = File.ReadAllText(queueStatePath);
+            var exitCode = RunResubmitCommand.Execute(CreateContext(repoRoot), ["G21"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run resubmitted for G21", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Branch: issue-70-g21", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Worktree path: " + worktreePath, writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/71", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(
+                [
+                    $"{worktreePath}::rev-parse --abbrev-ref HEAD",
+                    $"{worktreePath}::push -u origin issue-70-g21"
+                ],
+                gitRunner.Calls);
+
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal(3, runEvents.Count);
+            Assert.Equal("resubmitted", runEvents[^1].Event);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/71", runEvents[^1].LinkedPr);
+        }
+        finally
+        {
+            RunResubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+            RunResubmitCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = RunResubmitCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingQueueItem_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = RunResubmitCommand.Execute(CreateContext(repoRoot), ["G99"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("was not found in queue state", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenInvalidState_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Review)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G21", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+        var exitCode = RunResubmitCommand.Execute(CreateContext(repoRoot), ["G21"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must be fixing", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingLinkedIssue_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(withLinkedIssue: false)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G21", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+        var exitCode = RunResubmitCommand.Execute(CreateContext(repoRoot), ["G21"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must have a linked issue", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+
+        var exitCode = RunResubmitCommand.Execute(CreateContext(repoRoot), ["G21"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Projection packet artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingRunLog_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G21", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var exitCode = RunResubmitCommand.Execute(CreateContext(repoRoot), ["G21"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Run log was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingChildRepoPath_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G21"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G21", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+        var exitCode = RunResubmitCommand.Execute(CreateContext(repoRoot), ["G21"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Child repo path was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingWorktreePath_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G21", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+        var exitCode = RunResubmitCommand.Execute(CreateContext(repoRoot), ["G21"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Worktree path was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingLatestLinkedPr_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G21"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """{"ts":"2026-04-10T07:10:00Z","execution_unit":"G21","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/71#issuecomment-3"}""" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G21", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+        var exitCode = RunResubmitCommand.Execute(CreateContext(repoRoot), ["G21"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("No linked PR found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenBranchMismatch_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G21"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G21", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+        var originalGitFactory = RunResubmitCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunResubmitCommand.GitCommandRunnerFactory = () => new FakeGitRunner(branchName: "wrong-branch");
+
+            var originalQueueState = File.ReadAllText(queueStatePath);
+            var originalRunLog = File.ReadAllText(runLogPath);
+            var exitCode = RunResubmitCommand.Execute(CreateContext(repoRoot), ["G21"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("must match expected branch", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            RunResubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenGitPushFailure_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G21"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G21", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+        var originalGitFactory = RunResubmitCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunResubmitCommand.GitCommandRunnerFactory = () => new FakeGitRunner(branchName: "issue-70-g21", failOnPush: true);
+
+            var originalQueueState = File.ReadAllText(queueStatePath);
+            var originalRunLog = File.ReadAllText(runLogPath);
+            var exitCode = RunResubmitCommand.Execute(CreateContext(repoRoot), ["G21"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("git push failed", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            RunResubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+        }
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState(
+        QueueItemState selectedState = QueueItemState.Fixing,
+        bool withLinkedIssue = true)
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-10T07:12:34Z"),
+            Items =
+            [
+                CreateItem("G21", selectedState, withLinkedIssue),
+                CreateItem("G22", QueueItemState.Blocked, false) with
+                {
+                    Dependencies = ["G21"],
+                    BlockedBy = ["G21"]
+                }
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state, bool withLinkedIssue)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = "[G21] Run Resubmit Command",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            LinkedIssue = withLinkedIssue
+                ? new LinkedIssue
+                {
+                    Repo = "J-Tech-Japan/intent-system",
+                    Number = 70,
+                    Url = "https://github.com/J-Tech-Japan/intent-system/issues/70"
+                }
+                : null,
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static string CreatePacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G21] Run Resubmit Command"
+          issue_kind: "feature"
+          source_execution_unit: "G21"
+          goal: "Push the repair branch and append a resubmitted event."
+          in_scope:
+            - "run resubmit command"
+            - "repair branch push"
+          out_of_scope:
+            - "queue state mutation"
+            - "PR creation"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli run resubmit command"
+          dependencies:
+            - "G20"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "run resubmit stays push-only"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/05-intent-cli-surface.md"
+          acceptance_criteria:
+            - "resubmitted event appended"
+          verification_evidence:
+            - "dotnet test IntentSystem.sln"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G21"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/05-intent-cli-surface.md"
+          acceptance_criteria:
+            - "resubmitted event appended"
+          deterministic_review_checks:
+            - "run resubmit remains push-only"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private static string CreateRunLog()
+    {
+        return """
+        {"ts":"2026-04-10T07:00:00Z","execution_unit":"G21","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/71"}
+        {"ts":"2026-04-10T07:10:00Z","execution_unit":"G21","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/71#issuecomment-3"}
+        """ + Environment.NewLine;
+    }
+
+    private sealed class FakeGitRunner(string branchName, bool failOnPush = false) : IGitCommandRunner
+    {
+        public List<string> Calls { get; } = [];
+
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Calls.Add($"{workingDirectory}::{string.Join(' ', arguments)}");
+
+            if (arguments.Count >= 2
+                && arguments[0] == "push"
+                && arguments[1] == "-u"
+                && failOnPush)
+            {
+                return new GitCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr = "git push failed."
+                };
+            }
+
+            if (arguments.SequenceEqual(["rev-parse", "--abbrev-ref", "HEAD"]))
+            {
+                return new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = branchName + Environment.NewLine,
+                    StdErr = string.Empty
+                };
+            }
+
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-run-resubmit-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `intent-cli run resubmit <execution-unit>` as the repair branch push entry for the selected fixing item
- verify the existing deterministic worktree branch, push it to child repo `origin`, and append a same linked PR `resubmitted` event to `.intent-cli/runs.jsonl`
- keep queue state unchanged and cover command routing/runtime behavior with tests

## Testing
- dotnet test

Closes #70