### PR TITLE
[codex] Add intake launch command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -83,7 +83,8 @@ internal static class CommandRouter
                 ["execution"] = IntakeExecutionCommand.Execute,
                 ["issue"] = IntakeIssueCommand.Execute,
                 ["enqueue"] = IntakeEnqueueCommand.Execute,
-                ["autostart"] = IntakeAutostartCommand.Execute
+                ["autostart"] = IntakeAutostartCommand.Execute,
+                ["launch"] = IntakeLaunchCommand.Execute
             }
         };
 

--- a/src/IntentSystem.Cli/Commands/IntakeEnqueueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeEnqueueCommand.cs
@@ -44,7 +44,7 @@ internal static class IntakeEnqueueCommand
         }
     }
 
-    private static IReadOnlyList<string> LoadExecutionUnits(string repoRoot, string domain)
+    internal static IReadOnlyList<string> LoadExecutionUnits(string repoRoot, string domain)
     {
         var executionArtifactPath = Path.Combine(
             repoRoot,

--- a/src/IntentSystem.Cli/Commands/IntakeLaunchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeLaunchCommand.cs
@@ -1,4 +1,6 @@
 using IntentSystem.Supervisor.Serialization;
+using QueueItem = IntentSystem.Supervisor.Models.QueueItem;
+using QueueItemState = IntentSystem.Supervisor.Models.QueueItemState;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -32,19 +34,7 @@ internal static class IntakeLaunchCommand
                 return 1;
             }
 
-            var existingUnits = queueState.Items
-                .Select(item => item.ExecutionUnit)
-                .ToHashSet(StringComparer.Ordinal);
-            var skippedUnits = executionUnits
-                .Where(existingUnits.Contains)
-                .ToArray();
-            var launchUnits = executionUnits
-                .Where(unit => !existingUnits.Contains(unit))
-                .ToArray();
-
-            ValidateArtifacts(context, launchUnits);
-
-            var result = LaunchUnits(context, domain, launchUnits, skippedUnits);
+            var result = LaunchUnits(context, domain, executionUnits);
             IntakeLaunchRenderer.WriteSummary(writer, result);
             return 0;
         }
@@ -55,62 +45,98 @@ internal static class IntakeLaunchCommand
         }
     }
 
-    private static void ValidateArtifacts(CliContext context, IReadOnlyList<string> executionUnits)
+    private static void ValidatePacketArtifact(CliContext context, string executionUnit)
     {
-        foreach (var executionUnit in executionUnits)
+        var packetPath = QueueEnqueueCommand.ResolvePacketPath(context, executionUnit);
+        if (!File.Exists(packetPath))
         {
-            var packetPath = QueueEnqueueCommand.ResolvePacketPath(context, executionUnit);
-            if (!File.Exists(packetPath))
-            {
-                throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
-            }
+            throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
+        }
+    }
 
