### PR TITLE
[codex] Implement intake apply command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -78,6 +78,7 @@ internal static class CommandRouter
                 ["compile"] = IntakeCompileCommand.Execute,
                 ["foldin"] = IntakeFoldinCommand.Execute,
                 ["patch"] = IntakePatchCommand.Execute,
+                ["apply"] = IntakeApplyCommand.Execute,
                 ["autostart"] = IntakeAutostartCommand.Execute
             }
         };

--- a/src/IntentSystem.Cli/Commands/IntakeApplyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeApplyCommand.cs
@@ -70,12 +70,14 @@ internal static class IntakeApplyCommand
                 ? File.ReadAllText(absolutePath)
                 : string.Empty;
 
-            var updatedContent = UpsertManagedBlock(previousContent, request.Domain, fileDraft);
+            EnsureExcerptMatchesCurrentContent(previousContent, fileDraft);
+
+            var updatedContent = ApplyProposedEdits(previousContent, fileDraft);
             if (!string.Equals(previousContent, updatedContent, StringComparison.Ordinal))
             {
                 File.WriteAllText(absolutePath, updatedContent);
                 changedFilePaths.Add(fileDraft.TargetFilePath);
-                appliedEditCount += fileDraft.ProposedEdits.Count;
+                appliedEditCount += CountAppliedEdits(previousContent, fileDraft);
             }
         }
 
@@ -91,69 +93,78 @@ internal static class IntakeApplyCommand
         };
     }
 
