### PR TITLE
[G26] Interview Start Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -52,6 +52,10 @@ internal static class CommandRouter
                 ["comment"] = ReviewCommentCommand.Execute,
                 ["accept"] = ReviewAcceptCommand.Execute
             },
+            ["interview"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["start"] = InterviewStartCommand.Execute
+            },
             ["clarify"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["open"] = ClarifyOpenCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/InterviewStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/InterviewStartCommand.cs
@@ -1,0 +1,65 @@
+using IntentSystem.ConceptIntake.Interview;
+using IntentSystem.ConceptIntake.Models;
+using IntentSystem.ConceptIntake.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class InterviewStartCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Interview start command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0];
+
+        try
+        {
+            var items = DiscoverInterviewArtifacts(context.RepoRoot, domain);
+            var nextQuestion = InterviewQueue.GetNextPendingForDomain(items, domain);
+            InterviewStartRenderer.Write(writer, domain, nextQuestion);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static IReadOnlyList<InterviewQueueItem> DiscoverInterviewArtifacts(string repoRoot, string domain)
+    {
+        var interviewsRoot = Path.Combine(
+            repoRoot,
+            ".intent-cli",
+            "interviews",
+            domain.Replace('/', Path.DirectorySeparatorChar));
+
+        if (!Directory.Exists(interviewsRoot))
+        {
+            return [];
+        }
+
+        var items = new List<InterviewQueueItem>();
+        foreach (var artifactPath in Directory.EnumerateFiles(interviewsRoot, "*.json", SearchOption.AllDirectories))
+        {
+            var item = InterviewQueueSerializer.Deserialize(File.ReadAllText(artifactPath));
+            if (!string.Equals(item.DomainSlug, domain, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Interview artifact domain '{item.DomainSlug}' must match requested domain '{domain}'.");
+            }
+
+            items.Add(item);
+        }
+
+        return items;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/InterviewStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/InterviewStartCommand.cs
@@ -1,7 +1,5 @@
 using IntentSystem.ConceptIntake.Interview;
 using IntentSystem.ConceptIntake.Models;
-using IntentSystem.ConceptIntake.Serialization;
-
 namespace IntentSystem.Cli.Commands;
 
 internal static class InterviewStartCommand
@@ -48,9 +46,9 @@ internal static class InterviewStartCommand
         }
 
         var items = new List<InterviewQueueItem>();
-        foreach (var artifactPath in Directory.EnumerateFiles(interviewsRoot, "*.json", SearchOption.AllDirectories))
+        foreach (var artifactPath in Directory.EnumerateFiles(interviewsRoot, "*.yaml", SearchOption.AllDirectories))
         {
-            var item = InterviewQueueSerializer.Deserialize(File.ReadAllText(artifactPath));
+            var item = DeserializeInterviewArtifactYaml(File.ReadAllText(artifactPath));
             if (!string.Equals(item.DomainSlug, domain, StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
@@ -61,5 +59,244 @@ internal static class InterviewStartCommand
         }
 
         return items;
+    }
+
+    private static InterviewQueueItem DeserializeInterviewArtifactYaml(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateArtifactKind(values);
+        ValidateRequiredFields(values);
+
+        var status = ParseStatus(GetRequiredScalar(values, "status"));
+        var answer = GetOptionalScalar(values, "answer");
+        var answeredAt = GetOptionalDateTimeOffset(values, "answered_at");
+        var recommendedUpdates = GetOptionalList(values, "recommended_updates");
+
+        var item = new InterviewQueueItem
+        {
+            DomainSlug = GetRequiredScalar(values, "domain_slug"),
+            SourceConceptRef = GetRequiredScalar(values, "source_concept_ref"),
+            QuestionId = GetRequiredScalar(values, "question_id"),
+            QuestionText = GetRequiredScalar(values, "question_text"),
+            Reason = GetRequiredScalar(values, "reason"),
+            Affects = GetRequiredList(values, "affects"),
+            BlockingOrNonblocking = GetRequiredScalar(values, "blocking_or_nonblocking"),
+            Status = status,
+            ReturnToIntentPaths = GetRequiredList(values, "return_to_intent_paths"),
+            CreatedAt = DateTimeOffset.Parse(GetRequiredScalar(values, "created_at")),
+            Answer = answer,
+            AnsweredAt = answeredAt,
+            RecommendedUpdates = recommendedUpdates
+        };
+
+        ValidateStatusInvariant(item);
+        return item;
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("  - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !values.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException(
+                        $"Interview artifact YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[4..].TrimStart()));
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Interview artifact YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+
+            if (value.Length == 0)
+            {
+                values[key] = new List<string>();
+                currentListKey = key;
+                continue;
+            }
+
+            currentListKey = null;
+            values[key] = value switch
+            {
+                "[]" => Array.Empty<string>(),
+                "null" => null,
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static readonly string[] RequiredFields =
+    [
+        "artifact_kind",
+        "domain_slug",
+        "source_concept_ref",
+        "question_id",
+        "question_text",
+        "reason",
+        "affects",
+        "blocking_or_nonblocking",
+        "status",
+        "return_to_intent_paths",
+        "created_at",
+        "answer"
+    ];
+
+    private static void ValidateArtifactKind(IReadOnlyDictionary<string, object?> values)
+    {
+        var artifactKind = GetRequiredScalar(values, "artifact_kind");
+        if (!string.Equals(artifactKind, "interview", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Interview artifact YAML must use artifact_kind 'interview'.");
+        }
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException(
+                    $"Interview artifact YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException(
+                $"Interview artifact YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static string? GetOptionalScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        return values.TryGetValue(key, out var value) ? value as string : null;
+    }
+
+    private static DateTimeOffset? GetOptionalDateTimeOffset(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is null)
+        {
+            return null;
+        }
+
+        if (value is not string text)
+        {
+            throw new InvalidOperationException(
+                $"Interview artifact YAML field '{key}' must be a scalar string when present.");
+        }
+
+        return DateTimeOffset.Parse(text);
+    }
+
+    private static IReadOnlyList<string> GetRequiredList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException(
+                $"Interview artifact YAML field '{key}' must be a list.");
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException(
+                $"Interview artifact YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static IReadOnlyList<string>? GetOptionalList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is null)
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException(
+                $"Interview artifact YAML field '{key}' must be a list when present.")
+        };
+    }
+
+    private static InterviewQueueItemStatus ParseStatus(string value)
+    {
+        return value switch
+        {
+            "open" => InterviewQueueItemStatus.Open,
+            "answered" => InterviewQueueItemStatus.Answered,
+            "applied" => InterviewQueueItemStatus.Applied,
+            "cancelled" => InterviewQueueItemStatus.Cancelled,
+            _ => throw new InvalidOperationException(
+                $"Interview artifact YAML status '{value}' is not supported.")
+        };
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static void ValidateStatusInvariant(InterviewQueueItem item)
+    {
+        var hasAnswer = item.Answer is not null;
+        var hasAnsweredAt = item.AnsweredAt.HasValue;
+
+        switch (item.Status)
+        {
+            case InterviewQueueItemStatus.Open when hasAnswer || hasAnsweredAt:
+                throw new InvalidOperationException(
+                    "Open interview artifacts must not contain answer metadata.");
+            case InterviewQueueItemStatus.Answered or InterviewQueueItemStatus.Applied
+                when !hasAnswer || !hasAnsweredAt:
+                throw new InvalidOperationException(
+                    $"Interview artifacts in status '{item.Status}' must contain answer and answered_at.");
+        }
     }
 }

--- a/src/IntentSystem.Cli/Commands/InterviewStartRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/InterviewStartRenderer.cs
@@ -1,0 +1,27 @@
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class InterviewStartRenderer
+{
+    public static void Write(TextWriter writer, string domain, InterviewQueueItem? item)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+
+        if (item is null)
+        {
+            writer.WriteLine($"No open interview questions found for domain '{domain}'.");
+            return;
+        }
+
+        writer.WriteLine("Next interview question:");
+        writer.WriteLine($"Domain: {item.DomainSlug}");
+        writer.WriteLine($"Question: {item.QuestionText}");
+        writer.WriteLine($"Reason: {item.Reason}");
+        writer.WriteLine($"Affects: {string.Join(", ", item.Affects)}");
+        writer.WriteLine($"Blocking mode: {item.BlockingOrNonblocking}");
+        writer.WriteLine($"Return paths: {string.Join(", ", item.ReturnToIntentPaths)}");
+        writer.WriteLine($"Question id: {item.QuestionId}");
+    }
+}

--- a/src/IntentSystem.Cli/IntentSystem.Cli.csproj
+++ b/src/IntentSystem.Cli/IntentSystem.Cli.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\IntentSystem.ConceptIntake\IntentSystem.ConceptIntake.csproj" />
     <ProjectReference Include="..\IntentSystem.Projection\IntentSystem.Projection.csproj" />
     <ProjectReference Include="..\IntentSystem.Review\IntentSystem.Review.csproj" />
     <ProjectReference Include="..\IntentSystem.Supervisor\IntentSystem.Supervisor.csproj" />

--- a/src/IntentSystem.ConceptIntake/Interview/InterviewQueue.cs
+++ b/src/IntentSystem.ConceptIntake/Interview/InterviewQueue.cs
@@ -92,6 +92,26 @@ public static class InterviewQueue
         return items.Where(i => string.Equals(i.DomainSlug, domainSlug, StringComparison.Ordinal)).ToArray();
     }
 
+    /// <summary>
+    /// Selects the next open interview question for a domain using the current
+    /// E2 baseline: blocking questions take precedence, then oldest created_at,
+    /// then question_id for deterministic tie-breaking.
+    /// </summary>
+    public static InterviewQueueItem? GetNextPendingForDomain(
+        IReadOnlyList<InterviewQueueItem> items,
+        string domainSlug)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domainSlug);
+
+        return GetForDomain(items, domainSlug)
+            .Where(item => item.Status == InterviewQueueItemStatus.Open)
+            .OrderBy(item => IsBlocking(item) ? 0 : 1)
+            .ThenBy(item => item.CreatedAt)
+            .ThenBy(item => item.QuestionId, StringComparer.Ordinal)
+            .FirstOrDefault();
+    }
+
     private static bool IsBlocking(InterviewQueueItem item)
     {
         return string.Equals(item.BlockingOrNonblocking, BlockingValue, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1,6 +1,8 @@
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.ConceptIntake.Models;
+using IntentSystem.ConceptIntake.Serialization;
 using IntentSystem.Clarify.Models;
 using IntentSystem.Clarify.Serialization;
 using IntentSystem.Review;
@@ -145,6 +147,23 @@ public sealed class CommandRouterTests
             QueueDispatchCommand.GitCommandRunnerFactory = originalGitFactory;
             QueueDispatchCommand.TimestampFactory = originalTimestampFactory;
         }
+    }
+
+    [Fact]
+    public void Execute_GivenInterviewStartCommand_DispatchesToInterviewStartRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.json"),
+            InterviewQueueSerializer.Serialize(CreateInterviewStartItem()));
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["interview", "start", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Next interview question:", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Question: Which auth flow should be canonical?", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1759,6 +1778,24 @@ public sealed class CommandRouterTests
             ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
             Status = ClarificationStatus.Open,
             CreatedAt = DateTimeOffset.Parse("2026-04-12T06:50:00Z"),
+            Answer = null
+        };
+    }
+
+    private static InterviewQueueItem CreateInterviewStartItem()
+    {
+        return new InterviewQueueItem
+        {
+            DomainSlug = "auth",
+            SourceConceptRef = "intents/intent-cli/concepts/auth-oauth2.md",
+            QuestionId = "iq-1",
+            QuestionText = "Which auth flow should be canonical?",
+            Reason = "Auth direction is still underspecified.",
+            Affects = ["auth-oauth2"],
+            BlockingOrNonblocking = "blocking",
+            Status = InterviewQueueItemStatus.Open,
+            ReturnToIntentPaths = ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+            CreatedAt = DateTimeOffset.Parse("2026-04-13T08:00:00Z"),
             Answer = null
         };
     }

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -2,7 +2,6 @@ using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
 using IntentSystem.ConceptIntake.Models;
