### PR TITLE
[G30] Intake Concept Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -74,6 +74,7 @@ internal static class CommandRouter
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
+                ["concept"] = IntakeConceptCommand.Execute,
                 ["compile"] = IntakeCompileCommand.Execute
             }
         };

--- a/src/IntentSystem.Cli/Commands/IntakeConceptArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeConceptArtifactPathResolver.cs
@@ -1,0 +1,13 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeConceptArtifactPathResolver
+{
+    private const string IntakeDirectory = ".intent-cli/intake";
+
+    public static string Resolve(string domain)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+
+        return $"{IntakeDirectory}/{domain.Trim()}.concept.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeConceptArtifactWriter.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeConceptArtifactWriter.cs
@@ -1,0 +1,21 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeConceptArtifactWriter
+{
+    public static string Write(string yaml, string domain, string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+
+        var relativePath = IntakeConceptArtifactPathResolver.Resolve(domain);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Intake concept artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, yaml);
+
+        return absolutePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeConceptArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeConceptArtifactYaml.cs
@@ -1,0 +1,188 @@
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeConceptArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "domain_slug",
+        "concept_source",
+        "concept_text",
+        "upstream_paths",
+        "initial_goal",
+        "constraints",
+        "known_unknowns"
+    ];
+
+    public static string Serialize(ConceptIntakePacket packet)
+    {
+        ArgumentNullException.ThrowIfNull(packet);
+
+        var lines = new List<string>
+        {
+            $"domain_slug: {packet.DomainSlug}",
+            $"concept_source: {packet.ConceptSource}",
+            $"concept_text: {Quote(packet.ConceptText)}"
+        };
+
+        AppendList(lines, "upstream_paths", packet.UpstreamPaths);
+        lines.Add($"initial_goal: {Quote(packet.InitialGoal)}");
+        AppendList(lines, "constraints", packet.Constraints);
+        AppendList(lines, "known_unknowns", packet.KnownUnknowns);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static ConceptIntakePacket Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new ConceptIntakePacket
+        {
+            DomainSlug = GetRequiredScalar(values, "domain_slug"),
+            ConceptSource = GetRequiredScalar(values, "concept_source"),
+            ConceptText = GetRequiredScalar(values, "concept_text"),
+            UpstreamPaths = GetRequiredList(values, "upstream_paths"),
+            InitialGoal = GetRequiredScalar(values, "initial_goal"),
+            Constraints = GetRequiredList(values, "constraints"),
+            KnownUnknowns = GetRequiredList(values, "known_unknowns")
+        };
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add($"{label}: []");
+            return;
+        }
+
+        lines.Add($"{label}:");
+        lines.AddRange(values.Select(value => $"  - {Quote(value)}"));
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("  - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !values.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException(
+                        $"Intake concept YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[4..].TrimStart()));
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Intake concept YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+
+            if (value.Length == 0)
+            {
+                values[key] = new List<string>();
+                currentListKey = key;
+                continue;
+            }
+
+            currentListKey = null;
+            values[key] = value switch
+            {
+                "[]" => Array.Empty<string>(),
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException(
+                    $"Intake concept YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException(
+                $"Intake concept YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static IReadOnlyList<string> GetRequiredList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException(
+                $"Intake concept YAML field '{key}' must be a list.");
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException(
+                $"Intake concept YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeConceptCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeConceptCommand.cs
@@ -1,0 +1,127 @@
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeConceptCommand
+{
+    public static Func<TextReader> InputReaderFactory { get; set; } = () => Console.In;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, writer, out var domain, out var conceptFilePath))
+        {
+            return 1;
+        }
+
+        string conceptText;
+        try
+        {
+            conceptText = ReadConceptInput(context.RepoRoot, conceptFilePath, writer);
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+
+        var packet = new ConceptIntakePacket
+        {
+            DomainSlug = domain,
+            ConceptSource = conceptFilePath is null ? "interactive" : "from-file",
+            ConceptText = conceptText,
+            UpstreamPaths = [],
+            InitialGoal = DeriveInitialGoal(conceptText),
+            Constraints = [],
+            KnownUnknowns = []
+        };
+
+        var yaml = IntakeConceptArtifactYaml.Serialize(packet);
+        var artifactPath = IntakeConceptArtifactWriter.Write(yaml, domain, context.RepoRoot);
+        IntakeConceptRenderer.WriteSummary(writer, packet, artifactPath);
+        return 0;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        TextWriter writer,
+        out string domain,
+        out string? conceptFilePath)
+    {
+        domain = string.Empty;
+        conceptFilePath = null;
+
+        if (args.Length == 1 && !string.IsNullOrWhiteSpace(args[0]))
+        {
+            domain = args[0];
+            return true;
+        }
+
+        if (args.Length == 3
+            && !string.IsNullOrWhiteSpace(args[0])
+            && string.Equals(args[1], "--from-file", StringComparison.Ordinal)
+            && !string.IsNullOrWhiteSpace(args[2]))
+        {
+            domain = args[0];
+            conceptFilePath = args[2];
+            return true;
+        }
+
+        writer.WriteLine("Intake concept command requires a domain and optionally '--from-file <path>'.");
+        return false;
+    }
+
+    private static string ReadConceptInput(string repoRoot, string? conceptFilePath, TextWriter writer)
+    {
+        if (conceptFilePath is not null)
+        {
+            var resolvedPath = ResolvePath(repoRoot, conceptFilePath);
+            if (!File.Exists(resolvedPath))
+            {
+                throw new InvalidOperationException($"Intake concept file was not found at {resolvedPath}");
+            }
+
+            var fileConcept = File.ReadAllText(resolvedPath);
+            if (string.IsNullOrWhiteSpace(fileConcept))
+            {
+                throw new InvalidOperationException("Intake concept file must not be empty.");
+            }
+
+            return fileConcept.TrimEnd();
+        }
+
+        writer.Write("Concept input: ");
+        var concept = InputReaderFactory().ReadToEnd();
+        if (string.IsNullOrWhiteSpace(concept))
+        {
+            throw new InvalidOperationException("Concept input must not be empty.");
+        }
+
+        return concept.TrimEnd('\r', '\n');
+    }
+
+    private static string ResolvePath(string repoRoot, string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        return Path.IsPathRooted(path)
+            ? Path.GetFullPath(path)
+            : Path.GetFullPath(Path.Combine(repoRoot, path.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static string DeriveInitialGoal(string conceptText)
+    {
+        var firstLine = conceptText
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.None)
+            .FirstOrDefault(line => !string.IsNullOrWhiteSpace(line));
+
+        return string.IsNullOrWhiteSpace(firstLine)
+            ? conceptText
+            : firstLine.Trim();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeConceptRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeConceptRenderer.cs
@@ -1,0 +1,21 @@
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeConceptRenderer
+{
+    public static void WriteSummary(TextWriter writer, ConceptIntakePacket packet, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(packet);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Intake concept artifact generated for domain '{packet.DomainSlug}'.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Concept source: {packet.ConceptSource}");
+        writer.WriteLine($"Initial goal: {packet.InitialGoal}");
+        writer.WriteLine($"Upstream paths: {packet.UpstreamPaths.Count}");
+        writer.WriteLine($"Constraints: {packet.Constraints.Count}");
+        writer.WriteLine($"Known unknowns: {packet.KnownUnknowns.Count}");
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -241,6 +241,25 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeConceptCommand_DispatchesToIntakeConceptRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "concepts", "auth.txt"),
+            "Add OAuth2 provider support.");
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(
+            ["intake", "concept", "auth", "--from-file", "concepts/auth.txt"],
+            CreateContext(repoRoot),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Intake concept artifact generated for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenClarifyAnswerCommand_DispatchesToClarifyAnswerRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeConceptArtifactWriterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeConceptArtifactWriterTests.cs
@@ -1,0 +1,40 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeConceptArtifactWriterTests
+{
+    [Fact]
+    public void Write_GivenDomainAndYaml_WritesExpectedArtifactPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+
+        var artifactPath = IntakeConceptArtifactWriter.Write("domain_slug: auth" + Environment.NewLine, "auth", repoRoot);
+
+        Assert.Equal(
+            Path.Combine(repoRoot, ".intent-cli", "intake", "auth.concept.yaml"),
+            artifactPath);
+        Assert.Equal("domain_slug: auth" + Environment.NewLine, File.ReadAllText(artifactPath));
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-concept-writer-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeConceptArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeConceptArtifactYamlTests.cs
@@ -1,0 +1,66 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeConceptArtifactYamlTests
+{
+    [Fact]
+    public void Serialize_GivenPacket_ContainsAllRequiredFields()
+    {
+        var yaml = IntakeConceptArtifactYaml.Serialize(CreatePacket());
+
+        Assert.Contains("domain_slug: auth", yaml, StringComparison.Ordinal);
+        Assert.Contains("concept_source: interactive", yaml, StringComparison.Ordinal);
+        Assert.Contains("concept_text: \"Add OAuth2 provider support.\"", yaml, StringComparison.Ordinal);
+        Assert.Contains("upstream_paths:", yaml, StringComparison.Ordinal);
+        Assert.Contains("initial_goal: \"Add OAuth2 provider support.\"", yaml, StringComparison.Ordinal);
+        Assert.Contains("constraints:", yaml, StringComparison.Ordinal);
+        Assert.Contains("known_unknowns:", yaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Deserialize_GivenSerializedPacket_RestoresAllFields()
+    {
+        var packet = IntakeConceptArtifactYaml.Deserialize(IntakeConceptArtifactYaml.Serialize(CreatePacket()));
+
+        Assert.Equal("auth", packet.DomainSlug);
+        Assert.Equal("interactive", packet.ConceptSource);
+        Assert.Equal("Add OAuth2 provider support.", packet.ConceptText);
+        Assert.Single(packet.UpstreamPaths);
+        Assert.Equal("Add OAuth2 provider support.", packet.InitialGoal);
+        Assert.Single(packet.Constraints);
+        Assert.Single(packet.KnownUnknowns);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_ThrowsInvalidOperationException()
+    {
+        var yaml = """
+        domain_slug: auth
+        concept_source: interactive
+        concept_text: "Add OAuth2 provider support."
+        upstream_paths: []
+        constraints: []
+        known_unknowns: []
+        """;
+
+        var ex = Assert.Throws<InvalidOperationException>(() => IntakeConceptArtifactYaml.Deserialize(yaml));
+
+        Assert.Contains("required field", ex.Message, StringComparison.Ordinal);
+    }
+
+    private static ConceptIntakePacket CreatePacket()
+    {
+        return new ConceptIntakePacket
+        {
+            DomainSlug = "auth",
+            ConceptSource = "interactive",
+            ConceptText = "Add OAuth2 provider support.",
+            UpstreamPaths = ["intents/intent-cli/intent-tree/means/04-worker-interface-strategy.md"],
+            InitialGoal = "Add OAuth2 provider support.",
+            Constraints = ["Must not break existing session flow"],
+            KnownUnknowns = ["Which OAuth providers to support?"]
+        };
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeConceptCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeConceptCommandTests.cs
@@ -1,0 +1,148 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class IntakeConceptCommandTests
+{
+    [Fact]
+    public void Execute_GivenInteractiveInput_WritesConceptPacketArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalInputReaderFactory = IntakeConceptCommand.InputReaderFactory;
+
+        try
+        {
+            IntakeConceptCommand.InputReaderFactory = () => new StringReader(
+                "Add OAuth2 provider support." + Environment.NewLine +
+                "Prefer GitHub first." + Environment.NewLine);
+
+            var exitCode = IntakeConceptCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Intake concept artifact generated for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Concept source: interactive", output, StringComparison.Ordinal);
+
+            var packet = IntakeConceptArtifactYaml.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "intake", "auth.concept.yaml")));
+            Assert.Equal("auth", packet.DomainSlug);
+            Assert.Equal("interactive", packet.ConceptSource);
+            Assert.Equal(
+                "Add OAuth2 provider support." + Environment.NewLine + "Prefer GitHub first.",
+                packet.ConceptText);
+            Assert.Equal("Add OAuth2 provider support.", packet.InitialGoal);
+            Assert.Empty(packet.UpstreamPaths);
+            Assert.Empty(packet.Constraints);
+            Assert.Empty(packet.KnownUnknowns);
+        }
+        finally
+        {
+            IntakeConceptCommand.InputReaderFactory = originalInputReaderFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenFromFileInput_WritesConceptPacketArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "concepts", "auth.txt"),
+            "Add OAuth2 provider support." + Environment.NewLine + "Must work with GitHub.");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeConceptCommand.Execute(
+            CreateContext(repoRoot),
+            ["auth", "--from-file", "concepts/auth.txt"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Concept source: from-file", output, StringComparison.Ordinal);
+
+        var packet = IntakeConceptArtifactYaml.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "intake", "auth.concept.yaml")));
+        Assert.Equal("from-file", packet.ConceptSource);
+        Assert.Equal("Add OAuth2 provider support." + Environment.NewLine + "Must work with GitHub.", packet.ConceptText);
+        Assert.Equal("Add OAuth2 provider support.", packet.InitialGoal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingInputFile_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeConceptCommand.Execute(
+            CreateContext(repoRoot),
+            ["auth", "--from-file", "concepts/missing.txt"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Intake concept file was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeConceptCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-concept-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeConceptRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeConceptRendererTests.cs
@@ -1,0 +1,33 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeConceptRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenPacket_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        IntakeConceptRenderer.WriteSummary(writer, new ConceptIntakePacket
+        {
+            DomainSlug = "auth",
+            ConceptSource = "interactive",
+            ConceptText = "Add OAuth2 provider support.",
+            UpstreamPaths = ["intents/intent-cli/intent-tree/means/04-worker-interface-strategy.md"],
+            InitialGoal = "Add OAuth2 provider support.",
+            Constraints = ["Must not break existing session flow"],
+            KnownUnknowns = ["Which OAuth providers to support?"]
+        }, "/repo/.intent-cli/intake/auth.concept.yaml");
+
+        var output = writer.ToString();
+        Assert.Contains("Intake concept artifact generated for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: /repo/.intent-cli/intake/auth.concept.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Concept source: interactive", output, StringComparison.Ordinal);
+        Assert.Contains("Initial goal: Add OAuth2 provider support.", output, StringComparison.Ordinal);
+        Assert.Contains("Upstream paths: 1", output, StringComparison.Ordinal);
+        Assert.Contains("Constraints: 1", output, StringComparison.Ordinal);
+        Assert.Contains("Known unknowns: 1", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add the intake concept command and wire it into the CLI shell
- accept raw concept input from interactive stdin or --from-file and map it into the concept intake packet contract
- generate .intent-cli/intake/<domain>.concept.yaml without expanding into interview generation or compile/autostart

## Testing
- dotnet test IntentSystem.sln

Closes #86