-            var packetRef = QueueEnqueueCommand.ResolvePacketPaths(context.RepoRoot, executionUnit).Yaml;
-            var githubBodyPath = QueueDispatchCommand.ResolveGitHubBodyPath(context.RepoRoot, packetRef);
-            if (!File.Exists(githubBodyPath))
-            {
-                throw new InvalidOperationException($"GitHub issue body artifact was not found at {githubBodyPath}");
-            }
+    private static void ValidateGitHubBodyArtifact(CliContext context, string executionUnit)
+    {
+        var packetRef = QueueEnqueueCommand.ResolvePacketPaths(context.RepoRoot, executionUnit).Yaml;
+        var githubBodyPath = QueueDispatchCommand.ResolveGitHubBodyPath(context.RepoRoot, packetRef);
+        if (!File.Exists(githubBodyPath))
+        {
+            throw new InvalidOperationException($"GitHub issue body artifact was not found at {githubBodyPath}");
         }
     }
 
     private static IntakeLaunchResult LaunchUnits(
         CliContext context,
         string domain,
-        IReadOnlyList<string> launchUnits,
-        IReadOnlyList<string> skippedUnits)
+        IReadOnlyList<string> executionUnits)
     {
-        var launchedExecutionUnits = new List<string>(launchUnits.Count);
-        var createdIssueRefs = new List<string>(launchUnits.Count);
-        var worktreePaths = new List<string>(launchUnits.Count);
+        var launchedExecutionUnits = new List<string>(executionUnits.Count);
+        var createdIssueRefs = new List<string>(executionUnits.Count);
+        var worktreePaths = new List<string>(executionUnits.Count);
+        var skippedUnits = new List<string>();
 
-        foreach (var executionUnit in launchUnits)
+        foreach (var executionUnit in executionUnits)
         {
-            ExecuteStep(
-                (ctx, stepWriter) => QueueEnqueueCommand.Execute(ctx, [executionUnit], stepWriter),
-                context,
-                executionUnit,
-                "queue enqueue");
-            ExecuteStep(
-                (ctx, stepWriter) => QueueDispatchCommand.Execute(ctx, [executionUnit], stepWriter),
-                context,
-                executionUnit,
-                "queue dispatch");
+            var queueItem = TryLoadQueueItem(context, executionUnit);
+            var shouldEnqueue = queueItem is null;
+            var requiresDispatch = shouldEnqueue || queueItem?.LinkedIssue is null;
+
+            if (queueItem is not null && IsAlreadyLaunched(queueItem.State))
+            {
+                skippedUnits.Add(executionUnit);
+                continue;
+            }
+
+            ValidatePacketArtifact(context, executionUnit);
+            if (requiresDispatch)
+            {
+                ValidateGitHubBodyArtifact(context, executionUnit);
+            }
+
+            if (shouldEnqueue)
+            {
+                ExecuteStep(
+                    (ctx, stepWriter) => QueueEnqueueCommand.Execute(ctx, [executionUnit], stepWriter),
+                    context,
+                    executionUnit,
+                    "queue enqueue");
+                queueItem = LoadQueueItem(context, executionUnit);
+            }
+
+            queueItem ??= LoadQueueItem(context, executionUnit);
+            if (queueItem.State != QueueItemState.Queued)
+            {
+                throw new InvalidOperationException(
+                    $"Execution unit '{executionUnit}' is in state '{FormatState(queueItem.State)}' and cannot be intake-launched.");
+            }
+
+            if (queueItem.LinkedIssue is null)
+            {
+                ExecuteStep(
+                    (ctx, stepWriter) => QueueDispatchCommand.Execute(ctx, [executionUnit], stepWriter),
+                    context,
+                    executionUnit,
+                    "queue dispatch");
+            }
+
             ExecuteStep(
                 (ctx, stepWriter) => RunStartCommand.Execute(ctx, [executionUnit], stepWriter),
                 context,
                 executionUnit,
                 "run start");
 
-            var queueItem = LoadQueueItem(context, executionUnit);
-            if (queueItem.LinkedIssue is null)
+            var launchedQueueItem = LoadQueueItem(context, executionUnit);
+            if (launchedQueueItem.LinkedIssue is null)
             {
                 throw new InvalidOperationException(
                     $"Execution unit '{executionUnit}' must have a linked issue after intake launch.");
             }
 
             launchedExecutionUnits.Add(executionUnit);
-            createdIssueRefs.Add(queueItem.LinkedIssue.Url);
+            if (queueItem.LinkedIssue is null)
+            {
+                createdIssueRefs.Add(launchedQueueItem.LinkedIssue.Url);
+            }
+
             worktreePaths.Add(RunStartCommand.ResolveWorktreePath(context, executionUnit));
         }
 
@@ -143,12 +169,35 @@ internal static class IntakeLaunchCommand
         }
     }
 
