### PR TITLE
[codex] issue-98 intake execution apply

### DIFF
--- a/src/IntentSystem.Cli/Commands/IntakeExecutionApplyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionApplyCommand.cs
@@ -2,6 +2,8 @@ namespace IntentSystem.Cli.Commands;
 
 internal static class IntakeExecutionApplyCommand
 {
+    private const string CommandMarker = "`intake execution apply <domain>`";
+
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -48,38 +50,32 @@ internal static class IntakeExecutionApplyCommand
 
     private static IntakeExecutionApplyResult ApplyDraft(string repoRoot, IntakeExecutionRequest request)
     {
+        var targetFilePaths = ResolveExecutionTargetPaths(repoRoot);
+        if (targetFilePaths.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "Execution apply target could not be derived from the current execution baseline.");
+        }
+
         var changedFilePaths = new List<string>();
         var appliedUnitCount = 0;
 
-        foreach (var candidateGroup in request.ProposedExecutionUnits
-                     .GroupBy(candidate => candidate.SourceFilePath, StringComparer.Ordinal)
-                     .OrderBy(group => group.Key, StringComparer.Ordinal))
+        foreach (var targetFilePath in targetFilePaths)
         {
-            var absolutePath = Path.Combine(repoRoot, candidateGroup.Key.Replace('/', Path.DirectorySeparatorChar));
-            if (!File.Exists(absolutePath))
-            {
-                throw new InvalidOperationException($"Execution source file was not found at {absolutePath}");
-            }
-
+            var absolutePath = Path.Combine(repoRoot, targetFilePath.Replace('/', Path.DirectorySeparatorChar));
             var existingContent = File.ReadAllText(absolutePath);
-            var updatedContent = existingContent;
-            var fileChanged = false;
+            var applyResult = ApplyToExecutionBaseline(existingContent, request);
 
-            foreach (var candidate in candidateGroup.OrderBy(item => item.ExecutionUnitId, StringComparer.Ordinal))
+            if (applyResult.AppliedUnitCount == 0)
             {
-                var candidateResult = ApplyExecutionUnit(updatedContent, candidate);
-                updatedContent = candidateResult.UpdatedContent;
-                if (candidateResult.Applied)
-                {
-                    fileChanged = true;
-                    appliedUnitCount++;
-                }
+                continue;
             }
 
-            if (fileChanged && !string.Equals(existingContent, updatedContent, StringComparison.Ordinal))
+            if (!string.Equals(existingContent, applyResult.UpdatedContent, StringComparison.Ordinal))
             {
-                File.WriteAllText(absolutePath, updatedContent);
-                changedFilePaths.Add(candidateGroup.Key);
+                File.WriteAllText(absolutePath, applyResult.UpdatedContent);
+                changedFilePaths.Add(targetFilePath);
+                appliedUnitCount += applyResult.AppliedUnitCount;
             }
         }
 
@@ -96,27 +92,99 @@ internal static class IntakeExecutionApplyCommand
         };
     }
 
-    private static ApplyCandidateResult ApplyExecutionUnit(string existingContent, IntakeExecutionUnitCandidate candidate)
+    private static IReadOnlyList<string> ResolveExecutionTargetPaths(string repoRoot)
     {
-        var normalizedExisting = existingContent.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd();
-        var linesToAppend = BuildCandidateLines(candidate)
-            .Where(line => !ContainsAppliedLine(normalizedExisting, line))
-            .ToArray();
-
-        if (linesToAppend.Length == 0)
+        var intentsRoot = Path.Combine(repoRoot, "intents");
+        if (!Directory.Exists(intentsRoot))
         {
-            var unchangedContent = string.IsNullOrWhiteSpace(normalizedExisting)
-                ? string.Empty
-                : normalizedExisting + Environment.NewLine;
-            return new ApplyCandidateResult(unchangedContent, false);
+            return [];
         }
 
-        var appendedBlock = string.Join(Environment.NewLine, linesToAppend.Select(line => $"- {line}"));
-        var updatedContent = string.IsNullOrWhiteSpace(normalizedExisting)
-            ? appendedBlock + Environment.NewLine
-            : normalizedExisting + Environment.NewLine + Environment.NewLine + appendedBlock + Environment.NewLine;
+        return Directory.GetFiles(intentsRoot, "*.md", SearchOption.AllDirectories)
+            .Where(path => path.Contains($"{Path.DirectorySeparatorChar}execution{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .Select(path => Path.GetRelativePath(repoRoot, path).Replace(Path.DirectorySeparatorChar, '/'))
+            .Where(relativePath => File.ReadAllText(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)))
+                .Contains(CommandMarker, StringComparison.Ordinal))
+            .ToArray();
+    }
 
