### PR TITLE
[codex] Issue 100 intake issue command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -80,6 +80,7 @@ internal static class CommandRouter
                 ["patch"] = IntakePatchCommand.Execute,
                 ["apply"] = IntakeApplyCommand.Execute,
                 ["execution"] = IntakeExecutionCommand.Execute,
+                ["issue"] = IntakeIssueCommand.Execute,
                 ["autostart"] = IntakeAutostartCommand.Execute
             }
         };

--- a/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
@@ -6,7 +6,6 @@ namespace IntentSystem.Cli.Commands;
 
 internal static class IntakeIssueCommand
 {
-    private const string IntakeExecutionApplyMarker = "`intake execution apply <domain>`";
     private const string IntakeIssueMarker = "`intake issue <domain>`";
     private const string IssueBaselineExecutionUnit = "G37";
     private const string ParentIntentRoot = "intents/intent-cli/intent-tree/00-map.md";
@@ -70,7 +69,7 @@ internal static class IntakeIssueCommand
         try
         {
             var baseline = LoadIssueBaseline(context.RepoRoot);
-            var units = DiscoverExecutionUnits(context.RepoRoot, domain);
+            var units = LoadExecutionUnits(context.RepoRoot, domain);
             if (units.Count == 0)
             {
                 writer.WriteLine($"No intake-origin issue-ready execution units were found for domain '{domain}'.");
@@ -86,6 +85,56 @@ internal static class IntakeIssueCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    private static IReadOnlyList<IntakeOriginExecutionUnit> LoadExecutionUnits(string repoRoot, string domain)
+    {
+        var executionArtifactPath = Path.Combine(
+            repoRoot,
+            IntakeExecutionArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(executionArtifactPath))
+        {
+            throw new InvalidOperationException($"Intake execution artifact was not found at {executionArtifactPath}");
+        }
+
+        var request = IntakeExecutionArtifactMarkdown.Deserialize(File.ReadAllText(executionArtifactPath));
+        if (!string.Equals(request.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Intake execution artifact domain '{request.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        var units = new Dictionary<string, IntakeOriginExecutionUnit>(StringComparer.Ordinal);
+        foreach (var candidate in request.ProposedExecutionUnits)
+        {
+            var sourceAbsolutePath = Path.Combine(repoRoot, candidate.SourceFilePath.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(sourceAbsolutePath))
+            {
+                throw new InvalidOperationException(
+                    $"Intake execution unit '{candidate.ExecutionUnitId}' source file was not found at {sourceAbsolutePath}");
+            }
+
+            var unit = new IntakeOriginExecutionUnit
+            {
+                ExecutionUnitId = candidate.ExecutionUnitId,
+                SourceFilePath = candidate.SourceFilePath,
+                TargetPart = candidate.TargetPart,
+                Dependencies = candidate.Dependencies,
+                ReadinessNotes = candidate.ReadinessNotes,
+                VerificationHints = candidate.VerificationHints
+            };
+
+            if (!units.TryAdd(unit.ExecutionUnitId, unit))
+            {
+                throw new InvalidOperationException(
+                    $"Execution unit '{unit.ExecutionUnitId}' was defined multiple times in the intake execution artifact.");
+            }
+        }
+
+        return units.Values
+            .OrderBy(unit => unit.ExecutionUnitId, StringComparer.Ordinal)
+            .ToArray();
     }
 
     private static IntakeIssueResult GenerateArtifacts(
@@ -168,47 +217,6 @@ internal static class IntakeIssueCommand
             "Intake issue baseline could not be derived from the current execution source-of-truth.");
     }
 
-    private static IReadOnlyList<IntakeOriginExecutionUnit> DiscoverExecutionUnits(string repoRoot, string domain)
-    {
-        var executionUnits = new Dictionary<string, IntakeOriginExecutionUnit>(StringComparer.Ordinal);
-        var prefix = domain.Trim().ToUpperInvariant() + "-";
-
-        foreach (var relativePath in EnumerateExecutionFiles(repoRoot))
-        {
-            var absolutePath = Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
-            var content = File.ReadAllText(absolutePath);
-            if (!content.Contains(IntakeExecutionApplyMarker, StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            foreach (var unit in ParseExecutionUnits(content))
-            {
-                if (!unit.ExecutionUnitId.StartsWith(prefix, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                if (executionUnits.TryGetValue(unit.ExecutionUnitId, out var existing))
-                {
-                    if (!existing.Equals(unit))
-                    {
-                        throw new InvalidOperationException(
-                            $"Execution unit '{unit.ExecutionUnitId}' was defined multiple times in execution source files.");
-                    }
-
-                    continue;
-                }
-
-                executionUnits[unit.ExecutionUnitId] = unit;
-            }
-        }
-
-        return executionUnits.Values
-            .OrderBy(unit => unit.ExecutionUnitId, StringComparer.Ordinal)
-            .ToArray();
-    }
-
     private static IReadOnlyList<string> EnumerateExecutionFiles(string repoRoot)
     {
         var intentsRoot = Path.Combine(repoRoot, "intents");
@@ -222,85 +230,6 @@ internal static class IntakeIssueCommand
             .OrderBy(path => path, StringComparer.Ordinal)
             .Select(path => Path.GetRelativePath(repoRoot, path).Replace(Path.DirectorySeparatorChar, '/'))
             .ToArray();
-    }
-
-    private static IReadOnlyList<IntakeOriginExecutionUnit> ParseExecutionUnits(string markdown)
-    {
-        var lines = markdown.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n', StringSplitOptions.None);
-        var sectionStart = FindSectionStart(lines, IntakeExecutionApplyMarker);
-        if (sectionStart < 0)
-        {
-            return [];
-        }
-
-        var sectionEnd = FindSectionEnd(lines, sectionStart);
-        var builder = default(ExecutionUnitBuilder);
-        var units = new List<IntakeOriginExecutionUnit>();
-
-        for (var index = sectionStart + 1; index < sectionEnd; index++)
-        {
-            var trimmed = lines[index].Trim();
-            if (!trimmed.StartsWith("- ", StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            var bullet = trimmed[2..];
-            var separatorIndex = bullet.IndexOf(": ", StringComparison.Ordinal);
-            if (separatorIndex < 0)
-            {
-                continue;
-            }
-
-            var key = bullet[..separatorIndex];
-            var value = bullet[(separatorIndex + 2)..];
-
-            switch (key)
-            {
-                case "execution_unit":
-                    if (builder.ExecutionUnitId is not null)
-                    {
-                        units.Add(builder.Build());
-                    }
-
-                    builder = new ExecutionUnitBuilder(value);
-                    break;
-                case "source_file_path":
-                    builder.SourceFilePath = value;
-                    break;
-                case "target_part":
-                    builder.TargetPart = value;
-                    break;
-                case "dependencies":
-                    if (!string.Equals(value, "none", StringComparison.Ordinal))
-                    {
-                        builder.Dependencies.Add(value);
-                    }
-
-                    break;
-                case "readiness_notes":
-                    if (!string.Equals(value, "none", StringComparison.Ordinal))
-                    {
-                        builder.ReadinessNotes.Add(value);
-                    }
-
-                    break;
-                case "verification_hints":
-                    if (!string.Equals(value, "none", StringComparison.Ordinal))
-                    {
-                        builder.VerificationHints.Add(value);
-                    }
-
-                    break;
-            }
-        }
-
-        if (builder.ExecutionUnitId is not null)
-        {
-            units.Add(builder.Build());
-        }
-
-        return units;
     }
 
     private static IReadOnlyList<string> ExtractSectionBulletLines(string markdown, string marker)
@@ -515,51 +444,5 @@ internal static class IntakeIssueCommand
         public required IReadOnlyList<string> ReadinessNotes { get; init; }
 
         public required IReadOnlyList<string> VerificationHints { get; init; }
-    }
-
-    private struct ExecutionUnitBuilder
-    {
-        public ExecutionUnitBuilder(string executionUnitId)
-        {
-            ExecutionUnitId = executionUnitId;
-            SourceFilePath = null;
-            TargetPart = null;
-            Dependencies = [];
-            ReadinessNotes = [];
-            VerificationHints = [];
-        }
-
-        public string? ExecutionUnitId { get; }
-
-        public string? SourceFilePath { get; set; }
-
-        public string? TargetPart { get; set; }
-
-        public List<string> Dependencies { get; }
-
-        public List<string> ReadinessNotes { get; }
-
-        public List<string> VerificationHints { get; }
-
-        public IntakeOriginExecutionUnit Build()
-        {
-            if (string.IsNullOrWhiteSpace(ExecutionUnitId)
-                || string.IsNullOrWhiteSpace(SourceFilePath)
-                || string.IsNullOrWhiteSpace(TargetPart))
-            {
-                throw new InvalidOperationException(
-                    "Execution source-of-truth contained an incomplete intake-origin execution unit.");
-            }
-
-            return new IntakeOriginExecutionUnit
-            {
-                ExecutionUnitId = ExecutionUnitId,
-                SourceFilePath = SourceFilePath,
-                TargetPart = TargetPart,
-                Dependencies = Dependencies.ToArray(),
-                ReadinessNotes = ReadinessNotes.ToArray(),
-                VerificationHints = VerificationHints.ToArray()
-            };
-        }
     }
 }

--- a/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
@@ -1,0 +1,565 @@
+using System.Globalization;
+using IntentSystem.Projection;
+using IntentSystem.Projection.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeIssueCommand
+{
+    private const string IntakeExecutionApplyMarker = "`intake execution apply <domain>`";
+    private const string IntakeIssueMarker = "`intake issue <domain>`";
+    private const string IssueBaselineExecutionUnit = "G37";
+    private const string ParentIntentRoot = "intents/intent-cli/intent-tree/00-map.md";
+    private const string ClarificationReturnPath = "intents/intent-cli/clarifications/open.md";
+
+    private static readonly string[] RulesAndSpecs =
+    [
+        "intents/intent-cli/specs/04-concept-intake-and-interview.md",
+        "intents/intent-cli/specs/05-intent-cli-surface.md",
+        "intents/rules/feature-request-intake-and-autostart.md",
+        "intents/rules/issue-compilation-and-execution.md",
+        "intents/rules/issue-projection-format.md"
+    ];
+
+    private static readonly string[] TechnicalBaseline =
+    [
+        "C# / .NET",
+        ".NET 10.0.100+ baseline",
+        "dnx / dotnet tool exec",
+        "do not switch to Node or TypeScript toolchain",
+        "do not commit node_modules or vendor artifacts"
+    ];
+
+    private static readonly string[] ProjectLocalGuide =
+    [
+        "AGENTS.md",
+        "CLAUDE.md"
+    ];
+
+    private static readonly string[] VerificationEvidence =
+    [
+        "contract-reviewed",
+        "tests-passing",
+        "acceptance-criteria-checked"
+    ];
+
+    private static readonly string[] OutOfScope =
+    [
+        "queue mutation",
+        "child issue creation",
+        "autostart",
+        "review execution",
+        "merge / closeout",
+        "workflow execution"
+    ];
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Intake issue command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0].Trim();
+
+        try
+        {
+            var baseline = LoadIssueBaseline(context.RepoRoot);
+            var units = DiscoverExecutionUnits(context.RepoRoot, domain);
+            if (units.Count == 0)
+            {
+                writer.WriteLine($"No intake-origin issue-ready execution units were found for domain '{domain}'.");
+                return 1;
+            }
+
+            var result = GenerateArtifacts(context.RepoRoot, domain, units, baseline);
+            IntakeIssueRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static IntakeIssueResult GenerateArtifacts(
+        string repoRoot,
+        string domain,
+        IReadOnlyList<IntakeOriginExecutionUnit> units,
+        IntakeIssueBaseline baseline)
+    {
+        var generatedExecutionUnits = new List<string>();
+        var artifactPaths = new List<string>();
+        var skippedUnits = new List<string>();
+
+        foreach (var unit in units.OrderBy(item => item.ExecutionUnitId, StringComparer.Ordinal))
+        {
+            var packet = PacketGenerator.Generate(CreateRow(unit, baseline), CreateContext(unit, baseline));
+            var githubBodyPath = QueueDispatchCommand.ResolveGitHubBodyPath(repoRoot, packet.Paths.Yaml);
+            var githubBodyRelativePath = Path.GetRelativePath(repoRoot, githubBodyPath).Replace(Path.DirectorySeparatorChar, '/');
+
+            if (AnyArtifactExists(repoRoot, packet.Paths, githubBodyRelativePath))
+            {
+                skippedUnits.Add(unit.ExecutionUnitId);
+                continue;
+            }
+
+            ProjectionArtifactWriter.Write(packet, repoRoot, overwrite: false);
+
+            var githubBodyDirectory = Path.GetDirectoryName(githubBodyPath)
+                ?? throw new InvalidOperationException("GitHub body path did not contain a directory.");
+            Directory.CreateDirectory(githubBodyDirectory);
+            File.WriteAllText(githubBodyPath, packet.ImplementationMarkdown);
+
+            generatedExecutionUnits.Add(unit.ExecutionUnitId);
+            artifactPaths.Add(packet.Paths.Implementation);
+            artifactPaths.Add(packet.Paths.ReviewContext);
+            artifactPaths.Add(packet.Paths.Yaml);
+            artifactPaths.Add(githubBodyRelativePath);
+        }
+
+        return new IntakeIssueResult
+        {
+            Domain = domain,
+            GeneratedExecutionUnits = generatedExecutionUnits,
+            ArtifactPaths = artifactPaths,
+            SkippedUnits = skippedUnits
+        };
+    }
+
+    private static bool AnyArtifactExists(string repoRoot, ResolvedPacketPaths packetPaths, string githubBodyPath)
+    {
+        return File.Exists(Path.Combine(repoRoot, packetPaths.Implementation.Replace('/', Path.DirectorySeparatorChar)))
+            || File.Exists(Path.Combine(repoRoot, packetPaths.ReviewContext.Replace('/', Path.DirectorySeparatorChar)))
+            || File.Exists(Path.Combine(repoRoot, packetPaths.Yaml.Replace('/', Path.DirectorySeparatorChar)))
+            || File.Exists(Path.Combine(repoRoot, githubBodyPath.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static IntakeIssueBaseline LoadIssueBaseline(string repoRoot)
+    {
+        foreach (var relativePath in EnumerateExecutionFiles(repoRoot))
+        {
+            var absolutePath = Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            var content = File.ReadAllText(absolutePath);
+            if (!content.Contains(IntakeIssueMarker, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var baselineLines = ExtractSectionBulletLines(content, IntakeIssueMarker);
+            var row = ParseIssueBaselineRow(content);
+
+            return new IntakeIssueBaseline
+            {
+                ExecutionFilePath = relativePath,
+                TargetRepo = row.TargetRepo,
+                TargetPath = row.TargetPath,
+                IntentBaseline = baselineLines
+            };
+        }
+
+        throw new InvalidOperationException(
+            "Intake issue baseline could not be derived from the current execution source-of-truth.");
+    }
+
+    private static IReadOnlyList<IntakeOriginExecutionUnit> DiscoverExecutionUnits(string repoRoot, string domain)
+    {
+        var executionUnits = new Dictionary<string, IntakeOriginExecutionUnit>(StringComparer.Ordinal);
+        var prefix = domain.Trim().ToUpperInvariant() + "-";
+
+        foreach (var relativePath in EnumerateExecutionFiles(repoRoot))
+        {
+            var absolutePath = Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            var content = File.ReadAllText(absolutePath);
+            if (!content.Contains(IntakeExecutionApplyMarker, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (var unit in ParseExecutionUnits(content))
+            {
+                if (!unit.ExecutionUnitId.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (executionUnits.TryGetValue(unit.ExecutionUnitId, out var existing))
+                {
+                    if (!existing.Equals(unit))
+                    {
+                        throw new InvalidOperationException(
+                            $"Execution unit '{unit.ExecutionUnitId}' was defined multiple times in execution source files.");
+                    }
+
+                    continue;
+                }
+
+                executionUnits[unit.ExecutionUnitId] = unit;
+            }
+        }
+
+        return executionUnits.Values
+            .OrderBy(unit => unit.ExecutionUnitId, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> EnumerateExecutionFiles(string repoRoot)
+    {
+        var intentsRoot = Path.Combine(repoRoot, "intents");
+        if (!Directory.Exists(intentsRoot))
+        {
+            return [];
+        }
+
+        return Directory.GetFiles(intentsRoot, "*.md", SearchOption.AllDirectories)
+            .Where(path => path.Contains($"{Path.DirectorySeparatorChar}execution{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .Select(path => Path.GetRelativePath(repoRoot, path).Replace(Path.DirectorySeparatorChar, '/'))
+            .ToArray();
+    }
+
+    private static IReadOnlyList<IntakeOriginExecutionUnit> ParseExecutionUnits(string markdown)
+    {
+        var lines = markdown.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n', StringSplitOptions.None);
+        var sectionStart = FindSectionStart(lines, IntakeExecutionApplyMarker);
+        if (sectionStart < 0)
+        {
+            return [];
+        }
+
+        var sectionEnd = FindSectionEnd(lines, sectionStart);
+        var builder = default(ExecutionUnitBuilder);
+        var units = new List<IntakeOriginExecutionUnit>();
+
+        for (var index = sectionStart + 1; index < sectionEnd; index++)
+        {
+            var trimmed = lines[index].Trim();
+            if (!trimmed.StartsWith("- ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var bullet = trimmed[2..];
+            var separatorIndex = bullet.IndexOf(": ", StringComparison.Ordinal);
+            if (separatorIndex < 0)
+            {
+                continue;
+            }
+
+            var key = bullet[..separatorIndex];
+            var value = bullet[(separatorIndex + 2)..];
+
+            switch (key)
+            {
+                case "execution_unit":
+                    if (builder.ExecutionUnitId is not null)
+                    {
+                        units.Add(builder.Build());
+                    }
+
+                    builder = new ExecutionUnitBuilder(value);
+                    break;
+                case "source_file_path":
+                    builder.SourceFilePath = value;
+                    break;
+                case "target_part":
+                    builder.TargetPart = value;
+                    break;
+                case "dependencies":
+                    if (!string.Equals(value, "none", StringComparison.Ordinal))
+                    {
+                        builder.Dependencies.Add(value);
+                    }
+
+                    break;
+                case "readiness_notes":
+                    if (!string.Equals(value, "none", StringComparison.Ordinal))
+                    {
+                        builder.ReadinessNotes.Add(value);
+                    }
+
+                    break;
+                case "verification_hints":
+                    if (!string.Equals(value, "none", StringComparison.Ordinal))
+                    {
+                        builder.VerificationHints.Add(value);
+                    }
+
+                    break;
+            }
+        }
+
+        if (builder.ExecutionUnitId is not null)
+        {
+            units.Add(builder.Build());
+        }
+
+        return units;
+    }
+
+    private static IReadOnlyList<string> ExtractSectionBulletLines(string markdown, string marker)
+    {
+        var lines = markdown.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n', StringSplitOptions.None);
+        var sectionStart = FindSectionStart(lines, marker);
+        if (sectionStart < 0)
+        {
+            return [];
+        }
+
+        var sectionEnd = FindSectionEnd(lines, sectionStart);
+        var values = new List<string>();
+        for (var index = sectionStart + 1; index < sectionEnd; index++)
+        {
+            var trimmed = lines[index].Trim();
+            if (!trimmed.StartsWith("- ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            values.Add(trimmed[2..]);
+        }
+
+        return values;
+    }
+
+    private static int FindSectionStart(IReadOnlyList<string> lines, string marker)
+    {
+        for (var index = 0; index < lines.Count; index++)
+        {
+            if (!lines[index].StartsWith("## ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var sectionEnd = FindSectionEnd(lines, index);
+            var sectionContent = string.Join("\n", lines.Skip(index).Take(sectionEnd - index));
+            if (sectionContent.Contains(marker, StringComparison.Ordinal))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int FindSectionEnd(IReadOnlyList<string> lines, int sectionStart)
+    {
+        for (var index = sectionStart + 1; index < lines.Count; index++)
+        {
+            if (lines[index].StartsWith("## ", StringComparison.Ordinal))
+            {
+                return index;
+            }
+        }
+
+        return lines.Count;
+    }
+
+    private static IssueBaselineRow ParseIssueBaselineRow(string markdown)
+    {
+        var lines = markdown.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n', StringSplitOptions.None);
+        var row = lines.FirstOrDefault(line => line.StartsWith($"| {IssueBaselineExecutionUnit} |", StringComparison.Ordinal));
+        if (row is null)
+        {
+            throw new InvalidOperationException(
+                "Intake issue baseline row could not be derived from the current execution source-of-truth.");
+        }
+
+        var cells = row.Split('|', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (cells.Length < 8)
+        {
+            throw new InvalidOperationException(
+                "Intake issue baseline row did not contain the expected projection fields.");
+        }
+
+        return new IssueBaselineRow
+        {
+            TargetRepo = cells[4],
+            TargetPath = cells[5]
+        };
+    }
+
+    private static SubSliceRow CreateRow(IntakeOriginExecutionUnit unit, IntakeIssueBaseline baseline)
+    {
+        return new SubSliceRow
+        {
+            SourceExecutionUnit = unit.ExecutionUnitId,
+            Goal = $"Reflect the intake-origin update from `{unit.SourceFilePath}` into `{unit.TargetPart}`.",
+            TargetRepo = baseline.TargetRepo,
+            TargetPath = baseline.TargetPath,
+            TargetPart = unit.TargetPart,
+            DependsOnSubslices = unit.Dependencies,
+            RelatedIntents =
+            [
+                ParentIntentRoot,
+                baseline.ExecutionFilePath
+            ],
+            SourceConcepts =
+            [
+                unit.SourceFilePath,
+                .. RulesAndSpecs
+            ],
+            SuccessSignal = $"Updated intake-origin source `{unit.SourceFilePath}` is reflected within `{unit.TargetPart}`.",
+            ReviewMode = "deterministic-review",
+            CompletionAction = "wait-for-deterministic-review",
+            LandingPolicy = "merge-after-review"
+        };
+    }
+
+    private static ProjectionContext CreateContext(IntakeOriginExecutionUnit unit, IntakeIssueBaseline baseline)
+    {
+        var title = ResolveTitle(unit);
+
+        return new ProjectionContext
+        {
+            IssueTitle = $"[{unit.ExecutionUnitId}] {title}",
+            IssueKind = IssueKind.Feature,
+            ParentIntentRoot = ParentIntentRoot,
+            ClarificationReturnPath = ClarificationReturnPath,
+            AcceptanceCriteria =
+            [
+                $"Updated intake-origin source `{unit.SourceFilePath}` is reflected within `{unit.TargetPart}`.",
+                $"Changes stay limited to target part `{unit.TargetPart}`.",
+                $"Work remains scoped to execution unit `{unit.ExecutionUnitId}`."
+            ],
+            DeterministicReviewChecks = BuildDeterministicReviewChecks(unit),
+            VerificationEvidence = VerificationEvidence,
+            TechnicalBaseline = TechnicalBaseline,
+            ProjectLocalGuide = ProjectLocalGuide,
+            IntentBaseline = baseline.IntentBaseline
+                .Concat(unit.ReadinessNotes)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray(),
+            AdditionalInScope =
+            [
+                $"updated intake-origin source `{unit.SourceFilePath}`",
+                $"execution unit `{unit.ExecutionUnitId}`"
+            ],
+            OutOfScope = OutOfScope
+        };
+    }
+
+    private static IReadOnlyList<string> BuildDeterministicReviewChecks(IntakeOriginExecutionUnit unit)
+    {
+        var checks = new List<string>
+        {
+            $"implementation reflects `{unit.SourceFilePath}` within `{unit.TargetPart}`",
+            $"changes stay limited to execution unit `{unit.ExecutionUnitId}`"
+        };
+
+        if (unit.Dependencies.Count > 0)
+        {
+            checks.Add($"dependencies `{string.Join(", ", unit.Dependencies)}` remain satisfied");
+        }
+        else
+        {
+            checks.Add("no additional intake-origin dependency drift is introduced");
+        }
+
+        return checks;
+    }
+
+    private static string ResolveTitle(IntakeOriginExecutionUnit unit)
+    {
+        var heading = unit.ReadinessNotes
+            .FirstOrDefault(note => note.StartsWith("Current heading: ", StringComparison.Ordinal));
+
+        if (heading is not null)
+        {
+            return heading["Current heading: ".Length..].Trim().TrimStart('#', ' ');
+        }
+
+        var fileName = Path.GetFileNameWithoutExtension(unit.SourceFilePath.Replace('/', Path.DirectorySeparatorChar));
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return unit.TargetPart;
+        }
+
+        return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(fileName.Replace('-', ' '));
+    }
+
+    private readonly record struct IntakeIssueBaseline
+    {
+        public required string ExecutionFilePath { get; init; }
+
+        public required string TargetRepo { get; init; }
+
+        public required string TargetPath { get; init; }
+
+        public required IReadOnlyList<string> IntentBaseline { get; init; }
+    }
+
+    private readonly record struct IssueBaselineRow
+    {
+        public required string TargetRepo { get; init; }
+
+        public required string TargetPath { get; init; }
+    }
+
+    private sealed record IntakeOriginExecutionUnit
+    {
+        public required string ExecutionUnitId { get; init; }
+
+        public required string SourceFilePath { get; init; }
+
+        public required string TargetPart { get; init; }
+
+        public required IReadOnlyList<string> Dependencies { get; init; }
+
+        public required IReadOnlyList<string> ReadinessNotes { get; init; }
+
+        public required IReadOnlyList<string> VerificationHints { get; init; }
+    }
+
+    private struct ExecutionUnitBuilder
+    {
+        public ExecutionUnitBuilder(string executionUnitId)
+        {
+            ExecutionUnitId = executionUnitId;
+            SourceFilePath = null;
+            TargetPart = null;
+            Dependencies = [];
+            ReadinessNotes = [];
+            VerificationHints = [];
+        }
+
+        public string? ExecutionUnitId { get; }
+
+        public string? SourceFilePath { get; set; }
+
+        public string? TargetPart { get; set; }
+
+        public List<string> Dependencies { get; }
+
+        public List<string> ReadinessNotes { get; }
+
+        public List<string> VerificationHints { get; }
+
+        public IntakeOriginExecutionUnit Build()
+        {
+            if (string.IsNullOrWhiteSpace(ExecutionUnitId)
+                || string.IsNullOrWhiteSpace(SourceFilePath)
+                || string.IsNullOrWhiteSpace(TargetPart))
+            {
+                throw new InvalidOperationException(
+                    "Execution source-of-truth contained an incomplete intake-origin execution unit.");
+            }
+
+            return new IntakeOriginExecutionUnit
+            {
+                ExecutionUnitId = ExecutionUnitId,
+                SourceFilePath = SourceFilePath,
+                TargetPart = TargetPart,
+                Dependencies = Dependencies.ToArray(),
+                ReadinessNotes = ReadinessNotes.ToArray(),
+                VerificationHints = VerificationHints.ToArray()
+            };
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeIssueRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeIssueRenderer.cs
@@ -1,0 +1,32 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeIssueRenderer
+{
+    public static void WriteSummary(TextWriter writer, IntakeIssueResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Intake issue artifacts generated for domain '{result.Domain}'.");
+        writer.WriteLine("Generated execution units:");
+        WriteList(writer, result.GeneratedExecutionUnits);
+        writer.WriteLine("Artifact paths:");
+        WriteList(writer, result.ArtifactPaths);
+        writer.WriteLine("Skipped units:");
+        WriteList(writer, result.SkippedUnits);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeIssueResult.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeIssueResult.cs
@@ -1,0 +1,12 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeIssueResult
+{
+    public required string Domain { get; init; }
+
+    public required IReadOnlyList<string> GeneratedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> SkippedUnits { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -460,19 +460,33 @@ public sealed class CommandRouterTests
             |---|---|---|---|---|---|---|---|
             | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | submodules/intent-system | . | cli intake issue command | yes |
 
-            ## G36 の current baseline
-
-            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
-            - execution_unit: AUTH-01
-            - source_file_path: intents/intent-cli/concepts/oauth2.md
-            - target_part: concepts
-            - readiness_notes: Current heading: # Auth Concept
-            - verification_hints: dotnet test IntentSystem.sln
-
             ## G37 の current baseline
 
             - `intake issue <domain>` を最初の intake issue-artifact generation command にする
             """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            """
+            # Intake Execution Draft
+
+            ## Domain
+            `auth`
+
+            ## Proposed Execution Units
+
+            ### `AUTH-01`
+            source_file_path: intents/intent-cli/concepts/oauth2.md
+            target_part: concepts
+            dependencies:
+            - none
+            readiness_notes:
+            - Current heading: # Auth Concept
+            verification_hints:
+            - dotnet test IntentSystem.sln
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
+            "# Auth Concept");
         using var writer = new StringWriter();
 
         var exitCode = CommandRouter.Execute(["intake", "issue", "auth"], CreateContext(repoRoot), writer);

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -447,6 +447,41 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeIssueCommand_DispatchesToIntakeIssueRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
+            |---|---|---|---|---|---|---|---|
+            | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | submodules/intent-system | . | cli intake issue command | yes |
+
+            ## G36 の current baseline
+
+            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
+            - execution_unit: AUTH-01
+            - source_file_path: intents/intent-cli/concepts/oauth2.md
+            - target_part: concepts
+            - readiness_notes: Current heading: # Auth Concept
+            - verification_hints: dotnet test IntentSystem.sln
+
+            ## G37 の current baseline
+
+            - `intake issue <domain>` を最初の intake issue-artifact generation command にする
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["intake", "issue", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Intake issue artifacts generated for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenIntakeConceptCommand_DispatchesToIntakeConceptRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeIssueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeIssueCommandTests.cs
@@ -7,47 +7,22 @@ namespace IntentSystem.Cli.Tests;
 public sealed class IntakeIssueCommandTests
 {
     [Fact]
-    public void Execute_GivenIntakeOriginExecutionUnits_GeneratesIssueArtifacts()
+    public void Execute_GivenCanonicalExecutionArtifact_GeneratesIssueArtifacts()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
-            """
-            # Post-MVP Sub-Slices
-
-            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
-            |---|---|---|---|---|---|---|---|
-            | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | submodules/intent-system | . | cli intake issue command | yes |
-
-            ## G36 の current baseline
-
-            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
-            - execution_unit: AUTH-01
-            - source_file_path: intents/intent-cli/concepts/oauth2.md
-            - target_part: concepts
-            - readiness_notes: Current heading: # Auth Concept
-            - verification_hints: dotnet test IntentSystem.sln
-
-            - execution_unit: AUTH-02
-            - source_file_path: intents/intent-cli/intent-tree/means/device-code.md
-            - target_part: intent-tree/means
-            - dependencies: AUTH-01
-            - readiness_notes: Current heading: # Device Code
-            - verification_hints: dotnet test IntentSystem.sln
-
-            - execution_unit: BILLING-01
-            - source_file_path: intents/intent-cli/concepts/billing.md
-            - target_part: concepts
-            - readiness_notes: Current heading: # Billing
-            - verification_hints: dotnet test IntentSystem.sln
-
-            ## G37 の current baseline
-
-            - `intake issue <domain>` を最初の intake issue-artifact generation command にする
-            - canonical source は current `execution/` source files と current `G2` / `G29` / `G30` / `G32` / `G33` / `G34` / `G35` / `G36` intake baseline である
-            - successful output は selected domain の intake-origin issue-ready execution unit に対応する `.intent-cli/issues/<execution-unit>/implementation.md`, `review-context.md`, `packet.yaml`, and `github-body.md` の deterministic generation を baseline にする
-            """);
+            CreateExecutionBaselineMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateExecutionArtifactMarkdown("auth"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
+            "# Auth Concept");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "device-code.md"),
+            "# Device Code");
         using var writer = new StringWriter();
 
         var exitCode = IntakeIssueCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
@@ -57,7 +32,6 @@ public sealed class IntakeIssueCommandTests
         Assert.Contains("Intake issue artifacts generated for domain 'auth'.", output, StringComparison.Ordinal);
         Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
         Assert.Contains("- AUTH-02", output, StringComparison.Ordinal);
-        Assert.DoesNotContain("BILLING-01", output, StringComparison.Ordinal);
         Assert.Contains(".intent-cli/issues/AUTH-01/github-body.md", output, StringComparison.Ordinal);
 
         Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "implementation.md")));
@@ -81,7 +55,6 @@ public sealed class IntakeIssueCommandTests
 
         var githubBody = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "github-body.md"));
         Assert.Equal(implementationMarkdown, githubBody);
-        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "BILLING-01", "implementation.md")));
     }
 
     [Fact]
@@ -91,32 +64,16 @@ public sealed class IntakeIssueCommandTests
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
-            """
-            # Post-MVP Sub-Slices
-
-            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
-            |---|---|---|---|---|---|---|---|
-            | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | submodules/intent-system | . | cli intake issue command | yes |
-
-            ## G36 の current baseline
-
-            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
-            - execution_unit: AUTH-01
-            - source_file_path: intents/intent-cli/concepts/oauth2.md
-            - target_part: concepts
-            - readiness_notes: Current heading: # Auth Concept
-            - verification_hints: dotnet test IntentSystem.sln
-
-            - execution_unit: AUTH-02
-            - source_file_path: intents/intent-cli/intent-tree/means/device-code.md
-            - target_part: intent-tree/means
-            - readiness_notes: Current heading: # Device Code
-            - verification_hints: dotnet test IntentSystem.sln
-
-            ## G37 の current baseline
-
-            - `intake issue <domain>` を最初の intake issue-artifact generation command にする
-            """);
+            CreateExecutionBaselineMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateExecutionArtifactMarkdown("auth"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
+            "# Auth Concept");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "device-code.md"),
+            "# Device Code");
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "issues", "AUTH-02", "implementation.md"),
             "existing implementation");
@@ -135,31 +92,22 @@ public sealed class IntakeIssueCommandTests
     }
 
     [Fact]
-    public void Execute_GivenNoMatchingExecutionUnits_ReturnsExitCodeOne()
+    public void Execute_GivenExecutionArtifactWithNoUnits_ReturnsExitCodeOne()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            CreateExecutionBaselineMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
             """
-            # Post-MVP Sub-Slices
+            # Intake Execution Draft
 
-            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
-            |---|---|---|---|---|---|---|---|
-            | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | submodules/intent-system | . | cli intake issue command | yes |
+            ## Domain
+            `auth`
 
-            ## G36 の current baseline
-
-            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
-            - execution_unit: BILLING-01
-            - source_file_path: intents/intent-cli/concepts/billing.md
-            - target_part: concepts
-            - readiness_notes: Current heading: # Billing
-            - verification_hints: dotnet test IntentSystem.sln
-
-            ## G37 の current baseline
-
-            - `intake issue <domain>` を最初の intake issue-artifact generation command にする
+            ## Proposed Execution Units
             """);
         using var writer = new StringWriter();
 
@@ -167,6 +115,22 @@ public sealed class IntakeIssueCommandTests
 
         Assert.Equal(1, exitCode);
         Assert.Contains("No intake-origin issue-ready execution units were found for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            CreateExecutionBaselineMarkdown());
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeIssueCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Intake execution artifact was not found", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -178,6 +142,56 @@ public sealed class IntakeIssueCommandTests
 
         Assert.Equal(1, exitCode);
         Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string CreateExecutionBaselineMarkdown()
+    {
+        return """
+            # Post-MVP Sub-Slices
+
+            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
+            |---|---|---|---|---|---|---|---|
+            | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | submodules/intent-system | . | cli intake issue command | yes |
+
+            ## G37 の current baseline
+
+            - `intake issue <domain>` を最初の intake issue-artifact generation command にする
+            - canonical source は current `execution/` source files と current `G2` / `G29` / `G30` / `G32` / `G33` / `G34` / `G35` / `G36` intake baseline である
+            - successful output は selected domain の intake-origin issue-ready execution unit に対応する `.intent-cli/issues/<execution-unit>/implementation.md`, `review-context.md`, `packet.yaml`, and `github-body.md` の deterministic generation を baseline にする
+            """;
+    }
+
+    private static string CreateExecutionArtifactMarkdown(string domain)
+    {
+        return $$"""
+            # Intake Execution Draft
+
+            ## Domain
+            `{{domain}}`
+
+            ## Proposed Execution Units
+
+            ### `AUTH-01`
+            source_file_path: intents/intent-cli/concepts/oauth2.md
+            target_part: concepts
+            dependencies:
+            - none
+            readiness_notes:
+            - Current heading: # Auth Concept
+            verification_hints:
+            - dotnet test IntentSystem.sln
+
+            ### `AUTH-02`
+            source_file_path: intents/intent-cli/intent-tree/means/device-code.md
+            target_part: intent-tree/means
+            dependencies:
+            - AUTH-01
+            readiness_notes:
+            - Current heading: # Device Code
+            verification_hints:
+            - dotnet test IntentSystem.sln
+
+            """;
     }
 
     private static CliContext CreateContext(string repoRoot)

--- a/tests/IntentSystem.Cli.Tests/IntakeIssueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeIssueCommandTests.cs
@@ -1,0 +1,232 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Projection.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeIssueCommandTests
+{
+    [Fact]
+    public void Execute_GivenIntakeOriginExecutionUnits_GeneratesIssueArtifacts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
+            |---|---|---|---|---|---|---|---|
+            | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | submodules/intent-system | . | cli intake issue command | yes |
+
+            ## G36 の current baseline
+
+            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
+            - execution_unit: AUTH-01
+            - source_file_path: intents/intent-cli/concepts/oauth2.md
+            - target_part: concepts
+            - readiness_notes: Current heading: # Auth Concept
+            - verification_hints: dotnet test IntentSystem.sln
+
+            - execution_unit: AUTH-02
+            - source_file_path: intents/intent-cli/intent-tree/means/device-code.md
+            - target_part: intent-tree/means
+            - dependencies: AUTH-01
+            - readiness_notes: Current heading: # Device Code
+            - verification_hints: dotnet test IntentSystem.sln
+
+            - execution_unit: BILLING-01
+            - source_file_path: intents/intent-cli/concepts/billing.md
+            - target_part: concepts
+            - readiness_notes: Current heading: # Billing
+            - verification_hints: dotnet test IntentSystem.sln
+
+            ## G37 の current baseline
+
+            - `intake issue <domain>` を最初の intake issue-artifact generation command にする
+            - canonical source は current `execution/` source files と current `G2` / `G29` / `G30` / `G32` / `G33` / `G34` / `G35` / `G36` intake baseline である
+            - successful output は selected domain の intake-origin issue-ready execution unit に対応する `.intent-cli/issues/<execution-unit>/implementation.md`, `review-context.md`, `packet.yaml`, and `github-body.md` の deterministic generation を baseline にする
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeIssueCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake issue artifacts generated for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+        Assert.Contains("- AUTH-02", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("BILLING-01", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/issues/AUTH-01/github-body.md", output, StringComparison.Ordinal);
+
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "implementation.md")));
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "review-context.md")));
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "packet.yaml")));
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "github-body.md")));
+
+        var implementationMarkdown = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "implementation.md"));
+        Assert.Contains("# [AUTH-01] Auth Concept", implementationMarkdown, StringComparison.Ordinal);
+        Assert.Contains("updated intake-origin source `intents/intent-cli/concepts/oauth2.md`", implementationMarkdown, StringComparison.Ordinal);
+
+        var reviewMarkdown = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "review-context.md"));
+        Assert.Contains("intents/intent-cli/intent-tree/00-map.md", reviewMarkdown, StringComparison.Ordinal);
+
+        var packet = ProjectionPacketSerializer.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "packet.yaml")));
+        Assert.Equal("AUTH-01", packet.ImplementationIssuePacket.SourceExecutionUnit);
+        Assert.Equal("submodules/intent-system", packet.ImplementationIssuePacket.TargetRepo);
+        Assert.Equal(".", packet.ImplementationIssuePacket.TargetPath);
+        Assert.Equal("concepts", packet.ImplementationIssuePacket.TargetPart);
+
+        var githubBody = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "github-body.md"));
+        Assert.Equal(implementationMarkdown, githubBody);
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "BILLING-01", "implementation.md")));
+    }
+
+    [Fact]
+    public void Execute_GivenExistingArtifacts_SkipsExecutionUnit()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
+            |---|---|---|---|---|---|---|---|
+            | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | submodules/intent-system | . | cli intake issue command | yes |
+
+            ## G36 の current baseline
+
+            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
+            - execution_unit: AUTH-01
+            - source_file_path: intents/intent-cli/concepts/oauth2.md
+            - target_part: concepts
+            - readiness_notes: Current heading: # Auth Concept
+            - verification_hints: dotnet test IntentSystem.sln
+
+            - execution_unit: AUTH-02
+            - source_file_path: intents/intent-cli/intent-tree/means/device-code.md
+            - target_part: intent-tree/means
+            - readiness_notes: Current heading: # Device Code
+            - verification_hints: dotnet test IntentSystem.sln
+
+            ## G37 の current baseline
+
+            - `intake issue <domain>` を最初の intake issue-artifact generation command にする
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-02", "implementation.md"),
+            "existing implementation");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeIssueCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped units:", output, StringComparison.Ordinal);
+        Assert.Contains("- AUTH-02", output, StringComparison.Ordinal);
+        Assert.Equal(
+            "existing implementation",
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-02", "implementation.md")));
+    }
+
+    [Fact]
+    public void Execute_GivenNoMatchingExecutionUnits_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
+            |---|---|---|---|---|---|---|---|
+            | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | submodules/intent-system | . | cli intake issue command | yes |
+
+            ## G36 の current baseline
+
+            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
+            - execution_unit: BILLING-01
+            - source_file_path: intents/intent-cli/concepts/billing.md
+            - target_part: concepts
+            - readiness_notes: Current heading: # Billing
+            - verification_hints: dotnet test IntentSystem.sln
+
+            ## G37 の current baseline
+
+            - `intake issue <domain>` を最初の intake issue-artifact generation command にする
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeIssueCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("No intake-origin issue-ready execution units were found for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeIssueCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-issue-command-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeIssueRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeIssueRendererTests.cs
@@ -1,0 +1,37 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeIssueRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenIssueResult_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        IntakeIssueRenderer.WriteSummary(
+            writer,
+            new IntakeIssueResult
+            {
+                Domain = "auth",
+                GeneratedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                ArtifactPaths =
+                [
+                    ".intent-cli/issues/AUTH-01/implementation.md",
+                    ".intent-cli/issues/AUTH-01/review-context.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml",
+                    ".intent-cli/issues/AUTH-01/github-body.md"
+                ],
+                SkippedUnits = ["AUTH-03"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Intake issue artifacts generated for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Generated execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/issues/AUTH-01/github-body.md", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped units:", output, StringComparison.Ordinal);
+        Assert.Contains("- AUTH-03", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `intent-cli intake issue <domain>` as a thin issue artifact generation boundary
- resolve selected intake-origin issue-ready execution units from current `execution/` source-of-truth and generate issue artifacts deterministically
- keep the command read/write limited to issue artifact generation only, without queue mutation or downstream execution paths

## Testing
- dotnet test IntentSystem.sln