-    private static IntentSystem.Supervisor.Models.QueueItem LoadQueueItem(CliContext context, string executionUnit)
+    private static QueueItem? TryLoadQueueItem(CliContext context, string executionUnit)
     {
         var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(context.GetQueueStatePath()));
         return queueState.Items.FirstOrDefault(item =>
-                   string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+    }
+
+    private static QueueItem LoadQueueItem(CliContext context, string executionUnit)
+    {
+        return TryLoadQueueItem(context, executionUnit)
                ?? throw new InvalidOperationException(
                    $"Execution unit '{executionUnit}' was not found in queue state after intake launch.");
+    }
+
+    private static bool IsAlreadyLaunched(QueueItemState state)
+    {
+        return state is QueueItemState.Active
+            or QueueItemState.Review
+            or QueueItemState.Fixing
+            or QueueItemState.ClarifyBlocked
+            or QueueItemState.Completed;
+    }
+
+    private static string FormatState(QueueItemState state)
+    {
+        return state switch
+        {
+            QueueItemState.ClarifyBlocked => "clarify-blocked",
+            _ => state.ToString().ToLowerInvariant()
+        };
     }
 }

--- a/src/IntentSystem.Cli/Commands/IntakeLaunchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeLaunchCommand.cs
@@ -1,0 +1,154 @@
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeLaunchCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Intake launch command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0].Trim();
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            return 1;
+        }
+
+        try
+        {
+            var executionUnits = IntakeEnqueueCommand.LoadExecutionUnits(context.RepoRoot, domain);
+            if (executionUnits.Count == 0)
+            {
+                writer.WriteLine($"No generated issue-ready execution units were found for domain '{domain}'.");
+                return 1;
+            }
+
+            var existingUnits = queueState.Items
+                .Select(item => item.ExecutionUnit)
+                .ToHashSet(StringComparer.Ordinal);
+            var skippedUnits = executionUnits
+                .Where(existingUnits.Contains)
+                .ToArray();
+            var launchUnits = executionUnits
+                .Where(unit => !existingUnits.Contains(unit))
+                .ToArray();
+
+            ValidateArtifacts(context, launchUnits);
+
+            var result = LaunchUnits(context, domain, launchUnits, skippedUnits);
+            IntakeLaunchRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static void ValidateArtifacts(CliContext context, IReadOnlyList<string> executionUnits)
+    {
+        foreach (var executionUnit in executionUnits)
+        {
+            var packetPath = QueueEnqueueCommand.ResolvePacketPath(context, executionUnit);
+            if (!File.Exists(packetPath))
+            {
+                throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
+            }
+
+            var packetRef = QueueEnqueueCommand.ResolvePacketPaths(context.RepoRoot, executionUnit).Yaml;
+            var githubBodyPath = QueueDispatchCommand.ResolveGitHubBodyPath(context.RepoRoot, packetRef);
+            if (!File.Exists(githubBodyPath))
+            {
+                throw new InvalidOperationException($"GitHub issue body artifact was not found at {githubBodyPath}");
+            }
+        }
+    }
+
+    private static IntakeLaunchResult LaunchUnits(
+        CliContext context,
+        string domain,
+        IReadOnlyList<string> launchUnits,
+        IReadOnlyList<string> skippedUnits)
+    {
+        var launchedExecutionUnits = new List<string>(launchUnits.Count);
+        var createdIssueRefs = new List<string>(launchUnits.Count);
+        var worktreePaths = new List<string>(launchUnits.Count);
+
+        foreach (var executionUnit in launchUnits)
+        {
+            ExecuteStep(
+                (ctx, stepWriter) => QueueEnqueueCommand.Execute(ctx, [executionUnit], stepWriter),
+                context,
+                executionUnit,
+                "queue enqueue");
+            ExecuteStep(
+                (ctx, stepWriter) => QueueDispatchCommand.Execute(ctx, [executionUnit], stepWriter),
+                context,
+                executionUnit,
+                "queue dispatch");
+            ExecuteStep(
+                (ctx, stepWriter) => RunStartCommand.Execute(ctx, [executionUnit], stepWriter),
+                context,
+                executionUnit,
+                "run start");
+
+            var queueItem = LoadQueueItem(context, executionUnit);
+            if (queueItem.LinkedIssue is null)
+            {
+                throw new InvalidOperationException(
+                    $"Execution unit '{executionUnit}' must have a linked issue after intake launch.");
+            }
+
+            launchedExecutionUnits.Add(executionUnit);
+            createdIssueRefs.Add(queueItem.LinkedIssue.Url);
+            worktreePaths.Add(RunStartCommand.ResolveWorktreePath(context, executionUnit));
+        }
+
+        return new IntakeLaunchResult
+        {
+            Domain = domain,
+            LaunchedExecutionUnits = launchedExecutionUnits,
+            CreatedIssueRefs = createdIssueRefs,
+            WorktreePaths = worktreePaths,
+            SkippedUnits = skippedUnits
+        };
+    }
+
+    private static void ExecuteStep(
+        Func<CliContext, StringWriter, int> step,
+        CliContext context,
+        string executionUnit,
+        string stepName)
+    {
+        var stepWriter = new StringWriter();
+        var exitCode = step(context, stepWriter);
+
+        if (exitCode != 0)
+        {
+            var detail = stepWriter.ToString().TrimEnd();
+            throw new InvalidOperationException(
+                string.IsNullOrWhiteSpace(detail)
+                    ? $"Intake launch failed during {stepName} for '{executionUnit}'."
+                    : $"Intake launch failed during {stepName} for '{executionUnit}': {detail}");
+        }
+    }
+
+    private static IntentSystem.Supervisor.Models.QueueItem LoadQueueItem(CliContext context, string executionUnit)
+    {
+        var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(context.GetQueueStatePath()));
+        return queueState.Items.FirstOrDefault(item =>
+                   string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+               ?? throw new InvalidOperationException(
+                   $"Execution unit '{executionUnit}' was not found in queue state after intake launch.");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeLaunchRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeLaunchRenderer.cs
@@ -1,0 +1,34 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeLaunchRenderer
+{
+    public static void WriteSummary(TextWriter writer, IntakeLaunchResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Intake launch processed for domain '{result.Domain}'.");
+        writer.WriteLine("Launched execution units:");
+        WriteList(writer, result.LaunchedExecutionUnits);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Skipped units:");
+        WriteList(writer, result.SkippedUnits);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeLaunchResult.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeLaunchResult.cs
@@ -1,0 +1,14 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeLaunchResult
+{
+    public required string Domain { get; init; }
+
+    public required IReadOnlyList<string> LaunchedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> SkippedUnits { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -641,6 +641,111 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeLaunchCommand_DispatchesToIntakeLaunchRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueEnqueueQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            """
+            # Intake Execution Draft
+
+            ## Domain
+            `auth`
+
+            ## Proposed Execution Units
+
+            ### `AUTH-01`
+            source_file_path: intents/intent-cli/concepts/oauth2.md
+            target_part: concepts
+            dependencies:
+            - none
+            readiness_notes:
+            - Current heading: # Auth Concept
+            verification_hints:
+            - dotnet test IntentSystem.sln
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "packet.yaml"),
+            """
+            execution_unit: AUTH-01
+            implementation_issue:
+              issue_title: "AUTH-01 Intake Launch"
+              goal: "Launch generated issue-ready execution unit into queue and autostart flow."
+              in_scope:
+                - "queue insertion"
+                - "issue creation"
+                - "run start"
+              out_of_scope:
+                - "review execution"
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "cli intake launch command"
+              dependencies:
+                - "G3"
+              technical_baseline:
+                - "C# / .NET"
+              project_local_guidance:
+                - "AGENTS.md"
+              intent_baseline:
+                - "intake launch stays thin"
+              acceptance_criteria:
+                - "issue-ready unit launches deterministically"
+              verification:
+                - "tests-passing"
+
+            review:
+              summarize_first: true
+              require_explicit_diff_check: true
+              require_explicit_scope_check: true
+              require_explicit_contract_check: true
+              required_checks:
+                - "intake launch remains thin"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "github-body.md"),
+            "# AUTH-01");
+        using var writer = new StringWriter();
+        var originalEnqueueTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalRemoteGitFactory = QueueDispatchCommand.GitCommandRunnerFactory;
+        var originalDispatchTimestampFactory = QueueDispatchCommand.TimestampFactory;
+        var originalStartGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalStartTimestampFactory = RunStartCommand.TimestampFactory;
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:00:00Z");
+            QueueDispatchCommand.PublisherFactory = () => new FakeQueueDispatchPublisher();
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeQueueDispatchGitRunner();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:05:00Z");
+            RunStartCommand.GitCommandRunnerFactory = () => new FakeRunStartGitRunner();
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:10:00Z");
+
+            var exitCode = CommandRouter.Execute(["intake", "launch", "auth"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Intake launch processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalEnqueueTimestampFactory;
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalRemoteGitFactory;
+            QueueDispatchCommand.TimestampFactory = originalDispatchTimestampFactory;
+            RunStartCommand.GitCommandRunnerFactory = originalStartGitFactory;
+            RunStartCommand.TimestampFactory = originalStartTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenClarifyAnswerCommand_DispatchesToClarifyAnswerRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeLaunchCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeLaunchCommandTests.cs
@@ -1,0 +1,409 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Review;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class IntakeLaunchCommandTests
+{
+    [Fact]
+    public void Execute_GivenGeneratedUnits_LaunchesSelectedDomainUnits()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateExecutionArtifact("auth", ["AUTH-01", "AUTH-02"]));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "packet.yaml"),
+            CreatePacketYaml("AUTH-01"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "github-body.md"),
+            "# AUTH-01");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-02", "packet.yaml"),
+            CreatePacketYaml("AUTH-02"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-02", "github-body.md"),
+            "# AUTH-02");
+        using var writer = new StringWriter();
+        var originalEnqueueTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalRemoteGitFactory = QueueDispatchCommand.GitCommandRunnerFactory;
+        var originalDispatchTimestampFactory = QueueDispatchCommand.TimestampFactory;
+        var originalStartGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalStartTimestampFactory = RunStartCommand.TimestampFactory;
+        var startGitRunner = new FakeStartGitRunner();
+        var publisher = new FakePublisher();
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:00:00Z");
+            QueueDispatchCommand.PublisherFactory = () => publisher;
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeRemoteGitRunner();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:05:00Z");
+            RunStartCommand.GitCommandRunnerFactory = () => startGitRunner;
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:10:00Z");
+
+            var exitCode = IntakeLaunchCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Intake launch processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-02", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/issues/401", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/issues/402", output, StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Active, queueState.Items.Single(item => item.ExecutionUnit == "AUTH-01").State);
+            Assert.Equal(QueueItemState.Active, queueState.Items.Single(item => item.ExecutionUnit == "AUTH-02").State);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal(
+                ["queued", "issue-created", "activated", "queued", "issue-created", "activated"],
+                runEvents.Select(runEvent => runEvent.Event).ToArray());
+            Assert.Equal(
+                ["AUTH-01", "AUTH-01", "AUTH-01", "AUTH-02", "AUTH-02", "AUTH-02"],
+                runEvents.Select(runEvent => runEvent.ExecutionUnit).ToArray());
+
+            var auth01Worktree = Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "worktrees", "AUTH-01"));
+            var auth02Worktree = Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "worktrees", "AUTH-02"));
+            var childRepoPath = Path.Combine(repoRoot, "submodules", "intent-system");
+            Assert.Equal(
+                [
+                    $"{childRepoPath}::fetch origin main",
+                    $"{childRepoPath}::worktree add -b issue-401-auth-01 {auth01Worktree} origin/main",
+                    $"{childRepoPath}::fetch origin main",
+                    $"{childRepoPath}::worktree add -b issue-402-auth-02 {auth02Worktree} origin/main"
+                ],
+                startGitRunner.Calls);
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalEnqueueTimestampFactory;
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalRemoteGitFactory;
+            QueueDispatchCommand.TimestampFactory = originalDispatchTimestampFactory;
+            RunStartCommand.GitCommandRunnerFactory = originalStartGitFactory;
+            RunStartCommand.TimestampFactory = originalStartTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenExistingQueueItem_SkipsExistingUnitAndLaunchesRemainingUnits()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(includeExisting: true)));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateExecutionArtifact("auth", ["AUTH-01", "AUTH-02"]));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "packet.yaml"),
+            CreatePacketYaml("AUTH-01"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "github-body.md"),
+            "# AUTH-01");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-02", "packet.yaml"),
+            CreatePacketYaml("AUTH-02"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-02", "github-body.md"),
+            "# AUTH-02");
+        using var writer = new StringWriter();
+        var originalEnqueueTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalRemoteGitFactory = QueueDispatchCommand.GitCommandRunnerFactory;
+        var originalDispatchTimestampFactory = QueueDispatchCommand.TimestampFactory;
+        var originalStartGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalStartTimestampFactory = RunStartCommand.TimestampFactory;
+        var startGitRunner = new FakeStartGitRunner();
+        var publisher = new FakePublisher();
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:00:00Z");
+            QueueDispatchCommand.PublisherFactory = () => publisher;
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeRemoteGitRunner();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:05:00Z");
+            RunStartCommand.GitCommandRunnerFactory = () => startGitRunner;
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:10:00Z");
+
+            var exitCode = IntakeLaunchCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Skipped units:", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-02", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("issue-401-auth-01", string.Join(Environment.NewLine, startGitRunner.Calls), StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal(["AUTH-02", "AUTH-02", "AUTH-02"], runEvents.Select(runEvent => runEvent.ExecutionUnit).ToArray());
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalEnqueueTimestampFactory;
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalRemoteGitFactory;
+            QueueDispatchCommand.TimestampFactory = originalDispatchTimestampFactory;
+            RunStartCommand.GitCommandRunnerFactory = originalStartGitFactory;
+            RunStartCommand.TimestampFactory = originalStartTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingGitHubBodyArtifact_ReturnsExitCodeOneWithoutMutatingQueueArtifacts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateExecutionArtifact("auth", ["AUTH-01"]));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "packet.yaml"),
+            CreatePacketYaml("AUTH-01"));
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = IntakeLaunchCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("GitHub issue body artifact was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                },
+                Roles = new RoleMappings
+                {
+                    Implement = "Claude",
+                    Review = "Codex"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState(bool includeExisting = false)
+    {
+        var items = new List<QueueItem>
+        {
+            CreateItem("G3", QueueItemState.Completed)
+        };
+
+        if (includeExisting)
+        {
+            items.Add(CreateItem("AUTH-01", QueueItemState.Queued));
+        }
+
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-06T10:00:00Z"),
+            Items = items
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Existing Item",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            LinkedIssue = null,
+            WorkerRole = "Claude",
+            ReviewRole = "Codex",
+            Priority = "high"
+        };
+    }
+
+    private static string CreateExecutionArtifact(string domain, IReadOnlyList<string> executionUnits)
+    {
+        var sections = executionUnits.Select(executionUnit =>
+            $$"""
+
+            ### `{{executionUnit}}`
+            source_file_path: intents/intent-cli/concepts/{{executionUnit.ToLowerInvariant()}}.md
+            target_part: concepts
+            dependencies:
+            - none
+            readiness_notes:
+            - Current heading: # {{executionUnit}}
+            verification_hints:
+            - dotnet test IntentSystem.sln
+            """);
+
+        return $$"""
+            # Intake Execution Draft
+
+            ## Domain
+            `{{domain}}`
+
+            ## Proposed Execution Units{{string.Concat(sections)}}
+            """;
+    }
+
+    private static string CreatePacketYaml(string executionUnit)
+    {
+        return $$"""
+            execution_unit: {{executionUnit}}
+            implementation_issue:
+              issue_title: "{{executionUnit}} Intake Launch"
+              goal: "Launch generated issue-ready execution unit into queue and autostart flow."
+              in_scope:
+                - "queue insertion"
+                - "issue creation"
+                - "run start"
+              out_of_scope:
+                - "review execution"
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "cli intake launch command"
+              dependencies:
+                - "G3"
+              technical_baseline:
+                - "C# / .NET"
+              project_local_guidance:
+                - "AGENTS.md"
+              intent_baseline:
+                - "intake launch stays thin"
+              acceptance_criteria:
+                - "issue-ready unit launches deterministically"
+              verification:
+                - "tests-passing"
+
+            review:
+              summarize_first: true
+              require_explicit_diff_check: true
+              require_explicit_scope_check: true
+              require_explicit_contract_check: true
+              required_checks:
+                - "intake launch remains thin"
+            """;
+    }
+
+    private sealed class FakePublisher : IQueueDispatchPublisher
+    {
+        private int nextIssueNumber = 401;
+
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            var issueNumber = nextIssueNumber++;
+            return new LinkedIssue
+            {
+                Repo = targetRepo,
+                Number = issueNumber,
+                Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{issueNumber}"
+            };
+        }
+    }
+
+    private sealed class FakeRemoteGitRunner : IGitRemoteCommandRunner
+    {
+        public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            return new GitRemoteCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "https://github.com/J-Tech-Japan/intent-system.git",
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class FakeStartGitRunner : IGitCommandRunner
+    {
+        public List<string> Calls { get; } = [];
+
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Calls.Add($"{workingDirectory}::{string.Join(' ', arguments)}");
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-launch-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeLaunchCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeLaunchCommandTests.cs
@@ -103,14 +103,96 @@ public sealed class IntakeLaunchCommandTests
     }
 
     [Fact]
-    public void Execute_GivenExistingQueueItem_SkipsExistingUnitAndLaunchesRemainingUnits()
+    public void Execute_GivenExistingQueuedItem_ContinuesLaunchWithoutDuplicateEnqueue()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "queue-state.json"),
-            QueueStateSerializer.Serialize(CreateQueueState(includeExisting: true)));
+            QueueStateSerializer.Serialize(CreateQueueState(includeExistingQueued: true)));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateExecutionArtifact("auth", ["AUTH-01", "AUTH-02"]));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "packet.yaml"),
+            CreatePacketYaml("AUTH-01"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "github-body.md"),
+            "# AUTH-01");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-02", "packet.yaml"),
+            CreatePacketYaml("AUTH-02"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-02", "github-body.md"),
+            "# AUTH-02");
+        using var writer = new StringWriter();
+        var originalEnqueueTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalRemoteGitFactory = QueueDispatchCommand.GitCommandRunnerFactory;
+        var originalDispatchTimestampFactory = QueueDispatchCommand.TimestampFactory;
+        var originalStartGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalStartTimestampFactory = RunStartCommand.TimestampFactory;
+        var startGitRunner = new FakeStartGitRunner();
+        var publisher = new FakePublisher();
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:00:00Z");
+            QueueDispatchCommand.PublisherFactory = () => publisher;
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeRemoteGitRunner();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:05:00Z");
+            RunStartCommand.GitCommandRunnerFactory = () => startGitRunner;
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:10:00Z");
+
+            var exitCode = IntakeLaunchCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Launched execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-02", output, StringComparison.Ordinal);
+            Assert.Contains("Skipped units:", output, StringComparison.Ordinal);
+            Assert.Contains("- none", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/issues/401", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-02", output, StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Active, queueState.Items.Single(item => item.ExecutionUnit == "AUTH-01").State);
+            Assert.Equal(QueueItemState.Active, queueState.Items.Single(item => item.ExecutionUnit == "AUTH-02").State);
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal(
+                ["issue-created", "activated", "queued", "issue-created", "activated"],
+                runEvents.Select(runEvent => runEvent.Event).ToArray());
+            Assert.Equal(
+                ["AUTH-01", "AUTH-01", "AUTH-02", "AUTH-02", "AUTH-02"],
+                runEvents.Select(runEvent => runEvent.ExecutionUnit).ToArray());
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalEnqueueTimestampFactory;
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalRemoteGitFactory;
+            QueueDispatchCommand.TimestampFactory = originalDispatchTimestampFactory;
+            RunStartCommand.GitCommandRunnerFactory = originalStartGitFactory;
+            RunStartCommand.TimestampFactory = originalStartTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenAlreadyActiveUnit_SkipsOnlyLaunchedUnitAndContinuesOtherUnits()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(includeAlreadyActive: true)));
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "runs.jsonl"),
             string.Empty);
