### PR TITLE
[codex] Add intake start command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -84,7 +84,8 @@ internal static class CommandRouter
                 ["issue"] = IntakeIssueCommand.Execute,
                 ["enqueue"] = IntakeEnqueueCommand.Execute,
                 ["autostart"] = IntakeAutostartCommand.Execute,
-                ["launch"] = IntakeLaunchCommand.Execute
+                ["launch"] = IntakeLaunchCommand.Execute,
+                ["start"] = IntakeStartCommand.Execute
             }
         };
 

--- a/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
@@ -68,15 +68,7 @@ internal static class IntakeIssueCommand
 
         try
         {
-            var baseline = LoadIssueBaseline(context.RepoRoot);
-            var units = LoadExecutionUnits(context.RepoRoot, domain);
-            if (units.Count == 0)
-            {
-                writer.WriteLine($"No intake-origin issue-ready execution units were found for domain '{domain}'.");
-                return 1;
-            }
-
-            var result = GenerateArtifacts(context.RepoRoot, domain, units, baseline);
+            var result = ExecuteCore(context.RepoRoot, domain);
             IntakeIssueRenderer.WriteSummary(writer, result);
             return 0;
         }
@@ -85,6 +77,19 @@ internal static class IntakeIssueCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static IntakeIssueResult ExecuteCore(string repoRoot, string domain)
+    {
+        var baseline = LoadIssueBaseline(repoRoot);
+        var units = LoadExecutionUnits(repoRoot, domain);
+        if (units.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"No intake-origin issue-ready execution units were found for domain '{domain}'.");
+        }
+
+        return GenerateArtifacts(repoRoot, domain, units, baseline);
     }
 
     private static IReadOnlyList<IntakeOriginExecutionUnit> LoadExecutionUnits(string repoRoot, string domain)

--- a/src/IntentSystem.Cli/Commands/IntakeLaunchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeLaunchCommand.cs
@@ -19,22 +19,10 @@ internal static class IntakeLaunchCommand
         }
 
         var domain = args[0].Trim();
-        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
-        if (queueState is null)
-        {
-            return 1;
-        }
 
         try
         {
-            var executionUnits = IntakeEnqueueCommand.LoadExecutionUnits(context.RepoRoot, domain);
-            if (executionUnits.Count == 0)
-            {
-                writer.WriteLine($"No generated issue-ready execution units were found for domain '{domain}'.");
-                return 1;
-            }
-
-            var result = LaunchUnits(context, domain, executionUnits);
+            var result = ExecuteCore(context, domain, writer);
             IntakeLaunchRenderer.WriteSummary(writer, result);
             return 0;
         }
@@ -43,6 +31,24 @@ internal static class IntakeLaunchCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static IntakeLaunchResult ExecuteCore(CliContext context, string domain, TextWriter writer)
+    {
+        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
+        if (queueState is null)
+        {
+            throw new InvalidOperationException("Queue state could not be loaded.");
+        }
+
+        var executionUnits = IntakeEnqueueCommand.LoadExecutionUnits(context.RepoRoot, domain);
+        if (executionUnits.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"No generated issue-ready execution units were found for domain '{domain}'.");
+        }
+
+        return LaunchUnits(context, domain, executionUnits);
     }
 
     private static void ValidatePacketArtifact(CliContext context, string executionUnit)