-    private static string UpsertManagedBlock(string existingContent, string domain, IntakePatchFileDraft fileDraft)
+    private static void EnsureExcerptMatchesCurrentContent(string existingContent, IntakePatchFileDraft fileDraft)
     {
         var normalizedExisting = existingContent.Replace("\r\n", "\n", StringComparison.Ordinal);
-        var block = BuildManagedBlock(domain, fileDraft);
-        var startMarker = $"<!-- intake-apply:start domain:{domain} path:{fileDraft.TargetFilePath} -->";
-        var endMarker = $"<!-- intake-apply:end domain:{domain} path:{fileDraft.TargetFilePath} -->";
-        var startIndex = normalizedExisting.IndexOf(startMarker, StringComparison.Ordinal);
-
-        string updated;
-        if (startIndex >= 0)
+        var excerpt = fileDraft.CurrentFileExcerpt.Replace("\r\n", "\n", StringComparison.Ordinal);
+        if (string.IsNullOrWhiteSpace(excerpt)
+            || string.Equals(excerpt, "[missing]", StringComparison.Ordinal)
+            || string.Equals(excerpt, "[empty]", StringComparison.Ordinal))
         {
-            var endIndex = normalizedExisting.IndexOf(endMarker, startIndex, StringComparison.Ordinal);
-            if (endIndex < 0)
-            {
-                throw new InvalidOperationException(
-                    $"Existing intake apply block for '{fileDraft.TargetFilePath}' is missing its closing marker.");
-            }
-
-            endIndex += endMarker.Length;
-            updated = normalizedExisting[..startIndex] + block + normalizedExisting[endIndex..];
-        }
-        else if (string.IsNullOrWhiteSpace(normalizedExisting))
-        {
-            updated = block;
-        }
-        else
-        {
-            updated = normalizedExisting.TrimEnd() + Environment.NewLine + Environment.NewLine + block;
-        }
-
-        return updated.TrimEnd() + Environment.NewLine;
-    }
-
-    private static string BuildManagedBlock(string domain, IntakePatchFileDraft fileDraft)
-    {
-        var lines = new List<string>
-        {
-            $"<!-- intake-apply:start domain:{domain} path:{fileDraft.TargetFilePath} -->",
-            $"## Intake Apply Update ({domain})",
-            string.Empty,
-            "foldin_anchors:"
-        };
-
-        AppendList(lines, fileDraft.FoldinAnchors);
-        lines.Add("source_concept_refs:");
-        AppendList(lines, fileDraft.SourceConceptRefs);
-        lines.Add("proposed_edits:");
-        AppendList(lines, fileDraft.ProposedEdits);
-        lines.Add("rationale:");
-        AppendList(lines, fileDraft.Rationale);
-        lines.Add($"<!-- intake-apply:end domain:{domain} path:{fileDraft.TargetFilePath} -->");
-
-        return string.Join(Environment.NewLine, lines);
-    }
-
-    private static void AppendList(List<string> lines, IReadOnlyList<string> values)
-    {
-        if (values.Count == 0)
-        {
-            lines.Add("- none");
             return;
         }
 
-        lines.AddRange(values.Select(value => $"- {value}"));
+        if (!string.IsNullOrWhiteSpace(normalizedExisting)
+            && !normalizedExisting.Contains(excerpt, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Current file content for '{fileDraft.TargetFilePath}' no longer matches the patch draft excerpt.");
+        }
+    }
+
+    private static string ApplyProposedEdits(string existingContent, IntakePatchFileDraft fileDraft)
+    {
+        var normalizedExisting = existingContent.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd();
+        var linesToAppend = fileDraft.ProposedEdits
+            .Select(NormalizeAppliedLine)
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .Distinct(StringComparer.Ordinal)
+            .Where(line => !ContainsAppliedLine(normalizedExisting, line))
+            .ToArray();
+
+        if (linesToAppend.Length == 0)
+        {
+            return string.IsNullOrWhiteSpace(normalizedExisting)
+                ? string.Empty
+                : normalizedExisting + Environment.NewLine;
+        }
+
+        var appendedBlock = string.Join(Environment.NewLine, linesToAppend.Select(line => $"- {line}"));
+        if (string.IsNullOrWhiteSpace(normalizedExisting))
+        {
+            return appendedBlock + Environment.NewLine;
+        }
+
+        return normalizedExisting + Environment.NewLine + Environment.NewLine + appendedBlock + Environment.NewLine;
+    }
+
+    private static int CountAppliedEdits(string existingContent, IntakePatchFileDraft fileDraft)
+    {
+        var normalizedExisting = existingContent.Replace("\r\n", "\n", StringComparison.Ordinal);
+        return fileDraft.ProposedEdits
+            .Select(NormalizeAppliedLine)
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .Distinct(StringComparer.Ordinal)
+            .Count(line => !ContainsAppliedLine(normalizedExisting, line));
+    }
+
+    private static string NormalizeAppliedLine(string proposedEdit)
+    {
+        const string updatePrefix = "Apply update candidate: ";
+        if (proposedEdit.StartsWith(updatePrefix, StringComparison.Ordinal))
+        {
+            return proposedEdit[updatePrefix.Length..].Trim();
+        }
+
+        return proposedEdit.Trim();
+    }
+
+    private static bool ContainsAppliedLine(string content, string line)
+    {
+        return content.Split('\n', StringSplitOptions.None)
+            .Select(existingLine => existingLine.Trim())
+            .Any(existingLine =>
+                string.Equals(existingLine, line, StringComparison.Ordinal)
+                || string.Equals(existingLine, $"- {line}", StringComparison.Ordinal));
     }
 }

