### PR TITLE
[G28] Interview Resume Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -55,7 +55,8 @@ internal static class CommandRouter
             ["interview"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["start"] = InterviewStartCommand.Execute,
-                ["answer"] = InterviewAnswerCommand.Execute
+                ["answer"] = InterviewAnswerCommand.Execute,
+                ["resume"] = InterviewResumeCommand.Execute
             },
             ["clarify"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/InterviewResumeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/InterviewResumeCommand.cs
@@ -1,0 +1,68 @@
+using IntentSystem.ConceptIntake.Interview;
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class InterviewResumeCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Interview resume command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0];
+
+        try
+        {
+            var artifacts = InterviewArtifactYaml.Discover(context.RepoRoot, domain);
+            var result = CreateResult(domain, artifacts);
+            InterviewResumeRenderer.Write(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static InterviewResumeResult CreateResult(
+        string domain,
+        IReadOnlyList<InterviewArtifactYaml.ArtifactFile> artifacts)
+    {
+        var items = artifacts.Select(artifact => artifact.Item).ToArray();
+        var nextQuestion = InterviewQueue.GetNextPendingForDomain(items, domain);
+        var answeredItems = items
+            .Where(item => item.Status == InterviewQueueItemStatus.Answered)
+            .OrderBy(item => item.CreatedAt)
+            .ThenBy(item => item.QuestionId, StringComparer.Ordinal)
+            .ToArray();
+
+        return new InterviewResumeResult
+        {
+            Domain = domain,
+            HasArtifacts = artifacts.Count > 0,
+            NextQuestion = nextQuestion,
+            AnsweredQuestionIds = answeredItems
+                .Select(item => item.QuestionId)
+                .ToArray(),
+            RecommendedUpdates = answeredItems
+                .SelectMany(item => item.RecommendedUpdates ?? [])
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(update => update, StringComparer.Ordinal)
+                .ToArray(),
+            ReturnToIntentPaths = answeredItems
+                .SelectMany(item => item.ReturnToIntentPaths)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray()
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/InterviewResumeRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/InterviewResumeRenderer.cs
@@ -1,0 +1,50 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class InterviewResumeRenderer
+{
+    public static void Write(TextWriter writer, InterviewResumeResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+        ArgumentException.ThrowIfNullOrWhiteSpace(result.Domain);
+
+        if (result.NextQuestion is not null)
+        {
+            InterviewStartRenderer.Write(writer, result.Domain, result.NextQuestion);
+            return;
+        }
+
+        if (!result.HasArtifacts)
+        {
+            writer.WriteLine($"No interview artifacts found for domain '{result.Domain}'.");
+            return;
+        }
+
+        if (result.AnsweredQuestionIds.Count == 0)
+        {
+            writer.WriteLine($"No open interview questions or fold-in-ready answers found for domain '{result.Domain}'.");
+            return;
+        }
+
+        writer.WriteLine("Interview fold-in-ready summary:");
+        writer.WriteLine($"Domain: {result.Domain}");
+        WriteList(writer, "answered_question_ids", result.AnsweredQuestionIds);
+        WriteList(writer, "recommended_updates", result.RecommendedUpdates);
+        WriteList(writer, "return_to_intent_paths", result.ReturnToIntentPaths);
+    }
+
+    private static void WriteList(TextWriter writer, string label, IReadOnlyList<string> values)
+    {
+        writer.WriteLine($"{label}:");
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/InterviewResumeResult.cs
+++ b/src/IntentSystem.Cli/Commands/InterviewResumeResult.cs
@@ -1,0 +1,18 @@
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record InterviewResumeResult
+{
+    public required string Domain { get; init; }
+
+    public required bool HasArtifacts { get; init; }
+
+    public InterviewQueueItem? NextQuestion { get; init; }
+
+    public required IReadOnlyList<string> AnsweredQuestionIds { get; init; }
+
+    public required IReadOnlyList<string> RecommendedUpdates { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -202,6 +202,26 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenInterviewResumeCommand_DispatchesToInterviewResumeRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewStartItemYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["interview", "resume", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Next interview question:", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Question: Which auth flow should be canonical?", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenClarifyAnswerCommand_DispatchesToClarifyAnswerRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/InterviewResumeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/InterviewResumeCommandTests.cs
@@ -1,0 +1,308 @@
+using IntentSystem.ConceptIntake.Models;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class InterviewResumeCommandTests
+{
+    [Fact]
+    public void Execute_GivenOpenInterviewItems_RendersNextBlockingQuestion()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewArtifactYaml(CreateItem("iq-1", "blocking", InterviewQueueItemStatus.Open, createdAt: "2026-04-13T08:00:00Z")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-2.yaml"),
+            CreateInterviewArtifactYaml(CreateAnsweredItem("iq-2", "auth", "2026-04-13T07:00:00Z")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-2.md"),
+            "# Interview Question");
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewResumeCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Next interview question:", output, StringComparison.Ordinal);
+        Assert.Contains("Question: Question for iq-1", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Interview fold-in-ready summary:", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenAnsweredItemsWithoutOpenQuestions_RendersFoldInReadySummary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-2.yaml"),
+            CreateInterviewArtifactYaml(CreateAnsweredItem(
+                "iq-2",
+                "auth",
+                "2026-04-13T08:00:00Z",
+                returnToIntentPaths:
+                [
+                    "intents/intent-cli/intent-tree/means/auth-device-code.md",
+                    "intents/intent-cli/intent-tree/means/auth-oauth2.md"
+                ],
+                recommendedUpdates:
+                [
+                    "Document OAuth2 fallback",
+                    "Add device-code note"
+                ])));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-2.md"),
+            "# Interview Question");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewArtifactYaml(CreateAnsweredItem(
+                "iq-1",
+                "auth",
+                "2026-04-13T07:00:00Z",
+                returnToIntentPaths:
+                [
+                    "intents/intent-cli/intent-tree/means/auth-oauth2.md"
+                ],
+                recommendedUpdates:
+                [
+                    "Add device-code note",
+                    "Align login UX wording"
+                ])));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewResumeCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Interview fold-in-ready summary:", output, StringComparison.Ordinal);
+        Assert.Contains("Domain: auth", output, StringComparison.Ordinal);
+        Assert.Contains("answered_question_ids:", output, StringComparison.Ordinal);
+        Assert.True(output.IndexOf("- iq-1", StringComparison.Ordinal) < output.IndexOf("- iq-2", StringComparison.Ordinal));
+        Assert.True(output.IndexOf("- Add device-code note", StringComparison.Ordinal) < output.IndexOf("- Align login UX wording", StringComparison.Ordinal));
+        Assert.True(output.IndexOf("- Align login UX wording", StringComparison.Ordinal) < output.IndexOf("- Document OAuth2 fallback", StringComparison.Ordinal));
+        Assert.Equal(1, CountOccurrences(output, "- intents/intent-cli/intent-tree/means/auth-oauth2.md"));
+        Assert.True(output.IndexOf("- intents/intent-cli/intent-tree/means/auth-device-code.md", StringComparison.Ordinal) < output.IndexOf("- intents/intent-cli/intent-tree/means/auth-oauth2.md", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenNoInterviewDirectory_RendersDeterministicNoArtifactResult()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewResumeCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("No interview artifacts found for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenAppliedItemsOnly_RendersDeterministicNoOpenQuestionResult()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewArtifactYaml(CreateAppliedItem("iq-1", "auth")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewResumeCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("No open interview questions or fold-in-ready answers found for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewResumeCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int CountOccurrences(string text, string needle)
+    {
+        var count = 0;
+        var currentIndex = 0;
+
+        while ((currentIndex = text.IndexOf(needle, currentIndex, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            currentIndex += needle.Length;
+        }
+
+        return count;
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static InterviewQueueItem CreateItem(
+        string questionId,
+        string blockingOrNonblocking,
+        InterviewQueueItemStatus status,
+        string domainSlug = "auth",
+        string createdAt = "2026-04-13T06:00:00Z",
+        IReadOnlyList<string>? returnToIntentPaths = null,
+        IReadOnlyList<string>? recommendedUpdates = null)
+    {
+        return new InterviewQueueItem
+        {
+            DomainSlug = domainSlug,
+            SourceConceptRef = $"intents/intent-cli/concepts/{domainSlug}-oauth2.md",
+            QuestionId = questionId,
+            QuestionText = $"Question for {questionId}",
+            Reason = "Explore unknown area.",
+            Affects = ["auth-oauth2"],
+            BlockingOrNonblocking = blockingOrNonblocking,
+            Status = status,
+            ReturnToIntentPaths = returnToIntentPaths ?? ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+            CreatedAt = DateTimeOffset.Parse(createdAt),
+            Answer = null,
+            RecommendedUpdates = recommendedUpdates
+        };
+    }
+
+    private static InterviewQueueItem CreateAnsweredItem(
+        string questionId,
+        string domainSlug,
+        string createdAt,
+        IReadOnlyList<string>? returnToIntentPaths = null,
+        IReadOnlyList<string>? recommendedUpdates = null)
+    {
+        return CreateItem(
+            questionId,
+            "blocking",
+            InterviewQueueItemStatus.Answered,
+            domainSlug,
+            createdAt,
+            returnToIntentPaths,
+            recommendedUpdates) with
+        {
+            Answer = $"Answer for {questionId}",
+            AnsweredAt = DateTimeOffset.Parse("2026-04-13T10:00:00Z")
+        };
+    }
+
+    private static InterviewQueueItem CreateAppliedItem(string questionId, string domainSlug)
+    {
+        return CreateItem(questionId, "blocking", InterviewQueueItemStatus.Applied, domainSlug) with
+        {
+            Answer = "Use OAuth2 with PKCE.",
+            AnsweredAt = DateTimeOffset.Parse("2026-04-13T06:30:00Z"),
+            RecommendedUpdates = ["Update auth strategy"]
+        };
+    }
+
+    private static string CreateInterviewArtifactYaml(InterviewQueueItem item)
+    {
+        var lines = new List<string>
+        {
+            "artifact_kind: interview",
+            $"domain_slug: {item.DomainSlug}",
+            $"source_concept_ref: {Quote(item.SourceConceptRef)}",
+            $"question_id: {item.QuestionId}",
+            $"question_text: {Quote(item.QuestionText)}",
+            $"reason: {Quote(item.Reason)}",
+            "affects:"
+        };
+
+        lines.AddRange(item.Affects.Select(affect => $"  - {Quote(affect)}"));
+        lines.Add($"blocking_or_nonblocking: {item.BlockingOrNonblocking}");
+        lines.Add($"status: {FormatStatus(item.Status)}");
+        lines.Add("return_to_intent_paths:");
+        lines.AddRange(item.ReturnToIntentPaths.Select(path => $"  - {Quote(path)}"));
+        lines.Add($"created_at: {Quote(item.CreatedAt.ToString("O"))}");
+        lines.Add(item.Answer is null ? "answer: null" : $"answer: {Quote(item.Answer)}");
+
+        if (item.AnsweredAt.HasValue)
+        {
+            lines.Add($"answered_at: {Quote(item.AnsweredAt.Value.ToString("O"))}");
+        }
+
+        if (item.RecommendedUpdates is not null)
+        {
+            lines.Add(item.RecommendedUpdates.Count == 0 ? "recommended_updates: []" : "recommended_updates:");
+            if (item.RecommendedUpdates.Count > 0)
+            {
+                lines.AddRange(item.RecommendedUpdates.Select(update => $"  - {Quote(update)}"));
+            }
+        }
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    private static string FormatStatus(InterviewQueueItemStatus status)
+    {
+        return status.ToString().ToLowerInvariant();
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-interview-resume-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/InterviewResumeRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/InterviewResumeRendererTests.cs
@@ -1,0 +1,119 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class InterviewResumeRendererTests
+{
+    [Fact]
+    public void Write_GivenFoldInReadySummary_RendersDeterministicLists()
+    {
+        using var writer = new StringWriter();
+
+        InterviewResumeRenderer.Write(writer, new InterviewResumeResult
+        {
+            Domain = "auth",
+            HasArtifacts = true,
+            AnsweredQuestionIds = ["iq-1", "iq-2"],
+            RecommendedUpdates = ["Add device-code note", "Document OAuth2 fallback"],
+            ReturnToIntentPaths =
+            [
+                "intents/intent-cli/intent-tree/means/auth-device-code.md",
+                "intents/intent-cli/intent-tree/means/auth-oauth2.md"
+            ]
+        });
+
+        var output = writer.ToString();
+        Assert.Contains("Interview fold-in-ready summary:", output, StringComparison.Ordinal);
+        Assert.Contains("answered_question_ids:", output, StringComparison.Ordinal);
+        Assert.Contains("recommended_updates:", output, StringComparison.Ordinal);
+        Assert.Contains("return_to_intent_paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- iq-1", output, StringComparison.Ordinal);
+        Assert.Contains("- Add device-code note", output, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/intent-tree/means/auth-device-code.md", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Write_GivenFoldInReadySummaryWithoutUpdates_RendersNoneMarkers()
+    {
+        using var writer = new StringWriter();
+
+        InterviewResumeRenderer.Write(writer, new InterviewResumeResult
+        {
+            Domain = "auth",
+            HasArtifacts = true,
+            AnsweredQuestionIds = ["iq-1"],
+            RecommendedUpdates = [],
+            ReturnToIntentPaths = []
+        });
+
+        var output = writer.ToString();
+        Assert.Contains("recommended_updates:", output, StringComparison.Ordinal);
+        Assert.Contains("return_to_intent_paths:", output, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(output, "- none"));
+    }
+
+    [Fact]
+    public void Write_GivenNoArtifacts_RendersDeterministicMessage()
+    {
+        using var writer = new StringWriter();
+
+        InterviewResumeRenderer.Write(writer, new InterviewResumeResult
+        {
+            Domain = "auth",
+            HasArtifacts = false,
+            AnsweredQuestionIds = [],
+            RecommendedUpdates = [],
+            ReturnToIntentPaths = []
+        });
+
+        Assert.Contains("No interview artifacts found for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Write_GivenOpenQuestion_DelegatesToQuestionRenderer()
+    {
+        using var writer = new StringWriter();
+
+        InterviewResumeRenderer.Write(writer, new InterviewResumeResult
+        {
+            Domain = "auth",
+            HasArtifacts = true,
+            NextQuestion = new InterviewQueueItem
+            {
+                DomainSlug = "auth",
+                SourceConceptRef = "intents/intent-cli/concepts/auth-oauth2.md",
+                QuestionId = "iq-1",
+                QuestionText = "Which auth flow should be canonical?",
+                Reason = "Auth direction is still underspecified.",
+                Affects = ["auth-oauth2"],
+                BlockingOrNonblocking = "blocking",
+                Status = InterviewQueueItemStatus.Open,
+                ReturnToIntentPaths = ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+                CreatedAt = DateTimeOffset.Parse("2026-04-13T08:00:00Z"),
+                Answer = null
+            },
+            AnsweredQuestionIds = [],
+            RecommendedUpdates = [],
+            ReturnToIntentPaths = []
+        });
+
+        var output = writer.ToString();
+        Assert.Contains("Next interview question:", output, StringComparison.Ordinal);
+        Assert.Contains("Question id: iq-1", output, StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string text, string needle)
+    {
+        var count = 0;
+        var currentIndex = 0;
+
+        while ((currentIndex = text.IndexOf(needle, currentIndex, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            currentIndex += needle.Length;
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
## Summary
- add \ and route it from the CLI shell
- resolve the next open interview question or render a deterministic fold-in-ready summary from answered interview artifacts
- add command, renderer, and router coverage for no-artifact, no-open, and fold-in-ready paths

## Testing
- dotnet test IntentSystem.sln

Closes #82