@@ -154,8 +236,9 @@ public sealed class IntakeLaunchCommandTests
             var output = writer.ToString();
             Assert.Contains("Skipped units:", output, StringComparison.Ordinal);
             Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
-            Assert.Contains("- AUTH-02", output, StringComparison.Ordinal);
-            Assert.DoesNotContain("issue-401-auth-01", string.Join(Environment.NewLine, startGitRunner.Calls), StringComparison.Ordinal);
+            var launchedSectionIndex = output.IndexOf("Launched execution units:", StringComparison.Ordinal);
+            Assert.NotEqual(-1, launchedSectionIndex);
+            Assert.Contains("- AUTH-02", output[launchedSectionIndex..], StringComparison.Ordinal);
 
             var runEvents = RunLogSerializer.DeserializeAll(
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
@@ -223,16 +306,31 @@ public sealed class IntakeLaunchCommandTests
         };
     }
 
-    private static QueueState CreateQueueState(bool includeExisting = false)
+    private static QueueState CreateQueueState(
+        bool includeExistingQueued = false,
+        bool includeAlreadyActive = false)
     {
         var items = new List<QueueItem>
         {
             CreateItem("G3", QueueItemState.Completed)
         };
 
-        if (includeExisting)
+        if (includeExistingQueued)
         {
             items.Add(CreateItem("AUTH-01", QueueItemState.Queued));
+        }
+
+        if (includeAlreadyActive)
+        {
+            items.Add(CreateItem(
+                "AUTH-01",
+                QueueItemState.Active,
+                linkedIssue: new LinkedIssue
+                {
+                    Repo = "J-Tech-Japan/intent-system",
+                    Number = 299,
+                    Url = "https://github.com/J-Tech-Japan/intent-system/issues/299"
+                }));
         }
 
         return new QueueState
@@ -243,7 +341,10 @@ public sealed class IntakeLaunchCommandTests
         };
     }
 
-    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    private static QueueItem CreateItem(
+        string executionUnit,
+        QueueItemState state,
+        LinkedIssue? linkedIssue = null)
     {
         return new QueueItem
         {
@@ -259,7 +360,7 @@ public sealed class IntakeLaunchCommandTests
                 ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
                 Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
             },
-            LinkedIssue = null,
+            LinkedIssue = linkedIssue,
             WorkerRole = "Claude",
             ReviewRole = "Codex",
             Priority = "high"


### PR DESCRIPTION
## What Changed
- added `intent-cli intake launch <domain>` as a thin batch bridge from current `.intent-cli/intake/<domain>.execution.md` into existing `queue enqueue`, `queue dispatch`, and `run start` flows
- added a summary renderer/result that reports launched execution units, created issue refs, worktree paths, and skipped units
- added CLI coverage for success, skip, and missing-artifact failure paths, plus command router coverage

## Why
Issue 106 requires a domain-level launch path that reuses the current queue/autostart baseline without expanding into review, workflow execution, or worker launch after start.

## Impact
Generated issue-ready intake units for one domain can now be inserted into the queue, dispatched to child issues, linked back into queue state, started in isolated worktrees, and moved to `active` in one deterministic command.

## Validation
- `dotnet test IntentSystem.sln`
