### PR TITLE
[codex] Implement intake foldin command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -76,6 +76,7 @@ internal static class CommandRouter
             {
                 ["concept"] = IntakeConceptCommand.Execute,
                 ["compile"] = IntakeCompileCommand.Execute,
+                ["foldin"] = IntakeFoldinCommand.Execute,
                 ["autostart"] = IntakeAutostartCommand.Execute
             }
         };

--- a/src/IntentSystem.Cli/Commands/IntakeCompileArtifactMarkdown.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeCompileArtifactMarkdown.cs
@@ -1,0 +1,107 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeCompileArtifactMarkdown
+{
+    private static readonly string[] RequiredSections =
+    [
+        "answered_question_ids",
+        "recommended_updates",
+        "return_to_intent_paths",
+        "source_concept_refs"
+    ];
+
+    public static IntakeFoldinRequest Deserialize(string markdown)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(markdown);
+
+        var lines = markdown
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.None);
+
+        var sawTitle = false;
+        string? domain = null;
+        var sections = RequiredSections.ToDictionary(section => section, _ => new List<string>(), StringComparer.Ordinal);
+        var seenSections = new HashSet<string>(StringComparer.Ordinal);
+
+        string? currentSection = null;
+        var expectingDomain = false;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (string.Equals(line, "# Intake Compile", StringComparison.Ordinal))
+            {
+                sawTitle = true;
+                currentSection = null;
+                continue;
+            }
+
+            if (string.Equals(line, "## Domain", StringComparison.Ordinal))
+            {
+                expectingDomain = true;
+                currentSection = null;
+                continue;
+            }
+
+            if (expectingDomain)
+            {
+                if (line.StartsWith('`') && line.EndsWith('`') && line.Length >= 2)
+                {
+                    domain = line[1..^1];
+                    expectingDomain = false;
+                    continue;
+                }
+
+                throw new InvalidOperationException("Intake compile artifact must contain a backticked domain line.");
+            }
+
+            if (line.EndsWith(":", StringComparison.Ordinal) && sections.ContainsKey(line[..^1]))
+            {
+                currentSection = line[..^1];
+                seenSections.Add(currentSection);
+                continue;
+            }
+
+            if (!line.StartsWith("- ", StringComparison.Ordinal) || currentSection is null)
+            {
+                continue;
+            }
+
+            var value = line[2..];
+            if (!string.Equals(value, "none", StringComparison.Ordinal))
+            {
+                sections[currentSection].Add(value);
+            }
+        }
+
+        if (!sawTitle)
+        {
+            throw new InvalidOperationException("Intake compile artifact must start with '# Intake Compile'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            throw new InvalidOperationException("Intake compile artifact must contain a domain.");
+        }
+
+        var missingSection = RequiredSections.FirstOrDefault(section => !seenSections.Contains(section));
+        if (missingSection is not null)
+        {
+            throw new InvalidOperationException($"Intake compile artifact must contain section '{missingSection}:'.");
+        }
+
+        return new IntakeFoldinRequest
+        {
+            Domain = domain,
+            AnsweredQuestionIds = sections["answered_question_ids"].ToArray(),
+            RecommendedUpdates = sections["recommended_updates"].ToArray(),
+            ReturnToIntentPaths = sections["return_to_intent_paths"].ToArray(),
+            SourceConceptRefs = sections["source_concept_refs"].ToArray()
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeFoldinArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeFoldinArtifactPathResolver.cs
@@ -1,0 +1,13 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeFoldinArtifactPathResolver
+{
+    private const string IntakeDirectory = ".intent-cli/intake";
+
+    public static string Resolve(string domain)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+
+        return $"{IntakeDirectory}/{domain.Trim()}.foldin.md";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeFoldinArtifactWriter.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeFoldinArtifactWriter.cs
@@ -1,0 +1,21 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeFoldinArtifactWriter
+{
+    public static string Write(string markdown, string domain, string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(markdown);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+
+        var relativePath = IntakeFoldinArtifactPathResolver.Resolve(domain);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Intake fold-in artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, markdown);
+
+        return absolutePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeFoldinCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeFoldinCommand.cs
@@ -1,0 +1,49 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeFoldinCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Intake foldin command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0];
+        var compilePath = Path.Combine(
+            context.RepoRoot,
+            IntakeCompileArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(compilePath))
+        {
+            writer.WriteLine($"Intake compile artifact was not found at {compilePath}");
+            return 1;
+        }
+
+        try
+        {
+            var request = IntakeCompileArtifactMarkdown.Deserialize(File.ReadAllText(compilePath));
+            if (!string.Equals(request.Domain, domain, StringComparison.Ordinal))
+            {
+                writer.WriteLine(
+                    $"Intake compile artifact domain '{request.Domain}' does not match requested domain '{domain}'.");
+                return 1;
+            }
+
+            var markdown = IntakeFoldinRenderer.RenderMarkdown(request);
+            var artifactPath = IntakeFoldinArtifactWriter.Write(markdown, domain, context.RepoRoot);
+            IntakeFoldinRenderer.WriteSummary(writer, request, artifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeFoldinRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeFoldinRenderer.cs
@@ -1,0 +1,61 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeFoldinRenderer
+{
+    public static string RenderMarkdown(IntakeFoldinRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var lines = new List<string>
+        {
+            "# Intake Fold-In Draft",
+            string.Empty,
+            "## Domain",
+            string.Empty,
+            $"`{request.Domain}`",
+            string.Empty,
+            "## Interview Coverage",
+            string.Empty,
+            "## Parent Source-Of-Truth Update Candidates",
+            string.Empty,
+            "The following items are compile-derived update candidates for the parent source of truth.",
+            string.Empty
+        };
+
+        AppendList(lines, "answered_question_ids", request.AnsweredQuestionIds);
+        lines.Add(string.Empty);
+        AppendList(lines, "recommended_updates", request.RecommendedUpdates);
+        lines.Add(string.Empty);
+        AppendList(lines, "return_to_intent_paths", request.ReturnToIntentPaths);
+        lines.Add(string.Empty);
+        AppendList(lines, "source_concept_refs", request.SourceConceptRefs);
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    public static void WriteSummary(TextWriter writer, IntakeFoldinRequest request, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Intake fold-in draft generated for domain '{request.Domain}'.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Answered questions: {request.AnsweredQuestionIds.Count}");
+        writer.WriteLine($"Recommended updates: {request.RecommendedUpdates.Count}");
+        writer.WriteLine($"Return paths: {request.ReturnToIntentPaths.Count}");
+        writer.WriteLine($"Source concept refs: {request.SourceConceptRefs.Count}");
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        lines.Add($"{label}:");
+        if (values.Count == 0)
+        {
+            lines.Add("- none");
+            return;
+        }
+
+        lines.AddRange(values.Select(value => $"- {value}"));
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeFoldinRequest.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeFoldinRequest.cs
@@ -1,0 +1,14 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeFoldinRequest
+{
+    public required string Domain { get; init; }
+
+    public required IReadOnlyList<string> AnsweredQuestionIds { get; init; }
+
+    public required IReadOnlyList<string> RecommendedUpdates { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+
+    public required IReadOnlyList<string> SourceConceptRefs { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -241,6 +241,40 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeFoldinCommand_DispatchesToIntakeFoldinRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.compile.md"),
+            """
+            # Intake Compile
+
+            ## Domain
+
+            `auth`
+
+            answered_question_ids:
+            - iq-1
+
+            recommended_updates:
+            - Add device-code note
+
+            return_to_intent_paths:
+            - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["intake", "foldin", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Intake fold-in draft generated for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenIntakeConceptCommand_DispatchesToIntakeConceptRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeCompileArtifactMarkdownTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeCompileArtifactMarkdownTests.cs
@@ -1,0 +1,67 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeCompileArtifactMarkdownTests
+{
+    [Fact]
+    public void Deserialize_GivenCompileArtifactMarkdown_ParsesFoldinRequest()
+    {
+        var request = IntakeCompileArtifactMarkdown.Deserialize(
+            """
+            # Intake Compile
+
+            ## Domain
+
+            `auth`
+
+            answered_question_ids:
+            - iq-1
+            - iq-2
+
+            recommended_updates:
+            - Add device-code note
+
+            return_to_intent_paths:
+            - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+            """);
+
+        Assert.Equal("auth", request.Domain);
+        Assert.Equal(["iq-1", "iq-2"], request.AnsweredQuestionIds);
+        Assert.Equal(["Add device-code note"], request.RecommendedUpdates);
+        Assert.Equal(
+            ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+            request.ReturnToIntentPaths);
+        Assert.Equal(
+            ["intents/intent-cli/concepts/auth-oauth2.md"],
+            request.SourceConceptRefs);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredSection_ThrowsInvalidOperationException()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => IntakeCompileArtifactMarkdown.Deserialize(
+                """
+                # Intake Compile
+
+                ## Domain
+
+                `auth`
+
+                answered_question_ids:
+                - iq-1
+
+                recommended_updates:
+                - Add device-code note
+
+                source_concept_refs:
+                - intents/intent-cli/concepts/auth-oauth2.md
+                """));
+
+        Assert.Contains("return_to_intent_paths", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeFoldinArtifactWriterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeFoldinArtifactWriterTests.cs
@@ -1,0 +1,40 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeFoldinArtifactWriterTests
+{
+    [Fact]
+    public void Write_GivenDomainAndMarkdown_WritesExpectedArtifactPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+
+        var artifactPath = IntakeFoldinArtifactWriter.Write("# Intake Fold-In Draft", "auth", repoRoot);
+
+        Assert.Equal(
+            Path.Combine(repoRoot, ".intent-cli", "intake", "auth.foldin.md"),
+            artifactPath);
+        Assert.Equal("# Intake Fold-In Draft", File.ReadAllText(artifactPath));
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-foldin-writer-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeFoldinCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeFoldinCommandTests.cs
@@ -1,0 +1,161 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeFoldinCommandTests
+{
+    [Fact]
+    public void Execute_GivenCompileArtifact_WritesFoldinDraft()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.compile.md"),
+            """
+            # Intake Compile
+
+            ## Domain
+
+            `auth`
+
+            answered_question_ids:
+            - iq-1
+            - iq-2
+
+            recommended_updates:
+            - Add device-code note
+
+            return_to_intent_paths:
+            - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeFoldinCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake fold-in draft generated for domain 'auth'.", output, StringComparison.Ordinal);
+        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.foldin.md");
+        Assert.True(File.Exists(artifactPath));
+        var markdown = File.ReadAllText(artifactPath);
+        Assert.Contains("# Intake Fold-In Draft", markdown, StringComparison.Ordinal);
+        Assert.Contains("answered_question_ids:", markdown, StringComparison.Ordinal);
+        Assert.Contains("- iq-1", markdown, StringComparison.Ordinal);
+        Assert.Contains("recommended_updates:", markdown, StringComparison.Ordinal);
+        Assert.Contains("- Add device-code note", markdown, StringComparison.Ordinal);
+        Assert.Contains("return_to_intent_paths:", markdown, StringComparison.Ordinal);
+        Assert.Contains("source_concept_refs:", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingCompileArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeFoldinCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Intake compile artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMismatchedCompileArtifactDomain_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.compile.md"),
+            """
+            # Intake Compile
+
+            ## Domain
+
+            `payments`
+
+            answered_question_ids:
+            - iq-1
+
+            recommended_updates:
+            - Add device-code note
+
+            return_to_intent_paths:
+            - intents/intent-cli/intent-tree/means/payments.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/payments.md
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeFoldinCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("does not match requested domain", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.foldin.md")));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeFoldinCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-foldin-command-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeFoldinRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeFoldinRendererTests.cs
@@ -1,0 +1,90 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeFoldinRendererTests
+{
+    [Fact]
+    public void RenderMarkdown_GivenFoldinRequest_RendersDeterministicArtifact()
+    {
+        var markdown = IntakeFoldinRenderer.RenderMarkdown(new IntakeFoldinRequest
+        {
+            Domain = "auth",
+            AnsweredQuestionIds = ["iq-1", "iq-2"],
+            RecommendedUpdates = ["Add device-code note", "Document OAuth2 fallback"],
+            ReturnToIntentPaths =
+            [
+                "intents/intent-cli/intent-tree/means/auth-device-code.md",
+                "intents/intent-cli/intent-tree/means/auth-oauth2.md"
+            ],
+            SourceConceptRefs =
+            [
+                "intents/intent-cli/concepts/auth-device-code.md",
+                "intents/intent-cli/concepts/auth-oauth2.md"
+            ]
+        });
+
+        Assert.Contains("# Intake Fold-In Draft", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Interview Coverage", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Parent Source-Of-Truth Update Candidates", markdown, StringComparison.Ordinal);
+        Assert.Contains("answered_question_ids:", markdown, StringComparison.Ordinal);
+        Assert.Contains("recommended_updates:", markdown, StringComparison.Ordinal);
+        Assert.Contains("return_to_intent_paths:", markdown, StringComparison.Ordinal);
+        Assert.Contains("source_concept_refs:", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderMarkdown_GivenEmptyLists_RendersNoneMarkers()
+    {
+        var markdown = IntakeFoldinRenderer.RenderMarkdown(new IntakeFoldinRequest
+        {
+            Domain = "auth",
+            AnsweredQuestionIds = [],
+            RecommendedUpdates = [],
+            ReturnToIntentPaths = [],
+            SourceConceptRefs = []
+        });
+
+        Assert.Equal(4, CountOccurrences(markdown, "- none"));
+    }
+
+    [Fact]
+    public void WriteSummary_GivenFoldinRequest_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        IntakeFoldinRenderer.WriteSummary(
+            writer,
+            new IntakeFoldinRequest
+            {
+                Domain = "auth",
+                AnsweredQuestionIds = ["iq-1", "iq-2"],
+                RecommendedUpdates = ["Add device-code note"],
+                ReturnToIntentPaths = ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+                SourceConceptRefs = ["intents/intent-cli/concepts/auth-oauth2.md"]
+            },
+            "/repo/.intent-cli/intake/auth.foldin.md");
+
+        var output = writer.ToString();
+        Assert.Contains("Intake fold-in draft generated for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: /repo/.intent-cli/intake/auth.foldin.md", output, StringComparison.Ordinal);
+        Assert.Contains("Answered questions: 2", output, StringComparison.Ordinal);
+        Assert.Contains("Recommended updates: 1", output, StringComparison.Ordinal);
+        Assert.Contains("Return paths: 1", output, StringComparison.Ordinal);
+        Assert.Contains("Source concept refs: 1", output, StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string text, string needle)
+    {
+        var count = 0;
+        var currentIndex = 0;
+
+        while ((currentIndex = text.IndexOf(needle, currentIndex, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            currentIndex += needle.Length;
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
## Summary

- add `intent-cli intake foldin <domain>` to generate deterministic fold-in drafts from current compile artifacts
- parse and validate the current `.intent-cli/intake/<domain>.compile.md` contract before rendering `.intent-cli/intake/<domain>.foldin.md`
- cover the new command with parser, renderer, writer, command, and router tests

## Verification

- `dotnet test IntentSystem.sln`
