### PR TITLE
[G31] Intake Autostart Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -75,7 +75,8 @@ internal static class CommandRouter
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["concept"] = IntakeConceptCommand.Execute,
-                ["compile"] = IntakeCompileCommand.Execute
+                ["compile"] = IntakeCompileCommand.Execute,
+                ["autostart"] = IntakeAutostartCommand.Execute
             }
         };
 

--- a/src/IntentSystem.Cli/Commands/IntakeAutostartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeAutostartCommand.cs
@@ -1,0 +1,57 @@
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeAutostartCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Intake autostart command requires an execution unit.");
+            return 1;
+        }
+
+        var executionUnit = args[0];
+        var dispatchWriter = new StringWriter();
+        var dispatchExitCode = QueueDispatchCommand.Execute(context, [executionUnit], dispatchWriter);
+        if (dispatchExitCode != 0)
+        {
+            writer.Write(dispatchWriter.ToString());
+            return dispatchExitCode;
+        }
+
+        var startWriter = new StringWriter();
+        var startExitCode = RunStartCommand.Execute(context, [executionUnit], startWriter);
+        if (startExitCode != 0)
+        {
+            writer.Write(dispatchWriter.ToString());
+            writer.Write(startWriter.ToString());
+            return startExitCode;
+        }
+
+        var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(context.GetQueueStatePath()));
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem?.LinkedIssue is null)
+        {
+            writer.WriteLine($"Execution unit '{executionUnit}' must have a linked issue after intake autostart.");
+            return 1;
+        }
+
+        var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
+        var branchName = RunStartCommand.ResolveBranchName(executionUnit, queueItem.LinkedIssue);
+        IntakeAutostartRenderer.WriteSummary(
+            writer,
+            executionUnit,
+            queueItem.LinkedIssue.Url,
+            worktreePath,
+            branchName);
+        return 0;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeAutostartRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeAutostartRenderer.cs
@@ -1,0 +1,23 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeAutostartRenderer
+{
+    public static void WriteSummary(
+        TextWriter writer,
+        string executionUnit,
+        string linkedIssueUrl,
+        string worktreePath,
+        string branchName)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(linkedIssueUrl);
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(branchName);
+
+        writer.WriteLine($"Intake autostart completed for {executionUnit}.");
+        writer.WriteLine($"Linked issue: {linkedIssueUrl}");
+        writer.WriteLine($"Worktree path: {worktreePath}");
+        writer.WriteLine($"Branch: {branchName}");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ProjectionPacketRuntimeReader.cs
+++ b/src/IntentSystem.Cli/Commands/ProjectionPacketRuntimeReader.cs
@@ -1,0 +1,166 @@
+using IntentSystem.Projection.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class ProjectionPacketRuntimeReader
+{
+    internal sealed record RuntimePacket(
+        string ExecutionUnit,
+        string IssueTitle,
+        string TargetRepo);
+
+    public static RuntimePacket Read(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        try
+        {
+            var packet = ProjectionPacketSerializer.Deserialize(yaml);
+            return new RuntimePacket(
+                packet.ImplementationIssuePacket.SourceExecutionUnit,
+                packet.ImplementationIssuePacket.IssueTitle,
+                packet.ImplementationIssuePacket.TargetRepo);
+        }
+        catch (InvalidOperationException)
+        {
+            return ReadCurrentParentPacket(yaml);
+        }
+    }
+
+    private static RuntimePacket ReadCurrentParentPacket(string yaml)
+    {
+        var rootValues = new Dictionary<string, object>(StringComparer.Ordinal);
+        var sections = new Dictionary<string, Dictionary<string, object>>(StringComparer.Ordinal);
+        Dictionary<string, object>? currentSection = null;
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (!char.IsWhiteSpace(line[0]))
+            {
+                if (line.EndsWith(":", StringComparison.Ordinal))
+                {
+                    var sectionName = line[..^1];
+                    currentSection = new Dictionary<string, object>(StringComparer.Ordinal);
+                    sections[sectionName] = currentSection;
+                    currentListKey = null;
+                    continue;
+                }
+
+                var separatorIndex = line.IndexOf(':');
+                if (separatorIndex < 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Projection packet YAML contains invalid root field '{line}'.");
+                }
+
+                var key = line[..separatorIndex].Trim();
+                var value = line[(separatorIndex + 1)..].TrimStart();
+                rootValues[key] = ParseScalar(value);
+                currentSection = null;
+                currentListKey = null;
+                continue;
+            }
+
+            if (currentSection is null)
+            {
+                throw new InvalidOperationException(
+                    "Projection packet YAML must declare a section before its nested fields.");
+            }
+
+            if (line.StartsWith("    - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !currentSection.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException(
+                        $"Projection packet YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[6..]));
+                continue;
+            }
+
+            if (!line.StartsWith("  ", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Projection packet YAML contains invalid indentation: '{line}'.");
+            }
+
+            var trimmed = line[2..];
+            var separatorIndex2 = trimmed.IndexOf(':');
+            if (separatorIndex2 < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Projection packet YAML field line is missing ':': '{trimmed}'.");
+            }
+
+            var key2 = trimmed[..separatorIndex2];
+            var value2 = trimmed[(separatorIndex2 + 1)..].TrimStart();
+
+            if (value2.Length == 0)
+            {
+                currentSection[key2] = new List<string>();
+                currentListKey = key2;
+                continue;
+            }
+
+            currentListKey = null;
+            currentSection[key2] = value2 == "[]"
+                ? Array.Empty<string>()
+                : ParseScalar(value2);
+        }
+
+        if (!rootValues.TryGetValue("execution_unit", out var executionUnitValue)
+            || executionUnitValue is not string executionUnit
+            || string.IsNullOrWhiteSpace(executionUnit))
+        {
+            throw new InvalidOperationException("Projection packet YAML must contain root field 'execution_unit'.");
+        }
+
+        if (!sections.TryGetValue("implementation_issue", out var implementationIssue))
+        {
+            throw new InvalidOperationException("Projection packet YAML must contain required section 'implementation_issue'.");
+        }
+
+        if (!implementationIssue.TryGetValue("issue_title", out var issueTitleValue)
+            || issueTitleValue is not string issueTitle
+            || string.IsNullOrWhiteSpace(issueTitle))
+        {
+            throw new InvalidOperationException("Implementation issue must contain required field 'issue_title'.");
+        }
+
+        if (!implementationIssue.TryGetValue("target_repo", out var targetRepoValue)
+            || targetRepoValue is not string targetRepo
+            || string.IsNullOrWhiteSpace(targetRepo))
+        {
+            throw new InvalidOperationException("Implementation issue must contain required field 'target_repo'.");
+        }
+
+        return new RuntimePacket(executionUnit, issueTitle, targetRepo);
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
@@ -1,4 +1,3 @@
-using IntentSystem.Projection.Serialization;
 using IntentSystem.Supervisor;
 using IntentSystem.Supervisor.Serialization;
 
@@ -58,14 +57,14 @@ internal static class QueueDispatchCommand
 
         try
         {
-            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
-            var packetTargetRepo = packet.ImplementationIssuePacket.TargetRepo;
+            var packet = ProjectionPacketRuntimeReader.Read(File.ReadAllText(packetPath));
+            var packetTargetRepo = packet.TargetRepo;
             if (string.IsNullOrWhiteSpace(packetTargetRepo))
             {
                 throw new InvalidOperationException("Projection packet must contain a target repo.");
             }
 
-            var issueTitle = packet.ImplementationIssuePacket.IssueTitle;
+            var issueTitle = packet.IssueTitle;
             if (string.IsNullOrWhiteSpace(issueTitle))
             {
                 throw new InvalidOperationException("Projection packet must contain a non-empty issue title.");

--- a/src/IntentSystem.Cli/Commands/RunStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunStartCommand.cs
@@ -1,4 +1,3 @@
-using IntentSystem.Projection.Serialization;
 using IntentSystem.Review;
 using IntentSystem.Supervisor;
 using IntentSystem.Supervisor.Models;
@@ -59,8 +58,8 @@ internal static class RunStartCommand
 
         try
         {
-            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
-            var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
+            var packet = ProjectionPacketRuntimeReader.Read(File.ReadAllText(packetPath));
+            var childRepoRef = packet.TargetRepo;
             if (string.IsNullOrWhiteSpace(childRepoRef))
             {
                 throw new InvalidOperationException("Projection packet must contain a target repo.");

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -260,6 +260,54 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeAutostartCommand_DispatchesToIntakeAutostartRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueDispatchQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreateQueueDispatchPacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalRemoteGitFactory = QueueDispatchCommand.GitCommandRunnerFactory;
+        var originalDispatchTimestampFactory = QueueDispatchCommand.TimestampFactory;
+        var originalStartGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalStartTimestampFactory = RunStartCommand.TimestampFactory;
+
+        try
+        {
+            QueueDispatchCommand.PublisherFactory = () => new FakeQueueDispatchPublisher();
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeQueueDispatchGitRunner();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T06:00:00Z");
+            RunStartCommand.GitCommandRunnerFactory = () => new FakeRunStartGitRunner();
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T09:30:00Z");
+
+            var exitCode = CommandRouter.Execute(["intake", "autostart", "G13"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Intake autostart completed for G13.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalRemoteGitFactory;
+            QueueDispatchCommand.TimestampFactory = originalDispatchTimestampFactory;
+            RunStartCommand.GitCommandRunnerFactory = originalStartGitFactory;
+            RunStartCommand.TimestampFactory = originalStartTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenClarifyAnswerCommand_DispatchesToClarifyAnswerRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeAutostartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeAutostartCommandTests.cs
@@ -192,10 +192,9 @@ public sealed class IntakeAutostartCommandTests
     private static string CreatePacketYaml()
     {
         return """
-        implementation_issue_packet:
-          issue_title: "[G31] Intake Autostart Command"
-          issue_kind: "feature"
-          source_execution_unit: "G31"
+        execution_unit: G31
+        implementation_issue:
+          issue_title: "G31 Intake Autostart Command"
           goal: "Bridge intake queue item into dispatch and run start."
           in_scope:
             - "intake autostart command"
@@ -208,34 +207,21 @@ public sealed class IntakeAutostartCommandTests
             - "G30"
           technical_baseline:
             - "C# / .NET"
-          project_local_guide:
+          project_local_guidance:
             - "AGENTS.md"
           intent_baseline:
             - "autostart stays thin"
-          intent_references:
-            - "ICL.P.PRODUCT_GOAL"
-          rules_and_specs:
-            - "intents/intent-cli/specs/08-config-and-run-model.md"
           acceptance_criteria:
             - "queued item autostarts"
-          verification_evidence:
+          verification:
             - "tests-passing"
-          review_mode: "deterministic-review"
-          completion_action: "wait-for-deterministic-review"
-          landing_policy: "merge-after-review"
-
-        review_context_packet:
-          source_execution_unit: "G31"
-          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
-          intent_references:
-            - "ICL.P.PRODUCT_GOAL"
-          rules_and_specs:
-            - "intents/intent-cli/specs/08-config-and-run-model.md"
-          acceptance_criteria:
-            - "queued item autostarts"
-          deterministic_review_checks:
+        review:
+          summarize_first: true
+          require_explicit_diff_check: true
+          require_explicit_scope_check: true
+          require_explicit_contract_check: true
+          required_checks:
             - "autostart remains thin"
-          clarification_return_path: "intents/intent-cli/clarifications/open.md"
         """;
     }
 

--- a/tests/IntentSystem.Cli.Tests/IntakeAutostartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeAutostartCommandTests.cs
@@ -1,0 +1,314 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Review;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class IntakeAutostartCommandTests
+{
+    [Fact]
+    public void Execute_GivenQueuedItem_DispatchesAndStartsSelectedExecutionUnit()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G31", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G31", "github-body.md"),
+            "# Goal");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalRemoteGitFactory = QueueDispatchCommand.GitCommandRunnerFactory;
+        var originalDispatchTimestampFactory = QueueDispatchCommand.TimestampFactory;
+        var originalStartGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalStartTimestampFactory = RunStartCommand.TimestampFactory;
+        var startGitRunner = new FakeStartGitRunner();
+
+        try
+        {
+            QueueDispatchCommand.PublisherFactory = () => new FakePublisher();
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeRemoteGitRunner();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T06:00:00Z");
+            RunStartCommand.GitCommandRunnerFactory = () => startGitRunner;
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T06:10:00Z");
+
+            var exitCode = IntakeAutostartCommand.Execute(CreateContext(repoRoot), ["G31"], writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Intake autostart completed for G31.", output, StringComparison.Ordinal);
+            Assert.Contains("Linked issue: https://github.com/J-Tech-Japan/intent-system/issues/88", output, StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            var selectedItem = queueState.Items.Single(item => item.ExecutionUnit == "G31");
+            Assert.Equal(QueueItemState.Active, selectedItem.State);
+            Assert.NotNull(selectedItem.LinkedIssue);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/88", selectedItem.LinkedIssue!.Url);
+
+            var unrelatedItem = queueState.Items.Single(item => item.ExecutionUnit == "G32");
+            Assert.Equal(QueueItemState.Queued, unrelatedItem.State);
+            Assert.Null(unrelatedItem.LinkedIssue);
+
+            var worktreePath = Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "worktrees", "G31"));
+            var childRepoPath = Path.Combine(repoRoot, "submodules", "intent-system");
+            Assert.Equal(
+                [
+                    $"{childRepoPath}::fetch origin main",
+                    $"{childRepoPath}::worktree add -b issue-88-g31 {worktreePath} origin/main"
+                ],
+                startGitRunner.Calls);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal(2, runEvents.Count);
+            Assert.Equal("issue-created", runEvents[0].Event);
+            Assert.Equal("activated", runEvents[1].Event);
+            Assert.All(runEvents, runEvent => Assert.Equal("G31", runEvent.ExecutionUnit));
+        }
+        finally
+        {
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalRemoteGitFactory;
+            QueueDispatchCommand.TimestampFactory = originalDispatchTimestampFactory;
+            RunStartCommand.GitCommandRunnerFactory = originalStartGitFactory;
+            RunStartCommand.TimestampFactory = originalStartTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenDispatchFailure_ReturnsExitCodeOneAndDoesNotStartRun()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G31", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalStartGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var startGitRunner = new FakeStartGitRunner();
+
+        try
+        {
+            RunStartCommand.GitCommandRunnerFactory = () => startGitRunner;
+
+            var exitCode = IntakeAutostartCommand.Execute(CreateContext(repoRoot), ["G31"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("GitHub issue body artifact was not found", writer.ToString(), StringComparison.Ordinal);
+            Assert.Empty(startGitRunner.Calls);
+            Assert.Empty(File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+        }
+        finally
+        {
+            RunStartCommand.GitCommandRunnerFactory = originalStartGitFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionUnitArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeAutostartCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items =
+            [
+                CreateItem("G31", QueueItemState.Queued),
+                CreateItem("G32", QueueItemState.Queued)
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Intake Autostart",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            LinkedIssue = null,
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static string CreatePacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G31] Intake Autostart Command"
+          issue_kind: "feature"
+          source_execution_unit: "G31"
+          goal: "Bridge intake queue item into dispatch and run start."
+          in_scope:
+            - "intake autostart command"
+          out_of_scope:
+            - "worker launch"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli intake autostart command"
+          dependencies:
+            - "G30"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "autostart stays thin"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "queued item autostarts"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G31"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/08-config-and-run-model.md"
+          acceptance_criteria:
+            - "queued item autostarts"
+          deterministic_review_checks:
+            - "autostart remains thin"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private sealed class FakePublisher : IQueueDispatchPublisher
+    {
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            return new LinkedIssue
+            {
+                Repo = targetRepo,
+                Number = 88,
+                Url = "https://github.com/J-Tech-Japan/intent-system/issues/88"
+            };
+        }
+    }
+
+    private sealed class FakeRemoteGitRunner : IGitRemoteCommandRunner
+    {
+        public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            return new GitRemoteCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "https://github.com/J-Tech-Japan/intent-system.git",
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class FakeStartGitRunner : IGitCommandRunner
+    {
+        public List<string> Calls { get; } = [];
+
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Calls.Add($"{workingDirectory}::{string.Join(' ', arguments)}");
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-autostart-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeAutostartRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeAutostartRendererTests.cs
@@ -1,0 +1,25 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeAutostartRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenAutostartContext_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        IntakeAutostartRenderer.WriteSummary(
+            writer,
+            "G31",
+            "https://github.com/J-Tech-Japan/intent-system/issues/88",
+            "/repo/.intent-cli/worktrees/G31",
+            "issue-88-g31");
+
+        var output = writer.ToString();
+        Assert.Contains("Intake autostart completed for G31.", output, StringComparison.Ordinal);
+        Assert.Contains("Linked issue: https://github.com/J-Tech-Japan/intent-system/issues/88", output, StringComparison.Ordinal);
+        Assert.Contains("Worktree path: /repo/.intent-cli/worktrees/G31", output, StringComparison.Ordinal);
+        Assert.Contains("Branch: issue-88-g31", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add the intake autostart command and wire it into the CLI shell
- bridge intake-origin queued units through the existing queue dispatch and run start boundaries
- keep the command limited to child issue creation, linked issue recording, worktree creation, and active transition

## Testing
- dotnet test IntentSystem.sln

Closes #88