--- a/src/IntentSystem.Cli/Commands/IntakeApplyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeApplyCommand.cs
@@ -1,0 +1,159 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeApplyCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Intake apply command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0];
+        var patchPath = Path.Combine(
+            context.RepoRoot,
+            IntakePatchArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(patchPath))
+        {
+            writer.WriteLine($"Intake patch artifact was not found at {patchPath}");
+            return 1;
+        }
+
+        try
+        {
+            var request = IntakePatchArtifactMarkdown.Deserialize(File.ReadAllText(patchPath));
+            if (!string.Equals(request.Domain, domain, StringComparison.Ordinal))
+            {
+                writer.WriteLine(
+                    $"Intake patch artifact domain '{request.Domain}' does not match requested domain '{domain}'.");
+                return 1;
+            }
+
+            var result = ApplyDraft(context.RepoRoot, request);
+            IntakeApplyRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static IntakeApplyResult ApplyDraft(string repoRoot, IntakePatchRequest request)
+    {
+        var changedFilePaths = new List<string>();
+        var appliedEditCount = 0;
+        var allowedPaths = request.TargetFilePaths.ToHashSet(StringComparer.Ordinal);
+
+        foreach (var fileDraft in request.FileDrafts.OrderBy(draft => draft.TargetFilePath, StringComparer.Ordinal))
+        {
+            if (!allowedPaths.Contains(fileDraft.TargetFilePath))
+            {
+                throw new InvalidOperationException(
+                    $"Intake patch artifact file block '{fileDraft.TargetFilePath}' is not listed in target_file_paths.");
+            }
+
+            var absolutePath = Path.Combine(repoRoot, fileDraft.TargetFilePath.Replace('/', Path.DirectorySeparatorChar));
+            var directoryPath = Path.GetDirectoryName(absolutePath)
+                ?? throw new InvalidOperationException($"Target file path '{fileDraft.TargetFilePath}' did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+
+            var previousContent = File.Exists(absolutePath)
+                ? File.ReadAllText(absolutePath)
+                : string.Empty;
+
+            var updatedContent = UpsertManagedBlock(previousContent, request.Domain, fileDraft);
+            if (!string.Equals(previousContent, updatedContent, StringComparison.Ordinal))
+            {
+                File.WriteAllText(absolutePath, updatedContent);
+                changedFilePaths.Add(fileDraft.TargetFilePath);
+                appliedEditCount += fileDraft.ProposedEdits.Count;
+            }
+        }
+
+        return new IntakeApplyResult
+        {
+            Domain = request.Domain,
+            ChangedFilePaths = changedFilePaths,
+            AppliedEditCount = appliedEditCount,
+            SourceConceptRefs = request.SourceConceptRefs
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray()
+        };
+    }
+
+    private static string UpsertManagedBlock(string existingContent, string domain, IntakePatchFileDraft fileDraft)
+    {
+        var normalizedExisting = existingContent.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var block = BuildManagedBlock(domain, fileDraft);
+        var startMarker = $"<!-- intake-apply:start domain:{domain} path:{fileDraft.TargetFilePath} -->";
+        var endMarker = $"<!-- intake-apply:end domain:{domain} path:{fileDraft.TargetFilePath} -->";
+        var startIndex = normalizedExisting.IndexOf(startMarker, StringComparison.Ordinal);
+
+        string updated;
+        if (startIndex >= 0)
+        {
+            var endIndex = normalizedExisting.IndexOf(endMarker, startIndex, StringComparison.Ordinal);
+            if (endIndex < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Existing intake apply block for '{fileDraft.TargetFilePath}' is missing its closing marker.");
+            }
+
+            endIndex += endMarker.Length;
+            updated = normalizedExisting[..startIndex] + block + normalizedExisting[endIndex..];
+        }
+        else if (string.IsNullOrWhiteSpace(normalizedExisting))
+        {
+            updated = block;
+        }
+        else
+        {
+            updated = normalizedExisting.TrimEnd() + Environment.NewLine + Environment.NewLine + block;
+        }
+
+        return updated.TrimEnd() + Environment.NewLine;
+    }
+
+    private static string BuildManagedBlock(string domain, IntakePatchFileDraft fileDraft)
+    {
+        var lines = new List<string>
+        {
+            $"<!-- intake-apply:start domain:{domain} path:{fileDraft.TargetFilePath} -->",
+            $"## Intake Apply Update ({domain})",
+            string.Empty,
+            "foldin_anchors:"
+        };
+
+        AppendList(lines, fileDraft.FoldinAnchors);
+        lines.Add("source_concept_refs:");
+        AppendList(lines, fileDraft.SourceConceptRefs);
+        lines.Add("proposed_edits:");
+        AppendList(lines, fileDraft.ProposedEdits);
+        lines.Add("rationale:");
+        AppendList(lines, fileDraft.Rationale);
+        lines.Add($"<!-- intake-apply:end domain:{domain} path:{fileDraft.TargetFilePath} -->");
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static void AppendList(List<string> lines, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add("- none");
+            return;
+        }
+
+        lines.AddRange(values.Select(value => $"- {value}"));
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeApplyRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeApplyRenderer.cs
@@ -1,0 +1,38 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeApplyRenderer
+{
+    public static void WriteSummary(TextWriter writer, IntakeApplyResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Intake apply completed for domain '{result.Domain}'.");
+        writer.WriteLine($"Applied edit count: {result.AppliedEditCount}");
+        writer.WriteLine("Changed file paths:");
+
+        if (result.ChangedFilePaths.Count == 0)
+        {
+            writer.WriteLine("- none");
+        }
+        else
+        {
+            foreach (var path in result.ChangedFilePaths)
+            {
+                writer.WriteLine($"- {path}");
+            }
+        }
+
+        writer.WriteLine("Source concept refs:");
+        if (result.SourceConceptRefs.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var path in result.SourceConceptRefs)
+        {
+            writer.WriteLine($"- {path}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeApplyResult.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeApplyResult.cs
@@ -1,0 +1,12 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeApplyResult
+{
+    public required string Domain { get; init; }
+
+    public required IReadOnlyList<string> ChangedFilePaths { get; init; }
+
+    public required int AppliedEditCount { get; init; }
+
+    public required IReadOnlyList<string> SourceConceptRefs { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IntakePatchArtifactMarkdown.cs
+++ b/src/IntentSystem.Cli/Commands/IntakePatchArtifactMarkdown.cs
@@ -1,0 +1,275 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakePatchArtifactMarkdown
+{
+    private static readonly string[] RequiredTopLevelSections =
+    [
+        "target_file_paths",
+        "source_concept_refs"
+    ];
+
+    private static readonly string[] RequiredFileSections =
+    [
+        "foldin_anchors",
+        "source_concept_refs",
+        "proposed_edits",
+        "rationale"
+    ];
+
+    public static IntakePatchRequest Deserialize(string markdown)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(markdown);
+
+        var lines = markdown
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.None);
+
+        var sawTitle = false;
+        var sawFileByFileSection = false;
+        string? domain = null;
+        string? currentTopLevelSection = null;
+        var expectingDomain = false;
+        var topLevelSections = RequiredTopLevelSections.ToDictionary(section => section, _ => new List<string>(), StringComparer.Ordinal);
+        var seenTopLevelSections = new HashSet<string>(StringComparer.Ordinal);
+        var fileDrafts = new List<IntakePatchFileDraft>();
+        PatchFileDraftBuilder? currentFileDraft = null;
+
+        for (var index = 0; index < lines.Length; index++)
+        {
+            var line = lines[index].TrimEnd();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (string.Equals(line, "# Intake Patch Draft", StringComparison.Ordinal))
+            {
+                sawTitle = true;
+                continue;
+            }
+
+            if (string.Equals(line, "## Domain", StringComparison.Ordinal))
+            {
+                expectingDomain = true;
+                currentTopLevelSection = null;
+                continue;
+            }
+
+            if (expectingDomain)
+            {
+                if (line.StartsWith('`') && line.EndsWith('`') && line.Length >= 2)
+                {
+                    domain = line[1..^1];
+                    expectingDomain = false;
+                    continue;
+                }
+
+                throw new InvalidOperationException("Intake patch artifact must contain a backticked domain line.");
+            }
+
+            if (string.Equals(line, "## File-By-File Patch Candidates", StringComparison.Ordinal))
+            {
+                sawFileByFileSection = true;
+                currentTopLevelSection = null;
+                continue;
+            }
+
+            if (!sawFileByFileSection && line.EndsWith(":", StringComparison.Ordinal))
+            {
+                var sectionName = line[..^1];
+                if (topLevelSections.ContainsKey(sectionName))
+                {
+                    currentTopLevelSection = sectionName;
+                    seenTopLevelSections.Add(sectionName);
+                    continue;
+                }
+            }
+
+            if (!sawFileByFileSection)
+            {
+                if (line.StartsWith("- ", StringComparison.Ordinal) && currentTopLevelSection is not null)
+                {
+                    var value = line[2..];
+                    if (!string.Equals(value, "none", StringComparison.Ordinal))
+                    {
+                        topLevelSections[currentTopLevelSection].Add(value);
+                    }
+                }
+
+                continue;
+            }
+
+            if (line.StartsWith("### `", StringComparison.Ordinal) && line.EndsWith('`'))
+            {
+                if (currentFileDraft is not null)
+                {
+                    fileDrafts.Add(currentFileDraft.Build());
+                }
+
+                currentFileDraft = new PatchFileDraftBuilder(line["### `".Length..^1]);
+                continue;
+            }
+
+            if (currentFileDraft is null)
+            {
+                continue;
+            }
+
+            if (line.StartsWith("current_file_state: ", StringComparison.Ordinal))
+            {
+                currentFileDraft.CurrentFileState = line["current_file_state: ".Length..];
+                continue;
+            }
+
+            if (line == "current_file_excerpt:")
+            {
+                index = ParseExcerpt(lines, index, currentFileDraft);
+                continue;
+            }
+
+            if (line.EndsWith(":", StringComparison.Ordinal))
+            {
+                currentFileDraft.CurrentListSection = line[..^1];
+                if (RequiredFileSections.Contains(currentFileDraft.CurrentListSection, StringComparer.Ordinal))
+                {
+                    currentFileDraft.SeenSections.Add(currentFileDraft.CurrentListSection);
+                    continue;
+                }
+            }
+
+            if (line.StartsWith("- ", StringComparison.Ordinal) && currentFileDraft.CurrentListSection is not null)
+            {
+                var value = line[2..];
+                if (!string.Equals(value, "none", StringComparison.Ordinal))
+                {
+                    currentFileDraft.AddValue(value);
+                }
+            }
+        }
+
+        if (currentFileDraft is not null)
+        {
+            fileDrafts.Add(currentFileDraft.Build());
+        }
+
+        if (!sawTitle)
+        {
+            throw new InvalidOperationException("Intake patch artifact must start with '# Intake Patch Draft'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            throw new InvalidOperationException("Intake patch artifact must contain a domain.");
+        }
+
+        var missingTopLevelSection = RequiredTopLevelSections.FirstOrDefault(section => !seenTopLevelSections.Contains(section));
+        if (missingTopLevelSection is not null)
+        {
+            throw new InvalidOperationException($"Intake patch artifact must contain section '{missingTopLevelSection}:'.");
+        }
+
+        if (!sawFileByFileSection)
+        {
+            throw new InvalidOperationException("Intake patch artifact must contain '## File-By-File Patch Candidates'.");
+        }
+
+        return new IntakePatchRequest
+        {
+            Domain = domain,
+            TargetFilePaths = topLevelSections["target_file_paths"].ToArray(),
+            SourceConceptRefs = topLevelSections["source_concept_refs"].ToArray(),
+            FileDrafts = fileDrafts
+        };
+    }
+
+    private static int ParseExcerpt(string[] lines, int currentIndex, PatchFileDraftBuilder builder)
+    {
+        if (currentIndex + 1 >= lines.Length || !string.Equals(lines[currentIndex + 1], "```text", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Intake patch artifact current_file_excerpt must start with a ```text fence.");
+        }
+
+        var excerptLines = new List<string>();
+        var index = currentIndex + 2;
+        for (; index < lines.Length; index++)
+        {
+            if (string.Equals(lines[index], "```", StringComparison.Ordinal))
+            {
+                builder.CurrentFileExcerpt = string.Join(Environment.NewLine, excerptLines).TrimEnd();
+                return index;
+            }
+
+            excerptLines.Add(lines[index]);
+        }
+
+        throw new InvalidOperationException("Intake patch artifact current_file_excerpt fence was not closed.");
+    }
+
+    private sealed class PatchFileDraftBuilder
+    {
+        private readonly List<string> foldinAnchors = [];
+        private readonly List<string> sourceConceptRefs = [];
+        private readonly List<string> proposedEdits = [];
+        private readonly List<string> rationale = [];
+
+        public PatchFileDraftBuilder(string targetFilePath)
+        {
+            TargetFilePath = targetFilePath;
+        }
+
+        public string TargetFilePath { get; }
+
+        public string? CurrentFileState { get; set; }
+
+        public string CurrentFileExcerpt { get; set; } = string.Empty;
+
+        public string? CurrentListSection { get; set; }
+
+        public HashSet<string> SeenSections { get; } = new(StringComparer.Ordinal);
+
+        public void AddValue(string value)
+        {
+            switch (CurrentListSection)
+            {
+                case "foldin_anchors":
+                    foldinAnchors.Add(value);
+                    break;
+                case "source_concept_refs":
+                    sourceConceptRefs.Add(value);
+                    break;
+                case "proposed_edits":
+                    proposedEdits.Add(value);
+                    break;
+                case "rationale":
+                    rationale.Add(value);
+                    break;
+            }
+        }
+
+        public IntakePatchFileDraft Build()
+        {
+            if (string.IsNullOrWhiteSpace(CurrentFileState))
+            {
+                throw new InvalidOperationException($"Intake patch artifact file block '{TargetFilePath}' must contain current_file_state.");
+            }
+
+            var missingSection = RequiredFileSections.FirstOrDefault(section => !SeenSections.Contains(section));
+            if (missingSection is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Intake patch artifact file block '{TargetFilePath}' must contain section '{missingSection}:'.");
+            }
+
+            return new IntakePatchFileDraft
+            {
+                TargetFilePath = TargetFilePath,
+                CurrentFileState = CurrentFileState,
+                ProposedEdits = proposedEdits.ToArray(),
+                Rationale = rationale.ToArray(),
+                SourceConceptRefs = sourceConceptRefs.ToArray(),
+                FoldinAnchors = foldinAnchors.ToArray(),
+                CurrentFileExcerpt = string.IsNullOrEmpty(CurrentFileExcerpt) ? "[empty]" : CurrentFileExcerpt
+            };
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -355,7 +355,7 @@ public sealed class CommandRouterTests
             """);
         tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
-            "# Auth Means");
+            "# Auth Means" + Environment.NewLine + "Existing line");
         using var writer = new StringWriter();
 
         var exitCode = CommandRouter.Execute(["intake", "apply", "auth"], CreateContext(repoRoot), writer);

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -315,6 +315,56 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeApplyCommand_DispatchesToIntakeApplyRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.patch.md"),
+            """
+            # Intake Patch Draft
+
+            ## Domain
+
+            `auth`
+
+            target_file_paths:
+            - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+
+            ## File-By-File Patch Candidates
+
+            ### `intents/intent-cli/intent-tree/means/auth-oauth2.md`
+
+            current_file_state: present
+            foldin_anchors:
+            - answered_question_ids:iq-1
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+            proposed_edits:
+            - Apply update candidate: Add device-code note
+            rationale:
+            - This path is listed in return_to_intent_paths.
+            current_file_excerpt:
+            ```text
+            # Auth Means
+            Existing line
+            ```
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means");
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["intake", "apply", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Intake apply completed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenIntakeConceptCommand_DispatchesToIntakeConceptRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeApplyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeApplyCommandTests.cs
@@ -1,0 +1,249 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeApplyCommandTests
+{
+    [Fact]
+    public void Execute_GivenPatchArtifact_UpdatesOnlyTargetFilesAndWritesSummary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.patch.md"),
+            CreatePatchArtifactMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means" + Environment.NewLine + "Existing line");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "auth-oauth2.md"),
+            "# Auth Concept" + Environment.NewLine + "Known flow");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "README.md"),
+            "# Repo");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeApplyCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake apply completed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Applied edit count: 3", output, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/concepts/auth-oauth2.md", output, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/intent-tree/means/auth-oauth2.md", output, StringComparison.Ordinal);
+
+        var meansFile = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"));
+        Assert.Contains("<!-- intake-apply:start domain:auth path:intents/intent-cli/intent-tree/means/auth-oauth2.md -->", meansFile, StringComparison.Ordinal);
+        Assert.Contains("Apply update candidate: Add device-code note", meansFile, StringComparison.Ordinal);
+
+        var conceptFile = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "concepts", "auth-oauth2.md"));
+        Assert.Contains("Reconcile this source concept file with the current fold-in draft.", conceptFile, StringComparison.Ordinal);
+
+        var untouchedFile = File.ReadAllText(Path.Combine(repoRoot, "README.md"));
+        Assert.Equal("# Repo", untouchedFile);
+    }
+
+    [Fact]
+    public void Execute_GivenRepeatedApply_IsDeterministicNoOpOnSecondRun()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.patch.md"),
+            CreatePatchArtifactMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "auth-oauth2.md"),
+            "# Auth Concept");
+        using var firstWriter = new StringWriter();
+        using var secondWriter = new StringWriter();
+
+        var firstExitCode = IntakeApplyCommand.Execute(CreateContext(repoRoot), ["auth"], firstWriter);
+        var secondExitCode = IntakeApplyCommand.Execute(CreateContext(repoRoot), ["auth"], secondWriter);
+
+        Assert.Equal(0, firstExitCode);
+        Assert.Equal(0, secondExitCode);
+        Assert.Contains("Applied edit count: 0", secondWriter.ToString(), StringComparison.Ordinal);
+        Assert.Contains("- none", secondWriter.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenPatchFileBlockOutsideTargetPaths_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.patch.md"),
+            """
+            # Intake Patch Draft
+
+            ## Domain
+
+            `auth`
+
+            target_file_paths:
+            - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+
+            ## File-By-File Patch Candidates
+
+            ### `intents/intent-cli/concepts/auth-oauth2.md`
+
+            current_file_state: present
+            foldin_anchors:
+            - answered_question_ids:iq-1
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+            proposed_edits:
+            - Reconcile this source concept file with the current fold-in draft.
+            rationale:
+            - This path is listed in source_concept_refs.
+            current_file_excerpt:
+            ```text
+            # Auth Concept
+            ```
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeApplyCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("is not listed in target_file_paths", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPatchArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeApplyCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Intake patch artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeApplyCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static string CreatePatchArtifactMarkdown()
+    {
+        return """
+            # Intake Patch Draft
+
+            ## Domain
+
+            `auth`
+
+            target_file_paths:
+            - intents/intent-cli/concepts/auth-oauth2.md
+            - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+
+            ## File-By-File Patch Candidates
+
+            ### `intents/intent-cli/concepts/auth-oauth2.md`
+
+            current_file_state: present
+            foldin_anchors:
+            - answered_question_ids:iq-1
+            - source_concept_refs:intents/intent-cli/concepts/auth-oauth2.md
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+            proposed_edits:
+            - Reconcile this source concept file with the current fold-in draft.
+            rationale:
+            - This path is listed in source_concept_refs.
+            current_file_excerpt:
+            ```text
+            # Auth Concept
+            Known flow
+            ```
+
+            ### `intents/intent-cli/intent-tree/means/auth-oauth2.md`
+
+            current_file_state: present
+            foldin_anchors:
+            - answered_question_ids:iq-1
+            - recommended_updates:Add device-code note
+            - return_to_intent_paths:intents/intent-cli/intent-tree/means/auth-oauth2.md
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+            proposed_edits:
+            - Apply update candidate: Add device-code note
+            - Apply update candidate: Document OAuth2 fallback
+            rationale:
+            - This path is listed in return_to_intent_paths.
+            current_file_excerpt:
+            ```text
+            # Auth Means
+            Existing line
+            ```
+            """;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-apply-command-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeApplyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeApplyCommandTests.cs
@@ -34,10 +34,14 @@ public sealed class IntakeApplyCommandTests
         Assert.Contains("- intents/intent-cli/intent-tree/means/auth-oauth2.md", output, StringComparison.Ordinal);
 
         var meansFile = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"));
-        Assert.Contains("<!-- intake-apply:start domain:auth path:intents/intent-cli/intent-tree/means/auth-oauth2.md -->", meansFile, StringComparison.Ordinal);
-        Assert.Contains("Apply update candidate: Add device-code note", meansFile, StringComparison.Ordinal);
+        Assert.DoesNotContain("intake-apply:start", meansFile, StringComparison.Ordinal);
+        Assert.Contains("# Auth Means", meansFile, StringComparison.Ordinal);
+        Assert.Contains("Existing line", meansFile, StringComparison.Ordinal);
+        Assert.Contains("- Add device-code note", meansFile, StringComparison.Ordinal);
+        Assert.Contains("- Document OAuth2 fallback", meansFile, StringComparison.Ordinal);
 
         var conceptFile = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "concepts", "auth-oauth2.md"));
+        Assert.DoesNotContain("intake-apply:start", conceptFile, StringComparison.Ordinal);
         Assert.Contains("Reconcile this source concept file with the current fold-in draft.", conceptFile, StringComparison.Ordinal);
 
         var untouchedFile = File.ReadAllText(Path.Combine(repoRoot, "README.md"));
@@ -54,10 +58,10 @@ public sealed class IntakeApplyCommandTests
             CreatePatchArtifactMarkdown());
         tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
-            "# Auth Means");
+            "# Auth Means" + Environment.NewLine + "Existing line");
         tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "concepts", "auth-oauth2.md"),
-            "# Auth Concept");
+            "# Auth Concept" + Environment.NewLine + "Known flow");
         using var firstWriter = new StringWriter();
         using var secondWriter = new StringWriter();
 
@@ -67,6 +71,7 @@ public sealed class IntakeApplyCommandTests
         Assert.Equal(0, firstExitCode);
         Assert.Equal(0, secondExitCode);
         Assert.Contains("Applied edit count: 0", secondWriter.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Changed file paths:", secondWriter.ToString(), StringComparison.Ordinal);
         Assert.Contains("- none", secondWriter.ToString(), StringComparison.Ordinal);
     }
 
@@ -127,6 +132,28 @@ public sealed class IntakeApplyCommandTests
 
         Assert.Equal(1, exitCode);
         Assert.Contains("Intake patch artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenCurrentContentThatDoesNotMatchExcerpt_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.patch.md"),
+            CreatePatchArtifactMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means" + Environment.NewLine + "Drifted line");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "auth-oauth2.md"),
+            "# Auth Concept" + Environment.NewLine + "Known flow");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeApplyCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("no longer matches the patch draft excerpt", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IntakeApplyRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeApplyRendererTests.cs
@@ -1,0 +1,30 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeApplyRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenApplyResult_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        IntakeApplyRenderer.WriteSummary(
+            writer,
+            new IntakeApplyResult
+            {
+                Domain = "auth",
+                ChangedFilePaths = ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+                AppliedEditCount = 2,
+                SourceConceptRefs = ["intents/intent-cli/concepts/auth-oauth2.md"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Intake apply completed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Applied edit count: 2", output, StringComparison.Ordinal);
+        Assert.Contains("Changed file paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/intent-tree/means/auth-oauth2.md", output, StringComparison.Ordinal);
+        Assert.Contains("Source concept refs:", output, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/concepts/auth-oauth2.md", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakePatchArtifactMarkdownTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakePatchArtifactMarkdownTests.cs
@@ -1,0 +1,72 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakePatchArtifactMarkdownTests
+{
+    [Fact]
+    public void Deserialize_GivenPatchArtifactMarkdown_ParsesPatchRequest()
+    {
+        var request = IntakePatchArtifactMarkdown.Deserialize(
+            """
+            # Intake Patch Draft
+
+            ## Domain
+
+            `auth`
+
+            target_file_paths:
+            - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+
+            ## File-By-File Patch Candidates
+
+            ### `intents/intent-cli/intent-tree/means/auth-oauth2.md`
+
+            current_file_state: present
+            foldin_anchors:
+            - answered_question_ids:iq-1
+            source_concept_refs:
+            - intents/intent-cli/concepts/auth-oauth2.md
+            proposed_edits:
+            - Apply update candidate: Add device-code note
+            rationale:
+            - This path is listed in return_to_intent_paths.
+            current_file_excerpt:
+            ```text
+            # Auth Means
+            Existing line
+            ```
+            """);
+
+        Assert.Equal("auth", request.Domain);
+        Assert.Equal(["intents/intent-cli/intent-tree/means/auth-oauth2.md"], request.TargetFilePaths);
+        Assert.Equal(["intents/intent-cli/concepts/auth-oauth2.md"], request.SourceConceptRefs);
+        Assert.Single(request.FileDrafts);
+        Assert.Equal("present", request.FileDrafts[0].CurrentFileState);
+        Assert.Contains("Apply update candidate: Add device-code note", request.FileDrafts[0].ProposedEdits, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingTargetFilePaths_ThrowsInvalidOperationException()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => IntakePatchArtifactMarkdown.Deserialize(
+                """
+                # Intake Patch Draft
+
+                ## Domain
+
+                `auth`
+
+                source_concept_refs:
+                - intents/intent-cli/concepts/auth-oauth2.md
+
+                ## File-By-File Patch Candidates
+                """));
+
+        Assert.Contains("target_file_paths", exception.Message, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

- add `intent-cli intake apply <domain>` to read the current patch draft and deterministically update only the named parent source-of-truth files
- parse and validate the current `.intent-cli/intake/<domain>.patch.md` contract before applying idempotent managed update blocks per target file
- return a human-facing summary with changed file paths, applied edit count, and source concept refs, with command/parser/renderer/router coverage

## Verification

- `dotnet test IntentSystem.sln`