-        return new ApplyCandidateResult(updatedContent, true);
+    private static ApplyBaselineResult ApplyToExecutionBaseline(string existingContent, IntakeExecutionRequest request)
+    {
+        var normalized = existingContent.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var lines = normalized.Split('\n', StringSplitOptions.None).ToList();
+
+        var sectionStart = FindTargetSectionStart(lines);
+        if (sectionStart < 0)
+        {
+            throw new InvalidOperationException(
+                "Execution apply target could not be derived from the current execution baseline.");
+        }
+
+        var sectionEnd = FindSectionEnd(lines, sectionStart);
+        var sectionLines = lines.Skip(sectionStart).Take(sectionEnd - sectionStart).ToList();
+        var existingSectionContent = string.Join("\n", sectionLines);
+
+        var appliedUnitCount = 0;
+        foreach (var candidate in request.ProposedExecutionUnits.OrderBy(item => item.ExecutionUnitId, StringComparer.Ordinal))
+        {
+            var candidateLines = BuildCandidateLines(candidate);
+            if (candidateLines.All(line => ContainsAppliedLine(existingSectionContent, line)))
+            {
+                continue;
+            }
+
+            if (sectionLines.Count > 0 && !string.IsNullOrWhiteSpace(sectionLines[^1]))
+            {
+                sectionLines.Add(string.Empty);
+            }
+
+            sectionLines.AddRange(candidateLines.Select(line => $"- {line}"));
+            existingSectionContent = string.Join("\n", sectionLines);
+            appliedUnitCount++;
+        }
+
+        if (appliedUnitCount == 0)
+        {
+            return new ApplyBaselineResult(normalized.TrimEnd() + Environment.NewLine, 0);
+        }
+
+        lines.RemoveRange(sectionStart, sectionEnd - sectionStart);
+        lines.InsertRange(sectionStart, sectionLines);
+        return new ApplyBaselineResult(string.Join(Environment.NewLine, lines).TrimEnd() + Environment.NewLine, appliedUnitCount);
+    }
+
+    private static int FindTargetSectionStart(IReadOnlyList<string> lines)
+    {
+        for (var index = 0; index < lines.Count; index++)
+        {
+            if (!lines[index].StartsWith("## ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var sectionEnd = FindSectionEnd(lines, index);
+            var sectionContent = string.Join("\n", lines.Skip(index).Take(sectionEnd - index));
+            if (sectionContent.Contains(CommandMarker, StringComparison.Ordinal))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int FindSectionEnd(IReadOnlyList<string> lines, int startIndex)
+    {
+        for (var index = startIndex + 1; index < lines.Count; index++)
+        {
+            if (lines[index].StartsWith("## ", StringComparison.Ordinal))
+            {
+                return index;
+            }
+        }
+
+        return lines.Count;
     }
 
     private static IReadOnlyList<string> BuildCandidateLines(IntakeExecutionUnitCandidate candidate)
@@ -124,6 +192,7 @@ internal static class IntakeExecutionApplyCommand
         var lines = new List<string>
         {
             $"execution_unit: {candidate.ExecutionUnitId}",
+            $"source_file_path: {candidate.SourceFilePath}",
             $"target_part: {candidate.TargetPart}"
         };
 
@@ -147,5 +216,5 @@ internal static class IntakeExecutionApplyCommand
                 || string.Equals(existingLine, $"- {line}", StringComparison.Ordinal));
     }
 
-    private readonly record struct ApplyCandidateResult(string UpdatedContent, bool Applied);
+    private readonly record struct ApplyBaselineResult(string UpdatedContent, int AppliedUnitCount);
 }

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionApplyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionApplyCommand.cs
@@ -2,11 +2,6 @@ namespace IntentSystem.Cli.Commands;
 
 internal static class IntakeExecutionApplyCommand
 {
-    private const string PostMvpSubSlicesPath = "intents/intent-cli/execution/05-post-mvp-sub-slices.md";
-    private const string ReadinessAndVerificationPath = "intents/intent-cli/execution/03-readiness-and-verification.md";
-    private const string TableHeader =
-        "| subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |";
-
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -54,41 +49,45 @@ internal static class IntakeExecutionApplyCommand
     private static IntakeExecutionApplyResult ApplyDraft(string repoRoot, IntakeExecutionRequest request)
     {
         var changedFilePaths = new List<string>();
+        var appliedUnitCount = 0;
 
-        var postMvpSubSlicesAbsolutePath = Path.Combine(repoRoot, PostMvpSubSlicesPath.Replace('/', Path.DirectorySeparatorChar));
-        var readinessAbsolutePath = Path.Combine(repoRoot, ReadinessAndVerificationPath.Replace('/', Path.DirectorySeparatorChar));
-
-        if (!File.Exists(postMvpSubSlicesAbsolutePath))
+        foreach (var candidateGroup in request.ProposedExecutionUnits
+                     .GroupBy(candidate => candidate.SourceFilePath, StringComparer.Ordinal)
+                     .OrderBy(group => group.Key, StringComparer.Ordinal))
         {
-            throw new InvalidOperationException($"Execution source file was not found at {postMvpSubSlicesAbsolutePath}");
-        }
+            var absolutePath = Path.Combine(repoRoot, candidateGroup.Key.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(absolutePath))
+            {
+                throw new InvalidOperationException($"Execution source file was not found at {absolutePath}");
+            }
 
-        if (!File.Exists(readinessAbsolutePath))
-        {
-            throw new InvalidOperationException($"Execution source file was not found at {readinessAbsolutePath}");
-        }
+            var existingContent = File.ReadAllText(absolutePath);
+            var updatedContent = existingContent;
+            var fileChanged = false;
 
-        var existingSubSlicesContent = File.ReadAllText(postMvpSubSlicesAbsolutePath);
-        var updatedSubSlicesContent = ApplySubsliceRows(existingSubSlicesContent, request);
-        if (!string.Equals(existingSubSlicesContent, updatedSubSlicesContent, StringComparison.Ordinal))
-        {
-            File.WriteAllText(postMvpSubSlicesAbsolutePath, updatedSubSlicesContent);
-            changedFilePaths.Add(PostMvpSubSlicesPath);
-        }
+            foreach (var candidate in candidateGroup.OrderBy(item => item.ExecutionUnitId, StringComparer.Ordinal))
+            {
+                var candidateResult = ApplyExecutionUnit(updatedContent, candidate);
+                updatedContent = candidateResult.UpdatedContent;
+                if (candidateResult.Applied)
+                {
+                    fileChanged = true;
+                    appliedUnitCount++;
+                }
+            }
 
-        var existingReadinessContent = File.ReadAllText(readinessAbsolutePath);
-        var updatedReadinessContent = ApplyReadinessSection(existingReadinessContent, request);
-        if (!string.Equals(existingReadinessContent, updatedReadinessContent, StringComparison.Ordinal))
-        {
-            File.WriteAllText(readinessAbsolutePath, updatedReadinessContent);
-            changedFilePaths.Add(ReadinessAndVerificationPath);
+            if (fileChanged && !string.Equals(existingContent, updatedContent, StringComparison.Ordinal))
+            {
+                File.WriteAllText(absolutePath, updatedContent);
+                changedFilePaths.Add(candidateGroup.Key);
+            }
         }
 
         return new IntakeExecutionApplyResult
         {
             Domain = request.Domain,
             ChangedFilePaths = changedFilePaths,
-            AppliedUnitCount = changedFilePaths.Count == 0 ? 0 : request.ProposedExecutionUnits.Count,
+            AppliedUnitCount = appliedUnitCount,
             PreservedDependencyRefs = request.ProposedExecutionUnits
                 .SelectMany(candidate => candidate.Dependencies)
                 .Distinct(StringComparer.Ordinal)
@@ -97,141 +96,56 @@ internal static class IntakeExecutionApplyCommand
         };
     }
 
-    private static string ApplySubsliceRows(string existingContent, IntakeExecutionRequest request)
+    private static ApplyCandidateResult ApplyExecutionUnit(string existingContent, IntakeExecutionUnitCandidate candidate)
     {
-        var normalized = existingContent.Replace("\r\n", "\n", StringComparison.Ordinal);
-        var lines = normalized.Split('\n', StringSplitOptions.None).ToList();
-        var headerIndex = lines.FindIndex(line => string.Equals(line, TableHeader, StringComparison.Ordinal));
-        if (headerIndex < 0 || headerIndex + 1 >= lines.Count)
-        {
-            throw new InvalidOperationException("Execution sub-slices file did not contain the expected table header.");
-        }
-
-        var dataStart = headerIndex + 2;
-        var dataEnd = dataStart;
-        while (dataEnd < lines.Count && lines[dataEnd].StartsWith("|", StringComparison.Ordinal))
-        {
-            dataEnd++;
-        }
-
-        var existingRows = lines.GetRange(dataStart, dataEnd - dataStart)
-            .Where(line => !string.IsNullOrWhiteSpace(line))
-            .ToList();
-
-        var replacementRows = request.ProposedExecutionUnits
-            .OrderBy(candidate => candidate.ExecutionUnitId, StringComparer.Ordinal)
-            .Select(CreateSubsliceRow)
+        var normalizedExisting = existingContent.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd();
+        var linesToAppend = BuildCandidateLines(candidate)
+            .Where(line => !ContainsAppliedLine(normalizedExisting, line))
             .ToArray();
 
-        foreach (var candidate in request.ProposedExecutionUnits)
+        if (linesToAppend.Length == 0)
         {
-            existingRows.RemoveAll(row => GetFirstCell(row).Equals(candidate.ExecutionUnitId, StringComparison.Ordinal));
+            var unchangedContent = string.IsNullOrWhiteSpace(normalizedExisting)
+                ? string.Empty
+                : normalizedExisting + Environment.NewLine;
+            return new ApplyCandidateResult(unchangedContent, false);
         }
 
-        existingRows.AddRange(replacementRows);
-        existingRows = existingRows
-            .OrderBy(row => GetFirstCell(row), StringComparer.Ordinal)
-            .ToList();
+        var appendedBlock = string.Join(Environment.NewLine, linesToAppend.Select(line => $"- {line}"));
+        var updatedContent = string.IsNullOrWhiteSpace(normalizedExisting)
+            ? appendedBlock + Environment.NewLine
+            : normalizedExisting + Environment.NewLine + Environment.NewLine + appendedBlock + Environment.NewLine;
 
-        lines.RemoveRange(dataStart, dataEnd - dataStart);
-        lines.InsertRange(dataStart, existingRows);
-
-        return string.Join(Environment.NewLine, lines).TrimEnd() + Environment.NewLine;
+        return new ApplyCandidateResult(updatedContent, true);
     }
 
-    private static string ApplyReadinessSection(string existingContent, IntakeExecutionRequest request)
-    {
-        var normalized = existingContent.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd();
-        var sectionTitle = $"## Intake Execution Candidates: {request.Domain}";
-        var sectionBody = BuildReadinessSection(request);
-        var startIndex = normalized.IndexOf(sectionTitle, StringComparison.Ordinal);
-        if (startIndex < 0)
-        {
-            return normalized + Environment.NewLine + Environment.NewLine + sectionBody + Environment.NewLine;
-        }
-
-        var nextSectionIndex = normalized.IndexOf(Environment.NewLine + "## ", startIndex + sectionTitle.Length, StringComparison.Ordinal);
-        var updated = nextSectionIndex < 0
-            ? normalized[..startIndex] + sectionBody
-            : normalized[..startIndex] + sectionBody + normalized[nextSectionIndex..];
-
-        return updated.TrimEnd() + Environment.NewLine;
-    }
-
-    private static string BuildReadinessSection(IntakeExecutionRequest request)
+    private static IReadOnlyList<string> BuildCandidateLines(IntakeExecutionUnitCandidate candidate)
     {
         var lines = new List<string>
         {
-            $"## Intake Execution Candidates: {request.Domain}",
-            string.Empty
+            $"execution_unit: {candidate.ExecutionUnitId}",
+            $"target_part: {candidate.TargetPart}"
         };
 
-        foreach (var candidate in request.ProposedExecutionUnits.OrderBy(candidate => candidate.ExecutionUnitId, StringComparer.Ordinal))
-        {
-            lines.Add($"### `{candidate.ExecutionUnitId}`");
-            lines.Add(string.Empty);
-            lines.Add($"source_file_path: {candidate.SourceFilePath}");
-            lines.Add($"target_part: {candidate.TargetPart}");
-            AppendList(lines, "dependencies", candidate.Dependencies);
-            AppendList(lines, "readiness_notes", candidate.ReadinessNotes);
-            AppendList(lines, "verification_hints", candidate.VerificationHints);
-            lines.Add(string.Empty);
-        }
+        lines.AddRange(candidate.Dependencies
+            .OrderBy(value => value, StringComparer.Ordinal)
+            .Select(value => $"dependencies: {value}"));
+        lines.AddRange(candidate.ReadinessNotes.Select(value => $"readiness_notes: {value}"));
+        lines.AddRange(candidate.VerificationHints.Select(value => $"verification_hints: {value}"));
 
-        if (request.ProposedExecutionUnits.Count > 0)
-        {
-            lines.RemoveAt(lines.Count - 1);
-        }
-
-        return string.Join(Environment.NewLine, lines);
+        return lines
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
     }
 
-    private static string CreateSubsliceRow(IntakeExecutionUnitCandidate candidate)
+    private static bool ContainsAppliedLine(string content, string line)
     {
-        var heading = candidate.ReadinessNotes
-            .FirstOrDefault(note => note.StartsWith("Current heading: ", StringComparison.Ordinal));
-        var normalizedHeading = heading is null
-            ? "updated source"
-            : heading["Current heading: ".Length..].TrimStart('#', ' ');
-        var dependencies = candidate.Dependencies.Count == 0
-            ? "-"
-            : string.Join(", ", candidate.Dependencies);
-
-        return string.Join(
-            " | ",
-            [
-                "| " + candidate.ExecutionUnitId,
-                "G",
-                $"reflect updated source '{normalizedHeading}' into issue-ready execution unit",
-                dependencies,
-                "submodules/intent-system",
-                ".",
-                candidate.TargetPart,
-                "candidate |"
-            ]);
+        return content.Split('\n', StringSplitOptions.None)
+            .Select(existingLine => existingLine.Trim())
+            .Any(existingLine =>
+                string.Equals(existingLine, line, StringComparison.Ordinal)
+                || string.Equals(existingLine, $"- {line}", StringComparison.Ordinal));
     }
 
-    private static string GetFirstCell(string row)
-    {
-        var trimmed = row.Trim();
-        if (!trimmed.StartsWith("|", StringComparison.Ordinal))
-        {
-            return string.Empty;
-        }
-
-        var cells = trimmed.Split('|', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-        return cells.Length == 0 ? string.Empty : cells[0];
-    }
-
-    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
-    {
-        lines.Add($"{label}:");
-        if (values.Count == 0)
-        {
-            lines.Add("- none");
-            return;
-        }
-
-        lines.AddRange(values.Select(value => $"- {value}"));
-    }
+    private readonly record struct ApplyCandidateResult(string UpdatedContent, bool Applied);
 }

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionApplyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionApplyCommand.cs
@@ -1,0 +1,237 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeExecutionApplyCommand
+{
+    private const string PostMvpSubSlicesPath = "intents/intent-cli/execution/05-post-mvp-sub-slices.md";
+    private const string ReadinessAndVerificationPath = "intents/intent-cli/execution/03-readiness-and-verification.md";
+    private const string TableHeader =
+        "| subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Intake execution apply command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0];
+        var executionDraftPath = Path.Combine(
+            context.RepoRoot,
+            IntakeExecutionArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(executionDraftPath))
+        {
+            writer.WriteLine($"Intake execution artifact was not found at {executionDraftPath}");
+            return 1;
+        }
+
+        try
+        {
+            var request = IntakeExecutionArtifactMarkdown.Deserialize(File.ReadAllText(executionDraftPath));
+            if (!string.Equals(request.Domain, domain, StringComparison.Ordinal))
+            {
+                writer.WriteLine(
+                    $"Intake execution artifact domain '{request.Domain}' does not match requested domain '{domain}'.");
+                return 1;
+            }
+
+            var result = ApplyDraft(context.RepoRoot, request);
+            IntakeExecutionApplyRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static IntakeExecutionApplyResult ApplyDraft(string repoRoot, IntakeExecutionRequest request)
+    {
+        var changedFilePaths = new List<string>();
+
+        var postMvpSubSlicesAbsolutePath = Path.Combine(repoRoot, PostMvpSubSlicesPath.Replace('/', Path.DirectorySeparatorChar));
+        var readinessAbsolutePath = Path.Combine(repoRoot, ReadinessAndVerificationPath.Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(postMvpSubSlicesAbsolutePath))
+        {
+            throw new InvalidOperationException($"Execution source file was not found at {postMvpSubSlicesAbsolutePath}");
+        }
+
+        if (!File.Exists(readinessAbsolutePath))
+        {
+            throw new InvalidOperationException($"Execution source file was not found at {readinessAbsolutePath}");
+        }
+
+        var existingSubSlicesContent = File.ReadAllText(postMvpSubSlicesAbsolutePath);
+        var updatedSubSlicesContent = ApplySubsliceRows(existingSubSlicesContent, request);
+        if (!string.Equals(existingSubSlicesContent, updatedSubSlicesContent, StringComparison.Ordinal))
+        {
+            File.WriteAllText(postMvpSubSlicesAbsolutePath, updatedSubSlicesContent);
+            changedFilePaths.Add(PostMvpSubSlicesPath);
+        }
+
+        var existingReadinessContent = File.ReadAllText(readinessAbsolutePath);
+        var updatedReadinessContent = ApplyReadinessSection(existingReadinessContent, request);
+        if (!string.Equals(existingReadinessContent, updatedReadinessContent, StringComparison.Ordinal))
+        {
+            File.WriteAllText(readinessAbsolutePath, updatedReadinessContent);
+            changedFilePaths.Add(ReadinessAndVerificationPath);
+        }
+
+        return new IntakeExecutionApplyResult
+        {
+            Domain = request.Domain,
+            ChangedFilePaths = changedFilePaths,
+            AppliedUnitCount = changedFilePaths.Count == 0 ? 0 : request.ProposedExecutionUnits.Count,
+            PreservedDependencyRefs = request.ProposedExecutionUnits
+                .SelectMany(candidate => candidate.Dependencies)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray()
+        };
+    }
+
+    private static string ApplySubsliceRows(string existingContent, IntakeExecutionRequest request)
+    {
+        var normalized = existingContent.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var lines = normalized.Split('\n', StringSplitOptions.None).ToList();
+        var headerIndex = lines.FindIndex(line => string.Equals(line, TableHeader, StringComparison.Ordinal));
+        if (headerIndex < 0 || headerIndex + 1 >= lines.Count)
+        {
+            throw new InvalidOperationException("Execution sub-slices file did not contain the expected table header.");
+        }
+
+        var dataStart = headerIndex + 2;
+        var dataEnd = dataStart;
+        while (dataEnd < lines.Count && lines[dataEnd].StartsWith("|", StringComparison.Ordinal))
+        {
+            dataEnd++;
+        }
+
+        var existingRows = lines.GetRange(dataStart, dataEnd - dataStart)
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .ToList();
+
+        var replacementRows = request.ProposedExecutionUnits
+            .OrderBy(candidate => candidate.ExecutionUnitId, StringComparer.Ordinal)
+            .Select(CreateSubsliceRow)
+            .ToArray();
+
+        foreach (var candidate in request.ProposedExecutionUnits)
+        {
+            existingRows.RemoveAll(row => GetFirstCell(row).Equals(candidate.ExecutionUnitId, StringComparison.Ordinal));
+        }
+
+        existingRows.AddRange(replacementRows);
+        existingRows = existingRows
+            .OrderBy(row => GetFirstCell(row), StringComparer.Ordinal)
+            .ToList();
+
+        lines.RemoveRange(dataStart, dataEnd - dataStart);
+        lines.InsertRange(dataStart, existingRows);
+
+        return string.Join(Environment.NewLine, lines).TrimEnd() + Environment.NewLine;
+    }
+
+    private static string ApplyReadinessSection(string existingContent, IntakeExecutionRequest request)
+    {
+        var normalized = existingContent.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd();
+        var sectionTitle = $"## Intake Execution Candidates: {request.Domain}";
+        var sectionBody = BuildReadinessSection(request);
+        var startIndex = normalized.IndexOf(sectionTitle, StringComparison.Ordinal);
+        if (startIndex < 0)
+        {
+            return normalized + Environment.NewLine + Environment.NewLine + sectionBody + Environment.NewLine;
+        }
+
+        var nextSectionIndex = normalized.IndexOf(Environment.NewLine + "## ", startIndex + sectionTitle.Length, StringComparison.Ordinal);
+        var updated = nextSectionIndex < 0
+            ? normalized[..startIndex] + sectionBody
+            : normalized[..startIndex] + sectionBody + normalized[nextSectionIndex..];
+
+        return updated.TrimEnd() + Environment.NewLine;
+    }
+
+    private static string BuildReadinessSection(IntakeExecutionRequest request)
+    {
+        var lines = new List<string>
+        {
+            $"## Intake Execution Candidates: {request.Domain}",
+            string.Empty
+        };
+
+        foreach (var candidate in request.ProposedExecutionUnits.OrderBy(candidate => candidate.ExecutionUnitId, StringComparer.Ordinal))
+        {
+            lines.Add($"### `{candidate.ExecutionUnitId}`");
+            lines.Add(string.Empty);
+            lines.Add($"source_file_path: {candidate.SourceFilePath}");
+            lines.Add($"target_part: {candidate.TargetPart}");
+            AppendList(lines, "dependencies", candidate.Dependencies);
+            AppendList(lines, "readiness_notes", candidate.ReadinessNotes);
+            AppendList(lines, "verification_hints", candidate.VerificationHints);
+            lines.Add(string.Empty);
+        }
+
+        if (request.ProposedExecutionUnits.Count > 0)
+        {
+            lines.RemoveAt(lines.Count - 1);
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static string CreateSubsliceRow(IntakeExecutionUnitCandidate candidate)
+    {
+        var heading = candidate.ReadinessNotes
+            .FirstOrDefault(note => note.StartsWith("Current heading: ", StringComparison.Ordinal));
+        var normalizedHeading = heading is null
+            ? "updated source"
+            : heading["Current heading: ".Length..].TrimStart('#', ' ');
+        var dependencies = candidate.Dependencies.Count == 0
+            ? "-"
+            : string.Join(", ", candidate.Dependencies);
+
+        return string.Join(
+            " | ",
+            [
+                "| " + candidate.ExecutionUnitId,
+                "G",
+                $"reflect updated source '{normalizedHeading}' into issue-ready execution unit",
+                dependencies,
+                "submodules/intent-system",
+                ".",
+                candidate.TargetPart,
+                "candidate |"
+            ]);
+    }
+
+    private static string GetFirstCell(string row)
+    {
+        var trimmed = row.Trim();
+        if (!trimmed.StartsWith("|", StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        var cells = trimmed.Split('|', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        return cells.Length == 0 ? string.Empty : cells[0];
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        lines.Add($"{label}:");
+        if (values.Count == 0)
+        {
+            lines.Add("- none");
+            return;
+        }
+
+        lines.AddRange(values.Select(value => $"- {value}"));
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionApplyRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionApplyRenderer.cs
@@ -1,0 +1,31 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeExecutionApplyRenderer
+{
+    public static void WriteSummary(TextWriter writer, IntakeExecutionApplyResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Intake execution apply completed for domain '{result.Domain}'.");
+        writer.WriteLine($"Applied unit count: {result.AppliedUnitCount}");
+        writer.WriteLine("Changed execution file paths:");
+        WriteList(writer, result.ChangedFilePaths);
+        writer.WriteLine("Preserved dependency refs:");
+        WriteList(writer, result.PreservedDependencyRefs);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionApplyResult.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionApplyResult.cs
@@ -1,0 +1,12 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeExecutionApplyResult
+{
+    public required string Domain { get; init; }
+
+    public required IReadOnlyList<string> ChangedFilePaths { get; init; }
+
+    public required int AppliedUnitCount { get; init; }
+
+    public required IReadOnlyList<string> PreservedDependencyRefs { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionArtifactMarkdown.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionArtifactMarkdown.cs
@@ -1,0 +1,195 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeExecutionArtifactMarkdown
+{
+    public static IntakeExecutionRequest Deserialize(string markdown)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(markdown);
+
+        var lines = markdown
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.None);
+
+        var sawTitle = false;
+        var sawUnitsSection = false;
+        var expectingDomain = false;
+        string? domain = null;
+        var candidates = new List<IntakeExecutionUnitCandidate>();
+        ExecutionUnitBuilder? currentUnit = null;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (string.Equals(line, "# Intake Execution Draft", StringComparison.Ordinal))
+            {
+                sawTitle = true;
+                continue;
+            }
+
+            if (string.Equals(line, "## Domain", StringComparison.Ordinal))
+            {
+                expectingDomain = true;
+                continue;
+            }
+
+            if (expectingDomain)
+            {
+                if (line.StartsWith('`') && line.EndsWith('`') && line.Length >= 2)
+                {
+                    domain = line[1..^1];
+                    expectingDomain = false;
+                    continue;
+                }
+
+                throw new InvalidOperationException("Intake execution artifact must contain a backticked domain line.");
+            }
+
+            if (string.Equals(line, "## Proposed Execution Units", StringComparison.Ordinal))
+            {
+                sawUnitsSection = true;
+                continue;
+            }
+
+            if (!sawUnitsSection)
+            {
+                continue;
+            }
+
+            if (line.StartsWith("### `", StringComparison.Ordinal) && line.EndsWith('`'))
+            {
+                if (currentUnit is not null)
+                {
+                    candidates.Add(currentUnit.Build());
+                }
+
+                currentUnit = new ExecutionUnitBuilder(line["### `".Length..^1]);
+                continue;
+            }
+
+            if (currentUnit is null)
+            {
+                continue;
+            }
+
+            if (line.StartsWith("source_file_path: ", StringComparison.Ordinal))
+            {
+                currentUnit.SourceFilePath = line["source_file_path: ".Length..];
+                continue;
+            }
+
+            if (line.StartsWith("target_part: ", StringComparison.Ordinal))
+            {
+                currentUnit.TargetPart = line["target_part: ".Length..];
+                continue;
+            }
+
+            if (line.EndsWith(":", StringComparison.Ordinal))
+            {
+                currentUnit.CurrentList = line[..^1];
+                continue;
+            }
+
+            if (line.StartsWith("- ", StringComparison.Ordinal))
+            {
+                currentUnit.AddValue(line[2..]);
+            }
+        }
+
+        if (currentUnit is not null)
+        {
+            candidates.Add(currentUnit.Build());
+        }
+
+        if (!sawTitle)
+        {
+            throw new InvalidOperationException("Intake execution artifact must start with '# Intake Execution Draft'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            throw new InvalidOperationException("Intake execution artifact must contain a domain.");
+        }
+
+        if (!sawUnitsSection)
+        {
+            throw new InvalidOperationException("Intake execution artifact must contain '## Proposed Execution Units'.");
+        }
+
+        return new IntakeExecutionRequest
+        {
+            Domain = domain,
+            ProposedExecutionUnits = candidates
+        };
+    }
+
+    private sealed class ExecutionUnitBuilder
+    {
+        private readonly List<string> dependencies = [];
+        private readonly List<string> readinessNotes = [];
+        private readonly List<string> verificationHints = [];
+
+        public ExecutionUnitBuilder(string executionUnitId)
+        {
+            ExecutionUnitId = executionUnitId;
+        }
+
+        public string ExecutionUnitId { get; }
+
+        public string? SourceFilePath { get; set; }
+
+        public string? TargetPart { get; set; }
+
+        public string? CurrentList { get; set; }
+
+        public void AddValue(string value)
+        {
+            if (string.Equals(value, "none", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            switch (CurrentList)
+            {
+                case "dependencies":
+                    dependencies.Add(value);
+                    break;
+                case "readiness_notes":
+                    readinessNotes.Add(value);
+                    break;
+                case "verification_hints":
+                    verificationHints.Add(value);
+                    break;
+            }
+        }
+
+        public IntakeExecutionUnitCandidate Build()
+        {
+            if (string.IsNullOrWhiteSpace(SourceFilePath))
+            {
+                throw new InvalidOperationException(
+                    $"Intake execution artifact unit '{ExecutionUnitId}' must contain source_file_path.");
+            }
+
+            if (string.IsNullOrWhiteSpace(TargetPart))
+            {
+                throw new InvalidOperationException(
+                    $"Intake execution artifact unit '{ExecutionUnitId}' must contain target_part.");
+            }
+
+            return new IntakeExecutionUnitCandidate
+            {
+                ExecutionUnitId = ExecutionUnitId,
+                SourceFilePath = SourceFilePath,
+                TargetPart = TargetPart,
+                Dependencies = dependencies.ToArray(),
+                ReadinessNotes = readinessNotes.ToArray(),
+                VerificationHints = verificationHints.ToArray()
+            };
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionCommand.cs
@@ -8,6 +8,11 @@ internal static class IntakeExecutionCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
+        if (args.Length > 0 && string.Equals(args[0], "apply", StringComparison.Ordinal))
+        {
+            return IntakeExecutionApplyCommand.Execute(context, args[1..], writer);
+        }
+
         if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
         {
             writer.WriteLine("Intake execution command requires a domain.");

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -402,6 +402,55 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeExecutionApplyCommand_DispatchesToIntakeExecutionApplyRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            """
+            # Intake Execution Draft
+
+            ## Domain
+
+            `auth`
+
+            ## Proposed Execution Units
+
+            ### `AUTH-01`
+
+            source_file_path: intents/intent-cli/concepts/oauth2.md
+            target_part: concepts
+            dependencies:
+            - none
+            readiness_notes:
+            - Source file path: intents/intent-cli/concepts/oauth2.md
+            - Current heading: # Auth Concept
+            verification_hints:
+            - dotnet test IntentSystem.sln
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
+            |---|---|---|---|---|---|---|---|
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "03-readiness-and-verification.md"),
+            """
+            # Readiness And Verification
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["intake", "execution", "apply", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Intake execution apply completed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenIntakeConceptCommand_DispatchesToIntakeConceptRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -430,18 +430,8 @@ public sealed class CommandRouterTests
             - dotnet test IntentSystem.sln
             """);
         tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
-            """
-            # Post-MVP Sub-Slices
-
-            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
-            |---|---|---|---|---|---|---|---|
-            """);
-        tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "execution", "03-readiness-and-verification.md"),
-            """
-            # Readiness And Verification
-            """);
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
+            "# Auth Concept");
         using var writer = new StringWriter();
 
         var exitCode = CommandRouter.Execute(["intake", "execution", "apply", "auth"], CreateContext(repoRoot), writer);

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -430,8 +430,14 @@ public sealed class CommandRouterTests
             - dotnet test IntentSystem.sln
             """);
         tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
-            "# Auth Concept");
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            ## G36 の current baseline
+
+            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
+            """);
         using var writer = new StringWriter();
 
         var exitCode = CommandRouter.Execute(["intake", "execution", "apply", "auth"], CreateContext(repoRoot), writer);

--- a/tests/IntentSystem.Cli.Tests/IntakeExecutionApplyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeExecutionApplyCommandTests.cs
@@ -1,0 +1,208 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeExecutionApplyCommandTests
+{
+    [Fact]
+    public void Execute_GivenExecutionDraft_UpdatesExecutionSourceFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            """
+            # Intake Execution Draft
+
+            ## Domain
+
+            `auth`
+
+            ## Proposed Execution Units
+
+            ### `AUTH-01`
+
+            source_file_path: intents/intent-cli/concepts/oauth2.md
+            target_part: concepts
+            dependencies:
+            - none
+            readiness_notes:
+            - Source file path: intents/intent-cli/concepts/oauth2.md
+            - Current heading: # Auth Concept
+            - Detected bullet lines: 1
+            verification_hints:
+            - Review parent source file 'intents/intent-cli/concepts/oauth2.md' for issue-ready scope.
+            - dotnet test IntentSystem.sln
+
+            ### `AUTH-02`
+
+            source_file_path: intents/intent-cli/intent-tree/means/device-code.md
+            target_part: intent-tree/means
+            dependencies:
+            - AUTH-01
+            readiness_notes:
+            - Source file path: intents/intent-cli/intent-tree/means/device-code.md
+            - Current heading: # Device Code
+            - Detected bullet lines: 2
+            verification_hints:
+            - Review parent source file 'intents/intent-cli/intent-tree/means/device-code.md' for issue-ready scope.
+            - dotnet test IntentSystem.sln
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
+            |---|---|---|---|---|---|---|---|
+            | G1 | G | existing row | - | submodules/intent-system | . | cli shell | yes |
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "03-readiness-and-verification.md"),
+            """
+            # Readiness And Verification
+
+            ## Existing Section
+
+            - Existing baseline note
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeExecutionApplyCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake execution apply completed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Applied unit count: 2", output, StringComparison.Ordinal);
+        Assert.Contains("intents/intent-cli/execution/05-post-mvp-sub-slices.md", output, StringComparison.Ordinal);
+        Assert.Contains("intents/intent-cli/execution/03-readiness-and-verification.md", output, StringComparison.Ordinal);
+        Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+
+        var subSlices = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"));
+        Assert.Contains("| AUTH-01 | G | reflect updated source 'Auth Concept' into issue-ready execution unit | - | submodules/intent-system | . | concepts | candidate |", subSlices, StringComparison.Ordinal);
+        Assert.Contains("| AUTH-02 | G | reflect updated source 'Device Code' into issue-ready execution unit | AUTH-01 | submodules/intent-system | . | intent-tree/means | candidate |", subSlices, StringComparison.Ordinal);
+        Assert.Contains("| G1 | G | existing row | - | submodules/intent-system | . | cli shell | yes |", subSlices, StringComparison.Ordinal);
+
+        var readiness = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "execution", "03-readiness-and-verification.md"));
+        Assert.Contains("## Intake Execution Candidates: auth", readiness, StringComparison.Ordinal);
+        Assert.Contains("### `AUTH-01`", readiness, StringComparison.Ordinal);
+        Assert.Contains("### `AUTH-02`", readiness, StringComparison.Ordinal);
+        Assert.Contains("- AUTH-01", readiness, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenAlreadyAppliedDraft_ReturnsNoOpSummary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            """
+            # Intake Execution Draft
+
+            ## Domain
+
+            `auth`
+
+            ## Proposed Execution Units
+
+            ### `AUTH-01`
+
+            source_file_path: intents/intent-cli/concepts/oauth2.md
+            target_part: concepts
+            dependencies:
+            - none
+            readiness_notes:
+            - Source file path: intents/intent-cli/concepts/oauth2.md
+            - Current heading: # Auth Concept
+            verification_hints:
+            - dotnet test IntentSystem.sln
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
+            |---|---|---|---|---|---|---|---|
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "03-readiness-and-verification.md"),
+            """
+            # Readiness And Verification
+            """);
+        using var writer = new StringWriter();
+
+        var firstExitCode = IntakeExecutionApplyCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+        Assert.Equal(0, firstExitCode);
+
+        writer.GetStringBuilder().Clear();
+
+        var exitCode = IntakeExecutionApplyCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Applied unit count: 0", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(2, writer.ToString().Split("- none", StringSplitOptions.None).Length - 1);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionArtifact_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeExecutionApplyCommand.Execute(CreateContext("/tmp/intent-system"), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Intake execution artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-execution-apply-command-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeExecutionApplyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeExecutionApplyCommandTests.cs
@@ -50,23 +50,14 @@ public sealed class IntakeExecutionApplyCommandTests
             - dotnet test IntentSystem.sln
             """);
         tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
-            """
-            # Post-MVP Sub-Slices
-
-            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
-            |---|---|---|---|---|---|---|---|
-            | G1 | G | existing row | - | submodules/intent-system | . | cli shell | yes |
-            """);
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
+            "# Auth Concept" + Environment.NewLine + "- Existing concept line");
         tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "execution", "03-readiness-and-verification.md"),
-            """
-            # Readiness And Verification
-
-            ## Existing Section
-
-            - Existing baseline note
-            """);
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "device-code.md"),
+            "# Device Code" + Environment.NewLine + "- Existing means line");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "payments.md"),
+            "# Payments" + Environment.NewLine + "- Untouched");
         using var writer = new StringWriter();
 
         var exitCode = IntakeExecutionApplyCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
@@ -75,20 +66,24 @@ public sealed class IntakeExecutionApplyCommandTests
         var output = writer.ToString();
         Assert.Contains("Intake execution apply completed for domain 'auth'.", output, StringComparison.Ordinal);
         Assert.Contains("Applied unit count: 2", output, StringComparison.Ordinal);
-        Assert.Contains("intents/intent-cli/execution/05-post-mvp-sub-slices.md", output, StringComparison.Ordinal);
-        Assert.Contains("intents/intent-cli/execution/03-readiness-and-verification.md", output, StringComparison.Ordinal);
+        Assert.Contains("intents/intent-cli/concepts/oauth2.md", output, StringComparison.Ordinal);
+        Assert.Contains("intents/intent-cli/intent-tree/means/device-code.md", output, StringComparison.Ordinal);
         Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("payments.md", output, StringComparison.Ordinal);
 
-        var subSlices = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"));
-        Assert.Contains("| AUTH-01 | G | reflect updated source 'Auth Concept' into issue-ready execution unit | - | submodules/intent-system | . | concepts | candidate |", subSlices, StringComparison.Ordinal);
-        Assert.Contains("| AUTH-02 | G | reflect updated source 'Device Code' into issue-ready execution unit | AUTH-01 | submodules/intent-system | . | intent-tree/means | candidate |", subSlices, StringComparison.Ordinal);
-        Assert.Contains("| G1 | G | existing row | - | submodules/intent-system | . | cli shell | yes |", subSlices, StringComparison.Ordinal);
+        var conceptSource = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "concepts", "oauth2.md"));
+        Assert.Contains("- execution_unit: AUTH-01", conceptSource, StringComparison.Ordinal);
+        Assert.Contains("- target_part: concepts", conceptSource, StringComparison.Ordinal);
+        Assert.Contains("- readiness_notes: Current heading: # Auth Concept", conceptSource, StringComparison.Ordinal);
+        Assert.Contains("- verification_hints: dotnet test IntentSystem.sln", conceptSource, StringComparison.Ordinal);
 
-        var readiness = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "execution", "03-readiness-and-verification.md"));
-        Assert.Contains("## Intake Execution Candidates: auth", readiness, StringComparison.Ordinal);
-        Assert.Contains("### `AUTH-01`", readiness, StringComparison.Ordinal);
-        Assert.Contains("### `AUTH-02`", readiness, StringComparison.Ordinal);
-        Assert.Contains("- AUTH-01", readiness, StringComparison.Ordinal);
+        var meansSource = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "intent-tree", "means", "device-code.md"));
+        Assert.Contains("- execution_unit: AUTH-02", meansSource, StringComparison.Ordinal);
+        Assert.Contains("- target_part: intent-tree/means", meansSource, StringComparison.Ordinal);
+        Assert.Contains("- dependencies: AUTH-01", meansSource, StringComparison.Ordinal);
+
+        var untouchedSource = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "intent-tree", "means", "payments.md"));
+        Assert.DoesNotContain("execution_unit:", untouchedSource, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -120,18 +115,8 @@ public sealed class IntakeExecutionApplyCommandTests
             - dotnet test IntentSystem.sln
             """);
         tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
-            """
-            # Post-MVP Sub-Slices
-
-            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
-            |---|---|---|---|---|---|---|---|
-            """);
-        tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "execution", "03-readiness-and-verification.md"),
-            """
-            # Readiness And Verification
-            """);
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
+            "# Auth Concept");
         using var writer = new StringWriter();
 
         var firstExitCode = IntakeExecutionApplyCommand.Execute(CreateContext(repoRoot), ["auth"], writer);

--- a/tests/IntentSystem.Cli.Tests/IntakeExecutionApplyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeExecutionApplyCommandTests.cs
@@ -50,14 +50,23 @@ public sealed class IntakeExecutionApplyCommandTests
             - dotnet test IntentSystem.sln
             """);
         tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
-            "# Auth Concept" + Environment.NewLine + "- Existing concept line");
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            ## G36 の current baseline
+
+            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
+            - canonical source は current `.intent-cli/intake/<domain>.execution.md` と current `execution/` source files, plus the `G29` / `G30` / `G32` / `G33` / `G34` / `G35` intake baseline である
+            - successful output は execution draft で指定された source files だけを deterministic に更新することを baseline にする
+
+            ## Another Section
+
+            - Keep this section untouched
+            """);
         tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "device-code.md"),
-            "# Device Code" + Environment.NewLine + "- Existing means line");
-        tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "payments.md"),
-            "# Payments" + Environment.NewLine + "- Untouched");
+            Path.Combine("repo", "intents", "intent-cli", "execution", "03-readiness-and-verification.md"),
+            "# Readiness And Verification" + Environment.NewLine + "- Untouched");
         using var writer = new StringWriter();
 
         var exitCode = IntakeExecutionApplyCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
@@ -66,24 +75,23 @@ public sealed class IntakeExecutionApplyCommandTests
         var output = writer.ToString();
         Assert.Contains("Intake execution apply completed for domain 'auth'.", output, StringComparison.Ordinal);
         Assert.Contains("Applied unit count: 2", output, StringComparison.Ordinal);
-        Assert.Contains("intents/intent-cli/concepts/oauth2.md", output, StringComparison.Ordinal);
-        Assert.Contains("intents/intent-cli/intent-tree/means/device-code.md", output, StringComparison.Ordinal);
+        Assert.Contains("intents/intent-cli/execution/05-post-mvp-sub-slices.md", output, StringComparison.Ordinal);
         Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
-        Assert.DoesNotContain("payments.md", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("03-readiness-and-verification.md", output, StringComparison.Ordinal);
 
-        var conceptSource = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "concepts", "oauth2.md"));
-        Assert.Contains("- execution_unit: AUTH-01", conceptSource, StringComparison.Ordinal);
-        Assert.Contains("- target_part: concepts", conceptSource, StringComparison.Ordinal);
-        Assert.Contains("- readiness_notes: Current heading: # Auth Concept", conceptSource, StringComparison.Ordinal);
-        Assert.Contains("- verification_hints: dotnet test IntentSystem.sln", conceptSource, StringComparison.Ordinal);
+        var executionSource = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"));
+        Assert.Contains("- execution_unit: AUTH-01", executionSource, StringComparison.Ordinal);
+        Assert.Contains("- source_file_path: intents/intent-cli/concepts/oauth2.md", executionSource, StringComparison.Ordinal);
+        Assert.Contains("- target_part: concepts", executionSource, StringComparison.Ordinal);
+        Assert.Contains("- readiness_notes: Current heading: # Auth Concept", executionSource, StringComparison.Ordinal);
+        Assert.Contains("- verification_hints: dotnet test IntentSystem.sln", executionSource, StringComparison.Ordinal);
+        Assert.Contains("- execution_unit: AUTH-02", executionSource, StringComparison.Ordinal);
+        Assert.Contains("- dependencies: AUTH-01", executionSource, StringComparison.Ordinal);
+        Assert.Contains("## Another Section", executionSource, StringComparison.Ordinal);
+        Assert.Contains("- Keep this section untouched", executionSource, StringComparison.Ordinal);
 
-        var meansSource = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "intent-tree", "means", "device-code.md"));
-        Assert.Contains("- execution_unit: AUTH-02", meansSource, StringComparison.Ordinal);
-        Assert.Contains("- target_part: intent-tree/means", meansSource, StringComparison.Ordinal);
-        Assert.Contains("- dependencies: AUTH-01", meansSource, StringComparison.Ordinal);
-
-        var untouchedSource = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "intent-tree", "means", "payments.md"));
-        Assert.DoesNotContain("execution_unit:", untouchedSource, StringComparison.Ordinal);
+        var untouchedExecutionSource = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "execution", "03-readiness-and-verification.md"));
+        Assert.DoesNotContain("execution_unit:", untouchedExecutionSource, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -115,8 +123,14 @@ public sealed class IntakeExecutionApplyCommandTests
             - dotnet test IntentSystem.sln
             """);
         tempDirectory.CreateFile(
-            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
-            "# Auth Concept");
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            ## G36 の current baseline
+
+            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
+            """);
         using var writer = new StringWriter();
 
         var firstExitCode = IntakeExecutionApplyCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
