### PR TITLE
[codex] Add intake activate command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -82,6 +82,7 @@ internal static class CommandRouter
                 ["apply"] = IntakeApplyCommand.Execute,
                 ["execution"] = IntakeExecutionCommand.Execute,
                 ["advance"] = IntakeAdvanceCommand.Execute,
+                ["activate"] = IntakeActivateCommand.Execute,
                 ["issue"] = IntakeIssueCommand.Execute,
                 ["enqueue"] = IntakeEnqueueCommand.Execute,
                 ["autostart"] = IntakeAutostartCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/IntakeActivateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeActivateCommand.cs
@@ -1,0 +1,75 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeActivateCommand
+{
+    private static readonly string[] DeferredDownstreamStages =
+    [
+        "issue",
+        "enqueue",
+        "dispatch",
+        "start"
+    ];
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Intake activate command requires a domain.");
+            return 1;
+        }
+
+        var domain = args[0].Trim();
+
+        try
+        {
+            var result = ExecuteCore(context, domain, writer);
+            IntakeActivateRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static IntakeActivateResult ExecuteCore(CliContext context, string domain, TextWriter writer)
+    {
+        var advanceResult = IntakeAdvanceCommand.ExecuteCore(context, domain);
+        if (!string.Equals(advanceResult.ReadinessStatus, "ready", StringComparison.Ordinal))
+        {
+            return new IntakeActivateResult
+            {
+                Domain = domain,
+                ReadinessStatus = advanceResult.ReadinessStatus,
+                UpdatedSourceFilePaths = advanceResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = advanceResult.UpdatedExecutionFilePaths,
+                RegeneratedArtifactPaths = advanceResult.RegeneratedArtifactPaths,
+                StartedExecutionUnits = [],
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                SkippedStages = advanceResult.SkippedStages.Concat(DeferredDownstreamStages).ToArray()
+            };
+        }
+
+        var startResult = IntakeStartCommand.ExecuteCore(context, domain, writer);
+        return new IntakeActivateResult
+        {
+            Domain = domain,
+            ReadinessStatus = advanceResult.ReadinessStatus,
+            UpdatedSourceFilePaths = advanceResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = advanceResult.UpdatedExecutionFilePaths,
+            RegeneratedArtifactPaths = advanceResult.RegeneratedArtifactPaths,
+            StartedExecutionUnits = startResult.StartedExecutionUnits,
+            GeneratedIssueArtifactPaths = startResult.GeneratedArtifactPaths,
+            CreatedIssueRefs = startResult.CreatedIssueRefs,
+            WorktreePaths = startResult.WorktreePaths,
+            SkippedStages = advanceResult.SkippedStages
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeActivateRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeActivateRenderer.cs
@@ -1,0 +1,43 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeActivateRenderer
+{
+    public static void WriteSummary(TextWriter writer, IntakeActivateResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Intake activate processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Generated issue artifact paths:");
+        WriteList(writer, result.GeneratedIssueArtifactPaths);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeActivateResult.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeActivateResult.cs
@@ -1,0 +1,24 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeActivateResult
+{
+    public required string Domain { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> GeneratedIssueArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeAdvanceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeAdvanceCommand.cs
@@ -27,49 +27,8 @@ internal static class IntakeAdvanceCommand
 
         try
         {
-            EnsureConceptArtifactExists(context.RepoRoot, domain);
-
-            var compileResult = IntakeCompileCommand.ExecuteCore(context.RepoRoot, domain);
-            if (!compileResult.IsReady)
-            {
-                IntakeAdvanceRenderer.WriteSummary(writer, new IntakeAdvanceResult
-                {
-                    Domain = domain,
-                    ReadinessStatus = "not-ready",
-                    UpdatedSourceFilePaths = [],
-                    UpdatedExecutionFilePaths = [],
-                    RegeneratedArtifactPaths = [],
-                    SkippedStages = DeferredStages
-                });
-                return 0;
-            }
-
-            var (_, foldinPath) = IntakeFoldinCommand.ExecuteCore(context.RepoRoot, domain);
-            var (_, patchPath) = IntakePatchCommand.ExecuteCore(context.RepoRoot, domain);
-            var applyResult = IntakeApplyCommand.ExecuteCore(context.RepoRoot, domain);
-            var (_, executionPath) = IntakeExecutionCommand.ExecuteCore(context.RepoRoot, domain);
-            var executionApplyResult = IntakeExecutionApplyCommand.ExecuteCore(context.RepoRoot, domain);
-
-            var regeneratedArtifactPaths = new[]
-            {
-                compileResult.ArtifactPath,
-                foldinPath,
-                patchPath,
-                executionPath
-            }
-            .Where(path => !string.IsNullOrWhiteSpace(path))
-            .Select(path => ToRelativePath(context.RepoRoot, path!))
-            .ToArray();
-
-            IntakeAdvanceRenderer.WriteSummary(writer, new IntakeAdvanceResult
-            {
-                Domain = domain,
-                ReadinessStatus = "ready",
-                UpdatedSourceFilePaths = applyResult.ChangedFilePaths,
-                UpdatedExecutionFilePaths = executionApplyResult.ChangedFilePaths,
-                RegeneratedArtifactPaths = regeneratedArtifactPaths,
-                SkippedStages = []
-            });
+            var result = ExecuteCore(context, domain);
+            IntakeAdvanceRenderer.WriteSummary(writer, result);
             return 0;
         }
         catch (InvalidOperationException exception)
@@ -77,6 +36,52 @@ internal static class IntakeAdvanceCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static IntakeAdvanceResult ExecuteCore(CliContext context, string domain)
+    {
+        EnsureConceptArtifactExists(context.RepoRoot, domain);
+
+        var compileResult = IntakeCompileCommand.ExecuteCore(context.RepoRoot, domain);
+        if (!compileResult.IsReady)
+        {
+            return new IntakeAdvanceResult
+            {
+                Domain = domain,
+                ReadinessStatus = "not-ready",
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                SkippedStages = DeferredStages
+            };
+        }
+
+        var (_, foldinPath) = IntakeFoldinCommand.ExecuteCore(context.RepoRoot, domain);
+        var (_, patchPath) = IntakePatchCommand.ExecuteCore(context.RepoRoot, domain);
+        var applyResult = IntakeApplyCommand.ExecuteCore(context.RepoRoot, domain);
+        var (_, executionPath) = IntakeExecutionCommand.ExecuteCore(context.RepoRoot, domain);
+        var executionApplyResult = IntakeExecutionApplyCommand.ExecuteCore(context.RepoRoot, domain);
+
+        var regeneratedArtifactPaths = new[]
+        {
+            compileResult.ArtifactPath,
+            foldinPath,
+            patchPath,
+            executionPath
+        }
+        .Where(path => !string.IsNullOrWhiteSpace(path))
+        .Select(path => ToRelativePath(context.RepoRoot, path!))
+        .ToArray();
+
+        return new IntakeAdvanceResult
+        {
+            Domain = domain,
+            ReadinessStatus = "ready",
+            UpdatedSourceFilePaths = applyResult.ChangedFilePaths,
+            UpdatedExecutionFilePaths = executionApplyResult.ChangedFilePaths,
+            RegeneratedArtifactPaths = regeneratedArtifactPaths,
+            SkippedStages = []
+        };
     }
 
     private static void EnsureConceptArtifactExists(string repoRoot, string domain)

--- a/src/IntentSystem.Cli/Commands/IntakeStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeStartCommand.cs
@@ -18,18 +18,7 @@ internal static class IntakeStartCommand
 
         try
         {
-            var issueResult = IntakeIssueCommand.ExecuteCore(context.RepoRoot, domain);
-            var launchResult = IntakeLaunchCommand.ExecuteCore(context, domain, writer);
-            var result = new IntakeStartResult
-            {
-                Domain = domain,
-                StartedExecutionUnits = launchResult.LaunchedExecutionUnits,
-                GeneratedArtifactPaths = issueResult.ArtifactPaths,
-                CreatedIssueRefs = launchResult.CreatedIssueRefs,
-                WorktreePaths = launchResult.WorktreePaths,
-                SkippedUnits = launchResult.SkippedUnits
-            };
-
+            var result = ExecuteCore(context, domain, writer);
             IntakeStartRenderer.WriteSummary(writer, result);
             return 0;
         }
@@ -38,5 +27,21 @@ internal static class IntakeStartCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static IntakeStartResult ExecuteCore(CliContext context, string domain, TextWriter writer)
+    {
+        var issueResult = IntakeIssueCommand.ExecuteCore(context.RepoRoot, domain);
+        var launchResult = IntakeLaunchCommand.ExecuteCore(context, domain, writer);
+
+        return new IntakeStartResult
+        {
+            Domain = domain,
+            StartedExecutionUnits = launchResult.LaunchedExecutionUnits,
+            GeneratedArtifactPaths = issueResult.ArtifactPaths,
+            CreatedIssueRefs = launchResult.CreatedIssueRefs,
+            WorktreePaths = launchResult.WorktreePaths,
+            SkippedUnits = launchResult.SkippedUnits
+        };
     }
 }

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -829,6 +829,33 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeActivateCommand_DispatchesToIntakeActivateRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
+            """
+            domain_slug: auth
+            concept_source: interactive
+            concept_text: "Add OAuth2 provider support."
+            upstream_paths:
+              - "intents/intent-cli/intent-tree/means/04-worker-interface-strategy.md"
+            initial_goal: "Add OAuth2 provider support."
+            constraints:
+              - "Must not break existing session flow"
+            known_unknowns:
+              - "Which OAuth providers to support?"
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["intake", "activate", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Intake activate processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenIntakeAdvanceCommand_DispatchesToIntakeAdvanceRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeActivateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeActivateCommandTests.cs
@@ -1,0 +1,422 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Projection.Serialization;
+using IntentSystem.Review;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class IntakeActivateCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyIntakeArtifacts_AdvancesAndStartsUnits()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
+            CreateConceptArtifactYaml("auth"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewArtifactYaml(CreateAnsweredItem()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "auth-oauth2.md"),
+            "# Auth Concept" + Environment.NewLine + Environment.NewLine + "- Existing note" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means" + Environment.NewLine + Environment.NewLine + "- Existing rule" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            CreateExecutionBaselineMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalEnqueueTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalRemoteGitFactory = QueueDispatchCommand.GitCommandRunnerFactory;
+        var originalDispatchTimestampFactory = QueueDispatchCommand.TimestampFactory;
+        var originalStartGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalStartTimestampFactory = RunStartCommand.TimestampFactory;
+        var startGitRunner = new FakeStartGitRunner();
+        var publisher = new FakePublisher();
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:00:00Z");
+            QueueDispatchCommand.PublisherFactory = () => publisher;
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeRemoteGitRunner();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:05:00Z");
+            RunStartCommand.GitCommandRunnerFactory = () => startGitRunner;
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:10:00Z");
+
+            var exitCode = IntakeActivateCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Intake activate processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+            Assert.Contains("Updated source file paths:", output, StringComparison.Ordinal);
+            Assert.Contains("- intents/intent-cli/concepts/auth-oauth2.md", output, StringComparison.Ordinal);
+            Assert.Contains("- intents/intent-cli/intent-tree/means/auth-oauth2.md", output, StringComparison.Ordinal);
+            Assert.Contains("Updated execution file paths:", output, StringComparison.Ordinal);
+            Assert.Contains("- intents/intent-cli/execution/05-post-mvp-sub-slices.md", output, StringComparison.Ordinal);
+            Assert.Contains("Regenerated artifact paths:", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.compile.md", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.foldin.md", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.patch.md", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.execution.md", output, StringComparison.Ordinal);
+            Assert.Contains("Started execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-02", output, StringComparison.Ordinal);
+            Assert.Contains("Generated issue artifact paths:", output, StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/issues/AUTH-01/packet.yaml", output, StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/issues/AUTH-02/github-body.md", output, StringComparison.Ordinal);
+            Assert.Contains("Created issue refs:", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/issues/501", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/issues/502", output, StringComparison.Ordinal);
+            Assert.Contains("Worktree paths:", output, StringComparison.Ordinal);
+            Assert.Contains(Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "worktrees", "AUTH-01")), output, StringComparison.Ordinal);
+            Assert.Contains("Skipped stages:", output, StringComparison.Ordinal);
+            var skippedSectionIndex = output.IndexOf("Skipped stages:", StringComparison.Ordinal);
+            Assert.NotEqual(-1, skippedSectionIndex);
+            Assert.Contains("- none", output[skippedSectionIndex..], StringComparison.Ordinal);
+
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.compile.md")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.foldin.md")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.patch.md")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.execution.md")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "packet.yaml")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-02", "github-body.md")));
+
+            var packet = ProjectionPacketSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "packet.yaml")));
+            Assert.Equal("AUTH-01", packet.ImplementationIssuePacket.SourceExecutionUnit);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Active, queueState.Items.Single(item => item.ExecutionUnit == "AUTH-01").State);
+            Assert.Equal(QueueItemState.Active, queueState.Items.Single(item => item.ExecutionUnit == "AUTH-02").State);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal(
+                ["queued", "issue-created", "activated", "queued", "issue-created", "activated"],
+                runEvents.Select(runEvent => runEvent.Event).ToArray());
+
+            var updatedConcept = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "concepts", "auth-oauth2.md"));
+            Assert.Contains("- Reconcile this source concept file with the current fold-in draft.", updatedConcept, StringComparison.Ordinal);
+            var updatedMeans = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"));
+            Assert.Contains("- Align login UX wording", updatedMeans, StringComparison.Ordinal);
+
+            var executionSource = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"));
+            Assert.Contains("- execution_unit: AUTH-01", executionSource, StringComparison.Ordinal);
+            Assert.Contains("- execution_unit: AUTH-02", executionSource, StringComparison.Ordinal);
+
+            var auth01Worktree = Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "worktrees", "AUTH-01"));
+            var auth02Worktree = Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "worktrees", "AUTH-02"));
+            var childRepoPath = Path.Combine(repoRoot, "submodules", "intent-system");
+            Assert.Equal(
+                [
+                    $"{childRepoPath}::fetch origin main",
+                    $"{childRepoPath}::worktree add -b issue-501-auth-01 {auth01Worktree} origin/main",
+                    $"{childRepoPath}::fetch origin main",
+                    $"{childRepoPath}::worktree add -b issue-502-auth-02 {auth02Worktree} origin/main"
+                ],
+                startGitRunner.Calls);
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalEnqueueTimestampFactory;
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalRemoteGitFactory;
+            QueueDispatchCommand.TimestampFactory = originalDispatchTimestampFactory;
+            RunStartCommand.GitCommandRunnerFactory = originalStartGitFactory;
+            RunStartCommand.TimestampFactory = originalStartTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyCompileState_RendersNotReadySummaryAndSkipsDownstreamStages()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
+            CreateConceptArtifactYaml("auth"));
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeActivateCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake activate processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+        Assert.Contains("Started execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("Generated issue artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Created issue refs:", output, StringComparison.Ordinal);
+        Assert.Contains("Worktree paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped stages:", output, StringComparison.Ordinal);
+        Assert.Contains("- foldin", output, StringComparison.Ordinal);
+        Assert.Contains("- patch", output, StringComparison.Ordinal);
+        Assert.Contains("- apply", output, StringComparison.Ordinal);
+        Assert.Contains("- execution", output, StringComparison.Ordinal);
+        Assert.Contains("- execution-apply", output, StringComparison.Ordinal);
+        Assert.Contains("- issue", output, StringComparison.Ordinal);
+        Assert.Contains("- enqueue", output, StringComparison.Ordinal);
+        Assert.Contains("- dispatch", output, StringComparison.Ordinal);
+        Assert.Contains("- start", output, StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "packet.yaml")));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeActivateCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string CreateExecutionBaselineMarkdown()
+    {
+        return """
+            # Post-MVP Sub-Slices
+
+            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
+            |---|---|---|---|---|---|---|---|
+            | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | submodules/intent-system | . | cli intake issue command | yes |
+
+            ## G36 の current baseline
+
+            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
+            - canonical source は current `.intent-cli/intake/<domain>.execution.md` と current `execution/` source files, plus the `G29` / `G30` / `G32` / `G33` / `G34` / `G35` intake baseline である
+            - successful output は execution draft で指定された source files だけを deterministic に更新することを baseline にする
+
+            ## G37 の current baseline
+
+            - `intake issue <domain>` を最初の intake issue-artifact generation command にする
+            - canonical source は current `execution/` source files と current `G2` / `G29` / `G30` / `G32` / `G33` / `G34` / `G35` / `G36` intake baseline である
+            - successful output は selected domain の intake-origin issue-ready execution unit に対応する `.intent-cli/issues/<execution-unit>/implementation.md`, `review-context.md`, `packet.yaml`, and `github-body.md` の deterministic generation を baseline にする
+
+            ## Another Section
+
+            - Keep this section untouched
+            """;
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                },
+                Roles = new RoleMappings
+                {
+                    Implement = "Claude",
+                    Review = "Codex"
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-06T10:00:00Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "G3",
+                    Title = "[G3] Existing Item",
+                    State = QueueItemState.Completed,
+                    Dependencies = [],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G3/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G3/review-context.md",
+                        Yaml = ".intent-cli/issues/G3/packet.yaml"
+                    },
+                    LinkedIssue = null,
+                    WorkerRole = "Claude",
+                    ReviewRole = "Codex",
+                    Priority = "high"
+                }
+            ]
+        };
+    }
+
+    private static IntentSystem.ConceptIntake.Models.InterviewQueueItem CreateAnsweredItem()
+    {
+        return new IntentSystem.ConceptIntake.Models.InterviewQueueItem
+        {
+            DomainSlug = "auth",
+            SourceConceptRef = "intents/intent-cli/concepts/auth-oauth2.md",
+            QuestionId = "iq-1",
+            QuestionText = "What should be updated?",
+            Reason = "Clarify auth direction.",
+            Affects = ["auth-oauth2"],
+            BlockingOrNonblocking = "blocking",
+            Status = IntentSystem.ConceptIntake.Models.InterviewQueueItemStatus.Answered,
+            ReturnToIntentPaths = ["intents/intent-cli/intent-tree/means/auth-oauth2.md"],
+            CreatedAt = DateTimeOffset.Parse("2026-04-13T07:00:00Z"),
+            Answer = "Align login UX wording.",
+            AnsweredAt = DateTimeOffset.Parse("2026-04-13T10:00:00Z"),
+            RecommendedUpdates = ["Align login UX wording"]
+        };
+    }
+
+    private static string CreateConceptArtifactYaml(string domain)
+    {
+        return $$"""
+            domain_slug: {{domain}}
+            concept_source: interactive
+            concept_text: "Add OAuth2 provider support."
+            upstream_paths:
+              - "intents/intent-cli/intent-tree/means/04-worker-interface-strategy.md"
+            initial_goal: "Add OAuth2 provider support."
+            constraints:
+              - "Must not break existing session flow"
+            known_unknowns:
+              - "Which OAuth providers to support?"
+            """;
+    }
+
+    private static string CreateInterviewArtifactYaml(IntentSystem.ConceptIntake.Models.InterviewQueueItem item)
+    {
+        var lines = new List<string>
+        {
+            "artifact_kind: interview",
+            $"domain_slug: {item.DomainSlug}",
+            $"source_concept_ref: {Quote(item.SourceConceptRef)}",
+            $"question_id: {item.QuestionId}",
+            $"question_text: {Quote(item.QuestionText)}",
+            $"reason: {Quote(item.Reason)}",
+            "affects:"
+        };
+
+        lines.AddRange(item.Affects.Select(affect => $"  - {Quote(affect)}"));
+        lines.Add($"blocking_or_nonblocking: {item.BlockingOrNonblocking}");
+        lines.Add($"status: {item.Status.ToString().ToLowerInvariant()}");
+        lines.Add("return_to_intent_paths:");
+        lines.AddRange(item.ReturnToIntentPaths.Select(path => $"  - {Quote(path)}"));
+        lines.Add($"created_at: {Quote(item.CreatedAt.ToString("O"))}");
+        lines.Add(item.Answer is null ? "answer: null" : $"answer: {Quote(item.Answer)}");
+        lines.Add($"answered_at: {Quote(item.AnsweredAt!.Value.ToString("O"))}");
+        lines.Add("recommended_updates:");
+        lines.AddRange(item.RecommendedUpdates!.Select(update => $"  - {Quote(update)}"));
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+
+    private sealed class FakePublisher : IQueueDispatchPublisher
+    {
+        private int nextIssueNumber = 501;
+
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            var issueNumber = nextIssueNumber++;
+            return new LinkedIssue
+            {
+                Repo = targetRepo,
+                Number = issueNumber,
+                Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{issueNumber}"
+            };
+        }
+    }
+
+    private sealed class FakeRemoteGitRunner : IGitRemoteCommandRunner
+    {
+        public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            return new GitRemoteCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "https://github.com/J-Tech-Japan/intent-system.git",
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class FakeStartGitRunner : IGitCommandRunner
+    {
+        public List<string> Calls { get; } = [];
+
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Calls.Add($"{workingDirectory}::{string.Join(' ', arguments)}");
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-activate-command-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeActivateRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeActivateRendererTests.cs
@@ -1,0 +1,62 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeActivateRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenActivateResult_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        IntakeActivateRenderer.WriteSummary(
+            writer,
+            new IntakeActivateResult
+            {
+                Domain = "auth",
+                ReadinessStatus = "ready",
+                UpdatedSourceFilePaths =
+                [
+                    "intents/intent-cli/concepts/auth-oauth2.md"
+                ],
+                UpdatedExecutionFilePaths =
+                [
+                    "intents/intent-cli/execution/05-post-mvp-sub-slices.md"
+                ],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.compile.md",
+                    ".intent-cli/intake/auth.execution.md"
+                ],
+                StartedExecutionUnits =
+                [
+                    "AUTH-01"
+                ],
+                GeneratedIssueArtifactPaths =
+                [
+                    ".intent-cli/issues/AUTH-01/packet.yaml",
+                    ".intent-cli/issues/AUTH-01/github-body.md"
+                ],
+                CreatedIssueRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/issues/501"
+                ],
+                WorktreePaths =
+                [
+                    "/repo/.intent-cli/worktrees/AUTH-01"
+                ],
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Intake activate processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+        Assert.Contains("Updated source file paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/concepts/auth-oauth2.md", output, StringComparison.Ordinal);
+        Assert.Contains("Generated issue artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/issues/AUTH-01/github-body.md", output, StringComparison.Ordinal);
+        Assert.Contains("Created issue refs:", output, StringComparison.Ordinal);
+        Assert.Contains("Worktree paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped stages:", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## What changed
- add `intent-cli intake activate <domain>` as a thin bridge from intake artifacts through the existing advance and start flows
- keep `intake advance` and `intake start` outward behavior unchanged while exposing internal core helpers for composition
- add runtime, renderer, and command router coverage for ready and not-ready activation paths

## Why
- Issue 112 requires a deterministic command that advances a selected domain from intake artifacts through issue generation and launch until the selected units reach `active`

## Impact
- selected domains can now be advanced from intake artifacts to active queue items with a single command
- human-facing output now summarizes updated source files, updated execution files, regenerated intake artifacts, generated issue artifacts, started execution units, created issue refs, worktree paths, readiness status, and skipped stages

## Validation
- `dotnet test IntentSystem.sln`