### PR TITLE
[codex] Issue 102 queue enqueue command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -69,6 +69,7 @@ internal static class CommandRouter
                 ["list"] = QueueListCommand.Execute,
                 ["show"] = QueueShowCommand.Execute,
                 ["next"] = QueueNextCommand.Execute,
+                ["enqueue"] = QueueEnqueueCommand.Execute,
                 ["dispatch"] = QueueDispatchCommand.Execute,
                 ["transition"] = QueueTransitionCommand.Execute
             },

--- a/src/IntentSystem.Cli/Commands/ProjectionPacketRuntimeReader.cs
+++ b/src/IntentSystem.Cli/Commands/ProjectionPacketRuntimeReader.cs
@@ -4,10 +4,14 @@ namespace IntentSystem.Cli.Commands;
 
 internal static class ProjectionPacketRuntimeReader
 {
+    private const string DefaultClarificationReturnPath = "intents/intent-cli/clarifications/open.md";
+
     internal sealed record RuntimePacket(
         string ExecutionUnit,
         string IssueTitle,
-        string TargetRepo);
+        string TargetRepo,
+        IReadOnlyList<string> Dependencies,
+        string ClarificationReturnPath);
 
     public static RuntimePacket Read(string yaml)
     {
@@ -19,7 +23,9 @@ internal static class ProjectionPacketRuntimeReader
             return new RuntimePacket(
                 packet.ImplementationIssuePacket.SourceExecutionUnit,
                 packet.ImplementationIssuePacket.IssueTitle,
-                packet.ImplementationIssuePacket.TargetRepo);
+                packet.ImplementationIssuePacket.TargetRepo,
+                packet.ImplementationIssuePacket.Dependencies,
+                packet.ReviewContextPacket.ClarificationReturnPath);
         }
         catch (InvalidOperationException)
         {
@@ -145,7 +151,30 @@ internal static class ProjectionPacketRuntimeReader
             throw new InvalidOperationException("Implementation issue must contain required field 'target_repo'.");
         }
 
-        return new RuntimePacket(executionUnit, issueTitle, targetRepo);
+        return new RuntimePacket(
+            executionUnit,
+            issueTitle,
+            targetRepo,
+            GetOptionalList(implementationIssue, "dependencies"),
+            DefaultClarificationReturnPath);
+    }
+
+    private static IReadOnlyList<string> GetOptionalList(
+        IReadOnlyDictionary<string, object> values,
+        string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            return [];
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException(
+                $"Projection packet YAML field '{key}' must be a list.")
+        };
     }
 
     private static string ParseScalar(string value)

--- a/src/IntentSystem.Cli/Commands/QueueEnqueueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueEnqueueCommand.cs
@@ -1,4 +1,3 @@
-using IntentSystem.Projection.Serialization;
 using IntentSystem.Supervisor;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
@@ -90,33 +89,33 @@ internal static class QueueEnqueueCommand
 
     private static ResolvedQueuePacket ReadPacket(string yaml, string expectedExecutionUnit)
     {
-        var packet = ProjectionPacketSerializer.Deserialize(yaml);
+        var packet = ProjectionPacketRuntimeReader.Read(yaml);
 
         if (!string.Equals(
-                packet.ImplementationIssuePacket.SourceExecutionUnit,
+                packet.ExecutionUnit,
                 expectedExecutionUnit,
                 StringComparison.Ordinal))
         {
             throw new InvalidOperationException(
-                $"Projection packet execution unit '{packet.ImplementationIssuePacket.SourceExecutionUnit}' does not match requested execution unit '{expectedExecutionUnit}'.");
+                $"Projection packet execution unit '{packet.ExecutionUnit}' does not match requested execution unit '{expectedExecutionUnit}'.");
         }
 
-        if (string.IsNullOrWhiteSpace(packet.ImplementationIssuePacket.IssueTitle))
+        if (string.IsNullOrWhiteSpace(packet.IssueTitle))
         {
             throw new InvalidOperationException("Projection packet must contain a non-empty issue title.");
         }
 