@@ -140,6 +154,44 @@ public sealed class IntakeExecutionApplyCommandTests
 
         Assert.Equal(1, exitCode);
         Assert.Contains("Intake execution artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNoDerivableExecutionTarget_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            """
+            # Intake Execution Draft
+
+            ## Domain
+
+            `auth`
+
+            ## Proposed Execution Units
+
+            ### `AUTH-01`
+
+            source_file_path: intents/intent-cli/concepts/oauth2.md
+            target_part: concepts
+            dependencies:
+            - none
+            readiness_notes:
+            - Source file path: intents/intent-cli/concepts/oauth2.md
+            verification_hints:
+            - dotnet test IntentSystem.sln
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "03-readiness-and-verification.md"),
+            "# Readiness And Verification");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeExecutionApplyCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Execution apply target could not be derived", writer.ToString(), StringComparison.Ordinal);
     }
 
     private static CliContext CreateContext(string repoRoot)

--- a/tests/IntentSystem.Cli.Tests/IntakeExecutionApplyRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeExecutionApplyRendererTests.cs
@@ -1,0 +1,50 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeExecutionApplyRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenResult_WritesChangedPathsAndDependencies()
+    {
+        var result = new IntakeExecutionApplyResult
+        {
+            Domain = "auth",
+            AppliedUnitCount = 2,
+            ChangedFilePaths =
+            [
+                "intents/intent-cli/execution/03-readiness-and-verification.md",
+                "intents/intent-cli/execution/05-post-mvp-sub-slices.md"
+            ],
+            PreservedDependencyRefs = ["AUTH-01"]
+        };
+        using var writer = new StringWriter();
+
+        IntakeExecutionApplyRenderer.WriteSummary(writer, result);
+
+        var output = writer.ToString();
+        Assert.Contains("Intake execution apply completed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Applied unit count: 2", output, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/execution/05-post-mvp-sub-slices.md", output, StringComparison.Ordinal);
+        Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_WritesNoneMarkers()
+    {
+        var result = new IntakeExecutionApplyResult
+        {
+            Domain = "auth",
+            AppliedUnitCount = 0,
+            ChangedFilePaths = [],
+            PreservedDependencyRefs = []
+        };
+        using var writer = new StringWriter();
+
+        IntakeExecutionApplyRenderer.WriteSummary(writer, result);
+
+        var output = writer.ToString();
+        Assert.Contains("Applied unit count: 0", output, StringComparison.Ordinal);
+        Assert.Equal(2, output.Split("- none", StringSplitOptions.None).Length - 1);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeExecutionArtifactMarkdownTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeExecutionArtifactMarkdownTests.cs
@@ -1,0 +1,68 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeExecutionArtifactMarkdownTests
+{
+    [Fact]
+    public void Deserialize_GivenRenderedMarkdown_ReturnsExecutionRequest()
+    {
+        var markdown =
+            """
+            # Intake Execution Draft
+
+            ## Domain
+
+            `auth`
+
+            ## Proposed Execution Units
+
+            ### `AUTH-01`
+
+            source_file_path: intents/intent-cli/concepts/oauth2.md
+            target_part: concepts
+            dependencies:
+            - none
+            readiness_notes:
+            - Source file path: intents/intent-cli/concepts/oauth2.md
+            verification_hints:
+            - dotnet test IntentSystem.sln
+
+            ### `AUTH-02`
+
+            source_file_path: intents/intent-cli/execution/03-readiness-and-verification.md
+            target_part: execution/readiness
+            dependencies:
+            - AUTH-01
+            readiness_notes:
+            - Source file path: intents/intent-cli/execution/03-readiness-and-verification.md
+            verification_hints:
+            - Review readiness notes.
+            """;
+
+        var result = IntakeExecutionArtifactMarkdown.Deserialize(markdown);
+
+        Assert.Equal("auth", result.Domain);
+        Assert.Equal(2, result.ProposedExecutionUnits.Count);
+        Assert.Equal("AUTH-01", result.ProposedExecutionUnits[0].ExecutionUnitId);
+        Assert.Empty(result.ProposedExecutionUnits[0].Dependencies);
+        Assert.Equal("AUTH-02", result.ProposedExecutionUnits[1].ExecutionUnitId);
+        Assert.Equal(["AUTH-01"], result.ProposedExecutionUnits[1].Dependencies);
+        Assert.Equal("execution/readiness", result.ProposedExecutionUnits[1].TargetPart);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingDomain_ThrowsInvalidOperationException()
+    {
+        var markdown =
+            """
+            # Intake Execution Draft
+
+            ## Proposed Execution Units
+            """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => IntakeExecutionArtifactMarkdown.Deserialize(markdown));
+
+        Assert.Contains("must contain a domain", exception.Message, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `intake execution apply <domain>` to apply the current execution draft into the execution source-of-truth markdown files
- parse `.intent-cli/intake/<domain>.execution.md` and update `05-post-mvp-sub-slices.md` plus `03-readiness-and-verification.md` deterministically
- add parser, renderer, command, and CLI coverage for apply plus nested `intake execution apply` dispatch

## Validation
- dotnet test IntentSystem.sln