-using IntentSystem.ConceptIntake.Serialization;
 using IntentSystem.Clarify.Models;
 using IntentSystem.Clarify.Serialization;
 using IntentSystem.Review;
@@ -155,8 +154,11 @@ public sealed class CommandRouterTests
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.json"),
-            InterviewQueueSerializer.Serialize(CreateInterviewStartItem()));
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewStartItemYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
         using var writer = new StringWriter();
 
         var exitCode = CommandRouter.Execute(["interview", "start", "auth"], CreateContext(repoRoot), writer);
@@ -1782,22 +1784,24 @@ public sealed class CommandRouterTests
         };
     }
 
-    private static InterviewQueueItem CreateInterviewStartItem()
+    private static string CreateInterviewStartItemYaml()
     {
-        return new InterviewQueueItem
-        {
-            DomainSlug = "auth",
-            SourceConceptRef = "intents/intent-cli/concepts/auth-oauth2.md",
-            QuestionId = "iq-1",
-            QuestionText = "Which auth flow should be canonical?",
-            Reason = "Auth direction is still underspecified.",
-            Affects = ["auth-oauth2"],
-            BlockingOrNonblocking = "blocking",
-            Status = InterviewQueueItemStatus.Open,
-            ReturnToIntentPaths = ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
-            CreatedAt = DateTimeOffset.Parse("2026-04-13T08:00:00Z"),
-            Answer = null
-        };
+        return """
+artifact_kind: interview
+domain_slug: auth
+source_concept_ref: "intents/intent-cli/concepts/auth-oauth2.md"
+question_id: iq-1
+question_text: "Which auth flow should be canonical?"
+reason: "Auth direction is still underspecified."
+affects:
+  - "auth-oauth2"
+blocking_or_nonblocking: blocking
+status: open
+return_to_intent_paths:
+  - "intents/intent-cli/intent-tree/means/auth-oauth2.md"
+created_at: "2026-04-13T08:00:00.0000000+00:00"
+answer: null
+""";
     }
 
     private static string CreateRunImplementRunLog()

