### PR TITLE
[G22] Clarify Open Command

### DIFF
--- a/src/IntentSystem.Clarify/Models/ClarificationItem.cs
+++ b/src/IntentSystem.Clarify/Models/ClarificationItem.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace IntentSystem.Clarify.Models;
 
 /// <summary>
@@ -30,6 +32,7 @@ public sealed record ClarificationItem
 
     public required DateTimeOffset CreatedAt { get; init; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public string? Answer { get; init; }
 
     public DateTimeOffset? AnsweredAt { get; init; }

--- a/src/IntentSystem.Clarify/Serialization/ClarificationSerializer.cs
+++ b/src/IntentSystem.Clarify/Serialization/ClarificationSerializer.cs
@@ -96,7 +96,8 @@ public static class ClarificationSerializer
         "affected_execution_units",
         "blocking_or_nonblocking",
         "clarification_return_path",
-        "status"
+        "status",
+        "answer"
     ];
 
     private static void ValidateRequiredContractFields(JsonElement element)

--- a/src/IntentSystem.Cli/Commands/ClarifyOpenCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyOpenCommand.cs
@@ -1,0 +1,191 @@
+using IntentSystem.Clarify.Models;
+using IntentSystem.Clarify.Serialization;
+using IntentSystem.Projection.Serialization;
+using IntentSystem.Review;
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class ClarifyOpenCommand
+{
+    private const string TransitionActor = "intent-cli";
+    private const string ClarificationSource = "execution";
+    private const string QuestionId = "request";
+    private const string BlockingValue = "blocking";
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Clarify open command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
+            return 1;
+        }
+
+        var packetPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.Yaml);
+        if (!File.Exists(packetPath))
+        {
+            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
+            return 1;
+        }
+
+        var reviewContextPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.ReviewContext);
+        if (!File.Exists(reviewContextPath))
+        {
+            writer.WriteLine($"Review context artifact was not found at {reviewContextPath}");
+            return 1;
+        }
+
+        try
+        {
+            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+            if (!string.Equals(
+                    packet.ReviewContextPacket.SourceExecutionUnit,
+                    queueItem.ExecutionUnit,
+                    StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Review context packet execution unit '{packet.ReviewContextPacket.SourceExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
+            }
+
+            if (!string.Equals(
+                    packet.ReviewContextPacket.ClarificationReturnPath,
+                    queueItem.ClarificationReturnPath,
+                    StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Review context packet clarification return path '{packet.ReviewContextPacket.ClarificationReturnPath}' must match queue item clarification return path '{queueItem.ClarificationReturnPath}'.");
+            }
+
+            var reviewContext = ReviewContextMarkdownParser.Parse(File.ReadAllText(reviewContextPath));
+            if (!string.Equals(reviewContext.SourceExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Review context execution unit '{reviewContext.SourceExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
+            }
+
+            var timestamp = TimestampFactory();
+            var reason = BuildReason(packet.ImplementationIssuePacket);
+            var transition = QueueManager.TransitionBlocking(
+                queueState,
+                executionUnit,
+                QueueItemState.ClarifyBlocked,
+                reason,
+                TransitionActor,
+                timestamp);
+
+            var clarification = BuildClarification(queueItem, packet, reviewContext, timestamp, reason);
+            var artifactPath = PersistClarification(context.RepoRoot, clarification);
+            PersistTransition(context, transition);
+
+            writer.WriteLine($"Clarification opened for {executionUnit}.");
+            writer.WriteLine($"Artifact path: {artifactPath}");
+            writer.WriteLine($"Reason: {reason}");
+            writer.WriteLine($"Clarification return path: {clarification.ClarificationReturnPath}");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static ClarificationItem BuildClarification(
+        QueueItem queueItem,
+        Projection.Models.ProjectionPacketContract packet,
+        Review.Models.ReviewContextSnapshot reviewContext,
+        DateTimeOffset timestamp,
+        string reason)
+    {
+        return new ClarificationItem
+        {
+            ClarificationSource = ClarificationSource,
+            QuestionId = QuestionId,
+            ExecutionUnit = queueItem.ExecutionUnit,
+            QuestionText = BuildQuestionText(packet.ImplementationIssuePacket, reviewContext),
+            Reason = reason,
+            AffectedIntents = packet.ReviewContextPacket.IntentReferences,
+            AffectedExecutionUnits = [queueItem.ExecutionUnit],
+            BlockingOrNonblocking = BlockingValue,
+            ClarificationReturnPath = queueItem.ClarificationReturnPath,
+            Status = ClarificationStatus.Open,
+            CreatedAt = timestamp
+        };
+    }
+
+    private static string BuildQuestionText(
+        Projection.Models.ImplementationIssuePacket issuePacket,
+        Review.Models.ReviewContextSnapshot reviewContext)
+    {
+        var firstCheck = reviewContext.DeterministicReviewChecks.FirstOrDefault();
+        return string.IsNullOrWhiteSpace(firstCheck)
+            ? $"Clarify blocker for {issuePacket.TargetPart}: {issuePacket.Goal}"
+            : $"Clarify blocker for {issuePacket.TargetPart}: {firstCheck}";
+    }
+
+    private static string BuildReason(Projection.Models.ImplementationIssuePacket issuePacket)
+    {
+        return $"Clarification requested for {issuePacket.IssueTitle}: {issuePacket.Goal}";
+    }
+
+    private static string PersistClarification(string repoRoot, ClarificationItem clarification)
+    {
+        var artifactRelativePath = ResolveClarificationRequestPath(clarification.ExecutionUnit);
+        var artifactPath = ResolveArtifactPath(repoRoot, artifactRelativePath);
+        var directoryPath = Path.GetDirectoryName(artifactPath)
+            ?? throw new InvalidOperationException("Clarification artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(artifactPath, ClarificationSerializer.Serialize(clarification));
+        return artifactPath;
+    }
+
+    private static void PersistTransition(CliContext context, QueueTransitionResult result)
+    {
+        var queueStatePath = context.GetQueueStatePath();
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
+
+        var runLogPath = context.GetRunLogPath();
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(
+            runLogPath,
+            RunLogSerializer.SerializeLine(result.Event) + Environment.NewLine);
+    }
+
+    private static string ResolveClarificationRequestPath(string executionUnit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        return $".intent-cli/clarifications/{executionUnit}/request.json";
+    }
+
+    private static string ResolveArtifactPath(string repoRoot, string artifactRef)
+    {
+        return Path.GetFullPath(Path.Combine(repoRoot, artifactRef.Replace('/', Path.DirectorySeparatorChar)));
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -52,6 +52,10 @@ internal static class CommandRouter
                 ["comment"] = ReviewCommentCommand.Execute,
                 ["accept"] = ReviewAcceptCommand.Execute
             },
+            ["clarify"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["open"] = ClarifyOpenCommand.Execute
+            },
             ["queue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["list"] = QueueListCommand.Execute,

--- a/tests/IntentSystem.Clarify.Tests/ClarificationSerializerTests.cs
+++ b/tests/IntentSystem.Clarify.Tests/ClarificationSerializerTests.cs
@@ -28,10 +28,11 @@ public sealed class ClarificationSerializerTests
         Assert.Equal(["A2", "B1"], affectedExecutionUnits.EnumerateArray().Select(element => element.GetString()!).ToArray());
         Assert.Equal("blocking", root.GetProperty("blocking_or_nonblocking").GetString());
         Assert.Equal("intents/rules/issue-template-and-review-context.md", root.GetProperty("clarification_return_path").GetString());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("answer").ValueKind);
     }
 
     [Fact]
-    public void Serialize_GivenOpenClarification_UsesSnakeCaseAndOmitsNullFields()
+    public void Serialize_GivenOpenClarification_UsesSnakeCaseAndKeepsCanonicalAnswerField()
     {
         var item = CreateOpenItem();
 
@@ -41,7 +42,7 @@ public sealed class ClarificationSerializerTests
         Assert.DoesNotContain("\"questionId\"", serialized, StringComparison.Ordinal);
         Assert.DoesNotContain("\"executionUnit\"", serialized, StringComparison.Ordinal);
         Assert.DoesNotContain("\"questionText\"", serialized, StringComparison.Ordinal);
-        Assert.DoesNotContain("\"answer\"", serialized, StringComparison.Ordinal);
+        Assert.Contains("\"answer\": null", serialized, StringComparison.Ordinal);
         Assert.DoesNotContain("\"answered_at\"", serialized, StringComparison.Ordinal);
         Assert.DoesNotContain("\"state\"", serialized, StringComparison.Ordinal);
     }
@@ -155,6 +156,32 @@ public sealed class ClarificationSerializerTests
     }
 
     [Fact]
+    public void Deserialize_GivenMissingAnswer_ThrowsInvalidOperationException()
+    {
+        var json = """
+        {
+          "artifact_kind": "clarification",
+          "clarification_source": "review",
+          "question_id": "clar-1",
+          "execution_unit": "A2",
+          "question_text": "Missing answer field",
+          "reason": "test",
+          "affected_intents": [],
+          "affected_execution_units": ["A2"],
+          "blocking_or_nonblocking": "blocking",
+          "clarification_return_path": "path.md",
+          "status": "open",
+          "created_at": "2026-04-02T10:00:00Z"
+        }
+        """;
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ClarificationSerializer.Deserialize(json));
+
+        Assert.Contains("answer", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Serialize_GivenAppliedClarification_UsesKebabCaseStatusValue()
     {
         var item = CreateOpenItem() with
@@ -203,6 +230,7 @@ public sealed class ClarificationSerializerTests
           "clarification_return_path": "intents/rules/issue-template-and-review-context.md",
           "status": "answered",
           "created_at": "2026-04-02T10:00:00Z",
+          "answer": null,
           "answered_at": "2026-04-02T10:05:00Z"
         }
         """;

--- a/tests/IntentSystem.Cli.Tests/ClarifyOpenCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClarifyOpenCommandTests.cs
@@ -1,0 +1,384 @@
+using IntentSystem.Clarify.Serialization;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class ClarifyOpenCommandTests
+{
+    [Fact]
+    public void Execute_GivenQueueItemPacketAndReviewContext_TransitionsToClarifyBlockedWritesArtifactAndAppendsRunLog()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """{"ts":"2026-04-11T06:00:00Z","execution_unit":"G21","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/71"}""" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G22", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G22", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = ClarifyOpenCommand.TimestampFactory;
+
+        try
+        {
+            ClarifyOpenCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-11T06:10:00Z");
+
+            var exitCode = ClarifyOpenCommand.Execute(CreateContext(repoRoot), ["G22"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Clarification opened for G22", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Clarification return path: intents/intent-cli/clarifications/open.md", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = updatedState.Items.Single(item => item.ExecutionUnit == "G22");
+            Assert.Equal(QueueItemState.ClarifyBlocked, selectedItem.State);
+            Assert.Equal(
+                ["Clarification requested for [G22] Clarify Open Command: Open a clarification request for the current queue loop."],
+                selectedItem.BlockedBy);
+            Assert.Equal(QueueItemState.Blocked, updatedState.Items.Single(item => item.ExecutionUnit == "G23").State);
+            Assert.Equal(["G22"], updatedState.Items.Single(item => item.ExecutionUnit == "G23").BlockedBy);
+
+            var artifactPath = Path.Combine(repoRoot, ".intent-cli", "clarifications", "G22", "request.json");
+            Assert.True(File.Exists(artifactPath));
+            var artifact = ClarificationSerializer.Deserialize(File.ReadAllText(artifactPath));
+            Assert.Equal("execution", artifact.ClarificationSource);
+            Assert.Equal("request", artifact.QuestionId);
+            Assert.Equal("G22", artifact.ExecutionUnit);
+            Assert.Equal("blocking", artifact.BlockingOrNonblocking);
+            Assert.Equal("intents/intent-cli/clarifications/open.md", artifact.ClarificationReturnPath);
+            Assert.Equal(["ICL.P.PRODUCT_GOAL"], artifact.AffectedIntents);
+            Assert.Equal(["G22"], artifact.AffectedExecutionUnits);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal(2, runEvents.Count);
+            Assert.Equal("clarify-requested", runEvents[^1].Event);
+            Assert.Equal("intent-cli", runEvents[^1].By);
+            Assert.Equal(
+                "Clarification requested for [G22] Clarify Open Command: Open a clarification request for the current queue loop.",
+                runEvents[^1].Reason);
+        }
+        finally
+        {
+            ClarifyOpenCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionUnit_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = ClarifyOpenCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingQueueItem_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = ClarifyOpenCommand.Execute(CreateContext(repoRoot), ["G99"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("was not found in queue state", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G22", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+
+        var exitCode = ClarifyOpenCommand.Execute(CreateContext(repoRoot), ["G22"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Projection packet artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingReviewContextArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G22", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var exitCode = ClarifyOpenCommand.Execute(CreateContext(repoRoot), ["G22"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Review context artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenReviewContextPacketExecutionUnitMismatch_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G22", "packet.yaml"),
+            CreatePacketYaml(packetExecutionUnit: "G99"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G22", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+        var exitCode = ClarifyOpenCommand.Execute(CreateContext(repoRoot), ["G22"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Review context packet execution unit", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationReturnPathMismatch_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G22", "packet.yaml"),
+            CreatePacketYaml(clarificationReturnPath: "intents/intent-cli/clarifications/other.md"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G22", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+        var exitCode = ClarifyOpenCommand.Execute(CreateContext(repoRoot), ["G22"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("clarification return path", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenReviewContextMarkdownExecutionUnitMismatch_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G22", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G22", "review-context.md"),
+            CreateReviewContextMarkdown(executionUnit: "G99"));
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+        var exitCode = ClarifyOpenCommand.Execute(CreateContext(repoRoot), ["G22"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Review context execution unit", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-11T06:05:00Z"),
+            Items =
+            [
+                CreateItem("G22", QueueItemState.Review),
+                CreateItem("G23", QueueItemState.Blocked) with
+                {
+                    Dependencies = ["G22"],
+                    BlockedBy = ["G22"]
+                }
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Clarify Open Command",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static string CreatePacketYaml(
+        string packetExecutionUnit = "G22",
+        string clarificationReturnPath = "intents/intent-cli/clarifications/open.md")
+    {
+        return $$"""
+        implementation_issue_packet:
+          issue_title: "[G22] Clarify Open Command"
+          issue_kind: "feature"
+          source_execution_unit: "{{packetExecutionUnit}}"
+          goal: "Open a clarification request for the current queue loop."
+          in_scope:
+            - "clarify open command"
+          out_of_scope:
+            - "clarify answer"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli clarify open command"
+          dependencies:
+            - "G8"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "clarify open stays entry-only"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/06-interview-and-clarification-artifact-contract.md"
+          acceptance_criteria:
+            - "clarification artifact generated"
+          verification_evidence:
+            - "dotnet test IntentSystem.sln"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "{{packetExecutionUnit}}"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/06-interview-and-clarification-artifact-contract.md"
+          acceptance_criteria:
+            - "clarification artifact generated"
+          deterministic_review_checks:
+            - "clarify open command remains entry-only"
+          clarification_return_path: "{{clarificationReturnPath}}"
+        """;
+    }
+
+    private static string CreateReviewContextMarkdown(string executionUnit = "G22")
+    {
+        return $$"""
+        # Execution Unit
+
+        `{{executionUnit}}`
+
+        # Acceptance Criteria
+
+        - clarification artifact generated
+
+        # Deterministic Review Checks
+
+        - clarify open command remains entry-only
+        """;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-clarify-open-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/ClarifyOpenCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClarifyOpenCommandTests.cs
@@ -50,6 +50,8 @@ public sealed class ClarifyOpenCommandTests
 
             var artifactPath = Path.Combine(repoRoot, ".intent-cli", "clarifications", "G22", "request.json");
             Assert.True(File.Exists(artifactPath));
+            var serializedArtifact = File.ReadAllText(artifactPath);
+            Assert.Contains("\"answer\": null", serializedArtifact, StringComparison.Ordinal);
             var artifact = ClarificationSerializer.Deserialize(File.ReadAllText(artifactPath));
             Assert.Equal("execution", artifact.ClarificationSource);
             Assert.Equal("request", artifact.QuestionId);

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -569,6 +569,42 @@ public sealed class CommandRouterTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenClarifyOpenCommand_DispatchesToClarifyOpenRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateClarifyOpenQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G22", "packet.yaml"),
+            CreateClarifyOpenPacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G22", "review-context.md"),
+            CreateClarifyOpenReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = ClarifyOpenCommand.TimestampFactory;
+
+        try
+        {
+            ClarifyOpenCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-11T06:10:00Z");
+
+            var exitCode = CommandRouter.Execute(["clarify", "open", "G22"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Clarification opened for G22", writer.ToString(), StringComparison.Ordinal);
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "clarifications", "G22", "request.json")));
+        }
+        finally
+        {
+            ClarifyOpenCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext
@@ -895,6 +931,36 @@ public sealed class CommandRouterTests
                         Repo = "J-Tech-Japan/intent-system",
                         Number = 68,
                         Url = "https://github.com/J-Tech-Japan/intent-system/issues/68"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
+    private static QueueState CreateClarifyOpenQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-11T06:05:00Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G22",
+                    Title = "Clarify open command",
+                    State = QueueItemState.Review,
+                    Dependencies = ["G21"],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G22/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G22/review-context.md",
+                        Yaml = ".intent-cli/issues/G22/packet.yaml"
                     },
                     WorkerRole = "coder",
                     ReviewRole = "reviewer",
@@ -1402,6 +1468,56 @@ public sealed class CommandRouterTests
         """;
     }
 
+    private static string CreateClarifyOpenPacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G22] Clarify Open Command"
+          issue_kind: "feature"
+          source_execution_unit: "G22"
+          goal: "Open a clarification request for the current queue loop."
+          in_scope:
+            - "clarify open command"
+          out_of_scope:
+            - "clarify answer"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli clarify open command"
+          dependencies:
+            - "G8"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "clarify open stays entry-only"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/06-interview-and-clarification-artifact-contract.md"
+          acceptance_criteria:
+            - "clarification artifact generated"
+          verification_evidence:
+            - "dotnet test IntentSystem.sln"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G22"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/06-interview-and-clarification-artifact-contract.md"
+          acceptance_criteria:
+            - "clarification artifact generated"
+          deterministic_review_checks:
+            - "clarify open command remains entry-only"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
     private static string CreateRunResubmitPacketYaml()
     {
         return """
@@ -1501,6 +1617,23 @@ public sealed class CommandRouterTests
         # Expected Evidence
 
         - dotnet test IntentSystem.sln
+        """;
+    }
+
+    private static string CreateClarifyOpenReviewContextMarkdown()
+    {
+        return """
+        # Execution Unit
+
+        `G22`
+
+        # Acceptance Criteria
+
+        - clarification artifact generated
+
+        # Deterministic Review Checks
+
+        - clarify open command remains entry-only
         """;
     }
 


### PR DESCRIPTION
## Summary
- add `intent-cli clarify open <execution-unit>` as the clarification entry command for the current queue loop
- transition the selected queue item to `clarify-blocked`, write `.intent-cli/clarifications/<execution-unit>/request.json`, and append a reason-bearing clarify event to `.intent-cli/runs.jsonl`
- validate packet and review-context inputs and cover runtime/router behavior with tests

## Testing
- dotnet test

Closes #72