### PR TITLE
[codex] Implement intake execution command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -79,6 +79,7 @@ internal static class CommandRouter
                 ["foldin"] = IntakeFoldinCommand.Execute,
                 ["patch"] = IntakePatchCommand.Execute,
                 ["apply"] = IntakeApplyCommand.Execute,
+                ["execution"] = IntakeExecutionCommand.Execute,
                 ["autostart"] = IntakeAutostartCommand.Execute
             }
         };

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionArtifactPathResolver.cs
@@ -1,0 +1,13 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeExecutionArtifactPathResolver
+{
+    private const string IntakeDirectory = ".intent-cli/intake";
+
+    public static string Resolve(string domain)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+
+        return $"{IntakeDirectory}/{domain.Trim()}.execution.md";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionArtifactWriter.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionArtifactWriter.cs
@@ -1,0 +1,21 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeExecutionArtifactWriter
+{
+    public static string Write(string markdown, string domain, string repoRoot)
+    {
+        ArgumentNullException.ThrowIfNull(markdown);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+
+        var relativePath = IntakeExecutionArtifactPathResolver.Resolve(domain);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Intake execution artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, markdown);
+
+        return absolutePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionCommand.cs
@@ -1,0 +1,142 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeExecutionCommand
+{
+    private const string IntentCliDirectory = "intents/intent-cli";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Intake execution command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0];
+
+        try
+        {
+            var request = CreateRequest(context.RepoRoot, domain);
+            if (request.ProposedExecutionUnits.Count == 0)
+            {
+                writer.WriteLine($"No updated parent source files were found for domain '{domain}'.");
+                return 1;
+            }
+
+            var markdown = IntakeExecutionRenderer.RenderMarkdown(request);
+            var artifactPath = IntakeExecutionArtifactWriter.Write(markdown, domain, context.RepoRoot);
+            IntakeExecutionRenderer.WriteSummary(writer, request, artifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static IntakeExecutionRequest CreateRequest(string repoRoot, string domain)
+    {
+        var intentCliRoot = Path.Combine(repoRoot, IntentCliDirectory.Replace('/', Path.DirectorySeparatorChar));
+        if (!Directory.Exists(intentCliRoot))
+        {
+            return new IntakeExecutionRequest
+            {
+                Domain = domain,
+                ProposedExecutionUnits = []
+            };
+        }
+
+        var matchingFiles = Directory.EnumerateFiles(intentCliRoot, "*.md", SearchOption.AllDirectories)
+            .Select(path => Path.GetRelativePath(repoRoot, path).Replace(Path.DirectorySeparatorChar, '/'))
+            .Where(relativePath => relativePath.Contains(domain, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(relativePath => relativePath, StringComparer.Ordinal)
+            .ToArray();
+
+        var candidates = matchingFiles
+            .Select((relativePath, index) => CreateCandidate(repoRoot, domain, relativePath, index + 1))
+            .ToArray();
+
+        var conceptIds = candidates
+            .Where(candidate => string.Equals(candidate.TargetPart, "concepts", StringComparison.Ordinal))
+            .Select(candidate => candidate.ExecutionUnitId)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToArray();
+
+        var resolvedCandidates = candidates
+            .Select(candidate => candidate with
+            {
+                Dependencies = string.Equals(candidate.TargetPart, "concepts", StringComparison.Ordinal)
+                    ? Array.Empty<string>()
+                    : conceptIds
+            })
+            .ToArray();
+
+        return new IntakeExecutionRequest
+        {
+            Domain = domain,
+            ProposedExecutionUnits = resolvedCandidates
+        };
+    }
+
+    private static IntakeExecutionUnitCandidate CreateCandidate(
+        string repoRoot,
+        string domain,
+        string relativePath,
+        int ordinal)
+    {
+        var absolutePath = Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        var content = File.ReadAllText(absolutePath).Replace("\r\n", "\n", StringComparison.Ordinal);
+        var lines = content.Split('\n', StringSplitOptions.None);
+        var heading = lines.FirstOrDefault(line => line.StartsWith("#", StringComparison.Ordinal))?.Trim();
+        var bulletCount = lines.Count(line => line.TrimStart().StartsWith("- ", StringComparison.Ordinal));
+        var targetPart = ResolveTargetPart(relativePath);
+        var executionUnitId = $"{domain.ToUpperInvariant()}-{ordinal:00}";
+
+        var readinessNotes = new List<string>
+        {
+            $"Source file path: {relativePath}",
+            $"Current heading: {heading ?? "[none]"}",
+            $"Detected bullet lines: {bulletCount}"
+        };
+
+        var verificationHints = new List<string>
+        {
+            $"Review parent source file '{relativePath}' for issue-ready scope.",
+            $"Confirm target part '{targetPart}' in the execution draft.",
+            "dotnet test IntentSystem.sln"
+        };
+
+        return new IntakeExecutionUnitCandidate
+        {
+            ExecutionUnitId = executionUnitId,
+            SourceFilePath = relativePath,
+            TargetPart = targetPart,
+            Dependencies = [],
+            ReadinessNotes = readinessNotes,
+            VerificationHints = verificationHints
+        };
+    }
+
+    private static string ResolveTargetPart(string relativePath)
+    {
+        const string intentCliPrefix = "intents/intent-cli/";
+        var trimmed = relativePath.StartsWith(intentCliPrefix, StringComparison.Ordinal)
+            ? relativePath[intentCliPrefix.Length..]
+            : relativePath;
+
+        if (trimmed.StartsWith("concepts/", StringComparison.Ordinal))
+        {
+            return "concepts";
+        }
+
+        var lastSlashIndex = trimmed.LastIndexOf('/');
+        return lastSlashIndex > 0
+            ? trimmed[..lastSlashIndex]
+            : trimmed;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionCommand.cs
@@ -2,8 +2,6 @@ namespace IntentSystem.Cli.Commands;
 
 internal static class IntakeExecutionCommand
 {
-    private const string IntentCliDirectory = "intents/intent-cli";
-
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -17,10 +15,27 @@ internal static class IntakeExecutionCommand
         }
 
         var domain = args[0];
+        var patchPath = Path.Combine(
+            context.RepoRoot,
+            IntakePatchArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(patchPath))
+        {
+            writer.WriteLine($"Intake patch artifact was not found at {patchPath}");
+            return 1;
+        }
 
         try
         {
-            var request = CreateRequest(context.RepoRoot, domain);
+            var patchRequest = IntakePatchArtifactMarkdown.Deserialize(File.ReadAllText(patchPath));
+            if (!string.Equals(patchRequest.Domain, domain, StringComparison.Ordinal))
+            {
+                writer.WriteLine(
+                    $"Intake patch artifact domain '{patchRequest.Domain}' does not match requested domain '{domain}'.");
+                return 1;
+            }
+
+            var request = CreateRequest(context.RepoRoot, patchRequest);
             if (request.ProposedExecutionUnits.Count == 0)
             {
                 writer.WriteLine($"No updated parent source files were found for domain '{domain}'.");
@@ -39,26 +54,16 @@ internal static class IntakeExecutionCommand
         }
     }
 
-    private static IntakeExecutionRequest CreateRequest(string repoRoot, string domain)
+    private static IntakeExecutionRequest CreateRequest(string repoRoot, IntakePatchRequest patchRequest)
     {
-        var intentCliRoot = Path.Combine(repoRoot, IntentCliDirectory.Replace('/', Path.DirectorySeparatorChar));
-        if (!Directory.Exists(intentCliRoot))
-        {
-            return new IntakeExecutionRequest
-            {
-                Domain = domain,
-                ProposedExecutionUnits = []
-            };
-        }
-
-        var matchingFiles = Directory.EnumerateFiles(intentCliRoot, "*.md", SearchOption.AllDirectories)
-            .Select(path => Path.GetRelativePath(repoRoot, path).Replace(Path.DirectorySeparatorChar, '/'))
-            .Where(relativePath => relativePath.Contains(domain, StringComparison.OrdinalIgnoreCase))
+        var updatedSourceFiles = patchRequest.TargetFilePaths
+            .Distinct(StringComparer.Ordinal)
             .OrderBy(relativePath => relativePath, StringComparer.Ordinal)
+            .Where(relativePath => File.Exists(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar))))
             .ToArray();
 
-        var candidates = matchingFiles
-            .Select((relativePath, index) => CreateCandidate(repoRoot, domain, relativePath, index + 1))
+        var candidates = updatedSourceFiles
+            .Select((relativePath, index) => CreateCandidate(repoRoot, patchRequest.Domain, relativePath, index + 1))
             .ToArray();
 
         var conceptIds = candidates
@@ -78,7 +83,7 @@ internal static class IntakeExecutionCommand
 
         return new IntakeExecutionRequest
         {
-            Domain = domain,
+            Domain = patchRequest.Domain,
             ProposedExecutionUnits = resolvedCandidates
         };
     }

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionRenderer.cs
@@ -1,0 +1,67 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeExecutionRenderer
+{
+    public static string RenderMarkdown(IntakeExecutionRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var lines = new List<string>
+        {
+            "# Intake Execution Draft",
+            string.Empty,
+            "## Domain",
+            string.Empty,
+            $"`{request.Domain}`",
+            string.Empty,
+            "## Proposed Execution Units",
+            string.Empty
+        };
+
+        foreach (var candidate in request.ProposedExecutionUnits)
+        {
+            lines.Add($"### `{candidate.ExecutionUnitId}`");
+            lines.Add(string.Empty);
+            lines.Add($"source_file_path: {candidate.SourceFilePath}");
+            lines.Add($"target_part: {candidate.TargetPart}");
+            AppendList(lines, "dependencies", candidate.Dependencies);
+            AppendList(lines, "readiness_notes", candidate.ReadinessNotes);
+            AppendList(lines, "verification_hints", candidate.VerificationHints);
+            lines.Add(string.Empty);
+        }
+
+        if (request.ProposedExecutionUnits.Count > 0)
+        {
+            lines.RemoveAt(lines.Count - 1);
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    public static void WriteSummary(TextWriter writer, IntakeExecutionRequest request, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Intake execution draft generated for domain '{request.Domain}'.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Proposed execution units: {request.ProposedExecutionUnits.Count}");
+        writer.WriteLine(
+            $"Dependencies: {request.ProposedExecutionUnits.Sum(candidate => candidate.Dependencies.Count)}");
+        writer.WriteLine(
+            $"Verification hints: {request.ProposedExecutionUnits.Sum(candidate => candidate.VerificationHints.Count)}");
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        lines.Add($"{label}:");
+        if (values.Count == 0)
+        {
+            lines.Add("- none");
+            return;
+        }
+
+        lines.AddRange(values.Select(value => $"- {value}"));
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionRequest.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionRequest.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeExecutionRequest
+{
+    public required string Domain { get; init; }
+
+    public required IReadOnlyList<IntakeExecutionUnitCandidate> ProposedExecutionUnits { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionUnitCandidate.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionUnitCandidate.cs
@@ -1,0 +1,16 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeExecutionUnitCandidate
+{
+    public required string ExecutionUnitId { get; init; }
+
+    public required string SourceFilePath { get; init; }
+
+    public required string TargetPart { get; init; }
+
+    public required IReadOnlyList<string> Dependencies { get; init; }
+
+    public required IReadOnlyList<string> ReadinessNotes { get; init; }
+
+    public required IReadOnlyList<string> VerificationHints { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -370,10 +370,28 @@ public sealed class CommandRouterTests
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "concepts", "auth-oauth2.md"),
+            Path.Combine("repo", ".intent-cli", "intake", "auth.patch.md"),
+            """
+            # Intake Patch Draft
+
+            ## Domain
+
+            `auth`
+
+            target_file_paths:
+            - intents/intent-cli/concepts/oauth2.md
+            - intents/intent-cli/intent-tree/means/device-code.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/oauth2.md
+
+            ## File-By-File Patch Candidates
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
             "# Auth Concept" + Environment.NewLine + "- Reconcile this source concept file with the current fold-in draft.");
         tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "device-code.md"),
             "# Auth Means" + Environment.NewLine + "- Add device-code note");
         using var writer = new StringWriter();
 

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -365,6 +365,25 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeExecutionCommand_DispatchesToIntakeExecutionRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "auth-oauth2.md"),
+            "# Auth Concept" + Environment.NewLine + "- Reconcile this source concept file with the current fold-in draft.");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means" + Environment.NewLine + "- Add device-code note");
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["intake", "execution", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Intake execution draft generated for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenIntakeConceptCommand_DispatchesToIntakeConceptRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeExecutionArtifactWriterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeExecutionArtifactWriterTests.cs
@@ -1,0 +1,40 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeExecutionArtifactWriterTests
+{
+    [Fact]
+    public void Write_GivenDomainAndMarkdown_WritesExpectedArtifactPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+
+        var artifactPath = IntakeExecutionArtifactWriter.Write("# Intake Execution Draft", "auth", repoRoot);
+
+        Assert.Equal(
+            Path.Combine(repoRoot, ".intent-cli", "intake", "auth.execution.md"),
+            artifactPath);
+        Assert.Equal("# Intake Execution Draft", File.ReadAllText(artifactPath));
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-execution-writer-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeExecutionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeExecutionCommandTests.cs
@@ -11,10 +11,63 @@ public sealed class IntakeExecutionCommandTests
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "concepts", "auth-oauth2.md"),
+            Path.Combine("repo", ".intent-cli", "intake", "auth.patch.md"),
+            """
+            # Intake Patch Draft
+
+            ## Domain
+
+            `auth`
+
+            target_file_paths:
+            - intents/intent-cli/concepts/oauth2.md
+            - intents/intent-cli/intent-tree/means/device-code.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/oauth2.md
+
+            ## File-By-File Patch Candidates
+
+            ### `intents/intent-cli/concepts/oauth2.md`
+
+            current_file_state: present
+            foldin_anchors:
+            - answered_question_ids:iq-1
+            source_concept_refs:
+            - intents/intent-cli/concepts/oauth2.md
+            proposed_edits:
+            - Reconcile this source concept file with the current fold-in draft.
+            rationale:
+            - This path is listed in source_concept_refs.
+            current_file_excerpt:
+            ```text
+            # Auth Concept
+            - Reconcile this source concept file with the current fold-in draft.
+            ```
+
+            ### `intents/intent-cli/intent-tree/means/device-code.md`
+
+            current_file_state: present
+            foldin_anchors:
+            - answered_question_ids:iq-1
+            - recommended_updates:Add device-code note
+            source_concept_refs:
+            - intents/intent-cli/concepts/oauth2.md
+            proposed_edits:
+            - Apply update candidate: Add device-code note
+            rationale:
+            - This path is listed in return_to_intent_paths.
+            current_file_excerpt:
+            ```text
+            # Auth Means
+            - Add device-code note
+            ```
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
             "# Auth Concept" + Environment.NewLine + "- Reconcile this source concept file with the current fold-in draft.");
         tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "device-code.md"),
             "# Auth Means" + Environment.NewLine + "- Add device-code note");
         tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "payments.md"),
@@ -31,8 +84,8 @@ public sealed class IntakeExecutionCommandTests
         var markdown = File.ReadAllText(artifactPath);
         Assert.Contains("### `AUTH-01`", markdown, StringComparison.Ordinal);
         Assert.Contains("### `AUTH-02`", markdown, StringComparison.Ordinal);
-        Assert.Contains("source_file_path: intents/intent-cli/concepts/auth-oauth2.md", markdown, StringComparison.Ordinal);
-        Assert.Contains("source_file_path: intents/intent-cli/intent-tree/means/auth-oauth2.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("source_file_path: intents/intent-cli/concepts/oauth2.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("source_file_path: intents/intent-cli/intent-tree/means/device-code.md", markdown, StringComparison.Ordinal);
         Assert.Contains("target_part: concepts", markdown, StringComparison.Ordinal);
         Assert.Contains("target_part: intent-tree/means", markdown, StringComparison.Ordinal);
         Assert.Contains("- AUTH-01", markdown, StringComparison.Ordinal);
@@ -45,8 +98,22 @@ public sealed class IntakeExecutionCommandTests
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "concepts", "payments.md"),
-            "# Payments");
+            Path.Combine("repo", ".intent-cli", "intake", "auth.patch.md"),
+            """
+            # Intake Patch Draft
+
+            ## Domain
+
+            `auth`
+
+            target_file_paths:
+            - intents/intent-cli/concepts/oauth2.md
+
+            source_concept_refs:
+            - intents/intent-cli/concepts/oauth2.md
+
+            ## File-By-File Patch Candidates
+            """);
         using var writer = new StringWriter();
 
         var exitCode = IntakeExecutionCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
@@ -54,6 +121,19 @@ public sealed class IntakeExecutionCommandTests
         Assert.Equal(1, exitCode);
         Assert.Contains("No updated parent source files were found for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
         Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.execution.md")));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPatchArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeExecutionCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Intake patch artifact was not found", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IntakeExecutionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeExecutionCommandTests.cs
@@ -1,0 +1,118 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeExecutionCommandTests
+{
+    [Fact]
+    public void Execute_GivenUpdatedParentSourceFiles_WritesExecutionDraft()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "auth-oauth2.md"),
+            "# Auth Concept" + Environment.NewLine + "- Reconcile this source concept file with the current fold-in draft.");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means" + Environment.NewLine + "- Add device-code note");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "payments.md"),
+            "# Payments");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeExecutionCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake execution draft generated for domain 'auth'.", output, StringComparison.Ordinal);
+        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.execution.md");
+        Assert.True(File.Exists(artifactPath));
+        var markdown = File.ReadAllText(artifactPath);
+        Assert.Contains("### `AUTH-01`", markdown, StringComparison.Ordinal);
+        Assert.Contains("### `AUTH-02`", markdown, StringComparison.Ordinal);
+        Assert.Contains("source_file_path: intents/intent-cli/concepts/auth-oauth2.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("source_file_path: intents/intent-cli/intent-tree/means/auth-oauth2.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("target_part: concepts", markdown, StringComparison.Ordinal);
+        Assert.Contains("target_part: intent-tree/means", markdown, StringComparison.Ordinal);
+        Assert.Contains("- AUTH-01", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("payments.md", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNoMatchingParentSourceFiles_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "payments.md"),
+            "# Payments");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeExecutionCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("No updated parent source files were found for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.execution.md")));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeExecutionCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-execution-command-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeExecutionRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeExecutionRendererTests.cs
@@ -1,0 +1,86 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeExecutionRendererTests
+{
+    [Fact]
+    public void RenderMarkdown_GivenExecutionRequest_RendersDeterministicArtifact()
+    {
+        var markdown = IntakeExecutionRenderer.RenderMarkdown(new IntakeExecutionRequest
+        {
+            Domain = "auth",
+            ProposedExecutionUnits =
+            [
+                new IntakeExecutionUnitCandidate
+                {
+                    ExecutionUnitId = "AUTH-01",
+                    SourceFilePath = "intents/intent-cli/concepts/auth-oauth2.md",
+                    TargetPart = "concepts",
+                    Dependencies = [],
+                    ReadinessNotes =
+                    [
+                        "Source file path: intents/intent-cli/concepts/auth-oauth2.md",
+                        "Current heading: # Auth Concept"
+                    ],
+                    VerificationHints =
+                    [
+                        "Review parent source file 'intents/intent-cli/concepts/auth-oauth2.md' for issue-ready scope.",
+                        "dotnet test IntentSystem.sln"
+                    ]
+                }
+            ]
+        });
+
+        Assert.Contains("# Intake Execution Draft", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Proposed Execution Units", markdown, StringComparison.Ordinal);
+        Assert.Contains("### `AUTH-01`", markdown, StringComparison.Ordinal);
+        Assert.Contains("source_file_path: intents/intent-cli/concepts/auth-oauth2.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("target_part: concepts", markdown, StringComparison.Ordinal);
+        Assert.Contains("dependencies:", markdown, StringComparison.Ordinal);
+        Assert.Contains("readiness_notes:", markdown, StringComparison.Ordinal);
+        Assert.Contains("verification_hints:", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenExecutionRequest_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        IntakeExecutionRenderer.WriteSummary(
+            writer,
+            new IntakeExecutionRequest
+            {
+                Domain = "auth",
+                ProposedExecutionUnits =
+                [
+                    new IntakeExecutionUnitCandidate
+                    {
+                        ExecutionUnitId = "AUTH-01",
+                        SourceFilePath = "intents/intent-cli/concepts/auth-oauth2.md",
+                        TargetPart = "concepts",
+                        Dependencies = [],
+                        ReadinessNotes = ["Current heading: # Auth Concept"],
+                        VerificationHints = ["dotnet test IntentSystem.sln"]
+                    },
+                    new IntakeExecutionUnitCandidate
+                    {
+                        ExecutionUnitId = "AUTH-02",
+                        SourceFilePath = "intents/intent-cli/intent-tree/means/auth-oauth2.md",
+                        TargetPart = "intent-tree/means",
+                        Dependencies = ["AUTH-01"],
+                        ReadinessNotes = ["Current heading: # Auth Means"],
+                        VerificationHints = ["Review parent source file"]
+                    }
+                ]
+            },
+            "/repo/.intent-cli/intake/auth.execution.md");
+
+        var output = writer.ToString();
+        Assert.Contains("Intake execution draft generated for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: /repo/.intent-cli/intake/auth.execution.md", output, StringComparison.Ordinal);
+        Assert.Contains("Proposed execution units: 2", output, StringComparison.Ordinal);
+        Assert.Contains("Dependencies: 1", output, StringComparison.Ordinal);
+        Assert.Contains("Verification hints: 2", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

- add `intent-cli intake execution <domain>` to generate deterministic execution drafts from updated parent source-of-truth files
- derive proposed execution units, dependencies, target parts, readiness notes, and verification hints from current `intents/intent-cli` source files that match the selected domain
- cover the new command with renderer, writer, command, and router tests

## Verification

- `dotnet test IntentSystem.sln`