-        if (string.IsNullOrWhiteSpace(packet.ReviewContextPacket.ClarificationReturnPath))
+        if (string.IsNullOrWhiteSpace(packet.ClarificationReturnPath))
         {
             throw new InvalidOperationException("Projection packet must contain a clarification return path.");
         }
 
         return new ResolvedQueuePacket
         {
-            ExecutionUnit = packet.ImplementationIssuePacket.SourceExecutionUnit,
-            IssueTitle = packet.ImplementationIssuePacket.IssueTitle,
-            Dependencies = packet.ImplementationIssuePacket.Dependencies,
-            ClarificationReturnPath = packet.ReviewContextPacket.ClarificationReturnPath
+            ExecutionUnit = packet.ExecutionUnit,
+            IssueTitle = packet.IssueTitle,
+            Dependencies = packet.Dependencies,
+            ClarificationReturnPath = packet.ClarificationReturnPath
         };
     }
 

--- a/src/IntentSystem.Cli/Commands/QueueEnqueueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueEnqueueCommand.cs
@@ -1,0 +1,192 @@
+using IntentSystem.Projection.Serialization;
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class QueueEnqueueCommand
+{
+    private const string TransitionActor = "intent-cli";
+    private const string DefaultPriority = "high";
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Queue enqueue command requires an execution unit.");
+            return 1;
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        var executionUnit = args[0].Trim();
+        var packetPath = ResolvePacketPath(context, executionUnit);
+        if (!File.Exists(packetPath))
+        {
+            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
+            return 1;
+        }
+
+        try
+        {
+            var packet = ReadPacket(File.ReadAllText(packetPath), executionUnit);
+            var packetPaths = ResolvePacketPaths(context.RepoRoot, executionUnit);
+            var queueItem = CreateQueueItem(context, packet, packetPaths);
+            var result = QueueManager.Enqueue(
+                queueState,
+                queueItem,
+                TransitionActor,
+                TimestampFactory());
+
+            if (result.WasEnqueued)
+            {
+                PersistEnqueue(context, result);
+            }
+
+            QueueEnqueueRenderer.WriteSummary(writer, new QueueEnqueueCommandResult
+            {
+                ExecutionUnit = executionUnit,
+                EnqueuedExecutionUnits = result.WasEnqueued ? [executionUnit] : [],
+                PacketPaths =
+                [
+                    result.QueueItem.PacketPaths.Implementation,
+                    result.QueueItem.PacketPaths.ReviewContext,
+                    result.QueueItem.PacketPaths.Yaml
+                ],
+                SkippedUnits = result.WasEnqueued ? [] : [executionUnit]
+            });
+
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static string ResolvePacketPath(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        return Path.Combine(
+            context.ResolveArtifactRootPath(),
+            "issues",
+            executionUnit,
+            "packet.yaml");
+    }
+
+    private static ResolvedQueuePacket ReadPacket(string yaml, string expectedExecutionUnit)
+    {
+        var packet = ProjectionPacketSerializer.Deserialize(yaml);
+
+        if (!string.Equals(
+                packet.ImplementationIssuePacket.SourceExecutionUnit,
+                expectedExecutionUnit,
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Projection packet execution unit '{packet.ImplementationIssuePacket.SourceExecutionUnit}' does not match requested execution unit '{expectedExecutionUnit}'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(packet.ImplementationIssuePacket.IssueTitle))
+        {
+            throw new InvalidOperationException("Projection packet must contain a non-empty issue title.");
+        }
+
+        if (string.IsNullOrWhiteSpace(packet.ReviewContextPacket.ClarificationReturnPath))
+        {
+            throw new InvalidOperationException("Projection packet must contain a clarification return path.");
+        }
+
+        return new ResolvedQueuePacket
+        {
+            ExecutionUnit = packet.ImplementationIssuePacket.SourceExecutionUnit,
+            IssueTitle = packet.ImplementationIssuePacket.IssueTitle,
+            Dependencies = packet.ImplementationIssuePacket.Dependencies,
+            ClarificationReturnPath = packet.ReviewContextPacket.ClarificationReturnPath
+        };
+    }
+
+    private static PacketPaths ResolvePacketPaths(string repoRoot, string executionUnit)
+    {
+        var issueDirectory = Path.Combine(
+            repoRoot,
+            CliRuntimeContracts.IntentCliDirectoryName,
+            "issues",
+            executionUnit);
+
+        return new PacketPaths
+        {
+            Implementation = Path.GetRelativePath(repoRoot, Path.Combine(issueDirectory, "implementation.md"))
+                .Replace(Path.DirectorySeparatorChar, '/'),
+            ReviewContext = Path.GetRelativePath(repoRoot, Path.Combine(issueDirectory, "review-context.md"))
+                .Replace(Path.DirectorySeparatorChar, '/'),
+            Yaml = Path.GetRelativePath(repoRoot, Path.Combine(issueDirectory, "packet.yaml"))
+                .Replace(Path.DirectorySeparatorChar, '/')
+        };
+    }
+
+    private static QueueItem CreateQueueItem(
+        CliContext context,
+        ResolvedQueuePacket packet,
+        PacketPaths packetPaths)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = packet.ExecutionUnit,
+            Title = packet.IssueTitle,
+            State = QueueItemState.Queued,
+            Dependencies = packet.Dependencies,
+            BlockedBy = [],
+            ClarificationReturnPath = packet.ClarificationReturnPath,
+            PacketPaths = packetPaths,
+            LinkedIssue = null,
+            WorkerRole = context.Config.Roles.Implement,
+            ReviewRole = context.Config.Roles.Review,
+            Priority = DefaultPriority
+        };
+    }
+
+    private static void PersistEnqueue(CliContext context, QueueEnqueueResult result)
+    {
+        var queueStatePath = context.GetQueueStatePath();
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
+
+        if (result.Event is null)
+        {
+            return;
+        }
+
+        var runLogPath = context.GetRunLogPath();
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(
+            runLogPath,
+            RunLogSerializer.SerializeLine(result.Event) + Environment.NewLine);
+    }
+
+    private sealed record ResolvedQueuePacket
+    {
+        public required string ExecutionUnit { get; init; }
+
+        public required string IssueTitle { get; init; }
+
+        public required IReadOnlyList<string> Dependencies { get; init; }
+
+        public required string ClarificationReturnPath { get; init; }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/QueueEnqueueCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/QueueEnqueueCommandResult.cs
@@ -1,0 +1,12 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record QueueEnqueueCommandResult
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required IReadOnlyList<string> EnqueuedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> PacketPaths { get; init; }
+
+    public required IReadOnlyList<string> SkippedUnits { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/QueueEnqueueRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/QueueEnqueueRenderer.cs
@@ -1,0 +1,32 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class QueueEnqueueRenderer
+{
+    public static void WriteSummary(TextWriter writer, QueueEnqueueCommandResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Queue enqueue processed for execution unit '{result.ExecutionUnit}'.");
+        writer.WriteLine("Enqueued execution units:");
+        WriteList(writer, result.EnqueuedExecutionUnits);
+        writer.WriteLine("Packet paths:");
+        WriteList(writer, result.PacketPaths);
+        writer.WriteLine("Skipped units:");
+        WriteList(writer, result.SkippedUnits);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Supervisor/QueueEnqueueResult.cs
+++ b/src/IntentSystem.Supervisor/QueueEnqueueResult.cs
@@ -1,0 +1,14 @@
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Supervisor;
+
+public sealed record QueueEnqueueResult
+{
+    public required QueueState UpdatedState { get; init; }
+
+    public required QueueItem QueueItem { get; init; }
+
+    public required bool WasEnqueued { get; init; }
+
+    public RunEvent? Event { get; init; }
+}

--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -9,6 +9,67 @@ namespace IntentSystem.Supervisor;
 /// </summary>
 public static class QueueManager
 {
+    public static QueueEnqueueResult Enqueue(
+        QueueState state,
+        QueueItem queueItem,
+        string by,
+        DateTimeOffset ts)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(queueItem);
+        ArgumentException.ThrowIfNullOrWhiteSpace(by);
+
+        var existingItem = state.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal));
+        if (existingItem is not null)
+        {
+            return new QueueEnqueueResult
+            {
+                UpdatedState = state,
+                QueueItem = existingItem,
+                WasEnqueued = false,
+                Event = null
+            };
+        }
+
+        var completedUnits = state.Items
+            .Where(item => item.State == QueueItemState.Completed)
+            .Select(item => item.ExecutionUnit)
+            .ToHashSet(StringComparer.Ordinal);
+        var blockedBy = queueItem.Dependencies
+            .Where(dependency => !completedUnits.Contains(dependency))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(dependency => dependency, StringComparer.Ordinal)
+            .ToArray();
+        var normalizedItem = queueItem with
+        {
+            State = QueueItemState.Queued,
+            Dependencies = queueItem.Dependencies
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(dependency => dependency, StringComparer.Ordinal)
+                .ToArray(),
+            BlockedBy = blockedBy
+        };
+
+        return new QueueEnqueueResult
+        {
+            UpdatedState = state with
+            {
+                Items = state.Items.Concat([normalizedItem]).ToArray(),
+                UpdatedAt = ts
+            },
+            QueueItem = normalizedItem,
+            WasEnqueued = true,
+            Event = new RunEvent
+            {
+                Ts = ts,
+                ExecutionUnit = normalizedItem.ExecutionUnit,
+                Event = "queued",
+                By = by
+            }
+        };
+    }
+
     public static QueueTransitionResult TransitionNonBlocking(
         QueueState state,
         string executionUnit,

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -149,6 +149,35 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenQueueEnqueueCommand_DispatchesToQueueEnqueueRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueEnqueueQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G38", "packet.yaml"),
+            CreateQueueEnqueuePacketYaml());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T10:30:00Z");
+
+            var exitCode = CommandRouter.Execute(["queue", "enqueue", "G38"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Queue enqueue processed for execution unit 'G38'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenInterviewStartCommand_DispatchesToInterviewStartRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -1239,6 +1268,36 @@ public sealed class CommandRouterTests
         };
     }
 
+    private static QueueState CreateQueueEnqueueQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-06T10:00:00Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G3",
+                    Title = "Queue read commands",
+                    State = QueueItemState.Completed,
+                    Dependencies = [],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G3/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G3/review-context.md",
+                        Yaml = ".intent-cli/issues/G3/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
     private static QueueState CreateRunRereviewQueueState()
     {
         return new QueueState
@@ -1756,6 +1815,56 @@ public sealed class CommandRouterTests
             - "issue created"
           deterministic_review_checks:
             - "dispatch remains thin"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private static string CreateQueueEnqueuePacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "G38 Queue Enqueue Command"
+          issue_kind: "feature"
+          source_execution_unit: "G38"
+          goal: "Enqueue queue item from packet artifact."
+          in_scope:
+            - "queue enqueue command"
+          out_of_scope:
+            - "child issue creation"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli queue enqueue command"
+          dependencies:
+            - "G3"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "enqueue stays thin"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/03-queue-json-and-jsonl-schema.md"
+          acceptance_criteria:
+            - "queue item inserted"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G38"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/03-queue-json-and-jsonl-schema.md"
+          acceptance_criteria:
+            - "queue item inserted"
+          deterministic_review_checks:
+            - "enqueue remains thin"
           clarification_return_path: "intents/intent-cli/clarifications/open.md"
         """;
     }

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1822,10 +1822,9 @@ public sealed class CommandRouterTests
     private static string CreateQueueEnqueuePacketYaml()
     {
         return """
-        implementation_issue_packet:
+        execution_unit: G38
+        implementation_issue:
           issue_title: "G38 Queue Enqueue Command"
-          issue_kind: "feature"
-          source_execution_unit: "G38"
           goal: "Enqueue queue item from packet artifact."
           in_scope:
             - "queue enqueue command"
@@ -1850,22 +1849,14 @@ public sealed class CommandRouterTests
             - "queue item inserted"
           verification_evidence:
             - "tests-passing"
-          review_mode: "deterministic-review"
-          completion_action: "wait-for-deterministic-review"
-          landing_policy: "merge-after-review"
 
-        review_context_packet:
-          source_execution_unit: "G38"
-          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
-          intent_references:
-            - "ICL.P.PRODUCT_GOAL"
-          rules_and_specs:
-            - "intents/intent-cli/specs/03-queue-json-and-jsonl-schema.md"
-          acceptance_criteria:
-            - "queue item inserted"
-          deterministic_review_checks:
+        review:
+          summarize_first: true
+          require_explicit_diff_check: true
+          require_explicit_scope_check: true
+          require_explicit_contract_check: true
+          required_checks:
             - "enqueue remains thin"
-          clarification_return_path: "intents/intent-cli/clarifications/open.md"
         """;
     }
 

--- a/tests/IntentSystem.Cli.Tests/QueueEnqueueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueEnqueueCommandTests.cs
@@ -1,0 +1,268 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class QueueEnqueueCommandTests
+{
+    [Fact]
+    public void Execute_GivenPacketArtifact_EnqueuesItemAndAppendsRunLog()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G38", "packet.yaml"),
+            CreatePacketYaml());
+        var originalTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+        using var writer = new StringWriter();
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T10:30:00Z");
+
+            var exitCode = QueueEnqueueCommand.Execute(CreateContext(repoRoot), ["G38"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Queue enqueue processed for execution unit 'G38'.", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            var selectedItem = updatedState.Items.Single(item => item.ExecutionUnit == "G38");
+            Assert.Equal("G38 Queue Enqueue Command", selectedItem.Title);
+            Assert.Equal(QueueItemState.Queued, selectedItem.State);
+            Assert.Equal(["G3", "G4"], selectedItem.Dependencies);
+            Assert.Equal(["G4"], selectedItem.BlockedBy);
+            Assert.Equal("intents/intent-cli/clarifications/open.md", selectedItem.ClarificationReturnPath);
+            Assert.Equal(".intent-cli/issues/G38/packet.yaml", selectedItem.PacketPaths.Yaml);
+            Assert.Equal("Claude", selectedItem.WorkerRole);
+            Assert.Equal("Codex", selectedItem.ReviewRole);
+            Assert.Equal("high", selectedItem.Priority);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            var queued = Assert.Single(runEvents);
+            Assert.Equal("queued", queued.Event);
+            Assert.Equal("G38", queued.ExecutionUnit);
+            Assert.Equal("intent-cli", queued.By);
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenExistingQueueItem_SkipsWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(includeExisting: true)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G38", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = QueueEnqueueCommand.Execute(CreateContext(repoRoot), ["G38"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Skipped units:", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("- G38", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = QueueEnqueueCommand.Execute(CreateContext(repoRoot), ["G38"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Projection packet artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenPacketExecutionUnitMismatch_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G38", "packet.yaml"),
+            CreatePacketYaml(packetExecutionUnit: "G99"));
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = QueueEnqueueCommand.Execute(CreateContext(repoRoot), ["G38"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("does not match requested execution unit", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState(bool includeExisting = false)
+    {
+        var items = new List<QueueItem>
+        {
+            CreateItem("G3", QueueItemState.Completed),
+            CreateItem("G4", QueueItemState.Queued)
+        };
+
+        if (includeExisting)
+        {
+            items.Add(CreateItem("G38", QueueItemState.Queued));
+        }
+
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-06T10:00:00Z"),
+            Items = items
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Existing Item",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            LinkedIssue = null,
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static string CreatePacketYaml(string packetExecutionUnit = "G38")
+    {
+        return $"""
+        implementation_issue_packet:
+          issue_title: "G38 Queue Enqueue Command"
+          issue_kind: "feature"
+          source_execution_unit: "{packetExecutionUnit}"
+          goal: "Enqueue issue packet into queue artifacts."
+          in_scope:
+            - "queue enqueue command"
+          out_of_scope:
+            - "workflow execution"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli queue enqueue command"
+          dependencies:
+            - "G4"
+            - "G3"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "queue insertion stays thin"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/03-queue-json-and-jsonl-schema.md"
+          acceptance_criteria:
+            - "queue item inserted"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "{packetExecutionUnit}"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/intent-cli/specs/03-queue-json-and-jsonl-schema.md"
+          acceptance_criteria:
+            - "queue item inserted"
+          deterministic_review_checks:
+            - "queue insertion remains thin"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-queue-enqueue-command-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/QueueEnqueueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueEnqueueCommandTests.cs
@@ -187,10 +187,9 @@ public sealed class QueueEnqueueCommandTests
     private static string CreatePacketYaml(string packetExecutionUnit = "G38")
     {
         return $"""
-        implementation_issue_packet:
+        execution_unit: {packetExecutionUnit}
+        implementation_issue:
           issue_title: "G38 Queue Enqueue Command"
-          issue_kind: "feature"
-          source_execution_unit: "{packetExecutionUnit}"
           goal: "Enqueue issue packet into queue artifacts."
           in_scope:
             - "queue enqueue command"
@@ -216,22 +215,14 @@ public sealed class QueueEnqueueCommandTests
             - "queue item inserted"
           verification_evidence:
             - "tests-passing"
-          review_mode: "deterministic-review"
-          completion_action: "wait-for-deterministic-review"
-          landing_policy: "merge-after-review"
 
-        review_context_packet:
-          source_execution_unit: "{packetExecutionUnit}"
-          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
-          intent_references:
-            - "ICL.P.PRODUCT_GOAL"
-          rules_and_specs:
-            - "intents/intent-cli/specs/03-queue-json-and-jsonl-schema.md"
-          acceptance_criteria:
-            - "queue item inserted"
-          deterministic_review_checks:
+        review:
+          summarize_first: true
+          require_explicit_diff_check: true
+          require_explicit_scope_check: true
+          require_explicit_contract_check: true
+          required_checks:
             - "queue insertion remains thin"
-          clarification_return_path: "intents/intent-cli/clarifications/open.md"
         """;
     }
 

--- a/tests/IntentSystem.Cli.Tests/QueueEnqueueRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueEnqueueRendererTests.cs
@@ -1,0 +1,36 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class QueueEnqueueRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenCommandResult_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        QueueEnqueueRenderer.WriteSummary(
+            writer,
+            new QueueEnqueueCommandResult
+            {
+                ExecutionUnit = "G38",
+                EnqueuedExecutionUnits = ["G38"],
+                PacketPaths =
+                [
+                    ".intent-cli/issues/G38/implementation.md",
+                    ".intent-cli/issues/G38/review-context.md",
+                    ".intent-cli/issues/G38/packet.yaml"
+                ],
+                SkippedUnits = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Queue enqueue processed for execution unit 'G38'.", output, StringComparison.Ordinal);
+        Assert.Contains("Enqueued execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("- G38", output, StringComparison.Ordinal);
+        Assert.Contains("Packet paths:", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/issues/G38/packet.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped units:", output, StringComparison.Ordinal);
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
@@ -188,6 +188,50 @@ public sealed class QueueManagerTests
     }
 
     [Fact]
+    public void Enqueue_GivenNewItem_AppendsQueuedEventAndPopulatesBlockedBy()
+    {
+        var completedDependency = CreateItem("A1", QueueItemState.Completed);
+        var queuedDependency = CreateItem("A2", QueueItemState.Queued);
+        var state = CreateState([completedDependency, queuedDependency]);
+        var candidate = CreateItem("B1", QueueItemState.Active) with
+        {
+            Dependencies = ["A2", "A1", "A2"],
+            BlockedBy = ["stale-value"]
+        };
+
+        var result = QueueManager.Enqueue(state, candidate, "intent-cli", BaseTime);
+
+        Assert.True(result.WasEnqueued);
+        Assert.NotNull(result.Event);
+        Assert.Equal("queued", result.Event!.Event);
+        Assert.Equal("B1", result.Event.ExecutionUnit);
+        Assert.Equal("intent-cli", result.Event.By);
+
+        var insertedItem = FindItem(result.UpdatedState, "B1");
+        Assert.Equal(QueueItemState.Queued, insertedItem.State);
+        Assert.Equal(["A1", "A2"], insertedItem.Dependencies);
+        Assert.Equal(["A2"], insertedItem.BlockedBy);
+    }
+
+    [Fact]
+    public void Enqueue_GivenExistingExecutionUnit_SkipsWithoutMutation()
+    {
+        var existingItem = CreateItem("A1", QueueItemState.Queued);
+        var state = CreateState([existingItem]);
+        var candidate = CreateItem("A1", QueueItemState.Active) with
+        {
+            Title = "[A1] Replacement"
+        };
+
+        var result = QueueManager.Enqueue(state, candidate, "intent-cli", BaseTime);
+
+        Assert.False(result.WasEnqueued);
+        Assert.Null(result.Event);
+        Assert.Same(state, result.UpdatedState);
+        Assert.Equal(existingItem, result.QueueItem);
+    }
+
+    [Fact]
     public void RefreshDependencies_GivenAllDepsCompleted_UnblocksItem()
     {
         var a1 = CreateItem("A1", QueueItemState.Completed);


### PR DESCRIPTION
## Summary
- add `intent-cli queue enqueue <execution-unit>` as a thin queue insertion command from an existing packet artifact
- resolve queue item metadata from `.intent-cli/issues/<execution-unit>/packet.yaml` and append a deterministic `queued` run event
- keep duplicate handling and queue mutation isolated from child issue creation, autostart, and workflow or review execution

## Testing
- dotnet test IntentSystem.sln
