### PR TITLE
[codex] Add intake advance command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -81,6 +81,7 @@ internal static class CommandRouter
                 ["patch"] = IntakePatchCommand.Execute,
                 ["apply"] = IntakeApplyCommand.Execute,
                 ["execution"] = IntakeExecutionCommand.Execute,
+                ["advance"] = IntakeAdvanceCommand.Execute,
                 ["issue"] = IntakeIssueCommand.Execute,
                 ["enqueue"] = IntakeEnqueueCommand.Execute,
                 ["autostart"] = IntakeAutostartCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/IntakeAdvanceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeAdvanceCommand.cs
@@ -1,0 +1,97 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeAdvanceCommand
+{
+    private static readonly string[] DeferredStages =
+    [
+        "foldin",
+        "patch",
+        "apply",
+        "execution",
+        "execution-apply"
+    ];
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Intake advance command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0].Trim();
+
+        try
+        {
+            EnsureConceptArtifactExists(context.RepoRoot, domain);
+
+            var compileResult = IntakeCompileCommand.ExecuteCore(context.RepoRoot, domain);
+            if (!compileResult.IsReady)
+            {
+                IntakeAdvanceRenderer.WriteSummary(writer, new IntakeAdvanceResult
+                {
+                    Domain = domain,
+                    ReadinessStatus = "not-ready",
+                    UpdatedSourceFilePaths = [],
+                    UpdatedExecutionFilePaths = [],
+                    RegeneratedArtifactPaths = [],
+                    SkippedStages = DeferredStages
+                });
+                return 0;
+            }
+
+            var (_, foldinPath) = IntakeFoldinCommand.ExecuteCore(context.RepoRoot, domain);
+            var (_, patchPath) = IntakePatchCommand.ExecuteCore(context.RepoRoot, domain);
+            var applyResult = IntakeApplyCommand.ExecuteCore(context.RepoRoot, domain);
+            var (_, executionPath) = IntakeExecutionCommand.ExecuteCore(context.RepoRoot, domain);
+            var executionApplyResult = IntakeExecutionApplyCommand.ExecuteCore(context.RepoRoot, domain);
+
+            var regeneratedArtifactPaths = new[]
+            {
+                compileResult.ArtifactPath,
+                foldinPath,
+                patchPath,
+                executionPath
+            }
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => ToRelativePath(context.RepoRoot, path!))
+            .ToArray();
+
+            IntakeAdvanceRenderer.WriteSummary(writer, new IntakeAdvanceResult
+            {
+                Domain = domain,
+                ReadinessStatus = "ready",
+                UpdatedSourceFilePaths = applyResult.ChangedFilePaths,
+                UpdatedExecutionFilePaths = executionApplyResult.ChangedFilePaths,
+                RegeneratedArtifactPaths = regeneratedArtifactPaths,
+                SkippedStages = []
+            });
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    private static void EnsureConceptArtifactExists(string repoRoot, string domain)
+    {
+        var conceptPath = Path.Combine(
+            repoRoot,
+            IntakeConceptArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(conceptPath))
+        {
+            throw new InvalidOperationException($"Intake concept artifact was not found at {conceptPath}");
+        }
+    }
+
+    private static string ToRelativePath(string repoRoot, string absolutePath)
+    {
+        return Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeAdvanceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeAdvanceCommand.cs
@@ -88,6 +88,13 @@ internal static class IntakeAdvanceCommand
         {
             throw new InvalidOperationException($"Intake concept artifact was not found at {conceptPath}");
         }
+
+        var packet = IntakeConceptArtifactYaml.Deserialize(File.ReadAllText(conceptPath));
+        if (!string.Equals(packet.DomainSlug, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Intake concept artifact domain '{packet.DomainSlug}' does not match requested domain '{domain}'.");
+        }
     }
 
     private static string ToRelativePath(string repoRoot, string absolutePath)

--- a/src/IntentSystem.Cli/Commands/IntakeAdvanceRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeAdvanceRenderer.cs
@@ -1,0 +1,35 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeAdvanceRenderer
+{
+    public static void WriteSummary(TextWriter writer, IntakeAdvanceResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Intake advance processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeAdvanceResult.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeAdvanceResult.cs
@@ -1,0 +1,16 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeAdvanceResult
+{
+    public required string Domain { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeApplyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeApplyCommand.cs
@@ -15,27 +15,10 @@ internal static class IntakeApplyCommand
         }
 
         var domain = args[0];
-        var patchPath = Path.Combine(
-            context.RepoRoot,
-            IntakePatchArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
-
-        if (!File.Exists(patchPath))
-        {
-            writer.WriteLine($"Intake patch artifact was not found at {patchPath}");
-            return 1;
-        }
 
         try
         {
-            var request = IntakePatchArtifactMarkdown.Deserialize(File.ReadAllText(patchPath));
-            if (!string.Equals(request.Domain, domain, StringComparison.Ordinal))
-            {
-                writer.WriteLine(
-                    $"Intake patch artifact domain '{request.Domain}' does not match requested domain '{domain}'.");
-                return 1;
-            }
-
-            var result = ApplyDraft(context.RepoRoot, request);
+            var result = ExecuteCore(context.RepoRoot, domain);
             IntakeApplyRenderer.WriteSummary(writer, result);
             return 0;
         }
@@ -44,6 +27,27 @@ internal static class IntakeApplyCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static IntakeApplyResult ExecuteCore(string repoRoot, string domain)
+    {
+        var patchPath = Path.Combine(
+            repoRoot,
+            IntakePatchArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(patchPath))
+        {
+            throw new InvalidOperationException($"Intake patch artifact was not found at {patchPath}");
+        }
+
+        var request = IntakePatchArtifactMarkdown.Deserialize(File.ReadAllText(patchPath));
+        if (!string.Equals(request.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Intake patch artifact domain '{request.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        return ApplyDraft(repoRoot, request);
     }
 
     private static IntakeApplyResult ApplyDraft(string repoRoot, IntakePatchRequest request)

--- a/src/IntentSystem.Cli/Commands/IntakeCompileCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeCompileCommand.cs
@@ -21,25 +21,22 @@ internal static class IntakeCompileCommand
 
         try
         {
-            var artifacts = InterviewArtifactYaml.Discover(context.RepoRoot, domain);
-            if (artifacts.Count == 0)
+            var result = ExecuteCore(context.RepoRoot, domain);
+            if (!result.IsReady)
             {
-                IntakeCompileRenderer.WriteNoArtifactsNotReady(writer, domain);
+                if (result.NextQuestion is null)
+                {
+                    IntakeCompileRenderer.WriteNoArtifactsNotReady(writer, domain);
+                }
+                else
+                {
+                    IntakeCompileRenderer.WriteNotReady(writer, domain, result.NextQuestion);
+                }
+
                 return 0;
             }
 
-            var items = artifacts.Select(artifact => artifact.Item).ToArray();
-            var nextQuestion = InterviewQueue.GetNextPendingForDomain(items, domain);
-            if (nextQuestion is not null)
-            {
-                IntakeCompileRenderer.WriteNotReady(writer, domain, nextQuestion);
-                return 0;
-            }
-
-            var request = CreateRequest(domain, items);
-            var markdown = IntakeCompileRenderer.RenderMarkdown(request);
-            var artifactPath = IntakeCompileArtifactWriter.Write(markdown, domain, context.RepoRoot);
-            IntakeCompileRenderer.WriteSummary(writer, request, artifactPath);
+            IntakeCompileRenderer.WriteSummary(writer, result.Request!, result.ArtifactPath!);
             return 0;
         }
         catch (InvalidOperationException exception)
@@ -47,6 +44,48 @@ internal static class IntakeCompileCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static IntakeCompileCoreResult ExecuteCore(string repoRoot, string domain)
+    {
+        var artifacts = InterviewArtifactYaml.Discover(repoRoot, domain);
+        if (artifacts.Count == 0)
+        {
+            return new IntakeCompileCoreResult
+            {
+                Domain = domain,
+                IsReady = false,
+                Request = null,
+                ArtifactPath = null,
+                NextQuestion = null
+            };
+        }
+
+        var items = artifacts.Select(artifact => artifact.Item).ToArray();
+        var nextQuestion = InterviewQueue.GetNextPendingForDomain(items, domain);
+        if (nextQuestion is not null)
+        {
+            return new IntakeCompileCoreResult
+            {
+                Domain = domain,
+                IsReady = false,
+                Request = null,
+                ArtifactPath = null,
+                NextQuestion = nextQuestion
+            };
+        }
+
+        var request = CreateRequest(domain, items);
+        var markdown = IntakeCompileRenderer.RenderMarkdown(request);
+        var artifactPath = IntakeCompileArtifactWriter.Write(markdown, domain, repoRoot);
+        return new IntakeCompileCoreResult
+        {
+            Domain = domain,
+            IsReady = true,
+            Request = request,
+            ArtifactPath = artifactPath,
+            NextQuestion = null
+        };
     }
 
     private static IntakeCompileRequest CreateRequest(string domain, IReadOnlyList<InterviewQueueItem> items)

--- a/src/IntentSystem.Cli/Commands/IntakeCompileCoreResult.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeCompileCoreResult.cs
@@ -1,0 +1,16 @@
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeCompileCoreResult
+{
+    public required string Domain { get; init; }
+
+    public required bool IsReady { get; init; }
+
+    public IntakeCompileRequest? Request { get; init; }
+
+    public string? ArtifactPath { get; init; }
+
+    public InterviewQueueItem? NextQuestion { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionApplyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionApplyCommand.cs
@@ -17,27 +17,10 @@ internal static class IntakeExecutionApplyCommand
         }
 
         var domain = args[0];
-        var executionDraftPath = Path.Combine(
-            context.RepoRoot,
-            IntakeExecutionArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
-
-        if (!File.Exists(executionDraftPath))
-        {
-            writer.WriteLine($"Intake execution artifact was not found at {executionDraftPath}");
-            return 1;
-        }
 
         try
         {
-            var request = IntakeExecutionArtifactMarkdown.Deserialize(File.ReadAllText(executionDraftPath));
-            if (!string.Equals(request.Domain, domain, StringComparison.Ordinal))
-            {
-                writer.WriteLine(
-                    $"Intake execution artifact domain '{request.Domain}' does not match requested domain '{domain}'.");
-                return 1;
-            }
-
-            var result = ApplyDraft(context.RepoRoot, request);
+            var result = ExecuteCore(context.RepoRoot, domain);
             IntakeExecutionApplyRenderer.WriteSummary(writer, result);
             return 0;
         }
@@ -46,6 +29,27 @@ internal static class IntakeExecutionApplyCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static IntakeExecutionApplyResult ExecuteCore(string repoRoot, string domain)
+    {
+        var executionDraftPath = Path.Combine(
+            repoRoot,
+            IntakeExecutionArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(executionDraftPath))
+        {
+            throw new InvalidOperationException($"Intake execution artifact was not found at {executionDraftPath}");
+        }
+
+        var request = IntakeExecutionArtifactMarkdown.Deserialize(File.ReadAllText(executionDraftPath));
+        if (!string.Equals(request.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Intake execution artifact domain '{request.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        return ApplyDraft(repoRoot, request);
     }
 
     private static IntakeExecutionApplyResult ApplyDraft(string repoRoot, IntakeExecutionRequest request)

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionCommand.cs
@@ -20,35 +20,10 @@ internal static class IntakeExecutionCommand
         }
 
         var domain = args[0];
-        var patchPath = Path.Combine(
-            context.RepoRoot,
-            IntakePatchArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
-
-        if (!File.Exists(patchPath))
-        {
-            writer.WriteLine($"Intake patch artifact was not found at {patchPath}");
-            return 1;
-        }
 
         try
         {
-            var patchRequest = IntakePatchArtifactMarkdown.Deserialize(File.ReadAllText(patchPath));
-            if (!string.Equals(patchRequest.Domain, domain, StringComparison.Ordinal))
-            {
-                writer.WriteLine(
-                    $"Intake patch artifact domain '{patchRequest.Domain}' does not match requested domain '{domain}'.");
-                return 1;
-            }
-
-            var request = CreateRequest(context.RepoRoot, patchRequest);
-            if (request.ProposedExecutionUnits.Count == 0)
-            {
-                writer.WriteLine($"No updated parent source files were found for domain '{domain}'.");
-                return 1;
-            }
-
-            var markdown = IntakeExecutionRenderer.RenderMarkdown(request);
-            var artifactPath = IntakeExecutionArtifactWriter.Write(markdown, domain, context.RepoRoot);
+            var (request, artifactPath) = ExecuteCore(context.RepoRoot, domain);
             IntakeExecutionRenderer.WriteSummary(writer, request, artifactPath);
             return 0;
         }
@@ -57,6 +32,35 @@ internal static class IntakeExecutionCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static (IntakeExecutionRequest Request, string ArtifactPath) ExecuteCore(string repoRoot, string domain)
+    {
+        var patchPath = Path.Combine(
+            repoRoot,
+            IntakePatchArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(patchPath))
+        {
+            throw new InvalidOperationException($"Intake patch artifact was not found at {patchPath}");
+        }
+
+        var patchRequest = IntakePatchArtifactMarkdown.Deserialize(File.ReadAllText(patchPath));
+        if (!string.Equals(patchRequest.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Intake patch artifact domain '{patchRequest.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        var request = CreateRequest(repoRoot, patchRequest);
+        if (request.ProposedExecutionUnits.Count == 0)
+        {
+            throw new InvalidOperationException($"No updated parent source files were found for domain '{domain}'.");
+        }
+
+        var markdown = IntakeExecutionRenderer.RenderMarkdown(request);
+        var artifactPath = IntakeExecutionArtifactWriter.Write(markdown, domain, repoRoot);
+        return (request, artifactPath);
     }
 
     private static IntakeExecutionRequest CreateRequest(string repoRoot, IntakePatchRequest patchRequest)

--- a/src/IntentSystem.Cli/Commands/IntakeFoldinCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeFoldinCommand.cs
@@ -15,28 +15,10 @@ internal static class IntakeFoldinCommand
         }
 
         var domain = args[0];
-        var compilePath = Path.Combine(
-            context.RepoRoot,
-            IntakeCompileArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
-
-        if (!File.Exists(compilePath))
-        {
-            writer.WriteLine($"Intake compile artifact was not found at {compilePath}");
-            return 1;
-        }
 
         try
         {
-            var request = IntakeCompileArtifactMarkdown.Deserialize(File.ReadAllText(compilePath));
-            if (!string.Equals(request.Domain, domain, StringComparison.Ordinal))
-            {
-                writer.WriteLine(
-                    $"Intake compile artifact domain '{request.Domain}' does not match requested domain '{domain}'.");
-                return 1;
-            }
-
-            var markdown = IntakeFoldinRenderer.RenderMarkdown(request);
-            var artifactPath = IntakeFoldinArtifactWriter.Write(markdown, domain, context.RepoRoot);
+            var (request, artifactPath) = ExecuteCore(context.RepoRoot, domain);
             IntakeFoldinRenderer.WriteSummary(writer, request, artifactPath);
             return 0;
         }
@@ -45,5 +27,36 @@ internal static class IntakeFoldinCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static (IntakeFoldinRequest Request, string ArtifactPath) ExecuteCore(string repoRoot, string domain)
+    {
+        var compilePath = Path.Combine(
+            repoRoot,
+            IntakeCompileArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(compilePath))
+        {
+            throw new InvalidOperationException($"Intake compile artifact was not found at {compilePath}");
+        }
+
+        var compileRequest = IntakeCompileArtifactMarkdown.Deserialize(File.ReadAllText(compilePath));
+        if (!string.Equals(compileRequest.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Intake compile artifact domain '{compileRequest.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        var request = new IntakeFoldinRequest
+        {
+            Domain = compileRequest.Domain,
+            AnsweredQuestionIds = compileRequest.AnsweredQuestionIds,
+            RecommendedUpdates = compileRequest.RecommendedUpdates,
+            ReturnToIntentPaths = compileRequest.ReturnToIntentPaths,
+            SourceConceptRefs = compileRequest.SourceConceptRefs
+        };
+        var markdown = IntakeFoldinRenderer.RenderMarkdown(request);
+        var artifactPath = IntakeFoldinArtifactWriter.Write(markdown, domain, repoRoot);
+        return (request, artifactPath);
     }
 }

--- a/src/IntentSystem.Cli/Commands/IntakePatchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakePatchCommand.cs
@@ -15,29 +15,10 @@ internal static class IntakePatchCommand
         }
 
         var domain = args[0];
-        var foldinPath = Path.Combine(
-            context.RepoRoot,
-            IntakeFoldinArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
-
-        if (!File.Exists(foldinPath))
-        {
-            writer.WriteLine($"Intake fold-in artifact was not found at {foldinPath}");
-            return 1;
-        }
 
         try
         {
-            var foldinDraft = IntakeFoldinArtifactMarkdown.Deserialize(File.ReadAllText(foldinPath));
-            if (!string.Equals(foldinDraft.Domain, domain, StringComparison.Ordinal))
-            {
-                writer.WriteLine(
-                    $"Intake fold-in artifact domain '{foldinDraft.Domain}' does not match requested domain '{domain}'.");
-                return 1;
-            }
-
-            var request = CreateRequest(context.RepoRoot, foldinDraft);
-            var markdown = IntakePatchRenderer.RenderMarkdown(request);
-            var artifactPath = IntakePatchArtifactWriter.Write(markdown, domain, context.RepoRoot);
+            var (request, artifactPath) = ExecuteCore(context.RepoRoot, domain);
             IntakePatchRenderer.WriteSummary(writer, request, artifactPath);
             return 0;
         }
@@ -46,6 +27,30 @@ internal static class IntakePatchCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static (IntakePatchRequest Request, string ArtifactPath) ExecuteCore(string repoRoot, string domain)
+    {
+        var foldinPath = Path.Combine(
+            repoRoot,
+            IntakeFoldinArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(foldinPath))
+        {
+            throw new InvalidOperationException($"Intake fold-in artifact was not found at {foldinPath}");
+        }
+
+        var foldinDraft = IntakeFoldinArtifactMarkdown.Deserialize(File.ReadAllText(foldinPath));
+        if (!string.Equals(foldinDraft.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Intake fold-in artifact domain '{foldinDraft.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        var request = CreateRequest(repoRoot, foldinDraft);
+        var markdown = IntakePatchRenderer.RenderMarkdown(request);
+        var artifactPath = IntakePatchArtifactWriter.Write(markdown, domain, repoRoot);
+        return (request, artifactPath);
     }
 
     private static IntakePatchRequest CreateRequest(string repoRoot, IntakePatchFoldinDraft foldinDraft)

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -835,7 +835,18 @@ public sealed class CommandRouterTests
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
-            "domain_slug: auth" + Environment.NewLine);
+            """
+            domain_slug: auth
+            concept_source: interactive
+            concept_text: "Add OAuth2 provider support."
+            upstream_paths:
+              - "intents/intent-cli/intent-tree/means/04-worker-interface-strategy.md"
+            initial_goal: "Add OAuth2 provider support."
+            constraints:
+              - "Must not break existing session flow"
+            known_unknowns:
+              - "Which OAuth providers to support?"
+            """);
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
             """

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -829,6 +829,62 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeAdvanceCommand_DispatchesToIntakeAdvanceRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
+            "domain_slug: auth" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            """
+            artifact_kind: interview
+            domain_slug: auth
+            source_concept_ref: "intents/intent-cli/concepts/auth-oauth2.md"
+            question_id: iq-1
+            question_text: "What should be updated?"
+            reason: "Clarify auth direction."
+            affects:
+              - "auth-oauth2"
+            blocking_or_nonblocking: blocking
+            status: answered
+            return_to_intent_paths:
+              - "intents/intent-cli/intent-tree/means/auth-oauth2.md"
+            created_at: "2026-04-13T07:00:00.0000000+00:00"
+            answer: "Align login UX wording."
+            answered_at: "2026-04-13T10:00:00.0000000+00:00"
+            recommended_updates:
+              - "Align login UX wording"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "auth-oauth2.md"),
+            "# Auth Concept" + Environment.NewLine + Environment.NewLine + "- Existing note" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means" + Environment.NewLine + Environment.NewLine + "- Existing rule" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            ## G36 の current baseline
+
+            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
+            - successful output は execution draft で指定された source files だけを deterministic に更新することを baseline にする
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["intake", "advance", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Intake advance processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenClarifyAnswerCommand_DispatchesToClarifyAnswerRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeAdvanceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeAdvanceCommandTests.cs
@@ -12,7 +12,7 @@ public sealed class IntakeAdvanceCommandTests
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
-            "domain_slug: auth" + Environment.NewLine);
+            CreateConceptArtifactYaml("auth"));
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
             CreateInterviewArtifactYaml(CreateAnsweredItem()));
@@ -86,7 +86,7 @@ public sealed class IntakeAdvanceCommandTests
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
-            "domain_slug: auth" + Environment.NewLine);
+            CreateConceptArtifactYaml("auth"));
         using var writer = new StringWriter();
 
         var exitCode = IntakeAdvanceCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
@@ -150,6 +150,22 @@ public sealed class IntakeAdvanceCommandTests
             AnsweredAt = DateTimeOffset.Parse("2026-04-13T10:00:00Z"),
             RecommendedUpdates = ["Align login UX wording"]
         };
+    }
+
+    private static string CreateConceptArtifactYaml(string domain)
+    {
+        return $$"""
+            domain_slug: {{domain}}
+            concept_source: interactive
+            concept_text: "Add OAuth2 provider support."
+            upstream_paths:
+              - "intents/intent-cli/intent-tree/means/04-worker-interface-strategy.md"
+            initial_goal: "Add OAuth2 provider support."
+            constraints:
+              - "Must not break existing session flow"
+            known_unknowns:
+              - "Which OAuth providers to support?"
+            """;
     }
 
     private static string CreateInterviewArtifactYaml(IntentSystem.ConceptIntake.Models.InterviewQueueItem item)

--- a/tests/IntentSystem.Cli.Tests/IntakeAdvanceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeAdvanceCommandTests.cs
@@ -1,0 +1,223 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeAdvanceCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyIntakeArtifacts_AdvancesToUpdatedExecutionSourceOfTruth()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
+            "domain_slug: auth" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewArtifactYaml(CreateAnsweredItem()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "auth-oauth2.md"),
+            "# Auth Concept" + Environment.NewLine + Environment.NewLine + "- Existing note" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means" + Environment.NewLine + Environment.NewLine + "- Existing rule" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            ## G36 の current baseline
+
+            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
+            - canonical source は current `.intent-cli/intake/<domain>.execution.md` と current `execution/` source files, plus the `G29` / `G30` / `G32` / `G33` / `G34` / `G35` intake baseline である
+            - successful output は execution draft で指定された source files だけを deterministic に更新することを baseline にする
+
+            ## Another Section
+
+            - Keep this section untouched
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeAdvanceCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake advance processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+        Assert.Contains("Updated source file paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/concepts/auth-oauth2.md", output, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/intent-tree/means/auth-oauth2.md", output, StringComparison.Ordinal);
+        Assert.Contains("Updated execution file paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/execution/05-post-mvp-sub-slices.md", output, StringComparison.Ordinal);
+        Assert.Contains("Regenerated artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/intake/auth.compile.md", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/intake/auth.foldin.md", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/intake/auth.patch.md", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/intake/auth.execution.md", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped stages:", output, StringComparison.Ordinal);
+        var skippedSectionIndex = output.IndexOf("Skipped stages:", StringComparison.Ordinal);
+        Assert.NotEqual(-1, skippedSectionIndex);
+        Assert.Contains("- none", output[skippedSectionIndex..], StringComparison.Ordinal);
+
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.compile.md")));
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.foldin.md")));
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.patch.md")));
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.execution.md")));
+
+        var updatedConcept = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "concepts", "auth-oauth2.md"));
+        Assert.Contains("- Reconcile this source concept file with the current fold-in draft.", updatedConcept, StringComparison.Ordinal);
+        var updatedMeans = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"));
+        Assert.Contains("- Align login UX wording", updatedMeans, StringComparison.Ordinal);
+
+        var executionSource = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"));
+        Assert.Contains("- execution_unit: AUTH-01", executionSource, StringComparison.Ordinal);
+        Assert.Contains("- execution_unit: AUTH-02", executionSource, StringComparison.Ordinal);
+        Assert.Contains("## Another Section", executionSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyCompileState_RendersNotReadySummaryAndSkipsLaterStages()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
+            "domain_slug: auth" + Environment.NewLine);
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeAdvanceCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake advance processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped stages:", output, StringComparison.Ordinal);
+        Assert.Contains("- foldin", output, StringComparison.Ordinal);
+        Assert.Contains("- patch", output, StringComparison.Ordinal);
+        Assert.Contains("- apply", output, StringComparison.Ordinal);
+        Assert.Contains("- execution", output, StringComparison.Ordinal);
+        Assert.Contains("- execution-apply", output, StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.compile.md")));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeAdvanceCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static IntentSystem.ConceptIntake.Models.InterviewQueueItem CreateAnsweredItem()
+    {
+        return new IntentSystem.ConceptIntake.Models.InterviewQueueItem
+        {
+            DomainSlug = "auth",
+            SourceConceptRef = "intents/intent-cli/concepts/auth-oauth2.md",
+            QuestionId = "iq-1",
+            QuestionText = "What should be updated?",
+            Reason = "Clarify auth direction.",
+            Affects = ["auth-oauth2"],
+            BlockingOrNonblocking = "blocking",
+            Status = IntentSystem.ConceptIntake.Models.InterviewQueueItemStatus.Answered,
+            ReturnToIntentPaths = ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+            CreatedAt = DateTimeOffset.Parse("2026-04-13T07:00:00Z"),
+            Answer = "Align login UX wording.",
+            AnsweredAt = DateTimeOffset.Parse("2026-04-13T10:00:00Z"),
+            RecommendedUpdates = ["Align login UX wording"]
+        };
+    }
+
+    private static string CreateInterviewArtifactYaml(IntentSystem.ConceptIntake.Models.InterviewQueueItem item)
+    {
+        var lines = new List<string>
+        {
+            "artifact_kind: interview",
+            $"domain_slug: {item.DomainSlug}",
+            $"source_concept_ref: {Quote(item.SourceConceptRef)}",
+            $"question_id: {item.QuestionId}",
+            $"question_text: {Quote(item.QuestionText)}",
+            $"reason: {Quote(item.Reason)}",
+            "affects:"
+        };
+
+        lines.AddRange(item.Affects.Select(affect => $"  - {Quote(affect)}"));
+        lines.Add($"blocking_or_nonblocking: {item.BlockingOrNonblocking}");
+        lines.Add($"status: {item.Status.ToString().ToLowerInvariant()}");
+        lines.Add("return_to_intent_paths:");
+        lines.AddRange(item.ReturnToIntentPaths.Select(path => $"  - {Quote(path)}"));
+        lines.Add($"created_at: {Quote(item.CreatedAt.ToString("O"))}");
+        lines.Add(item.Answer is null ? "answer: null" : $"answer: {Quote(item.Answer)}");
+        lines.Add($"answered_at: {Quote(item.AnsweredAt!.Value.ToString("O"))}");
+        lines.Add("recommended_updates:");
+        lines.AddRange(item.RecommendedUpdates!.Select(update => $"  - {Quote(update)}"));
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-advance-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What Changed
- added `intent-cli intake advance <domain>` as the thin bridge from intake artifacts into updated `execution/` source-of-truth
- reused the existing compile, foldin, patch, apply, execution draft, and execution apply baselines through internal core helpers instead of widening their outward contracts
- added CLI/runtime coverage for ready advancement, compile not-ready gating, and command routing

## Why
Issue 110 requires a single domain command that deterministically advances selected intake artifacts to updated execution source-of-truth, while staying outside issue generation, queue insertion, launch, review, merge, and workflow execution.

## Impact
A selected domain can now be moved from concept/interview intake artifacts through compile, foldin, patch, source apply, execution draft, and execution apply in one command, with a summary of updated source paths, updated execution paths, regenerated artifacts, readiness status, and skipped stages.

## Validation
- `dotnet test IntentSystem.sln`