--- a/tests/IntentSystem.Cli.Tests/InterviewStartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/InterviewStartCommandTests.cs
@@ -1,0 +1,178 @@
+using IntentSystem.ConceptIntake.Models;
+using IntentSystem.ConceptIntake.Serialization;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class InterviewStartCommandTests
+{
+    [Fact]
+    public void Execute_GivenOpenInterviewItems_RendersNextBlockingQuestion()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var questionPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.json"),
+            InterviewQueueSerializer.Serialize(CreateItem("iq-1", "blocking", InterviewQueueItemStatus.Open, createdAt: "2026-04-13T08:00:00Z")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-2.json"),
+            InterviewQueueSerializer.Serialize(CreateItem("iq-2", "nonblocking", InterviewQueueItemStatus.Open, createdAt: "2026-04-13T07:00:00Z")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-3.json"),
+            InterviewQueueSerializer.Serialize(CreateAppliedItem("iq-3", "auth")));
+        using var writer = new StringWriter();
+
+        var originalQuestion = File.ReadAllText(questionPath);
+        var exitCode = InterviewStartCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Next interview question:", output, StringComparison.Ordinal);
+        Assert.Contains("Domain: auth", output, StringComparison.Ordinal);
+        Assert.Contains("Question: Question for iq-1", output, StringComparison.Ordinal);
+        Assert.Contains("Reason: Explore unknown area.", output, StringComparison.Ordinal);
+        Assert.Contains("Affects: auth-oauth2", output, StringComparison.Ordinal);
+        Assert.Contains("Blocking mode: blocking", output, StringComparison.Ordinal);
+        Assert.Contains("Return paths: intents/intent-cli/intent-tree/means/auth-oauth2.md", output, StringComparison.Ordinal);
+        Assert.Contains("Question id: iq-1", output, StringComparison.Ordinal);
+        Assert.Equal(originalQuestion, File.ReadAllText(questionPath));
+    }
+
+    [Fact]
+    public void Execute_GivenNoInterviewDirectory_ReturnsDeterministicNoOpenResult()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewStartCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("No open interview questions found for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenOnlyAnsweredItems_ReturnsDeterministicNoOpenResult()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.json"),
+            InterviewQueueSerializer.Serialize(CreateAppliedItem("iq-1", "auth")));
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewStartCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("No open interview questions found for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewStartCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenArtifactDomainMismatch_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.json"),
+            InterviewQueueSerializer.Serialize(CreateItem("iq-1", "blocking", InterviewQueueItemStatus.Open, domainSlug: "billing")));
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewStartCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must match requested domain 'auth'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static InterviewQueueItem CreateItem(
+        string questionId,
+        string blockingOrNonblocking,
+        InterviewQueueItemStatus status,
+        string domainSlug = "auth",
+        string createdAt = "2026-04-13T06:00:00Z")
+    {
+        return new InterviewQueueItem
+        {
+            DomainSlug = domainSlug,
+            SourceConceptRef = $"intents/intent-cli/concepts/{domainSlug}-oauth2.md",
+            QuestionId = questionId,
+            QuestionText = $"Question for {questionId}",
+            Reason = "Explore unknown area.",
+            Affects = ["auth-oauth2"],
+            BlockingOrNonblocking = blockingOrNonblocking,
+            Status = status,
+            ReturnToIntentPaths = ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+            CreatedAt = DateTimeOffset.Parse(createdAt),
+            Answer = null
+        };
+    }
+
+    private static InterviewQueueItem CreateAppliedItem(string questionId, string domainSlug)
+    {
+        return CreateItem(questionId, "blocking", InterviewQueueItemStatus.Applied, domainSlug) with
+        {
+            Answer = "Use OAuth2 with PKCE.",
+            AnsweredAt = DateTimeOffset.Parse("2026-04-13T06:30:00Z"),
+            RecommendedUpdates = ["Update auth strategy"]
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-interview-start-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/InterviewStartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/InterviewStartCommandTests.cs
@@ -1,5 +1,4 @@
 using IntentSystem.ConceptIntake.Models;
-using IntentSystem.ConceptIntake.Serialization;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
 
@@ -13,14 +12,23 @@ public sealed class InterviewStartCommandTests
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         var questionPath = tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.json"),
-            InterviewQueueSerializer.Serialize(CreateItem("iq-1", "blocking", InterviewQueueItemStatus.Open, createdAt: "2026-04-13T08:00:00Z")));
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewArtifactYaml(CreateItem("iq-1", "blocking", InterviewQueueItemStatus.Open, createdAt: "2026-04-13T08:00:00Z")));
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-2.json"),
-            InterviewQueueSerializer.Serialize(CreateItem("iq-2", "nonblocking", InterviewQueueItemStatus.Open, createdAt: "2026-04-13T07:00:00Z")));
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-3.json"),
-            InterviewQueueSerializer.Serialize(CreateAppliedItem("iq-3", "auth")));
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-2.yaml"),
+            CreateInterviewArtifactYaml(CreateItem("iq-2", "nonblocking", InterviewQueueItemStatus.Open, createdAt: "2026-04-13T07:00:00Z")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-2.md"),
+            "# Interview Question");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-3.yaml"),
+            CreateInterviewArtifactYaml(CreateAppliedItem("iq-3", "auth")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-3.md"),
+            "# Interview Question");
         using var writer = new StringWriter();
 
         var originalQuestion = File.ReadAllText(questionPath);
