### PR TITLE
[G23] Clarify List Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/ClarifyListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyListCommand.cs
@@ -1,0 +1,73 @@
+using IntentSystem.Clarify.Models;
+using IntentSystem.Clarify.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class ClarifyListCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 0)
+        {
+            writer.WriteLine("Clarify list command does not accept arguments.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        try
+        {
+            var clarifications = DiscoverOpenClarifications(context.RepoRoot);
+            var queueItemsByExecutionUnit = queueState.Items.ToDictionary(
+                item => item.ExecutionUnit,
+                StringComparer.Ordinal);
+
+            ClarifyListRenderer.Write(writer, clarifications, queueItemsByExecutionUnit);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static IReadOnlyList<ClarificationItem> DiscoverOpenClarifications(string repoRoot)
+    {
+        var clarificationsRoot = Path.Combine(
+            repoRoot,
+            ".intent-cli",
+            "clarifications");
+
+        if (!Directory.Exists(clarificationsRoot))
+        {
+            return [];
+        }
+
+        var clarifications = new List<ClarificationItem>();
+        foreach (var artifactPath in Directory.EnumerateFiles(
+                     clarificationsRoot,
+                     "request.json",
+                     SearchOption.AllDirectories))
+        {
+            var clarification = ClarificationSerializer.Deserialize(File.ReadAllText(artifactPath));
+            if (clarification.Status == ClarificationStatus.Open)
+            {
+                clarifications.Add(clarification);
+            }
+        }
+
+        return clarifications
+            .OrderBy(item => item.ExecutionUnit, StringComparer.Ordinal)
+            .ThenBy(item => item.QuestionId, StringComparer.Ordinal)
+            .ToArray();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ClarifyListRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyListRenderer.cs
@@ -1,0 +1,43 @@
+using IntentSystem.Clarify.Models;
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class ClarifyListRenderer
+{
+    public static void Write(
+        TextWriter writer,
+        IReadOnlyList<ClarificationItem> clarifications,
+        IReadOnlyDictionary<string, QueueItem> queueItemsByExecutionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(clarifications);
+        ArgumentNullException.ThrowIfNull(queueItemsByExecutionUnit);
+
+        if (clarifications.Count == 0)
+        {
+            writer.WriteLine("No open clarifications found.");
+            return;
+        }
+
+        writer.WriteLine("Open clarifications:");
+
+        foreach (var clarification in clarifications)
+        {
+            writer.WriteLine($"Execution unit: {clarification.ExecutionUnit}");
+            writer.WriteLine($"Status: {clarification.Status}");
+            writer.WriteLine($"Question: {clarification.QuestionText}");
+            writer.WriteLine($"Reason: {clarification.Reason}");
+            writer.WriteLine($"Return path: {clarification.ClarificationReturnPath}");
+
+            if (queueItemsByExecutionUnit.TryGetValue(clarification.ExecutionUnit, out var queueItem))
+            {
+                writer.WriteLine($"Queue title: {queueItem.Title}");
+                writer.WriteLine($"Queue state: {queueItem.State}");
+            }
+
+            writer.WriteLine($"Artifact question id: {clarification.QuestionId}");
+            writer.WriteLine(string.Empty);
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -54,7 +54,8 @@ internal static class CommandRouter
             },
             ["clarify"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
-                ["open"] = ClarifyOpenCommand.Execute
+                ["open"] = ClarifyOpenCommand.Execute,
+                ["list"] = ClarifyListCommand.Execute
             },
             ["queue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/tests/IntentSystem.Cli.Tests/ClarifyListCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClarifyListCommandTests.cs
@@ -1,0 +1,235 @@
+using IntentSystem.Clarify.Models;
+using IntentSystem.Clarify.Serialization;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ClarifyListCommandTests
+{
+    [Fact]
+    public void Execute_GivenOpenClarificationArtifacts_RendersOpenItemsWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """{"ts":"2026-04-12T06:00:00Z","execution_unit":"G22","event":"clarify-requested","by":"intent-cli","reason":"need clarification"}""" + Environment.NewLine);
+        var openArtifactPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "clarifications", "G22", "request.json"),
+            ClarificationSerializer.Serialize(CreateClarification("G22", ClarificationStatus.Open)));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "clarifications", "G23", "request.json"),
+            ClarificationSerializer.Serialize(CreateClarification("G23", ClarificationStatus.Answered) with
+            {
+                Answer = "resolved",
+                AnsweredAt = DateTimeOffset.Parse("2026-04-12T06:05:00Z")
+            }));
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var originalRunLog = File.ReadAllText(runLogPath);
+        var originalArtifact = File.ReadAllText(openArtifactPath);
+
+        var exitCode = ClarifyListCommand.Execute(CreateContext(repoRoot), [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Open clarifications:", output, StringComparison.Ordinal);
+        Assert.Contains("Execution unit: G22", output, StringComparison.Ordinal);
+        Assert.Contains("Status: Open", output, StringComparison.Ordinal);
+        Assert.Contains("Question: Clarify blocker for cli clarify open command", output, StringComparison.Ordinal);
+        Assert.Contains("Reason: Clarification requested for [G22] Clarify Open Command", output, StringComparison.Ordinal);
+        Assert.Contains("Return path: intents/intent-cli/clarifications/open.md", output, StringComparison.Ordinal);
+        Assert.Contains("Queue title: [G22] Clarify Open Command", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Execution unit: G23", output, StringComparison.Ordinal);
+
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+        Assert.Equal(originalArtifact, File.ReadAllText(openArtifactPath));
+    }
+
+    [Fact]
+    public void Execute_GivenNoClarificationsDirectory_WritesNoOpenClarificationsMessage()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = ClarifyListCommand.Execute(CreateContext(repoRoot), [], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("No open clarifications found.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenOnlyClosedClarifications_WritesNoOpenClarificationsMessage()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "clarifications", "G23", "request.json"),
+            ClarificationSerializer.Serialize(CreateClarification("G23", ClarificationStatus.Applied) with
+            {
+                Answer = "resolved",
+                AnsweredAt = DateTimeOffset.Parse("2026-04-12T06:05:00Z")
+            }));
+        using var writer = new StringWriter();
+
+        var exitCode = ClarifyListCommand.Execute(CreateContext(repoRoot), [], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("No open clarifications found.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenArguments_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = ClarifyListCommand.Execute(CreateContext("/tmp/intent-system"), ["G22"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("does not accept arguments", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingQueueState_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = ClarifyListCommand.Execute(CreateContext(repoRoot), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("No queue state found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-12T06:00:00Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G22",
+                    Title = "[G22] Clarify Open Command",
+                    State = QueueItemState.ClarifyBlocked,
+                    Dependencies = [],
+                    BlockedBy = ["need clarification"],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G22/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G22/review-context.md",
+                        Yaml = ".intent-cli/issues/G22/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                },
+                new QueueItem
+                {
+                    ExecutionUnit = "G23",
+                    Title = "[G23] Clarify List Command",
+                    State = QueueItemState.Review,
+                    Dependencies = [],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G23/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G23/review-context.md",
+                        Yaml = ".intent-cli/issues/G23/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
+    private static ClarificationItem CreateClarification(string executionUnit, ClarificationStatus status)
+    {
+        return new ClarificationItem
+        {
+            ClarificationSource = "execution",
+            QuestionId = "request",
+            ExecutionUnit = executionUnit,
+            QuestionText = $"Clarify blocker for cli clarify open command: review check for {executionUnit}",
+            Reason = $"Clarification requested for [${executionUnit}] Clarify Open Command".Replace("$", string.Empty),
+            AffectedIntents = ["ICL.P.PRODUCT_GOAL"],
+            AffectedExecutionUnits = [executionUnit],
+            BlockingOrNonblocking = "blocking",
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            Status = status,
+            CreatedAt = DateTimeOffset.Parse("2026-04-12T06:00:00Z"),
+            Answer = status == ClarificationStatus.Open ? null : "resolved",
+            AnsweredAt = status == ClarificationStatus.Open ? null : DateTimeOffset.Parse("2026-04-12T06:05:00Z")
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-clarify-list-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1,6 +1,8 @@
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Clarify.Models;
+using IntentSystem.Clarify.Serialization;
 using IntentSystem.Review;
 using IntentSystem.Review.Serialization;
 using IntentSystem.Supervisor.Models;
@@ -603,6 +605,26 @@ public sealed class CommandRouterTests
         {
             ClarifyOpenCommand.TimestampFactory = originalTimestampFactory;
         }
+    }
+
+    [Fact]
+    public void Execute_GivenClarifyListCommand_DispatchesToClarifyListRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateClarifyOpenQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "clarifications", "G22", "request.json"),
+            ClarificationSerializer.Serialize(CreateClarifyListItem()));
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["clarify", "list"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Open clarifications:", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Execution unit: G22", writer.ToString(), StringComparison.Ordinal);
     }
 
     private static CliContext CreateContext(string repoRoot)
@@ -1635,6 +1657,25 @@ public sealed class CommandRouterTests
 
         - clarify open command remains entry-only
         """;
+    }
+
+    private static ClarificationItem CreateClarifyListItem()
+    {
+        return new ClarificationItem
+        {
+            ClarificationSource = "execution",
+            QuestionId = "request",
+            ExecutionUnit = "G22",
+            QuestionText = "Clarify blocker for cli clarify open command: clarify open command remains entry-only",
+            Reason = "Clarification requested for [G22] Clarify Open Command: Open a clarification request for the current queue loop.",
+            AffectedIntents = ["ICL.P.PRODUCT_GOAL"],
+            AffectedExecutionUnits = ["G22"],
+            BlockingOrNonblocking = "blocking",
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            Status = ClarificationStatus.Open,
+            CreatedAt = DateTimeOffset.Parse("2026-04-11T06:10:00Z"),
+            Answer = null
+        };
     }
 
     private static string CreateRunImplementRunLog()


### PR DESCRIPTION
## Summary
- add `intent-cli clarify list` as a read-only clarification visibility command
- read current queue state and `.intent-cli/clarifications/` artifacts, then render only open clarifications
- cover router dispatch and read-only behavior with CLI tests

## Verification
- `dotnet test`

Closes #74