### PR TITLE
[G29] Intake Compile Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -71,6 +71,10 @@ internal static class CommandRouter
                 ["next"] = QueueNextCommand.Execute,
                 ["dispatch"] = QueueDispatchCommand.Execute,
                 ["transition"] = QueueTransitionCommand.Execute
+            },
+            ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["compile"] = IntakeCompileCommand.Execute
             }
         };
 

--- a/src/IntentSystem.Cli/Commands/IntakeCompileArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeCompileArtifactPathResolver.cs
@@ -1,0 +1,13 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeCompileArtifactPathResolver
+{
+    private const string IntakeDirectory = ".intent-cli/intake";
+
+    public static string Resolve(string domain)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+
+        return $"{IntakeDirectory}/{domain.Trim()}.compile.md";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeCompileArtifactWriter.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeCompileArtifactWriter.cs
@@ -1,0 +1,21 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeCompileArtifactWriter
+{
+    public static string Write(string markdown, string domain, string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(markdown);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+
+        var relativePath = IntakeCompileArtifactPathResolver.Resolve(domain);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Intake compile artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, markdown);
+
+        return absolutePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeCompileCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeCompileCommand.cs
@@ -22,6 +22,12 @@ internal static class IntakeCompileCommand
         try
         {
             var artifacts = InterviewArtifactYaml.Discover(context.RepoRoot, domain);
+            if (artifacts.Count == 0)
+            {
+                IntakeCompileRenderer.WriteNoArtifactsNotReady(writer, domain);
+                return 0;
+            }
+
             var items = artifacts.Select(artifact => artifact.Item).ToArray();
             var nextQuestion = InterviewQueue.GetNextPendingForDomain(items, domain);
             if (nextQuestion is not null)

--- a/src/IntentSystem.Cli/Commands/IntakeCompileCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeCompileCommand.cs
@@ -1,0 +1,77 @@
+using IntentSystem.ConceptIntake.Interview;
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeCompileCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Intake compile command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0];
+
+        try
+        {
+            var artifacts = InterviewArtifactYaml.Discover(context.RepoRoot, domain);
+            var items = artifacts.Select(artifact => artifact.Item).ToArray();
+            var nextQuestion = InterviewQueue.GetNextPendingForDomain(items, domain);
+            if (nextQuestion is not null)
+            {
+                IntakeCompileRenderer.WriteNotReady(writer, domain, nextQuestion);
+                return 0;
+            }
+
+            var request = CreateRequest(domain, items);
+            var markdown = IntakeCompileRenderer.RenderMarkdown(request);
+            var artifactPath = IntakeCompileArtifactWriter.Write(markdown, domain, context.RepoRoot);
+            IntakeCompileRenderer.WriteSummary(writer, request, artifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static IntakeCompileRequest CreateRequest(string domain, IReadOnlyList<InterviewQueueItem> items)
+    {
+        var answeredItems = items
+            .Where(item => item.Status == InterviewQueueItemStatus.Answered)
+            .OrderBy(item => item.CreatedAt)
+            .ThenBy(item => item.QuestionId, StringComparer.Ordinal)
+            .ToArray();
+
+        return new IntakeCompileRequest
+        {
+            Domain = domain,
+            AnsweredQuestionIds = answeredItems
+                .Select(item => item.QuestionId)
+                .ToArray(),
+            RecommendedUpdates = answeredItems
+                .SelectMany(item => item.RecommendedUpdates ?? [])
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(update => update, StringComparer.Ordinal)
+                .ToArray(),
+            ReturnToIntentPaths = answeredItems
+                .SelectMany(item => item.ReturnToIntentPaths)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray(),
+            SourceConceptRefs = answeredItems
+                .Select(item => item.SourceConceptRef)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray()
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeCompileRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeCompileRenderer.cs
@@ -1,0 +1,67 @@
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeCompileRenderer
+{
+    public static string RenderMarkdown(IntakeCompileRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var lines = new List<string>
+        {
+            "# Intake Compile",
+            string.Empty,
+            "## Domain",
+            string.Empty,
+            $"`{request.Domain}`",
+            string.Empty
+        };
+
+        AppendList(lines, "answered_question_ids", request.AnsweredQuestionIds);
+        lines.Add(string.Empty);
+        AppendList(lines, "recommended_updates", request.RecommendedUpdates);
+        lines.Add(string.Empty);
+        AppendList(lines, "return_to_intent_paths", request.ReturnToIntentPaths);
+        lines.Add(string.Empty);
+        AppendList(lines, "source_concept_refs", request.SourceConceptRefs);
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    public static void WriteNotReady(TextWriter writer, string domain, InterviewQueueItem nextQuestion)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        ArgumentNullException.ThrowIfNull(nextQuestion);
+
+        writer.WriteLine($"Intake compile is not ready for domain '{domain}'.");
+        InterviewStartRenderer.Write(writer, domain, nextQuestion);
+    }
+
+    public static void WriteSummary(TextWriter writer, IntakeCompileRequest request, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Intake compile artifact generated for domain '{request.Domain}'.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Answered questions: {request.AnsweredQuestionIds.Count}");
+        writer.WriteLine($"Recommended updates: {request.RecommendedUpdates.Count}");
+        writer.WriteLine($"Return paths: {request.ReturnToIntentPaths.Count}");
+        writer.WriteLine($"Source concept refs: {request.SourceConceptRefs.Count}");
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        lines.Add($"{label}:");
+        if (values.Count == 0)
+        {
+            lines.Add("- none");
+            return;
+        }
+
+        lines.AddRange(values.Select(value => $"- {value}"));
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeCompileRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeCompileRenderer.cs
@@ -4,6 +4,15 @@ namespace IntentSystem.Cli.Commands;
 
 internal static class IntakeCompileRenderer
 {
+    public static void WriteNoArtifactsNotReady(TextWriter writer, string domain)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+
+        writer.WriteLine($"Intake compile is not ready for domain '{domain}'.");
+        writer.WriteLine($"No interview artifacts found for domain '{domain}'.");
+    }
+
     public static string RenderMarkdown(IntakeCompileRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);

--- a/src/IntentSystem.Cli/Commands/IntakeCompileRequest.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeCompileRequest.cs
@@ -1,0 +1,14 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeCompileRequest
+{
+    public required string Domain { get; init; }
+
+    public required IReadOnlyList<string> AnsweredQuestionIds { get; init; }
+
+    public required IReadOnlyList<string> RecommendedUpdates { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+
+    public required IReadOnlyList<string> SourceConceptRefs { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -222,6 +222,25 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeCompileCommand_DispatchesToIntakeCompileRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewAnswerItemYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["intake", "compile", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Intake compile is not ready", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenClarifyAnswerCommand_DispatchesToClarifyAnswerRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeCompileArtifactWriterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeCompileArtifactWriterTests.cs
@@ -1,0 +1,40 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeCompileArtifactWriterTests
+{
+    [Fact]
+    public void Write_GivenDomainAndMarkdown_WritesExpectedArtifactPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+
+        var artifactPath = IntakeCompileArtifactWriter.Write("# Intake Compile", "auth", repoRoot);
+
+        Assert.Equal(
+            Path.Combine(repoRoot, ".intent-cli", "intake", "auth.compile.md"),
+            artifactPath);
+        Assert.Equal("# Intake Compile", File.ReadAllText(artifactPath));
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-compile-writer-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeCompileCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeCompileCommandTests.cs
@@ -99,7 +99,7 @@ public sealed class IntakeCompileCommandTests
     }
 
     [Fact]
-    public void Execute_GivenNoInterviewArtifacts_WritesDeterministicEmptyCompileArtifact()
+    public void Execute_GivenNoInterviewArtifacts_RendersDeterministicNotReadyResult()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -108,11 +108,11 @@ public sealed class IntakeCompileCommandTests
         var exitCode = IntakeCompileCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
 
         Assert.Equal(0, exitCode);
-        Assert.Contains("Intake compile artifact generated for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        var output = writer.ToString();
+        Assert.Contains("Intake compile is not ready for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("No interview artifacts found for domain 'auth'.", output, StringComparison.Ordinal);
         var artifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.compile.md");
-        Assert.True(File.Exists(artifactPath));
-        var markdown = File.ReadAllText(artifactPath);
-        Assert.Equal(4, CountOccurrences(markdown, "- none"));
+        Assert.False(File.Exists(artifactPath));
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IntakeCompileCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeCompileCommandTests.cs
@@ -1,0 +1,286 @@
+using IntentSystem.ConceptIntake.Models;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeCompileCommandTests
+{
+    [Fact]
+    public void Execute_GivenOpenInterviewQuestion_RendersNotReadyAndDoesNotWriteArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewArtifactYaml(CreateItem("iq-1", InterviewQueueItemStatus.Open, createdAt: "2026-04-13T08:00:00Z")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeCompileCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake compile is not ready for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Next interview question:", output, StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.compile.md")));
+    }
+
+    [Fact]
+    public void Execute_GivenAnsweredItems_WritesCompileArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-2.yaml"),
+            CreateInterviewArtifactYaml(CreateAnsweredItem(
+                "iq-2",
+                "2026-04-13T08:00:00Z",
+                sourceConceptRef: "intents/intent-cli/concepts/auth-device-code.md",
+                returnToIntentPaths:
+                [
+                    "intents/intent-cli/intent-tree/means/auth-device-code.md",
+                    "intents/intent-cli/intent-tree/means/auth-oauth2.md"
+                ],
+                recommendedUpdates:
+                [
+                    "Document OAuth2 fallback",
+                    "Add device-code note"
+                ])));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-2.md"),
+            "# Interview Question");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewArtifactYaml(CreateAnsweredItem(
+                "iq-1",
+                "2026-04-13T07:00:00Z",
+                sourceConceptRef: "intents/intent-cli/concepts/auth-oauth2.md",
+                returnToIntentPaths:
+                [
+                    "intents/intent-cli/intent-tree/means/auth-oauth2.md"
+                ],
+                recommendedUpdates:
+                [
+                    "Add device-code note",
+                    "Align login UX wording"
+                ])));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-3.yaml"),
+            CreateInterviewArtifactYaml(CreateAppliedItem("iq-3")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-3.md"),
+            "# Interview Question");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeCompileCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake compile artifact generated for domain 'auth'.", output, StringComparison.Ordinal);
+        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.compile.md");
+        Assert.True(File.Exists(artifactPath));
+        var markdown = File.ReadAllText(artifactPath);
+        Assert.Contains("answered_question_ids:", markdown, StringComparison.Ordinal);
+        Assert.True(markdown.IndexOf("- iq-1", StringComparison.Ordinal) < markdown.IndexOf("- iq-2", StringComparison.Ordinal));
+        Assert.True(markdown.IndexOf("- Add device-code note", StringComparison.Ordinal) < markdown.IndexOf("- Align login UX wording", StringComparison.Ordinal));
+        Assert.True(markdown.IndexOf("- Align login UX wording", StringComparison.Ordinal) < markdown.IndexOf("- Document OAuth2 fallback", StringComparison.Ordinal));
+        Assert.Contains("- intents/intent-cli/intent-tree/means/auth-device-code.md", markdown, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(markdown, "- intents/intent-cli/intent-tree/means/auth-oauth2.md"));
+        Assert.Contains("source_concept_refs:", markdown, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/concepts/auth-device-code.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/concepts/auth-oauth2.md", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("Use OAuth2 with PKCE.", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNoInterviewArtifacts_WritesDeterministicEmptyCompileArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeCompileCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Intake compile artifact generated for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.compile.md");
+        Assert.True(File.Exists(artifactPath));
+        var markdown = File.ReadAllText(artifactPath);
+        Assert.Equal(4, CountOccurrences(markdown, "- none"));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeCompileCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int CountOccurrences(string text, string needle)
+    {
+        var count = 0;
+        var currentIndex = 0;
+
+        while ((currentIndex = text.IndexOf(needle, currentIndex, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            currentIndex += needle.Length;
+        }
+
+        return count;
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static InterviewQueueItem CreateItem(
+        string questionId,
+        InterviewQueueItemStatus status,
+        string createdAt = "2026-04-13T06:00:00Z",
+        string sourceConceptRef = "intents/intent-cli/concepts/auth-oauth2.md",
+        IReadOnlyList<string>? returnToIntentPaths = null,
+        IReadOnlyList<string>? recommendedUpdates = null)
+    {
+        return new InterviewQueueItem
+        {
+            DomainSlug = "auth",
+            SourceConceptRef = sourceConceptRef,
+            QuestionId = questionId,
+            QuestionText = $"Question for {questionId}",
+            Reason = "Explore unknown area.",
+            Affects = ["auth-oauth2"],
+            BlockingOrNonblocking = "blocking",
+            Status = status,
+            ReturnToIntentPaths = returnToIntentPaths ?? ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+            CreatedAt = DateTimeOffset.Parse(createdAt),
+            Answer = null,
+            RecommendedUpdates = recommendedUpdates
+        };
+    }
+
+    private static InterviewQueueItem CreateAnsweredItem(
+        string questionId,
+        string createdAt,
+        string sourceConceptRef,
+        IReadOnlyList<string>? returnToIntentPaths = null,
+        IReadOnlyList<string>? recommendedUpdates = null)
+    {
+        return CreateItem(questionId, InterviewQueueItemStatus.Answered, createdAt, sourceConceptRef, returnToIntentPaths, recommendedUpdates) with
+        {
+            Answer = $"Answer for {questionId}",
+            AnsweredAt = DateTimeOffset.Parse("2026-04-13T10:00:00Z")
+        };
+    }
+
+    private static InterviewQueueItem CreateAppliedItem(string questionId)
+    {
+        return CreateItem(questionId, InterviewQueueItemStatus.Applied) with
+        {
+            Answer = "Use OAuth2 with PKCE.",
+            AnsweredAt = DateTimeOffset.Parse("2026-04-13T06:30:00Z"),
+            RecommendedUpdates = ["Update auth strategy"]
+        };
+    }
+
+    private static string CreateInterviewArtifactYaml(InterviewQueueItem item)
+    {
+        var lines = new List<string>
+        {
+            "artifact_kind: interview",
+            $"domain_slug: {item.DomainSlug}",
+            $"source_concept_ref: {Quote(item.SourceConceptRef)}",
+            $"question_id: {item.QuestionId}",
+            $"question_text: {Quote(item.QuestionText)}",
+            $"reason: {Quote(item.Reason)}",
+            "affects:"
+        };
+
+        lines.AddRange(item.Affects.Select(affect => $"  - {Quote(affect)}"));
+        lines.Add($"blocking_or_nonblocking: {item.BlockingOrNonblocking}");
+        lines.Add($"status: {item.Status.ToString().ToLowerInvariant()}");
+        lines.Add("return_to_intent_paths:");
+        lines.AddRange(item.ReturnToIntentPaths.Select(path => $"  - {Quote(path)}"));
+        lines.Add($"created_at: {Quote(item.CreatedAt.ToString("O"))}");
+        lines.Add(item.Answer is null ? "answer: null" : $"answer: {Quote(item.Answer)}");
+
+        if (item.AnsweredAt.HasValue)
+        {
+            lines.Add($"answered_at: {Quote(item.AnsweredAt.Value.ToString("O"))}");
+        }
+
+        if (item.RecommendedUpdates is not null)
+        {
+            lines.Add(item.RecommendedUpdates.Count == 0 ? "recommended_updates: []" : "recommended_updates:");
+            if (item.RecommendedUpdates.Count > 0)
+            {
+                lines.AddRange(item.RecommendedUpdates.Select(update => $"  - {Quote(update)}"));
+            }
+        }
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-compile-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeCompileRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeCompileRendererTests.cs
@@ -75,6 +75,18 @@ public sealed class IntakeCompileRendererTests
         Assert.Contains("Question id: iq-1", output, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void WriteNoArtifactsNotReady_RendersDeterministicMessage()
+    {
+        using var writer = new StringWriter();
+
+        IntakeCompileRenderer.WriteNoArtifactsNotReady(writer, "auth");
+
+        var output = writer.ToString();
+        Assert.Contains("Intake compile is not ready for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("No interview artifacts found for domain 'auth'.", output, StringComparison.Ordinal);
+    }
+
     private static int CountOccurrences(string text, string needle)
     {
         var count = 0;

--- a/tests/IntentSystem.Cli.Tests/IntakeCompileRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeCompileRendererTests.cs
@@ -1,0 +1,91 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeCompileRendererTests
+{
+    [Fact]
+    public void RenderMarkdown_GivenCompileRequest_RendersDeterministicArtifact()
+    {
+        var markdown = IntakeCompileRenderer.RenderMarkdown(new IntakeCompileRequest
+        {
+            Domain = "auth",
+            AnsweredQuestionIds = ["iq-1", "iq-2"],
+            RecommendedUpdates = ["Add device-code note", "Document OAuth2 fallback"],
+            ReturnToIntentPaths =
+            [
+                "intents/intent-cli/intent-tree/means/auth-device-code.md",
+                "intents/intent-cli/intent-tree/means/auth-oauth2.md"
+            ],
+            SourceConceptRefs =
+            [
+                "intents/intent-cli/concepts/auth-device-code.md",
+                "intents/intent-cli/concepts/auth-oauth2.md"
+            ]
+        });
+
+        Assert.Contains("# Intake Compile", markdown, StringComparison.Ordinal);
+        Assert.Contains("`auth`", markdown, StringComparison.Ordinal);
+        Assert.Contains("answered_question_ids:", markdown, StringComparison.Ordinal);
+        Assert.Contains("- iq-1", markdown, StringComparison.Ordinal);
+        Assert.Contains("recommended_updates:", markdown, StringComparison.Ordinal);
+        Assert.Contains("return_to_intent_paths:", markdown, StringComparison.Ordinal);
+        Assert.Contains("source_concept_refs:", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderMarkdown_GivenEmptyLists_RendersNoneMarkers()
+    {
+        var markdown = IntakeCompileRenderer.RenderMarkdown(new IntakeCompileRequest
+        {
+            Domain = "auth",
+            AnsweredQuestionIds = [],
+            RecommendedUpdates = [],
+            ReturnToIntentPaths = [],
+            SourceConceptRefs = []
+        });
+
+        Assert.Equal(4, CountOccurrences(markdown, "- none"));
+    }
+
+    [Fact]
+    public void WriteNotReady_GivenOpenQuestion_RendersDeterministicMessage()
+    {
+        using var writer = new StringWriter();
+
+        IntakeCompileRenderer.WriteNotReady(writer, "auth", new InterviewQueueItem
+        {
+            DomainSlug = "auth",
+            SourceConceptRef = "intents/intent-cli/concepts/auth-oauth2.md",
+            QuestionId = "iq-1",
+            QuestionText = "Which auth flow should be canonical?",
+            Reason = "Auth direction is still underspecified.",
+            Affects = ["auth-oauth2"],
+            BlockingOrNonblocking = "blocking",
+            Status = InterviewQueueItemStatus.Open,
+            ReturnToIntentPaths = ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+            CreatedAt = DateTimeOffset.Parse("2026-04-13T08:00:00Z"),
+            Answer = null
+        });
+
+        var output = writer.ToString();
+        Assert.Contains("Intake compile is not ready for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Next interview question:", output, StringComparison.Ordinal);
+        Assert.Contains("Question id: iq-1", output, StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string text, string needle)
+    {
+        var count = 0;
+        var currentIndex = 0;
+
+        while ((currentIndex = text.IndexOf(needle, currentIndex, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            currentIndex += needle.Length;
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
## Summary
- add the intake compile command and wire it into the CLI shell
- detect open interview questions as a deterministic not-ready path
- generate .intent-cli/intake/<domain>.compile.md from answered interview artifacts

## Testing
- dotnet test IntentSystem.sln

Closes #84