### PR TITLE
[codex] Issue 104 intake enqueue command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -82,6 +82,7 @@ internal static class CommandRouter
                 ["apply"] = IntakeApplyCommand.Execute,
                 ["execution"] = IntakeExecutionCommand.Execute,
                 ["issue"] = IntakeIssueCommand.Execute,
+                ["enqueue"] = IntakeEnqueueCommand.Execute,
                 ["autostart"] = IntakeAutostartCommand.Execute
             }
         };

--- a/src/IntentSystem.Cli/Commands/IntakeEnqueueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeEnqueueCommand.cs
@@ -1,0 +1,179 @@
+using IntentSystem.Supervisor;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeEnqueueCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Intake enqueue command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0].Trim();
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        try
+        {
+            var units = LoadExecutionUnits(context.RepoRoot, domain);
+            if (units.Count == 0)
+            {
+                writer.WriteLine($"No generated execution units were found for domain '{domain}'.");
+                return 1;
+            }
+
+            var candidateQueueItems = ResolveQueueItems(context, units);
+            var result = EnqueueQueueItems(context, domain, queueState, candidateQueueItems);
+            IntakeEnqueueRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static IReadOnlyList<string> LoadExecutionUnits(string repoRoot, string domain)
+    {
+        var executionArtifactPath = Path.Combine(
+            repoRoot,
+            IntakeExecutionArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(executionArtifactPath))
+        {
+            throw new InvalidOperationException($"Intake execution artifact was not found at {executionArtifactPath}");
+        }
+
+        var request = IntakeExecutionArtifactMarkdown.Deserialize(File.ReadAllText(executionArtifactPath));
+        if (!string.Equals(request.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Intake execution artifact domain '{request.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        return request.ProposedExecutionUnits
+            .Select(unit => unit.ExecutionUnitId)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(unit => unit, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<CandidateQueueItem> ResolveQueueItems(
+        CliContext context,
+        IReadOnlyList<string> executionUnits)
+    {
+        var results = new List<CandidateQueueItem>(executionUnits.Count);
+
+        foreach (var executionUnit in executionUnits)
+        {
+            var packetPath = QueueEnqueueCommand.ResolvePacketPath(context, executionUnit);
+            if (!File.Exists(packetPath))
+            {
+                throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
+            }
+
+            var packet = QueueEnqueueCommand.ReadPacket(File.ReadAllText(packetPath), executionUnit);
+            var packetPaths = QueueEnqueueCommand.ResolvePacketPaths(context.RepoRoot, executionUnit);
+            var queueItem = QueueEnqueueCommand.CreateQueueItem(context, packet, packetPaths);
+
+            results.Add(new CandidateQueueItem
+            {
+                ExecutionUnit = executionUnit,
+                QueueItem = queueItem
+            });
+        }
+
+        return results;
+    }
+
+    private static IntakeEnqueueResult EnqueueQueueItems(
+        CliContext context,
+        string domain,
+        IntentSystem.Supervisor.Models.QueueState initialQueueState,
+        IReadOnlyList<CandidateQueueItem> candidates)
+    {
+        var currentQueueState = initialQueueState;
+        var enqueuedExecutionUnits = new List<string>();
+        var packetPaths = new List<string>();
+        var skippedUnits = new List<string>();
+        var events = new List<IntentSystem.Supervisor.Models.RunEvent>();
+
+        foreach (var candidate in candidates)
+        {
+            var enqueueResult = QueueManager.Enqueue(
+                currentQueueState,
+                candidate.QueueItem,
+                "intent-cli",
+                QueueEnqueueCommand.TimestampFactory());
+
+            currentQueueState = enqueueResult.UpdatedState;
+
+            if (!enqueueResult.WasEnqueued)
+            {
+                skippedUnits.Add(candidate.ExecutionUnit);
+                continue;
+            }
+
+            enqueuedExecutionUnits.Add(candidate.ExecutionUnit);
+            packetPaths.Add(candidate.QueueItem.PacketPaths.Implementation);
+            packetPaths.Add(candidate.QueueItem.PacketPaths.ReviewContext);
+            packetPaths.Add(candidate.QueueItem.PacketPaths.Yaml);
+            if (enqueueResult.Event is not null)
+            {
+                events.Add(enqueueResult.Event);
+            }
+        }
+
+        if (events.Count > 0)
+        {
+            Persist(context, currentQueueState, events);
+        }
+
+        return new IntakeEnqueueResult
+        {
+            Domain = domain,
+            EnqueuedExecutionUnits = enqueuedExecutionUnits,
+            PacketPaths = packetPaths,
+            SkippedUnits = skippedUnits
+        };
+    }
+
+    private static void Persist(
+        CliContext context,
+        IntentSystem.Supervisor.Models.QueueState queueState,
+        IReadOnlyList<IntentSystem.Supervisor.Models.RunEvent> events)
+    {
+        var queueStatePath = context.GetQueueStatePath();
+        File.WriteAllText(
+            queueStatePath,
+            IntentSystem.Supervisor.Serialization.QueueStateSerializer.Serialize(queueState));
+
+        var runLogPath = context.GetRunLogPath();
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+
+        var serializedEvents = string.Join(
+            Environment.NewLine,
+            events.Select(IntentSystem.Supervisor.Serialization.RunLogSerializer.SerializeLine));
+        File.AppendAllText(runLogPath, serializedEvents + Environment.NewLine);
+    }
+
+    private sealed record CandidateQueueItem
+    {
+        public required string ExecutionUnit { get; init; }
+
+        public required IntentSystem.Supervisor.Models.QueueItem QueueItem { get; init; }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeEnqueueRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeEnqueueRenderer.cs
@@ -1,0 +1,32 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeEnqueueRenderer
+{
+    public static void WriteSummary(TextWriter writer, IntakeEnqueueResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Intake enqueue processed for domain '{result.Domain}'.");
+        writer.WriteLine("Enqueued execution units:");
+        WriteList(writer, result.EnqueuedExecutionUnits);
+        writer.WriteLine("Packet paths:");
+        WriteList(writer, result.PacketPaths);
+        writer.WriteLine("Skipped units:");
+        WriteList(writer, result.SkippedUnits);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeEnqueueResult.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeEnqueueResult.cs
@@ -1,0 +1,12 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeEnqueueResult
+{
+    public required string Domain { get; init; }
+
+    public required IReadOnlyList<string> EnqueuedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> PacketPaths { get; init; }
+
+    public required IReadOnlyList<string> SkippedUnits { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/QueueEnqueueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueEnqueueCommand.cs
@@ -75,7 +75,7 @@ internal static class QueueEnqueueCommand
         }
     }
 
-    private static string ResolvePacketPath(CliContext context, string executionUnit)
+    internal static string ResolvePacketPath(CliContext context, string executionUnit)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
@@ -87,7 +87,7 @@ internal static class QueueEnqueueCommand
             "packet.yaml");
     }
 
-    private static ResolvedQueuePacket ReadPacket(string yaml, string expectedExecutionUnit)
+    internal static ResolvedQueuePacket ReadPacket(string yaml, string expectedExecutionUnit)
     {
         var packet = ProjectionPacketRuntimeReader.Read(yaml);
 
@@ -119,7 +119,7 @@ internal static class QueueEnqueueCommand
         };
     }
 
-    private static PacketPaths ResolvePacketPaths(string repoRoot, string executionUnit)
+    internal static PacketPaths ResolvePacketPaths(string repoRoot, string executionUnit)
     {
         var issueDirectory = Path.Combine(
             repoRoot,
@@ -138,7 +138,7 @@ internal static class QueueEnqueueCommand
         };
     }
 
-    private static QueueItem CreateQueueItem(
+    internal static QueueItem CreateQueueItem(
         CliContext context,
         ResolvedQueuePacket packet,
         PacketPaths packetPaths)
@@ -159,7 +159,7 @@ internal static class QueueEnqueueCommand
         };
     }
 
-    private static void PersistEnqueue(CliContext context, QueueEnqueueResult result)
+    internal static void PersistEnqueue(CliContext context, QueueEnqueueResult result)
     {
         var queueStatePath = context.GetQueueStatePath();
         File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
@@ -178,7 +178,7 @@ internal static class QueueEnqueueCommand
             RunLogSerializer.SerializeLine(result.Event) + Environment.NewLine);
     }
 
-    private sealed record ResolvedQueuePacket
+    internal sealed record ResolvedQueuePacket
     {
         public required string ExecutionUnit { get; init; }
 

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -525,6 +525,55 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeEnqueueCommand_DispatchesToIntakeEnqueueRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueEnqueueQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            """
+            # Intake Execution Draft
+
+            ## Domain
+            `auth`
+
+            ## Proposed Execution Units
+
+            ### `AUTH-01`
+            source_file_path: intents/intent-cli/concepts/oauth2.md
+            target_part: concepts
+            dependencies:
+            - none
+            readiness_notes:
+            - Current heading: # Auth Concept
+            verification_hints:
+            - dotnet test IntentSystem.sln
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "packet.yaml"),
+            CreateIntakeEnqueuePacketYaml("AUTH-01"));
+        using var writer = new StringWriter();
+        var originalTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:00:00Z");
+
+            var exitCode = CommandRouter.Execute(["intake", "enqueue", "auth"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Intake enqueue processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenIntakeConceptCommand_DispatchesToIntakeConceptRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -1296,6 +1345,43 @@ public sealed class CommandRouterTests
                 }
             ]
         };
+    }
+
+    private static string CreateIntakeEnqueuePacketYaml(string executionUnit)
+    {
+        return $"""
+        execution_unit: {executionUnit}
+        implementation_issue:
+          issue_title: "{executionUnit} Queue Item"
+          goal: "Enqueue generated issue artifact into queue artifacts."
+          in_scope:
+            - "queue insertion"
+          out_of_scope:
+            - "workflow execution"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli intake enqueue command"
+          dependencies:
+            - "G3"
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guidance:
+            - "AGENTS.md"
+          intent_baseline:
+            - "intake enqueue stays thin"
+          acceptance_criteria:
+            - "queue item inserted"
+          verification:
+            - "tests-passing"
+
+        review:
+          summarize_first: true
+          require_explicit_diff_check: true
+          require_explicit_scope_check: true
+          require_explicit_contract_check: true
+          required_checks:
+            - "intake enqueue remains thin"
+        """;
     }
 
     private static QueueState CreateRunRereviewQueueState()

--- a/tests/IntentSystem.Cli.Tests/IntakeEnqueueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeEnqueueCommandTests.cs
@@ -1,0 +1,296 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeEnqueueCommandTests
+{
+    [Fact]
+    public void Execute_GivenExecutionArtifactAndPackets_EnqueuesSelectedDomainUnitsAndAppendsRunLog()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateExecutionArtifact("auth", ["AUTH-01", "AUTH-02"]));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "packet.yaml"),
+            CreatePacketYaml("AUTH-01", ["G3"]));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-02", "packet.yaml"),
+            CreatePacketYaml("AUTH-02", ["AUTH-01", "G4"]));
+        var originalTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+        using var writer = new StringWriter();
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:00:00Z");
+
+            var exitCode = IntakeEnqueueCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Intake enqueue processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-02", output, StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            var auth01 = queueState.Items.Single(item => item.ExecutionUnit == "AUTH-01");
+            var auth02 = queueState.Items.Single(item => item.ExecutionUnit == "AUTH-02");
+            Assert.Equal(QueueItemState.Queued, auth01.State);
+            Assert.Equal(["G3"], auth01.Dependencies);
+            Assert.Empty(auth01.BlockedBy);
+            Assert.Equal(".intent-cli/issues/AUTH-01/packet.yaml", auth01.PacketPaths.Yaml);
+            Assert.Equal("Claude", auth01.WorkerRole);
+            Assert.Equal("Codex", auth01.ReviewRole);
+            Assert.Equal(QueueItemState.Queued, auth02.State);
+            Assert.Equal(["AUTH-01", "G4"], auth02.Dependencies);
+            Assert.Equal(["AUTH-01", "G4"], auth02.BlockedBy);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal(2, runEvents.Count);
+            Assert.All(runEvents, runEvent => Assert.Equal("queued", runEvent.Event));
+            Assert.Equal(["AUTH-01", "AUTH-02"], runEvents.Select(runEvent => runEvent.ExecutionUnit).ToArray());
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenExistingQueueItem_SkipsWithoutDuplicateEnqueue()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(includeExisting: true)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateExecutionArtifact("auth", ["AUTH-01"]));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "packet.yaml"),
+            CreatePacketYaml("AUTH-01", ["G3"]));
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = IntakeEnqueueCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Skipped units:", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("- AUTH-01", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingExecutionArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeEnqueueCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Intake execution artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketArtifact_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateExecutionArtifact("auth", ["AUTH-01"]));
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = IntakeEnqueueCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Projection packet artifact was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState(bool includeExisting = false)
+    {
+        var items = new List<QueueItem>
+        {
+            CreateItem("G3", QueueItemState.Completed),
+            CreateItem("G4", QueueItemState.Queued)
+        };
+
+        if (includeExisting)
+        {
+            items.Add(CreateItem("AUTH-01", QueueItemState.Queued));
+        }
+
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-06T10:00:00Z"),
+            Items = items
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Existing Item",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            LinkedIssue = null,
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "high"
+        };
+    }
+
+    private static string CreateExecutionArtifact(string domain, IReadOnlyList<string> executionUnits)
+    {
+        var sections = executionUnits.Select(executionUnit =>
+            $$"""
+
+            ### `{{executionUnit}}`
+            source_file_path: intents/intent-cli/concepts/{{executionUnit.ToLowerInvariant()}}.md
+            target_part: concepts
+            dependencies:
+            - none
+            readiness_notes:
+            - Current heading: # {{executionUnit}}
+            verification_hints:
+            - dotnet test IntentSystem.sln
+            """);
+
+        return $$"""
+            # Intake Execution Draft
+
+            ## Domain
+            `{{domain}}`
+
+            ## Proposed Execution Units{{string.Concat(sections)}}
+            """;
+    }
+
+    private static string CreatePacketYaml(string executionUnit, IReadOnlyList<string> dependencies)
+    {
+        var dependencyLines = dependencies.Count == 0
+            ? "    - \"none\""
+            : string.Join(Environment.NewLine, dependencies.Select(value => $"    - \"{value}\""));
+
+        return $$"""
+            execution_unit: {{executionUnit}}
+            implementation_issue:
+              issue_title: "{{executionUnit}} Queue Item"
+              goal: "Enqueue generated issue artifact into queue artifacts."
+              in_scope:
+                - "queue insertion"
+              out_of_scope:
+                - "workflow execution"
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "cli intake enqueue command"
+              dependencies:
+            {{dependencyLines}}
+              technical_baseline:
+                - "C# / .NET"
+              project_local_guidance:
+                - "AGENTS.md"
+              intent_baseline:
+                - "intake enqueue stays thin"
+              acceptance_criteria:
+                - "queue item inserted"
+              verification:
+                - "tests-passing"
+
+            review:
+              summarize_first: true
+              require_explicit_diff_check: true
+              require_explicit_scope_check: true
+              require_explicit_contract_check: true
+              required_checks:
+                - "intake enqueue remains thin"
+            """;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-enqueue-command-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeEnqueueRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeEnqueueRendererTests.cs
@@ -1,0 +1,36 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeEnqueueRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenResult_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        IntakeEnqueueRenderer.WriteSummary(
+            writer,
+            new IntakeEnqueueResult
+            {
+                Domain = "auth",
+                EnqueuedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                PacketPaths =
+                [
+                    ".intent-cli/issues/AUTH-01/implementation.md",
+                    ".intent-cli/issues/AUTH-01/review-context.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                SkippedUnits = ["AUTH-03"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Intake enqueue processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Enqueued execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+        Assert.Contains("Packet paths:", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/issues/AUTH-01/packet.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped units:", output, StringComparison.Ordinal);
+        Assert.Contains("- AUTH-03", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `intent-cli intake enqueue <domain>` as a thin domain-to-queue bridge from the intake execution artifact and generated packet artifacts
- resolve selected execution units from `.intent-cli/intake/<domain>.execution.md`, read packet metadata, and batch enqueue queue items deterministically
- append per-execution-unit `queued` events without expanding into child issue creation, autostart, or workflow/review execution

## Testing
- dotnet test IntentSystem.sln