--- a/src/IntentSystem.Cli/Commands/IntakeStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeStartCommand.cs
@@ -1,0 +1,42 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeStartCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Intake start command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0].Trim();
+
+        try
+        {
+            var issueResult = IntakeIssueCommand.ExecuteCore(context.RepoRoot, domain);
+            var launchResult = IntakeLaunchCommand.ExecuteCore(context, domain, writer);
+            var result = new IntakeStartResult
+            {
+                Domain = domain,
+                StartedExecutionUnits = launchResult.LaunchedExecutionUnits,
+                GeneratedArtifactPaths = issueResult.ArtifactPaths,
+                CreatedIssueRefs = launchResult.CreatedIssueRefs,
+                WorktreePaths = launchResult.WorktreePaths,
+                SkippedUnits = launchResult.SkippedUnits
+            };
+
+            IntakeStartRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeStartRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeStartRenderer.cs
@@ -1,0 +1,36 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeStartRenderer
+{
+    public static void WriteSummary(TextWriter writer, IntakeStartResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Intake start processed for domain '{result.Domain}'.");
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Generated artifact paths:");
+        WriteList(writer, result.GeneratedArtifactPaths);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Skipped units:");
+        WriteList(writer, result.SkippedUnits);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeStartResult.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeStartResult.cs
@@ -1,0 +1,16 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeStartResult
+{
+    public required string Domain { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> GeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> SkippedUnits { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -746,6 +746,89 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeStartCommand_DispatchesToIntakeStartRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
+            |---|---|---|---|---|---|---|---|
+            | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | submodules/intent-system | . | cli intake issue command | yes |
+
+            ## G37 の current baseline
+
+            - `intake issue <domain>` を最初の intake issue-artifact generation command にする
+            - canonical source は current `execution/` source files と current `G2` / `G29` / `G30` / `G32` / `G33` / `G34` / `G35` / `G36` intake baseline である
+            - successful output は selected domain の intake-origin issue-ready execution unit に対応する `.intent-cli/issues/<execution-unit>/implementation.md`, `review-context.md`, `packet.yaml`, and `github-body.md` の deterministic generation を baseline にする
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            """
+            # Intake Execution Draft
+
+            ## Domain
+            `auth`
+
+            ## Proposed Execution Units
+
+            ### `AUTH-01`
+            source_file_path: intents/intent-cli/concepts/oauth2.md
+            target_part: concepts
+            dependencies:
+            - none
+            readiness_notes:
+            - Current heading: # Auth Concept
+            verification_hints:
+            - dotnet test IntentSystem.sln
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
+            "# Auth Concept");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueEnqueueQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalEnqueueTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalRemoteGitFactory = QueueDispatchCommand.GitCommandRunnerFactory;
+        var originalDispatchTimestampFactory = QueueDispatchCommand.TimestampFactory;
+        var originalStartGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalStartTimestampFactory = RunStartCommand.TimestampFactory;
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:00:00Z");
+            QueueDispatchCommand.PublisherFactory = () => new FakeQueueDispatchPublisher();
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeQueueDispatchGitRunner();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:05:00Z");
+            RunStartCommand.GitCommandRunnerFactory = () => new FakeRunStartGitRunner();
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:10:00Z");
+
+            var exitCode = CommandRouter.Execute(["intake", "start", "auth"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Intake start processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalEnqueueTimestampFactory;
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalRemoteGitFactory;
+            QueueDispatchCommand.TimestampFactory = originalDispatchTimestampFactory;
+            RunStartCommand.GitCommandRunnerFactory = originalStartGitFactory;
+            RunStartCommand.TimestampFactory = originalStartTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenClarifyAnswerCommand_DispatchesToClarifyAnswerRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeStartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeStartCommandTests.cs
@@ -1,0 +1,471 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Projection.Serialization;
+using IntentSystem.Review;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class IntakeStartCommandTests
+{
+    [Fact]
+    public void Execute_GivenIssueReadyDomain_GeneratesArtifactsAndStartsUnits()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            CreateExecutionBaselineMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateExecutionArtifactMarkdown("auth"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
+            "# Auth Concept");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "device-code.md"),
+            "# Device Code");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalEnqueueTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalRemoteGitFactory = QueueDispatchCommand.GitCommandRunnerFactory;
+        var originalDispatchTimestampFactory = QueueDispatchCommand.TimestampFactory;
+        var originalStartGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalStartTimestampFactory = RunStartCommand.TimestampFactory;
+        var startGitRunner = new FakeStartGitRunner();
+        var publisher = new FakePublisher();
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:00:00Z");
+            QueueDispatchCommand.PublisherFactory = () => publisher;
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeRemoteGitRunner();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:05:00Z");
+            RunStartCommand.GitCommandRunnerFactory = () => startGitRunner;
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:10:00Z");
+
+            var exitCode = IntakeStartCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Intake start processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Started execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-02", output, StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/issues/AUTH-01/github-body.md", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/issues/501", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/issues/502", output, StringComparison.Ordinal);
+
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "packet.yaml")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-02", "github-body.md")));
+            var packet = ProjectionPacketSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "packet.yaml")));
+            Assert.Equal("AUTH-01", packet.ImplementationIssuePacket.SourceExecutionUnit);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Active, queueState.Items.Single(item => item.ExecutionUnit == "AUTH-01").State);
+            Assert.Equal(QueueItemState.Active, queueState.Items.Single(item => item.ExecutionUnit == "AUTH-02").State);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal(
+                ["queued", "issue-created", "activated", "queued", "issue-created", "activated"],
+                runEvents.Select(runEvent => runEvent.Event).ToArray());
+
+            var auth01Worktree = Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "worktrees", "AUTH-01"));
+            var auth02Worktree = Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "worktrees", "AUTH-02"));
+            var childRepoPath = Path.Combine(repoRoot, "submodules", "intent-system");
+            Assert.Equal(
+                [
+                    $"{childRepoPath}::fetch origin main",
+                    $"{childRepoPath}::worktree add -b issue-501-auth-01 {auth01Worktree} origin/main",
+                    $"{childRepoPath}::fetch origin main",
+                    $"{childRepoPath}::worktree add -b issue-502-auth-02 {auth02Worktree} origin/main"
+                ],
+                startGitRunner.Calls);
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalEnqueueTimestampFactory;
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalRemoteGitFactory;
+            QueueDispatchCommand.TimestampFactory = originalDispatchTimestampFactory;
+            RunStartCommand.GitCommandRunnerFactory = originalStartGitFactory;
+            RunStartCommand.TimestampFactory = originalStartTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenExistingArtifactsAndQueuedUnit_SkipsGenerationButContinuesStart()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            CreateExecutionBaselineMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateExecutionArtifactMarkdown("auth-single"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
+            "# Auth Concept");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "implementation.md"),
+            "existing implementation");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "review-context.md"),
+            "existing review");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "packet.yaml"),
+            CreateCanonicalLaunchPacketYaml("AUTH-01"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "AUTH-01", "github-body.md"),
+            "existing body");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(includeExistingQueued: true)));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalEnqueueTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalRemoteGitFactory = QueueDispatchCommand.GitCommandRunnerFactory;
+        var originalDispatchTimestampFactory = QueueDispatchCommand.TimestampFactory;
+        var originalStartGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalStartTimestampFactory = RunStartCommand.TimestampFactory;
+        var startGitRunner = new FakeStartGitRunner();
+        var publisher = new FakePublisher();
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:00:00Z");
+            QueueDispatchCommand.PublisherFactory = () => publisher;
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeRemoteGitRunner();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:05:00Z");
+            RunStartCommand.GitCommandRunnerFactory = () => startGitRunner;
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:10:00Z");
+
+            var exitCode = IntakeStartCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Started execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("Generated artifact paths:", output, StringComparison.Ordinal);
+            Assert.Contains("- none", output, StringComparison.Ordinal);
+            Assert.Contains("Skipped units:", output, StringComparison.Ordinal);
+            var skippedSectionIndex = output.IndexOf("Skipped units:", StringComparison.Ordinal);
+            Assert.NotEqual(-1, skippedSectionIndex);
+            Assert.Contains("- none", output[skippedSectionIndex..], StringComparison.Ordinal);
+            Assert.Equal("existing implementation", File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "implementation.md")));
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Active, queueState.Items.Single(item => item.ExecutionUnit == "AUTH-01").State);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal(["issue-created", "activated"], runEvents.Select(runEvent => runEvent.Event).ToArray());
+            Assert.Equal(["AUTH-01", "AUTH-01"], runEvents.Select(runEvent => runEvent.ExecutionUnit).ToArray());
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalEnqueueTimestampFactory;
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalRemoteGitFactory;
+            QueueDispatchCommand.TimestampFactory = originalDispatchTimestampFactory;
+            RunStartCommand.GitCommandRunnerFactory = originalStartGitFactory;
+            RunStartCommand.TimestampFactory = originalStartTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeStartCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string CreateExecutionBaselineMarkdown()
+    {
+        return """
+            # Post-MVP Sub-Slices
+
+            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
+            |---|---|---|---|---|---|---|---|
+            | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | submodules/intent-system | . | cli intake issue command | yes |
+
+            ## G37 の current baseline
+
+            - `intake issue <domain>` を最初の intake issue-artifact generation command にする
+            - canonical source は current `execution/` source files と current `G2` / `G29` / `G30` / `G32` / `G33` / `G34` / `G35` / `G36` intake baseline である
+            - successful output は selected domain の intake-origin issue-ready execution unit に対応する `.intent-cli/issues/<execution-unit>/implementation.md`, `review-context.md`, `packet.yaml`, and `github-body.md` の deterministic generation を baseline にする
+            """;
+    }
+
+    private static string CreateExecutionArtifactMarkdown(string domain)
+    {
+        if (string.Equals(domain, "auth-single", StringComparison.Ordinal))
+        {
+            return """
+                # Intake Execution Draft
+
+                ## Domain
+                `auth`
+
+                ## Proposed Execution Units
+
+                ### `AUTH-01`
+                source_file_path: intents/intent-cli/concepts/oauth2.md
+                target_part: concepts
+                dependencies:
+                - none
+                readiness_notes:
+                - Current heading: # Auth Concept
+                verification_hints:
+                - dotnet test IntentSystem.sln
+                """;
+        }
+
+        return """
+            # Intake Execution Draft
+
+            ## Domain
+            `auth`
+
+            ## Proposed Execution Units
+
+            ### `AUTH-01`
+            source_file_path: intents/intent-cli/concepts/oauth2.md
+            target_part: concepts
+            dependencies:
+            - none
+            readiness_notes:
+            - Current heading: # Auth Concept
+            verification_hints:
+            - dotnet test IntentSystem.sln
+
+            ### `AUTH-02`
+            source_file_path: intents/intent-cli/intent-tree/means/device-code.md
+            target_part: intent-tree/means
+            dependencies:
+            - AUTH-01
+            readiness_notes:
+            - Current heading: # Device Code
+            verification_hints:
+            - dotnet test IntentSystem.sln
+            """;
+    }
+
+    private static string CreateCanonicalLaunchPacketYaml(string executionUnit)
+    {
+        return $$"""
+            execution_unit: {{executionUnit}}
+            implementation_issue:
+              issue_title: "{{executionUnit}} Intake Start"
+              goal: "Start generated issue-ready execution unit through issue-generation and launch flow."
+              in_scope:
+                - "issue generation"
+                - "queue insertion"
+                - "run start"
+              out_of_scope:
+                - "review execution"
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "cli intake start command"
+              dependencies:
+                - "G3"
+              technical_baseline:
+                - "C# / .NET"
+              project_local_guidance:
+                - "AGENTS.md"
+              intent_baseline:
+                - "intake start stays thin"
+              acceptance_criteria:
+                - "issue-ready unit starts deterministically"
+              verification:
+                - "tests-passing"
+
+            review:
+              summarize_first: true
+              require_explicit_diff_check: true
+              require_explicit_scope_check: true
+              require_explicit_contract_check: true
+              required_checks:
+                - "intake start remains thin"
+            """;
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                },
+                Roles = new RoleMappings
+                {
+                    Implement = "Claude",
+                    Review = "Codex"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState(bool includeExistingQueued = false)
+    {
+        var items = new List<QueueItem>
+        {
+            new()
+            {
+                ExecutionUnit = "G3",
+                Title = "[G3] Existing Item",
+                State = QueueItemState.Completed,
+                Dependencies = [],
+                BlockedBy = [],
+                ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                PacketPaths = new PacketPaths
+                {
+                    Implementation = ".intent-cli/issues/G3/implementation.md",
+                    ReviewContext = ".intent-cli/issues/G3/review-context.md",
+                    Yaml = ".intent-cli/issues/G3/packet.yaml"
+                },
+                LinkedIssue = null,
+                WorkerRole = "Claude",
+                ReviewRole = "Codex",
+                Priority = "high"
+            }
+        };
+
+        if (includeExistingQueued)
+        {
+            items.Add(new QueueItem
+            {
+                ExecutionUnit = "AUTH-01",
+                Title = "[AUTH-01] Existing Item",
+                State = QueueItemState.Queued,
+                Dependencies = ["G3"],
+                BlockedBy = [],
+                ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                PacketPaths = new PacketPaths
+                {
+                    Implementation = ".intent-cli/issues/AUTH-01/implementation.md",
+                    ReviewContext = ".intent-cli/issues/AUTH-01/review-context.md",
+                    Yaml = ".intent-cli/issues/AUTH-01/packet.yaml"
+                },
+                LinkedIssue = null,
+                WorkerRole = "Claude",
+                ReviewRole = "Codex",
+                Priority = "high"
+            });
+        }
+
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-06T10:00:00Z"),
+            Items = items
+        };
+    }
+
+    private sealed class FakePublisher : IQueueDispatchPublisher
+    {
+        private int nextIssueNumber = 501;
+
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            var issueNumber = nextIssueNumber++;
+            return new LinkedIssue
+            {
+                Repo = targetRepo,
+                Number = issueNumber,
+                Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{issueNumber}"
+            };
+        }
+    }
+
+    private sealed class FakeRemoteGitRunner : IGitRemoteCommandRunner
+    {
+        public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            return new GitRemoteCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "https://github.com/J-Tech-Japan/intent-system.git",
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class FakeStartGitRunner : IGitCommandRunner
+    {
+        public List<string> Calls { get; } = [];
+
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Calls.Add($"{workingDirectory}::{string.Join(' ', arguments)}");
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-start-command-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What Changed
- added `intent-cli intake start <domain>` as the thin domain-level bridge from current intake execution source-of-truth into the existing issue-generation and launch flow
- reused the existing `intake issue` and `intake launch` baselines through internal core helpers so the new command stays scoped to issue artifact generation plus launch
- added CLI/runtime coverage for full start, existing-artifact queued start, and command routing

## Why
Issue 108 requires a single domain command that connects updated intake-origin execution source-of-truth to the already implemented issue-generation and queue/autostart flow without expanding into review, workflow execution, merge, or worker launch after start.

## Impact
Selected domain issue-ready units can now be generated into `.intent-cli/issues/<execution-unit>/` and launched to `active` in one deterministic command, with summaries for started units, generated artifact paths, created issue refs, worktree paths, and skipped units.

## Validation
- `dotnet test IntentSystem.sln`
