### PR TITLE
[codex] Implement intake patch command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -77,6 +77,7 @@ internal static class CommandRouter
                 ["concept"] = IntakeConceptCommand.Execute,
                 ["compile"] = IntakeCompileCommand.Execute,
                 ["foldin"] = IntakeFoldinCommand.Execute,
+                ["patch"] = IntakePatchCommand.Execute,
                 ["autostart"] = IntakeAutostartCommand.Execute
             }
         };

--- a/src/IntentSystem.Cli/Commands/IntakeFoldinArtifactMarkdown.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeFoldinArtifactMarkdown.cs
@@ -1,0 +1,107 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeFoldinArtifactMarkdown
+{
+    private static readonly string[] RequiredSections =
+    [
+        "answered_question_ids",
+        "recommended_updates",
+        "return_to_intent_paths",
+        "source_concept_refs"
+    ];
+
+    public static IntakePatchFoldinDraft Deserialize(string markdown)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(markdown);
+
+        var lines = markdown
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.None);
+
+        var sawTitle = false;
+        string? domain = null;
+        var sections = RequiredSections.ToDictionary(section => section, _ => new List<string>(), StringComparer.Ordinal);
+        var seenSections = new HashSet<string>(StringComparer.Ordinal);
+
+        string? currentSection = null;
+        var expectingDomain = false;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (string.Equals(line, "# Intake Fold-In Draft", StringComparison.Ordinal))
+            {
+                sawTitle = true;
+                currentSection = null;
+                continue;
+            }
+
+            if (string.Equals(line, "## Domain", StringComparison.Ordinal))
+            {
+                expectingDomain = true;
+                currentSection = null;
+                continue;
+            }
+
+            if (expectingDomain)
+            {
+                if (line.StartsWith('`') && line.EndsWith('`') && line.Length >= 2)
+                {
+                    domain = line[1..^1];
+                    expectingDomain = false;
+                    continue;
+                }
+
+                throw new InvalidOperationException("Intake fold-in artifact must contain a backticked domain line.");
+            }
+
+            if (line.EndsWith(":", StringComparison.Ordinal) && sections.ContainsKey(line[..^1]))
+            {
+                currentSection = line[..^1];
+                seenSections.Add(currentSection);
+                continue;
+            }
+
+            if (!line.StartsWith("- ", StringComparison.Ordinal) || currentSection is null)
+            {
+                continue;
+            }
+
+            var value = line[2..];
+            if (!string.Equals(value, "none", StringComparison.Ordinal))
+            {
+                sections[currentSection].Add(value);
+            }
+        }
+
+        if (!sawTitle)
+        {
+            throw new InvalidOperationException("Intake fold-in artifact must start with '# Intake Fold-In Draft'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            throw new InvalidOperationException("Intake fold-in artifact must contain a domain.");
+        }
+
+        var missingSection = RequiredSections.FirstOrDefault(section => !seenSections.Contains(section));
+        if (missingSection is not null)
+        {
+            throw new InvalidOperationException($"Intake fold-in artifact must contain section '{missingSection}:'.");
+        }
+
+        return new IntakePatchFoldinDraft
+        {
+            Domain = domain,
+            AnsweredQuestionIds = sections["answered_question_ids"].ToArray(),
+            RecommendedUpdates = sections["recommended_updates"].ToArray(),
+            ReturnToIntentPaths = sections["return_to_intent_paths"].ToArray(),
+            SourceConceptRefs = sections["source_concept_refs"].ToArray()
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakePatchArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/IntakePatchArtifactPathResolver.cs
@@ -1,0 +1,13 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakePatchArtifactPathResolver
+{
+    private const string IntakeDirectory = ".intent-cli/intake";
+
+    public static string Resolve(string domain)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+
+        return $"{IntakeDirectory}/{domain.Trim()}.patch.md";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakePatchArtifactWriter.cs
+++ b/src/IntentSystem.Cli/Commands/IntakePatchArtifactWriter.cs
@@ -1,0 +1,21 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakePatchArtifactWriter
+{
+    public static string Write(string markdown, string domain, string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(markdown);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+
+        var relativePath = IntakePatchArtifactPathResolver.Resolve(domain);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Intake patch artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, markdown);
+
+        return absolutePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakePatchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakePatchCommand.cs
@@ -1,0 +1,171 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakePatchCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Intake patch command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0];
+        var foldinPath = Path.Combine(
+            context.RepoRoot,
+            IntakeFoldinArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(foldinPath))
+        {
+            writer.WriteLine($"Intake fold-in artifact was not found at {foldinPath}");
+            return 1;
+        }
+
+        try
+        {
+            var foldinDraft = IntakeFoldinArtifactMarkdown.Deserialize(File.ReadAllText(foldinPath));
+            if (!string.Equals(foldinDraft.Domain, domain, StringComparison.Ordinal))
+            {
+                writer.WriteLine(
+                    $"Intake fold-in artifact domain '{foldinDraft.Domain}' does not match requested domain '{domain}'.");
+                return 1;
+            }
+
+            var request = CreateRequest(context.RepoRoot, foldinDraft);
+            var markdown = IntakePatchRenderer.RenderMarkdown(request);
+            var artifactPath = IntakePatchArtifactWriter.Write(markdown, domain, context.RepoRoot);
+            IntakePatchRenderer.WriteSummary(writer, request, artifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static IntakePatchRequest CreateRequest(string repoRoot, IntakePatchFoldinDraft foldinDraft)
+    {
+        var targetFilePaths = foldinDraft.ReturnToIntentPaths
+            .Concat(foldinDraft.SourceConceptRefs)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        var fileDrafts = targetFilePaths
+            .Select(targetFilePath => CreateFileDraft(repoRoot, foldinDraft, targetFilePath))
+            .ToArray();
+
+        return new IntakePatchRequest
+        {
+            Domain = foldinDraft.Domain,
+            TargetFilePaths = targetFilePaths,
+            SourceConceptRefs = foldinDraft.SourceConceptRefs
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray(),
+            FileDrafts = fileDrafts
+        };
+    }
+
+    private static IntakePatchFileDraft CreateFileDraft(
+        string repoRoot,
+        IntakePatchFoldinDraft foldinDraft,
+        string targetFilePath)
+    {
+        var isReturnTarget = foldinDraft.ReturnToIntentPaths.Contains(targetFilePath, StringComparer.Ordinal);
+        var isSourceConceptTarget = foldinDraft.SourceConceptRefs.Contains(targetFilePath, StringComparer.Ordinal);
+        var absolutePath = Path.Combine(repoRoot, targetFilePath.Replace('/', Path.DirectorySeparatorChar));
+        var fileExists = File.Exists(absolutePath);
+        var currentFileState = fileExists ? "present" : "missing";
+        var currentFileExcerpt = fileExists
+            ? CreateExcerpt(File.ReadAllText(absolutePath))
+            : "[missing]";
+
+        var proposedEdits = new List<string>();
+        if (isReturnTarget)
+        {
+            if (foldinDraft.RecommendedUpdates.Count == 0)
+            {
+                proposedEdits.Add("Align this target file with the current fold-in draft coverage.");
+            }
+            else
+            {
+                proposedEdits.AddRange(
+                    foldinDraft.RecommendedUpdates
+                        .OrderBy(update => update, StringComparer.Ordinal)
+                        .Select(update => $"Apply update candidate: {update}"));
+            }
+        }
+
+        if (isSourceConceptTarget)
+        {
+            proposedEdits.Add("Reconcile this source concept file with the current fold-in draft.");
+        }
+
+        if (!fileExists)
+        {
+            proposedEdits.Add("Draft this target file as a new parent source-of-truth entry if creation is intended.");
+        }
+
+        var rationale = new List<string>();
+        if (isReturnTarget)
+        {
+            rationale.Add("This path is listed in return_to_intent_paths.");
+        }
+
+        if (isSourceConceptTarget)
+        {
+            rationale.Add("This path is listed in source_concept_refs.");
+        }
+
+        rationale.Add($"Answered question ids informing this draft: {FormatList(foldinDraft.AnsweredQuestionIds)}.");
+        rationale.Add("This patch draft uses current parent source file context only as read-only input.");
+
+        var sourceConceptRefs = (isSourceConceptTarget
+                ? [targetFilePath]
+                : foldinDraft.SourceConceptRefs.ToArray())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        var foldinAnchors = foldinDraft.AnsweredQuestionIds
+            .Select(questionId => $"answered_question_ids:{questionId}")
+            .Concat(foldinDraft.RecommendedUpdates.OrderBy(update => update, StringComparer.Ordinal)
+                .Select(update => $"recommended_updates:{update}"))
+            .Concat(isReturnTarget ? [$"return_to_intent_paths:{targetFilePath}"] : [])
+            .Concat(isSourceConceptTarget ? [$"source_concept_refs:{targetFilePath}"] : [])
+            .ToArray();
+
+        return new IntakePatchFileDraft
+        {
+            TargetFilePath = targetFilePath,
+            CurrentFileState = currentFileState,
+            ProposedEdits = proposedEdits.Distinct(StringComparer.Ordinal).ToArray(),
+            Rationale = rationale,
+            SourceConceptRefs = sourceConceptRefs,
+            FoldinAnchors = foldinAnchors,
+            CurrentFileExcerpt = currentFileExcerpt
+        };
+    }
+
+    private static string CreateExcerpt(string content)
+    {
+        var normalized = content.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var lines = normalized.Split('\n', StringSplitOptions.None);
+        var excerptLines = lines.Take(6).ToArray();
+        var excerpt = string.Join(Environment.NewLine, excerptLines).TrimEnd();
+        return string.IsNullOrEmpty(excerpt) ? "[empty]" : excerpt;
+    }
+
+    private static string FormatList(IReadOnlyList<string> values)
+    {
+        return values.Count == 0
+            ? "none"
+            : string.Join(", ", values.OrderBy(value => value, StringComparer.Ordinal));
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakePatchFileDraft.cs
+++ b/src/IntentSystem.Cli/Commands/IntakePatchFileDraft.cs
@@ -1,0 +1,18 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakePatchFileDraft
+{
+    public required string TargetFilePath { get; init; }
+
+    public required string CurrentFileState { get; init; }
+
+    public required IReadOnlyList<string> ProposedEdits { get; init; }
+
+    public required IReadOnlyList<string> Rationale { get; init; }
+
+    public required IReadOnlyList<string> SourceConceptRefs { get; init; }
+
+    public required IReadOnlyList<string> FoldinAnchors { get; init; }
+
+    public required string CurrentFileExcerpt { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IntakePatchFoldinDraft.cs
+++ b/src/IntentSystem.Cli/Commands/IntakePatchFoldinDraft.cs
@@ -1,0 +1,14 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakePatchFoldinDraft
+{
+    public required string Domain { get; init; }
+
+    public required IReadOnlyList<string> AnsweredQuestionIds { get; init; }
+
+    public required IReadOnlyList<string> RecommendedUpdates { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+
+    public required IReadOnlyList<string> SourceConceptRefs { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IntakePatchRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakePatchRenderer.cs
@@ -1,0 +1,74 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakePatchRenderer
+{
+    public static string RenderMarkdown(IntakePatchRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var lines = new List<string>
+        {
+            "# Intake Patch Draft",
+            string.Empty,
+            "## Domain",
+            string.Empty,
+            $"`{request.Domain}`",
+            string.Empty
+        };
+
+        AppendList(lines, "target_file_paths", request.TargetFilePaths);
+        lines.Add(string.Empty);
+        AppendList(lines, "source_concept_refs", request.SourceConceptRefs);
+        lines.Add(string.Empty);
+        lines.Add("## File-By-File Patch Candidates");
+        lines.Add(string.Empty);
+
+        foreach (var fileDraft in request.FileDrafts)
+        {
+            lines.Add($"### `{fileDraft.TargetFilePath}`");
+            lines.Add(string.Empty);
+            lines.Add($"current_file_state: {fileDraft.CurrentFileState}");
+            AppendList(lines, "foldin_anchors", fileDraft.FoldinAnchors);
+            AppendList(lines, "source_concept_refs", fileDraft.SourceConceptRefs);
+            AppendList(lines, "proposed_edits", fileDraft.ProposedEdits);
+            AppendList(lines, "rationale", fileDraft.Rationale);
+            lines.Add("current_file_excerpt:");
+            lines.Add("```text");
+            lines.Add(fileDraft.CurrentFileExcerpt);
+            lines.Add("```");
+            lines.Add(string.Empty);
+        }
+
+        if (request.FileDrafts.Count > 0)
+        {
+            lines.RemoveAt(lines.Count - 1);
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    public static void WriteSummary(TextWriter writer, IntakePatchRequest request, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Intake patch draft generated for domain '{request.Domain}'.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Target file paths: {request.TargetFilePaths.Count}");
+        writer.WriteLine($"File draft sections: {request.FileDrafts.Count}");
+        writer.WriteLine($"Source concept refs: {request.SourceConceptRefs.Count}");
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        lines.Add($"{label}:");
+        if (values.Count == 0)
+        {
+            lines.Add("- none");
+            return;
+        }
+
+        lines.AddRange(values.Select(value => $"- {value}"));
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakePatchRequest.cs
+++ b/src/IntentSystem.Cli/Commands/IntakePatchRequest.cs
@@ -1,0 +1,12 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakePatchRequest
+{
+    public required string Domain { get; init; }
+
+    public required IReadOnlyList<string> TargetFilePaths { get; init; }
+
+    public required IReadOnlyList<string> SourceConceptRefs { get; init; }
+
+    public required IReadOnlyList<IntakePatchFileDraft> FileDrafts { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -275,6 +275,46 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakePatchCommand_DispatchesToIntakePatchRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.foldin.md"),
+            """
+            # Intake Fold-In Draft
+
+            ## Domain
+
+            `auth`
+
+            answered_question_ids:
+            - iq-1
+
+            recommended_updates:
+            - Add device-code note
+
+            return_to_intent_paths:
+            - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "auth-oauth2.md"),
+            "# Auth Concept");
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["intake", "patch", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Intake patch draft generated for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenIntakeConceptCommand_DispatchesToIntakeConceptRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeFoldinArtifactMarkdownTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeFoldinArtifactMarkdownTests.cs
@@ -1,0 +1,66 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeFoldinArtifactMarkdownTests
+{
+    [Fact]
+    public void Deserialize_GivenFoldinArtifactMarkdown_ParsesPatchDraftSeed()
+    {
+        var draft = IntakeFoldinArtifactMarkdown.Deserialize(
+            """
+            # Intake Fold-In Draft
+
+            ## Domain
+
+            `auth`
+
+            ## Interview Coverage
+
+            answered_question_ids:
+            - iq-1
+
+            ## Parent Source-Of-Truth Update Candidates
+
+            recommended_updates:
+            - Add device-code note
+
+            return_to_intent_paths:
+            - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+            """);
+
+        Assert.Equal("auth", draft.Domain);
+        Assert.Equal(["iq-1"], draft.AnsweredQuestionIds);
+        Assert.Equal(["Add device-code note"], draft.RecommendedUpdates);
+        Assert.Equal(["intents/intent-cli/intent-tree/means/auth-oauth2.md"], draft.ReturnToIntentPaths);
+        Assert.Equal(["intents/intent-cli/concepts/auth-oauth2.md"], draft.SourceConceptRefs);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredSection_ThrowsInvalidOperationException()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => IntakeFoldinArtifactMarkdown.Deserialize(
+                """
+                # Intake Fold-In Draft
+
+                ## Domain
+
+                `auth`
+
+                answered_question_ids:
+                - iq-1
+
+                return_to_intent_paths:
+                - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+                source_concept_refs:
+                - intents/intent-cli/concepts/auth-oauth2.md
+                """));
+
+        Assert.Contains("recommended_updates", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakePatchArtifactWriterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakePatchArtifactWriterTests.cs
@@ -1,0 +1,40 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakePatchArtifactWriterTests
+{
+    [Fact]
+    public void Write_GivenDomainAndMarkdown_WritesExpectedArtifactPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+
+        var artifactPath = IntakePatchArtifactWriter.Write("# Intake Patch Draft", "auth", repoRoot);
+
+        Assert.Equal(
+            Path.Combine(repoRoot, ".intent-cli", "intake", "auth.patch.md"),
+            artifactPath);
+        Assert.Equal("# Intake Patch Draft", File.ReadAllText(artifactPath));
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-patch-writer-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakePatchCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakePatchCommandTests.cs
@@ -1,0 +1,175 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakePatchCommandTests
+{
+    [Fact]
+    public void Execute_GivenFoldinArtifactAndParentFiles_WritesPatchDraft()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.foldin.md"),
+            """
+            # Intake Fold-In Draft
+
+            ## Domain
+
+            `auth`
+
+            ## Interview Coverage
+
+            answered_question_ids:
+            - iq-1
+            - iq-2
+
+            ## Parent Source-Of-Truth Update Candidates
+
+            recommended_updates:
+            - Add device-code note
+            - Document OAuth2 fallback
+
+            return_to_intent_paths:
+            - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means" + Environment.NewLine + "Existing line");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "auth-oauth2.md"),
+            "# Auth Concept" + Environment.NewLine + "Known flow");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakePatchCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake patch draft generated for domain 'auth'.", output, StringComparison.Ordinal);
+        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.patch.md");
+        Assert.True(File.Exists(artifactPath));
+        var markdown = File.ReadAllText(artifactPath);
+        Assert.Contains("target_file_paths:", markdown, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/concepts/auth-oauth2.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/intent-tree/means/auth-oauth2.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("### `intents/intent-cli/intent-tree/means/auth-oauth2.md`", markdown, StringComparison.Ordinal);
+        Assert.Contains("current_file_state: present", markdown, StringComparison.Ordinal);
+        Assert.Contains("recommended_updates:Add device-code note", markdown, StringComparison.Ordinal);
+        Assert.Contains("Apply update candidate: Add device-code note", markdown, StringComparison.Ordinal);
+        Assert.Contains("# Auth Means", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingParentFile_RendersMissingFileState()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.foldin.md"),
+            """
+            # Intake Fold-In Draft
+
+            ## Domain
+
+            `auth`
+
+            answered_question_ids:
+            - iq-1
+
+            recommended_updates:
+            - Add device-code note
+
+            return_to_intent_paths:
+            - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = IntakePatchCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var markdown = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.patch.md"));
+        Assert.Contains("current_file_state: missing", markdown, StringComparison.Ordinal);
+        Assert.Contains("[missing]", markdown, StringComparison.Ordinal);
+        Assert.Contains("Draft this target file as a new parent source-of-truth entry if creation is intended.", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFoldinArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakePatchCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Intake fold-in artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = IntakePatchCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-patch-command-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakePatchRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakePatchRendererTests.cs
@@ -1,0 +1,84 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakePatchRendererTests
+{
+    [Fact]
+    public void RenderMarkdown_GivenPatchRequest_RendersDeterministicArtifact()
+    {
+        var markdown = IntakePatchRenderer.RenderMarkdown(new IntakePatchRequest
+        {
+            Domain = "auth",
+            TargetFilePaths =
+            [
+                "intents/intent-cli/concepts/auth-oauth2.md",
+                "intents/intent-cli/intent-tree/means/auth-oauth2.md"
+            ],
+            SourceConceptRefs = ["intents/intent-cli/concepts/auth-oauth2.md"],
+            FileDrafts =
+            [
+                new IntakePatchFileDraft
+                {
+                    TargetFilePath = "intents/intent-cli/intent-tree/means/auth-oauth2.md",
+                    CurrentFileState = "present",
+                    ProposedEdits = ["Apply update candidate: Add device-code note"],
+                    Rationale = ["This path is listed in return_to_intent_paths."],
+                    SourceConceptRefs = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                    FoldinAnchors =
+                    [
+                        "answered_question_ids:iq-1",
+                        "recommended_updates:Add device-code note",
+                        "return_to_intent_paths:intents/intent-cli/intent-tree/means/auth-oauth2.md"
+                    ],
+                    CurrentFileExcerpt = "# Existing Heading"
+                }
+            ]
+        });
+
+        Assert.Contains("# Intake Patch Draft", markdown, StringComparison.Ordinal);
+        Assert.Contains("target_file_paths:", markdown, StringComparison.Ordinal);
+        Assert.Contains("## File-By-File Patch Candidates", markdown, StringComparison.Ordinal);
+        Assert.Contains("current_file_state: present", markdown, StringComparison.Ordinal);
+        Assert.Contains("foldin_anchors:", markdown, StringComparison.Ordinal);
+        Assert.Contains("proposed_edits:", markdown, StringComparison.Ordinal);
+        Assert.Contains("rationale:", markdown, StringComparison.Ordinal);
+        Assert.Contains("current_file_excerpt:", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenPatchRequest_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        IntakePatchRenderer.WriteSummary(
+            writer,
+            new IntakePatchRequest
+            {
+                Domain = "auth",
+                TargetFilePaths = ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+                SourceConceptRefs = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                FileDrafts =
+                [
+                    new IntakePatchFileDraft
+                    {
+                        TargetFilePath = "intents/intent-cli/intent-tree/means/auth-oauth2.md",
+                        CurrentFileState = "present",
+                        ProposedEdits = ["Apply update candidate: Add device-code note"],
+                        Rationale = ["This path is listed in return_to_intent_paths."],
+                        SourceConceptRefs = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                        FoldinAnchors = ["answered_question_ids:iq-1"],
+                        CurrentFileExcerpt = "# Existing Heading"
+                    }
+                ]
+            },
+            "/repo/.intent-cli/intake/auth.patch.md");
+
+        var output = writer.ToString();
+        Assert.Contains("Intake patch draft generated for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: /repo/.intent-cli/intake/auth.patch.md", output, StringComparison.Ordinal);
+        Assert.Contains("Target file paths: 1", output, StringComparison.Ordinal);
+        Assert.Contains("File draft sections: 1", output, StringComparison.Ordinal);
+        Assert.Contains("Source concept refs: 1", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

- add `intent-cli intake patch <domain>` to generate deterministic patch drafts from current fold-in drafts and read-only parent source file context
- validate the current `.intent-cli/intake/<domain>.foldin.md` contract and resolve file-by-file patch candidates with target paths, proposed edits, rationale, source concept refs, and fold-in anchors
- cover the new command with parser, renderer, writer, command, and router tests

## Verification

- `dotnet test IntentSystem.sln`