@@ -58,8 +66,11 @@ public sealed class InterviewStartCommandTests
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.json"),
-            InterviewQueueSerializer.Serialize(CreateAppliedItem("iq-1", "auth")));
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewArtifactYaml(CreateAppliedItem("iq-1", "auth")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
         using var writer = new StringWriter();
 
         var exitCode = InterviewStartCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
@@ -85,8 +96,11 @@ public sealed class InterviewStartCommandTests
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.json"),
-            InterviewQueueSerializer.Serialize(CreateItem("iq-1", "blocking", InterviewQueueItemStatus.Open, domainSlug: "billing")));
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewArtifactYaml(CreateItem("iq-1", "blocking", InterviewQueueItemStatus.Open, domainSlug: "billing")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
         using var writer = new StringWriter();
 
         var exitCode = InterviewStartCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
@@ -143,6 +157,58 @@ public sealed class InterviewStartCommandTests
             AnsweredAt = DateTimeOffset.Parse("2026-04-13T06:30:00Z"),
             RecommendedUpdates = ["Update auth strategy"]
         };
+    }
+
+    private static string CreateInterviewArtifactYaml(InterviewQueueItem item)
+    {
+        var lines = new List<string>
+        {
+            "artifact_kind: interview",
+            $"domain_slug: {item.DomainSlug}",
+            $"source_concept_ref: {Quote(item.SourceConceptRef)}",
+            $"question_id: {item.QuestionId}",
+            $"question_text: {Quote(item.QuestionText)}",
+            $"reason: {Quote(item.Reason)}",
+            "affects:"
+        };
+
+        lines.AddRange(item.Affects.Select(affect => $"  - {Quote(affect)}"));
+        lines.Add($"blocking_or_nonblocking: {item.BlockingOrNonblocking}");
+        lines.Add($"status: {FormatStatus(item.Status)}");
+        lines.Add("return_to_intent_paths:");
+        lines.AddRange(item.ReturnToIntentPaths.Select(path => $"  - {Quote(path)}"));
+        lines.Add($"created_at: {Quote(item.CreatedAt.ToString("O"))}");
+        lines.Add(item.Answer is null ? "answer: null" : $"answer: {Quote(item.Answer)}");
+
+        if (item.AnsweredAt.HasValue)
+        {
+            lines.Add($"answered_at: {Quote(item.AnsweredAt.Value.ToString("O"))}");
+        }
+
+        if (item.RecommendedUpdates is not null)
+        {
+            lines.Add(item.RecommendedUpdates.Count == 0 ? "recommended_updates: []" : "recommended_updates:");
+            if (item.RecommendedUpdates.Count > 0)
+            {
+                lines.AddRange(item.RecommendedUpdates.Select(update => $"  - {Quote(update)}"));
+            }
+        }
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    private static string FormatStatus(InterviewQueueItemStatus status)
+    {
+        return status.ToString().ToLowerInvariant();
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/tests/IntentSystem.ConceptIntake.Tests/InterviewQueueTests.cs
+++ b/tests/IntentSystem.ConceptIntake.Tests/InterviewQueueTests.cs
@@ -131,6 +131,66 @@ public sealed class InterviewQueueTests
         Assert.All(authItems, i => Assert.Equal("auth", i.DomainSlug));
     }
 
+    [Fact]
+    public void GetNextPendingForDomain_GivenBlockingAndNonblockingOpen_SelectsBlockingFirst()
+    {
+        IReadOnlyList<InterviewQueueItem> items =
+        [
+            CreateItem("iq-2", "nonblocking", InterviewQueueItemStatus.Open, domainSlug: "auth") with
+            {
+                CreatedAt = BaseTime.AddHours(-2)
+            },
+            CreateItem("iq-1", "blocking", InterviewQueueItemStatus.Open, domainSlug: "auth") with
+            {
+                CreatedAt = BaseTime.AddHours(-1)
+            }
+        ];
+
+        var next = InterviewQueue.GetNextPendingForDomain(items, "auth");
+
+        Assert.NotNull(next);
+        Assert.Equal("iq-1", next!.QuestionId);
+    }
+
+    [Fact]
+    public void GetNextPendingForDomain_GivenOnlyNonblockingQuestions_SelectsOldestThenQuestionId()
+    {
+        IReadOnlyList<InterviewQueueItem> items =
+        [
+            CreateItem("iq-2", "nonblocking", InterviewQueueItemStatus.Open, domainSlug: "auth") with
+            {
+                CreatedAt = BaseTime.AddHours(-2)
+            },
+            CreateItem("iq-1", "nonblocking", InterviewQueueItemStatus.Open, domainSlug: "auth") with
+            {
+                CreatedAt = BaseTime.AddHours(-2)
+            },
+            CreateItem("iq-3", "blocking", InterviewQueueItemStatus.Applied, domainSlug: "auth")
+        ];
+
+        var next = InterviewQueue.GetNextPendingForDomain(items, "auth");
+
+        Assert.NotNull(next);
+        Assert.Equal("iq-1", next!.QuestionId);
+    }
+
+    [Fact]
+    public void GetNextPendingForDomain_GivenNoOpenQuestions_ReturnsNull()
+    {
+        IReadOnlyList<InterviewQueueItem> items =
+        [
+            CreateItem("iq-1", "blocking", InterviewQueueItemStatus.Applied, domainSlug: "auth") with
+            {
+                Answer = "Already answered.",
+                AnsweredAt = BaseTime
+            }
+        ];
+
+        var next = InterviewQueue.GetNextPendingForDomain(items, "auth");
+
+        Assert.Null(next);
+    }
+
     private static InterviewQueueItem CreateItem(
         string questionId, string blockingOrNonblocking, InterviewQueueItemStatus status,
         string domainSlug = "auth")


### PR DESCRIPTION
## Summary
- add `intent-cli interview start <domain>` as a read-only interview entry command
- discover interview artifacts under `.intent-cli/interviews/<domain>/` and select the next open question deterministically
- render the selected question context and cover command routing and selection behavior with tests

## Verification
- `dotnet test`

Closes #78
