### PR TITLE
[codex] Add generate-from-current command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -3,6 +3,7 @@ namespace IntentSystem.Cli.Commands;
 internal static class CommandRouter
 {
     private delegate int CommandHandler(CliContext context, string[] args, TextWriter writer);
+    private const string GenerateFromCurrentCommandName = "generate-from-current";
 
     private static readonly string[] CommandGroups =
     [
@@ -103,6 +104,11 @@ internal static class CommandRouter
             return 0;
         }
 
+        if (string.Equals(args[0], GenerateFromCurrentCommandName, StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentCommand.Execute(context, args[1..], writer);
+        }
+
         if (args.Length < 2)
         {
             writer.WriteLine("A command group and subcommand are required.");
@@ -137,5 +143,8 @@ internal static class CommandRouter
         {
             writer.WriteLine($"- {group}");
         }
+
+        writer.WriteLine("Additional top-level commands:");
+        writer.WriteLine($"- {GenerateFromCurrentCommandName}");
     }
 }

--- a/src/IntentSystem.Cli/Commands/CurrentSourcesArtifact.cs
+++ b/src/IntentSystem.Cli/Commands/CurrentSourcesArtifact.cs
@@ -1,0 +1,22 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record CurrentSourcesArtifact
+{
+    public required string DomainSlug { get; init; }
+
+    public required string SourceRoot { get; init; }
+
+    public required IReadOnlyList<string> SelectedAltitudes { get; init; }
+
+    public required string SelectedIssueScope { get; init; }
+
+    public required string SelectedPrScope { get; init; }
+
+    public required IReadOnlyList<string> SelectedPaths { get; init; }
+
+    public required IReadOnlyList<string> SourceRefs { get; init; }
+
+    public required IReadOnlyList<string> SamplingNotes { get; init; }
+
+    public required IReadOnlyList<string> Gaps { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/CurrentSourcesArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/CurrentSourcesArtifactPathResolver.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class CurrentSourcesArtifactPathResolver
+{
+    public static string Resolve(string domain)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        return $".intent-cli/intake/{domain}.current-sources.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CurrentSourcesArtifactWriter.cs
+++ b/src/IntentSystem.Cli/Commands/CurrentSourcesArtifactWriter.cs
@@ -1,0 +1,19 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class CurrentSourcesArtifactWriter
+{
+    public static string Write(string repoRoot, string domain, CurrentSourcesArtifact artifact)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var relativePath = CurrentSourcesArtifactPathResolver.Resolve(domain);
+        var artifactPath = Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        var directoryPath = Path.GetDirectoryName(artifactPath)
+            ?? throw new InvalidOperationException("Current sources artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(artifactPath, CurrentSourcesArtifactYaml.Serialize(artifact));
+        return artifactPath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CurrentSourcesArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/CurrentSourcesArtifactYaml.cs
@@ -1,0 +1,192 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class CurrentSourcesArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "domain_slug",
+        "source_root",
+        "selected_altitudes",
+        "selected_issue_scope",
+        "selected_pr_scope",
+        "selected_paths",
+        "source_refs",
+        "sampling_notes",
+        "gaps"
+    ];
+
+    public static string Serialize(CurrentSourcesArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"domain_slug: {artifact.DomainSlug}",
+            $"source_root: {Quote(artifact.SourceRoot)}"
+        };
+
+        AppendList(lines, "selected_altitudes", artifact.SelectedAltitudes);
+        lines.Add($"selected_issue_scope: {Quote(artifact.SelectedIssueScope)}");
+        lines.Add($"selected_pr_scope: {Quote(artifact.SelectedPrScope)}");
+        AppendList(lines, "selected_paths", artifact.SelectedPaths);
+        AppendList(lines, "source_refs", artifact.SourceRefs);
+        AppendList(lines, "sampling_notes", artifact.SamplingNotes);
+        AppendList(lines, "gaps", artifact.Gaps);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static CurrentSourcesArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new CurrentSourcesArtifact
+        {
+            DomainSlug = GetRequiredScalar(values, "domain_slug"),
+            SourceRoot = GetRequiredScalar(values, "source_root"),
+            SelectedAltitudes = GetRequiredList(values, "selected_altitudes"),
+            SelectedIssueScope = GetRequiredScalar(values, "selected_issue_scope"),
+            SelectedPrScope = GetRequiredScalar(values, "selected_pr_scope"),
+            SelectedPaths = GetRequiredList(values, "selected_paths"),
+            SourceRefs = GetRequiredList(values, "source_refs"),
+            SamplingNotes = GetRequiredList(values, "sampling_notes"),
+            Gaps = GetRequiredList(values, "gaps")
+        };
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add($"{label}: []");
+            return;
+        }
+
+        lines.Add($"{label}:");
+        lines.AddRange(values.Select(value => $"  - {Quote(value)}"));
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("  - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !values.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException(
+                        $"Current sources YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[4..].TrimStart()));
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Current sources YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+
+            if (value.Length == 0)
+            {
+                values[key] = new List<string>();
+                currentListKey = key;
+                continue;
+            }
+
+            currentListKey = null;
+            values[key] = value switch
+            {
+                "[]" => Array.Empty<string>(),
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException(
+                    $"Current sources YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException(
+                $"Current sources YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static IReadOnlyList<string> GetRequiredList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException(
+                $"Current sources YAML field '{key}' must be a list.");
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException(
+                $"Current sources YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -1,0 +1,707 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentCommand
+{
+    private static readonly string[] SupportedAltitudes =
+    [
+        "purpose",
+        "user-context",
+        "means",
+        "rules",
+        "specs",
+        "execution"
+    ];
+
+    private static readonly HashSet<string> TextFileExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".cs",
+        ".csproj",
+        ".fs",
+        ".json",
+        ".md",
+        ".props",
+        ".sln",
+        ".targets",
+        ".toml",
+        ".txt",
+        ".xml",
+        ".yaml",
+        ".yml"
+    };
+
+    public static Func<IGitHubCommandRunner> GitHubCommandRunnerFactory { get; set; } = () => new GhCommandRunner();
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentResult ExecuteCore(CliContext context, string[] args)
+    {
+        var options = ParseOptions(args);
+        var sourceRootRelativePath = ResolvePathWithinRepo(context.RepoRoot, options.FromPath);
+        var selectedPaths = new List<string>();
+        var sourceRefs = new List<string>();
+        var samplingNotes = new List<string>();
+        var gaps = new List<string>();
+
+        CollectCodeSignals(
+            context.RepoRoot,
+            sourceRootRelativePath,
+            options.MaxFiles,
+            selectedPaths,
+            sourceRefs,
+            samplingNotes,
+            gaps);
+
+        if (options.IncludeReadme)
+        {
+            CollectReadmeSignals(context.RepoRoot, selectedPaths, sourceRefs, samplingNotes, gaps);
+        }
+
+        if (options.IncludeDocs)
+        {
+            CollectDocSignals(context.RepoRoot, selectedPaths, sourceRefs, samplingNotes, gaps);
+        }
+
+        if (options.IncludeTests)
+        {
+            CollectTestSignals(context.RepoRoot, selectedPaths, sourceRefs, samplingNotes, gaps);
+        }
+
+        var runner = GitHubCommandRunnerFactory();
+        CollectIssueSignals(options.IssueScope, runner, sourceRefs, samplingNotes, gaps);
+        CollectPullRequestSignals(options.PrScope, runner, sourceRefs, samplingNotes, gaps);
+
+        var artifact = new CurrentSourcesArtifact
+        {
+            DomainSlug = options.Domain,
+            SourceRoot = sourceRootRelativePath,
+            SelectedAltitudes = options.SelectedAltitudes,
+            SelectedIssueScope = options.IssueScope.NormalizedValue,
+            SelectedPrScope = options.PrScope.NormalizedValue,
+            SelectedPaths = selectedPaths,
+            SourceRefs = sourceRefs,
+            SamplingNotes = samplingNotes,
+            Gaps = gaps
+        };
+
+        var artifactPath = CurrentSourcesArtifactWriter.Write(context.RepoRoot, options.Domain, artifact);
+        return new GenerateFromCurrentResult
+        {
+            Domain = options.Domain,
+            ArtifactPath = ToRelativePath(context.RepoRoot, artifactPath),
+            SourceRoot = sourceRootRelativePath,
+            SelectedIssueScope = options.IssueScope.NormalizedValue,
+            SelectedPrScope = options.PrScope.NormalizedValue,
+            SelectedAltitudes = options.SelectedAltitudes,
+            SelectedPaths = selectedPaths,
+            SourceRefs = sourceRefs,
+            SamplingNotes = samplingNotes,
+            Gaps = gaps
+        };
+    }
+
+    private static GenerateFromCurrentOptions ParseOptions(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current command requires a domain.");
+        }
+
+        var domain = args[0].Trim();
+        string? fromPath = null;
+        var issueScope = ScopeSelection.None("issues");
+        var prScope = ScopeSelection.None("pull requests");
+        IReadOnlyList<string> selectedAltitudes = SupportedAltitudes;
+        var includeReadme = false;
+        var includeDocs = false;
+        var includeTests = false;
+        var maxFiles = 20;
+
+        for (var index = 1; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-path":
+                    fromPath = ReadRequiredOptionValue(args, ref index, "--from-path");
+                    break;
+                case "--issues":
+                    issueScope = ScopeSelection.Parse(ReadRequiredOptionValue(args, ref index, "--issues"), "issues");
+                    break;
+                case "--prs":
+                    prScope = ScopeSelection.Parse(ReadRequiredOptionValue(args, ref index, "--prs"), "pull requests");
+                    break;
+                case "--altitudes":
+                    selectedAltitudes = ParseAltitudes(ReadRequiredOptionValue(args, ref index, "--altitudes"));
+                    break;
+                case "--include-readme":
+                    includeReadme = true;
+                    break;
+                case "--include-docs":
+                    includeDocs = true;
+                    break;
+                case "--include-tests":
+                    includeTests = true;
+                    break;
+                case "--max-files":
+                    maxFiles = ParsePositiveInteger(ReadRequiredOptionValue(args, ref index, "--max-files"), "--max-files");
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unknown generate-from-current option '{argument}'.");
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromPath))
+        {
+            throw new InvalidOperationException("Generate-from-current command requires --from-path <path>.");
+        }
+
+        return new GenerateFromCurrentOptions
+        {
+            Domain = domain,
+            FromPath = fromPath,
+            IssueScope = issueScope,
+            PrScope = prScope,
+            SelectedAltitudes = selectedAltitudes,
+            IncludeReadme = includeReadme,
+            IncludeDocs = includeDocs,
+            IncludeTests = includeTests,
+            MaxFiles = maxFiles
+        };
+    }
+
+    private static string ReadRequiredOptionValue(string[] args, ref int index, string optionName)
+    {
+        if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+        {
+            throw new InvalidOperationException($"{optionName} requires a value.");
+        }
+
+        index++;
+        return args[index];
+    }
+
+    private static IReadOnlyList<string> ParseAltitudes(string value)
+    {
+        var selected = value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Distinct(StringComparer.Ordinal)
+            .ToHashSet(StringComparer.Ordinal);
+        if (selected.Count == 0)
+        {
+            throw new InvalidOperationException("--altitudes must include at least one altitude.");
+        }
+
+        var unknownAltitude = selected.FirstOrDefault(altitude => !SupportedAltitudes.Contains(altitude, StringComparer.Ordinal));
+        if (unknownAltitude is not null)
+        {
+            throw new InvalidOperationException($"Unsupported altitude '{unknownAltitude}'.");
+        }
+
+        return SupportedAltitudes.Where(selected.Contains).ToArray();
+    }
+
+    private static int ParsePositiveInteger(string value, string optionName)
+    {
+        if (!int.TryParse(value, out var parsed) || parsed <= 0)
+        {
+            throw new InvalidOperationException($"{optionName} must be a positive integer.");
+        }
+
+        return parsed;
+    }
+
+    private static string ResolvePathWithinRepo(string repoRoot, string fromPath)
+    {
+        var fullRepoRoot = Path.GetFullPath(repoRoot);
+        var absolutePath = Path.IsPathRooted(fromPath)
+            ? Path.GetFullPath(fromPath)
+            : Path.GetFullPath(Path.Combine(repoRoot, fromPath));
+
+        if (!absolutePath.StartsWith(fullRepoRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+            && !string.Equals(absolutePath, fullRepoRoot, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Generate-from-current path '{fromPath}' must resolve within repo root '{repoRoot}'.");
+        }
+
+        if (!File.Exists(absolutePath) && !Directory.Exists(absolutePath))
+        {
+            throw new InvalidOperationException($"Generate-from-current path was not found at {absolutePath}");
+        }
+
+        return ToRelativePath(repoRoot, absolutePath);
+    }
+
+    private static void CollectCodeSignals(
+        string repoRoot,
+        string sourceRootRelativePath,
+        int maxFiles,
+        List<string> selectedPaths,
+        List<string> sourceRefs,
+        List<string> samplingNotes,
+        List<string> gaps)
+    {
+        var sourceRootAbsolutePath = Path.Combine(repoRoot, sourceRootRelativePath.Replace('/', Path.DirectorySeparatorChar));
+        var eligibleFiles = EnumerateEligibleFiles(sourceRootAbsolutePath, repoRoot).ToArray();
+        if (eligibleFiles.Length == 0)
+        {
+            gaps.Add($"No readable files were found under selected path '{sourceRootRelativePath}'.");
+            return;
+        }
+
+        var sampledFiles = eligibleFiles.Take(maxFiles).ToArray();
+        if (eligibleFiles.Length > sampledFiles.Length)
+        {
+            samplingNotes.Add(
+                $"code scope truncated to first {sampledFiles.Length} files out of {eligibleFiles.Length} eligible files under '{sourceRootRelativePath}'.");
+        }
+        else
+        {
+            samplingNotes.Add($"code scope sampled {sampledFiles.Length} files under '{sourceRootRelativePath}'.");
+        }
+
+        foreach (var relativePath in sampledFiles)
+        {
+            AddSourceFile("code", repoRoot, relativePath, selectedPaths, sourceRefs, samplingNotes);
+        }
+    }
+
+    private static void CollectReadmeSignals(
+        string repoRoot,
+        List<string> selectedPaths,
+        List<string> sourceRefs,
+        List<string> samplingNotes,
+        List<string> gaps)
+    {
+        var readmePath = Path.Combine(repoRoot, "README.md");
+        if (!File.Exists(readmePath))
+        {
+            gaps.Add("README.md was requested but not found.");
+            return;
+        }
+
+        AddSourceFile("readme", repoRoot, "README.md", selectedPaths, sourceRefs, samplingNotes);
+    }
+
+    private static void CollectDocSignals(
+        string repoRoot,
+        List<string> selectedPaths,
+        List<string> sourceRefs,
+        List<string> samplingNotes,
+        List<string> gaps)
+    {
+        var topLevelMarkdownFiles = Directory.GetFiles(repoRoot, "*.md", SearchOption.TopDirectoryOnly)
+            .Select(path => ToRelativePath(repoRoot, path))
+            .Where(path => !string.Equals(path, "README.md", StringComparison.Ordinal))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+        var docsDirectory = Path.Combine(repoRoot, "docs");
+        var docsDirectoryMarkdownFiles = Directory.Exists(docsDirectory)
+            ? Directory.GetFiles(docsDirectory, "*.md", SearchOption.AllDirectories)
+                .Select(path => ToRelativePath(repoRoot, path))
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray()
+            : [];
+
+        var docFiles = topLevelMarkdownFiles
+            .Concat(docsDirectoryMarkdownFiles)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (docFiles.Length == 0)
+        {
+            gaps.Add("Repo docs were requested but no doc markdown files were found.");
+            return;
+        }
+
+        samplingNotes.Add($"repo docs included {docFiles.Length} markdown files.");
+        foreach (var relativePath in docFiles)
+        {
+            AddSourceFile("doc", repoRoot, relativePath, selectedPaths, sourceRefs, samplingNotes);
+        }
+    }
+
+    private static void CollectTestSignals(
+        string repoRoot,
+        List<string> selectedPaths,
+        List<string> sourceRefs,
+        List<string> samplingNotes,
+        List<string> gaps)
+    {
+        var testsRoot = Path.Combine(repoRoot, "tests");
+        if (!Directory.Exists(testsRoot))
+        {
+            gaps.Add("Tests were requested but the tests directory was not found.");
+            return;
+        }
+
+        var testFiles = EnumerateEligibleFiles(testsRoot, repoRoot)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+        if (testFiles.Length == 0)
+        {
+            gaps.Add("Tests were requested but no readable test files were found.");
+            return;
+        }
+
+        samplingNotes.Add($"test scope included {testFiles.Length} files from 'tests'.");
+        foreach (var relativePath in testFiles)
+        {
+            AddSourceFile("test", repoRoot, relativePath, selectedPaths, sourceRefs, samplingNotes);
+        }
+    }
+
+    private static void CollectIssueSignals(
+        ScopeSelection scope,
+        IGitHubCommandRunner runner,
+        List<string> sourceRefs,
+        List<string> samplingNotes,
+        List<string> gaps)
+    {
+        if (scope.Mode == ScopeMode.None)
+        {
+            return;
+        }
+
+        var issueNumbers = ResolveGitHubNumbers(scope, "issue", runner);
+        if (issueNumbers.Count == 0)
+        {
+            gaps.Add("Selected issue scope resolved to no issues.");
+            return;
+        }
+
+        foreach (var issueNumber in issueNumbers)
+        {
+            var result = RunGitHub(
+                runner,
+                ["issue", "view", issueNumber.ToString(), "--comments", "--json", "number,title,body,url,state,comments"],
+                "gh issue view failed.");
+
+            using var document = JsonDocument.Parse(result.StdOut);
+            var root = document.RootElement;
+            var title = root.GetProperty("title").GetString() ?? string.Empty;
+            var url = root.GetProperty("url").GetString() ?? string.Empty;
+            var body = root.GetProperty("body").GetString() ?? string.Empty;
+            var comments = root.TryGetProperty("comments", out var commentsElement) && commentsElement.ValueKind == JsonValueKind.Array
+                ? commentsElement.GetArrayLength()
+                : 0;
+
+            sourceRefs.Add($"issue:{issueNumber} {url} {title}");
+            samplingNotes.Add(
+                $"issue:{issueNumber} state={root.GetProperty("state").GetString()} body={SummarizeText(body)} comments={comments}");
+            if (string.IsNullOrWhiteSpace(body) && comments == 0)
+            {
+                gaps.Add($"Issue {issueNumber} has sparse signal.");
+            }
+        }
+    }
+
+    private static void CollectPullRequestSignals(
+        ScopeSelection scope,
+        IGitHubCommandRunner runner,
+        List<string> sourceRefs,
+        List<string> samplingNotes,
+        List<string> gaps)
+    {
+        if (scope.Mode == ScopeMode.None)
+        {
+            return;
+        }
+
+        var pullNumbers = ResolveGitHubNumbers(scope, "pr", runner);
+        if (pullNumbers.Count == 0)
+        {
+            gaps.Add("Selected PR scope resolved to no pull requests.");
+            return;
+        }
+
+        foreach (var pullNumber in pullNumbers)
+        {
+            var result = RunGitHub(
+                runner,
+                ["pr", "view", pullNumber.ToString(), "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"],
+                "gh pr view failed.");
+
+            using var document = JsonDocument.Parse(result.StdOut);
+            var root = document.RootElement;
+            var title = root.GetProperty("title").GetString() ?? string.Empty;
+            var url = root.GetProperty("url").GetString() ?? string.Empty;
+            var body = root.GetProperty("body").GetString() ?? string.Empty;
+            var comments = root.TryGetProperty("comments", out var commentsElement) && commentsElement.ValueKind == JsonValueKind.Array
+                ? commentsElement.GetArrayLength()
+                : 0;
+            var reviews = root.TryGetProperty("reviews", out var reviewsElement) && reviewsElement.ValueKind == JsonValueKind.Array
+                ? reviewsElement.GetArrayLength()
+                : 0;
+
+            sourceRefs.Add($"pr:{pullNumber} {url} {title}");
+            samplingNotes.Add(
+                $"pr:{pullNumber} state={root.GetProperty("state").GetString()} merge_state={root.GetProperty("mergeStateStatus").GetString()} body={SummarizeText(body)} comments={comments} reviews={reviews}");
+            if (string.IsNullOrWhiteSpace(body) && comments == 0 && reviews == 0)
+            {
+                gaps.Add($"PR {pullNumber} has sparse signal.");
+            }
+        }
+    }
+
+    private static IReadOnlyList<int> ResolveGitHubNumbers(ScopeSelection scope, string resourceKind, IGitHubCommandRunner runner)
+    {
+        return scope.Mode switch
+        {
+            ScopeMode.None => [],
+            ScopeMode.All => ListAllNumbers(resourceKind, runner),
+            ScopeMode.Explicit => scope.Numbers,
+            _ => throw new InvalidOperationException($"Unsupported scope mode '{scope.Mode}'.")
+        };
+    }
+
+    private static IReadOnlyList<int> ListAllNumbers(string resourceKind, IGitHubCommandRunner runner)
+    {
+        var result = RunGitHub(
+            runner,
+            [resourceKind, "list", "--state", "all", "--limit", "1000", "--json", "number"],
+            $"gh {resourceKind} list failed.");
+
+        using var document = JsonDocument.Parse(result.StdOut);
+        if (document.RootElement.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidOperationException($"gh {resourceKind} list response must be an array.");
+        }
+
+        return document.RootElement
+            .EnumerateArray()
+            .Select(element => element.GetProperty("number").GetInt32())
+            .OrderBy(number => number)
+            .ToArray();
+    }
+
+    private static GitHubCommandResult RunGitHub(
+        IGitHubCommandRunner runner,
+        IReadOnlyList<string> arguments,
+        string defaultError)
+    {
+        var result = runner.Run(arguments);
+        if (result.ExitCode != 0)
+        {
+            var error = string.IsNullOrWhiteSpace(result.StdErr)
+                ? defaultError
+                : result.StdErr.Trim();
+            throw new InvalidOperationException(error);
+        }
+
+        return result;
+    }
+
+    private static IEnumerable<string> EnumerateEligibleFiles(string absolutePath, string repoRoot)
+    {
+        if (File.Exists(absolutePath))
+        {
+            var singleFile = ToRelativePath(repoRoot, absolutePath);
+            return IsReadableTextFile(absolutePath) ? [singleFile] : [];
+        }
+
+        return Directory.GetFiles(absolutePath, "*", SearchOption.AllDirectories)
+            .Where(path => !IsIgnoredPath(path))
+            .Where(IsReadableTextFile)
+            .Select(path => ToRelativePath(repoRoot, path))
+            .OrderBy(path => path, StringComparer.Ordinal);
+    }
+
+    private static bool IsIgnoredPath(string absolutePath)
+    {
+        return absolutePath.Contains($"{Path.DirectorySeparatorChar}.git{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+            || absolutePath.Contains($"{Path.DirectorySeparatorChar}.intent-cli{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+            || absolutePath.Contains($"{Path.DirectorySeparatorChar}.takt{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+            || absolutePath.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+            || absolutePath.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+    }
+
+    private static bool IsReadableTextFile(string absolutePath)
+    {
+        if (!TextFileExtensions.Contains(Path.GetExtension(absolutePath)))
+        {
+            return false;
+        }
+
+        return new FileInfo(absolutePath).Length <= 256 * 1024;
+    }
+
+    private static void AddSourceFile(
+        string kind,
+        string repoRoot,
+        string relativePath,
+        List<string> selectedPaths,
+        List<string> sourceRefs,
+        List<string> samplingNotes)
+    {
+        if (!selectedPaths.Contains(relativePath, StringComparer.Ordinal))
+        {
+            selectedPaths.Add(relativePath);
+        }
+
+        sourceRefs.Add($"{kind}:{relativePath}");
+        var absolutePath = Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        var summary = SummarizeText(File.ReadAllText(absolutePath));
+        samplingNotes.Add($"{kind}:{relativePath} summary={summary}");
+    }
+
+    private static string SummarizeText(string text)
+    {
+        var line = text
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.None)
+            .Select(candidate => candidate.Trim())
+            .FirstOrDefault(candidate => !string.IsNullOrWhiteSpace(candidate));
+
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return "none";
+        }
+
+        return line.Length <= 120 ? line : line[..120];
+    }
+
+    private static string ToRelativePath(string repoRoot, string absolutePath)
+    {
+        return Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    private sealed record GenerateFromCurrentOptions
+    {
+        public required string Domain { get; init; }
+
+        public required string FromPath { get; init; }
+
+        public required ScopeSelection IssueScope { get; init; }
+
+        public required ScopeSelection PrScope { get; init; }
+
+        public required IReadOnlyList<string> SelectedAltitudes { get; init; }
+
+        public required bool IncludeReadme { get; init; }
+
+        public required bool IncludeDocs { get; init; }
+
+        public required bool IncludeTests { get; init; }
+
+        public required int MaxFiles { get; init; }
+    }
+
+    internal enum ScopeMode
+    {
+        None,
+        All,
+        Explicit
+    }
+
+    internal sealed record ScopeSelection
+    {
+        public required ScopeMode Mode { get; init; }
+
+        public required string NormalizedValue { get; init; }
+
+        public required IReadOnlyList<int> Numbers { get; init; }
+
+        public static ScopeSelection None(string label)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(label);
+            return new ScopeSelection
+            {
+                Mode = ScopeMode.None,
+                NormalizedValue = "none",
+                Numbers = []
+            };
+        }
+
+        public static ScopeSelection Parse(string rawValue, string label)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(rawValue);
+            ArgumentException.ThrowIfNullOrWhiteSpace(label);
+
+            var value = rawValue.Trim();
+            if (string.Equals(value, "none", StringComparison.Ordinal))
+            {
+                return None(label);
+            }
+
+            if (string.Equals(value, "all", StringComparison.Ordinal))
+            {
+                return new ScopeSelection
+                {
+                    Mode = ScopeMode.All,
+                    NormalizedValue = "all",
+                    Numbers = []
+                };
+            }
+
+            var numbers = value.Contains('-', StringComparison.Ordinal)
+                ? ParseRange(value, label)
+                : ParseList(value, label);
+
+            return new ScopeSelection
+            {
+                Mode = ScopeMode.Explicit,
+                NormalizedValue = string.Join(',', numbers),
+                Numbers = numbers
+            };
+        }
+
+        private static IReadOnlyList<int> ParseRange(string value, string label)
+        {
+            var parts = value.Split('-', StringSplitOptions.TrimEntries);
+            if (parts.Length != 2
+                || !int.TryParse(parts[0], out var start)
+                || !int.TryParse(parts[1], out var end)
+                || start <= 0
+                || end < start)
+            {
+                throw new InvalidOperationException($"{label} scope '{value}' must be 'start-end'.");
+            }
+
+            return Enumerable.Range(start, end - start + 1).ToArray();
+        }
+
+        private static IReadOnlyList<int> ParseList(string value, string label)
+        {
+            var numbers = value
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(part =>
+                {
+                    if (!int.TryParse(part, out var parsed) || parsed <= 0)
+                    {
+                        throw new InvalidOperationException($"{label} scope '{value}' must contain positive integers.");
+                    }
+
+                    return parsed;
+                })
+                .Distinct()
+                .OrderBy(number => number)
+                .ToArray();
+
+            if (numbers.Length == 0)
+            {
+                throw new InvalidOperationException($"{label} scope '{value}' must not be empty.");
+            }
+
+            return numbers;
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -407,6 +407,7 @@ internal static class GenerateFromCurrentCommand
             sourceRefs.Add($"issue:{issueNumber} {url} {title}");
             samplingNotes.Add(
                 $"issue:{issueNumber} state={root.GetProperty("state").GetString()} body={SummarizeText(body)} comments={comments}");
+            AppendIssueCommentSignals(issueNumber, root, sourceRefs, samplingNotes);
             if (string.IsNullOrWhiteSpace(body) && comments == 0)
             {
                 gaps.Add($"Issue {issueNumber} has sparse signal.");
@@ -455,6 +456,8 @@ internal static class GenerateFromCurrentCommand
             sourceRefs.Add($"pr:{pullNumber} {url} {title}");
             samplingNotes.Add(
                 $"pr:{pullNumber} state={root.GetProperty("state").GetString()} merge_state={root.GetProperty("mergeStateStatus").GetString()} body={SummarizeText(body)} comments={comments} reviews={reviews}");
+            AppendPullRequestCommentSignals(pullNumber, root, sourceRefs, samplingNotes);
+            AppendPullRequestReviewSignals(pullNumber, root, sourceRefs, samplingNotes);
             if (string.IsNullOrWhiteSpace(body) && comments == 0 && reviews == 0)
             {
                 gaps.Add($"PR {pullNumber} has sparse signal.");
@@ -508,6 +511,103 @@ internal static class GenerateFromCurrentCommand
         }
 
         return result;
+    }
+
+    private static void AppendIssueCommentSignals(
+        int issueNumber,
+        JsonElement issue,
+        List<string> sourceRefs,
+        List<string> samplingNotes)
+    {
+        if (!issue.TryGetProperty("comments", out var commentsElement)
+            || commentsElement.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        var commentIndex = 0;
+        foreach (var comment in commentsElement.EnumerateArray())
+        {
+            var body = GetOptionalText(comment, "body");
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                continue;
+            }
+
+            commentIndex++;
+            var summary = SummarizeText(body);
+            sourceRefs.Add($"issue-comment:{issueNumber}#{commentIndex} {summary}");
+            samplingNotes.Add($"issue-comment:{issueNumber}#{commentIndex} body={summary}");
+        }
+    }
+
+    private static void AppendPullRequestCommentSignals(
+        int pullNumber,
+        JsonElement pullRequest,
+        List<string> sourceRefs,
+        List<string> samplingNotes)
+    {
+        if (!pullRequest.TryGetProperty("comments", out var commentsElement)
+            || commentsElement.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        var commentIndex = 0;
+        foreach (var comment in commentsElement.EnumerateArray())
+        {
+            var body = GetOptionalText(comment, "body");
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                continue;
+            }
+
+            commentIndex++;
+            var summary = SummarizeText(body);
+            sourceRefs.Add($"pr-comment:{pullNumber}#{commentIndex} {summary}");
+            samplingNotes.Add($"pr-comment:{pullNumber}#{commentIndex} body={summary}");
+        }
+    }
+
+    private static void AppendPullRequestReviewSignals(
+        int pullNumber,
+        JsonElement pullRequest,
+        List<string> sourceRefs,
+        List<string> samplingNotes)
+    {
+        if (!pullRequest.TryGetProperty("reviews", out var reviewsElement)
+            || reviewsElement.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        var reviewIndex = 0;
+        foreach (var review in reviewsElement.EnumerateArray())
+        {
+            var body = GetOptionalText(review, "body");
+            var state = GetOptionalText(review, "state");
+            if (string.IsNullOrWhiteSpace(body) && string.IsNullOrWhiteSpace(state))
+            {
+                continue;
+            }
+
+            reviewIndex++;
+            var summary = string.IsNullOrWhiteSpace(body) ? "none" : SummarizeText(body);
+            var normalizedState = string.IsNullOrWhiteSpace(state) ? "unknown" : state;
+            sourceRefs.Add($"pr-review:{pullNumber}#{reviewIndex} state={normalizedState} {summary}");
+            samplingNotes.Add($"pr-review:{pullNumber}#{reviewIndex} state={normalizedState} body={summary}");
+        }
+    }
+
+    private static string? GetOptionalText(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property)
+            || property.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        return property.GetString();
     }
 
     private static IEnumerable<string> EnumerateEligibleFiles(string absolutePath, string repoRoot)

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentRenderer.cs
@@ -1,0 +1,40 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Artifact path: {result.ArtifactPath}");
+        writer.WriteLine($"Source root: {result.SourceRoot}");
+        writer.WriteLine($"Selected issue scope: {result.SelectedIssueScope}");
+        writer.WriteLine($"Selected PR scope: {result.SelectedPrScope}");
+        writer.WriteLine("Selected altitudes:");
+        WriteList(writer, result.SelectedAltitudes);
+        writer.WriteLine("Selected paths:");
+        WriteList(writer, result.SelectedPaths);
+        writer.WriteLine("Source refs:");
+        WriteList(writer, result.SourceRefs);
+        writer.WriteLine("Sampling notes:");
+        WriteList(writer, result.SamplingNotes);
+        writer.WriteLine("Gaps:");
+        WriteList(writer, result.Gaps);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentResult.cs
@@ -1,0 +1,24 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentResult
+{
+    public required string Domain { get; init; }
+
+    public required string ArtifactPath { get; init; }
+
+    public required string SourceRoot { get; init; }
+
+    public required string SelectedIssueScope { get; init; }
+
+    public required string SelectedPrScope { get; init; }
+
+    public required IReadOnlyList<string> SelectedAltitudes { get; init; }
+
+    public required IReadOnlyList<string> SelectedPaths { get; init; }
+
+    public required IReadOnlyList<string> SourceRefs { get; init; }
+
+    public required IReadOnlyList<string> SamplingNotes { get; init; }
+
+    public required IReadOnlyList<string> Gaps { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -33,6 +33,7 @@ public sealed class CommandRouterTests
         Assert.Contains("clarify", output, StringComparison.Ordinal);
         Assert.Contains("workflow", output, StringComparison.Ordinal);
         Assert.Contains("intake", output, StringComparison.Ordinal);
+        Assert.Contains("generate-from-current", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -56,6 +57,34 @@ public sealed class CommandRouterTests
 
         Assert.Equal(0, exitCode);
         Assert.Contains("intent-cli", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenGenerateFromCurrentCommand_DispatchesToTopLevelRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
     }
 
     [Fact]
@@ -3090,6 +3119,34 @@ recommended_updates:
                     : string.Empty,
                 StdErr = string.Empty
             };
+        }
+    }
+
+    private sealed class FakeGenerateFromCurrentGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return new GitHubCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = """{"number":114,"title":"[G44] Generate From Current","body":"Reverse intake entry point.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"keep it deterministic"}]}""",
+                    StdErr = string.Empty
+                };
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return new GitHubCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = """{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"ok"}],"reviews":[{"state":"COMMENTED"}]}""",
+                    StdErr = string.Empty
+                };
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/CurrentSourcesArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CurrentSourcesArtifactYamlTests.cs
@@ -1,0 +1,58 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class CurrentSourcesArtifactYamlTests
+{
+    [Fact]
+    public void SerializeAndDeserialize_GivenCurrentSourcesArtifact_RoundTripsDeterministically()
+    {
+        var artifact = new CurrentSourcesArtifact
+        {
+            DomainSlug = "auth",
+            SourceRoot = "src/IntentSystem.Cli",
+            SelectedAltitudes = ["means", "execution"],
+            SelectedIssueScope = "114,115",
+            SelectedPrScope = "113",
+            SelectedPaths = ["src/IntentSystem.Cli/Program.cs", "README.md"],
+            SourceRefs = ["code:src/IntentSystem.Cli/Program.cs", "issue:114 https://github.com/org/repo/issues/114 Title"],
+            SamplingNotes = ["code scope sampled 1 files under 'src/IntentSystem.Cli'."],
+            Gaps = ["PR 113 has sparse signal."]
+        };
+
+        var yaml = CurrentSourcesArtifactYaml.Serialize(artifact);
+        var parsed = CurrentSourcesArtifactYaml.Deserialize(yaml);
+
+        Assert.Equal(artifact.DomainSlug, parsed.DomainSlug);
+        Assert.Equal(artifact.SourceRoot, parsed.SourceRoot);
+        Assert.Equal(artifact.SelectedAltitudes, parsed.SelectedAltitudes);
+        Assert.Equal(artifact.SelectedIssueScope, parsed.SelectedIssueScope);
+        Assert.Equal(artifact.SelectedPrScope, parsed.SelectedPrScope);
+        Assert.Equal(artifact.SelectedPaths, parsed.SelectedPaths);
+        Assert.Equal(artifact.SourceRefs, parsed.SourceRefs);
+        Assert.Equal(artifact.SamplingNotes, parsed.SamplingNotes);
+        Assert.Equal(artifact.Gaps, parsed.Gaps);
+        Assert.Contains("selected_issue_scope: \"114,115\"", yaml, StringComparison.Ordinal);
+        Assert.Contains("source_refs:", yaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_ThrowsInvalidOperationException()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => CurrentSourcesArtifactYaml.Deserialize(
+                """
+                domain_slug: auth
+                source_root: "src/IntentSystem.Cli"
+                selected_altitudes:
+                  - "means"
+                selected_issue_scope: "none"
+                selected_pr_scope: "none"
+                selected_paths: []
+                source_refs: []
+                sampling_notes: []
+                """));
+
+        Assert.Contains("gaps", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCommandTests.cs
@@ -1,0 +1,167 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentCommandTests
+{
+    [Fact]
+    public void Execute_GivenSelectedSignals_WritesCurrentSourcesArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "CLAUDE.md"), "# Claude Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureB.cs"), "namespace FeatureB;");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureC.cs"), "namespace FeatureC;");
+        tempDirectory.CreateFile(Path.Combine("repo", "tests", "FeatureA.Tests", "FeatureATests.cs"), "namespace FeatureATests;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "means,execution", "--include-readme", "--include-docs", "--include-tests", "--max-files", "2"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Artifact path: .intent-cli/intake/auth.current-sources.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("Source root: src/feature", output, StringComparison.Ordinal);
+            Assert.Contains("Selected issue scope: 114", output, StringComparison.Ordinal);
+            Assert.Contains("Selected PR scope: 113", output, StringComparison.Ordinal);
+            Assert.Contains("- means", output, StringComparison.Ordinal);
+            Assert.Contains("- execution", output, StringComparison.Ordinal);
+            Assert.Contains("- src/feature/FeatureA.cs", output, StringComparison.Ordinal);
+            Assert.Contains("- src/feature/FeatureB.cs", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("FeatureC.cs", output, StringComparison.Ordinal);
+            Assert.Contains("- issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current", output, StringComparison.Ordinal);
+            Assert.Contains("- pr:113 https://github.com/J-Tech-Japan/intent-system/pull/113 [codex] Add intake activate command", output, StringComparison.Ordinal);
+            Assert.Contains("code scope truncated to first 2 files out of 3 eligible files", output, StringComparison.Ordinal);
+
+            var artifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.current-sources.yaml");
+            Assert.True(File.Exists(artifactPath));
+            var artifact = CurrentSourcesArtifactYaml.Deserialize(File.ReadAllText(artifactPath));
+            Assert.Equal("auth", artifact.DomainSlug);
+            Assert.Equal("src/feature", artifact.SourceRoot);
+            Assert.Equal(["means", "execution"], artifact.SelectedAltitudes);
+            Assert.Equal("114", artifact.SelectedIssueScope);
+            Assert.Equal("113", artifact.SelectedPrScope);
+            Assert.Equal(
+                [
+                    "src/feature/FeatureA.cs",
+                    "src/feature/FeatureB.cs",
+                    "README.md",
+                    "AGENTS.md",
+                    "CLAUDE.md",
+                    "tests/FeatureA.Tests/FeatureATests.cs"
+                ],
+                artifact.SelectedPaths);
+            Assert.Contains("issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current", artifact.SourceRefs, StringComparer.Ordinal);
+            Assert.Contains("pr:113 https://github.com/J-Tech-Japan/intent-system/pull/113 [codex] Add intake activate command", artifact.SourceRefs, StringComparer.Ordinal);
+            Assert.DoesNotContain(artifact.Gaps, gap => gap.Contains("sparse signal", StringComparison.Ordinal));
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFromPath_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentCommand.Execute(CreateContext("/tmp/intent-system"), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-path", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED"}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCommandTests.cs
@@ -44,8 +44,14 @@ public sealed class GenerateFromCurrentCommandTests
             Assert.Contains("- src/feature/FeatureB.cs", output, StringComparison.Ordinal);
             Assert.DoesNotContain("FeatureC.cs", output, StringComparison.Ordinal);
             Assert.Contains("- issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current", output, StringComparison.Ordinal);
+            Assert.Contains("- issue-comment:114#1 Need deterministic output.", output, StringComparison.Ordinal);
             Assert.Contains("- pr:113 https://github.com/J-Tech-Japan/intent-system/pull/113 [codex] Add intake activate command", output, StringComparison.Ordinal);
+            Assert.Contains("- pr-comment:113#1 Looks good.", output, StringComparison.Ordinal);
+            Assert.Contains("- pr-review:113#1 state=COMMENTED Scope stayed thin.", output, StringComparison.Ordinal);
             Assert.Contains("code scope truncated to first 2 files out of 3 eligible files", output, StringComparison.Ordinal);
+            Assert.Contains("issue-comment:114#1 body=Need deterministic output.", output, StringComparison.Ordinal);
+            Assert.Contains("pr-comment:113#1 body=Looks good.", output, StringComparison.Ordinal);
+            Assert.Contains("pr-review:113#1 state=COMMENTED body=Scope stayed thin.", output, StringComparison.Ordinal);
 
             var artifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.current-sources.yaml");
             Assert.True(File.Exists(artifactPath));
@@ -66,7 +72,13 @@ public sealed class GenerateFromCurrentCommandTests
                 ],
                 artifact.SelectedPaths);
             Assert.Contains("issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current", artifact.SourceRefs, StringComparer.Ordinal);
+            Assert.Contains("issue-comment:114#1 Need deterministic output.", artifact.SourceRefs, StringComparer.Ordinal);
             Assert.Contains("pr:113 https://github.com/J-Tech-Japan/intent-system/pull/113 [codex] Add intake activate command", artifact.SourceRefs, StringComparer.Ordinal);
+            Assert.Contains("pr-comment:113#1 Looks good.", artifact.SourceRefs, StringComparer.Ordinal);
+            Assert.Contains("pr-review:113#1 state=COMMENTED Scope stayed thin.", artifact.SourceRefs, StringComparer.Ordinal);
+            Assert.Contains("issue-comment:114#1 body=Need deterministic output.", artifact.SamplingNotes, StringComparer.Ordinal);
+            Assert.Contains("pr-comment:113#1 body=Looks good.", artifact.SamplingNotes, StringComparer.Ordinal);
+            Assert.Contains("pr-review:113#1 state=COMMENTED body=Scope stayed thin.", artifact.SamplingNotes, StringComparer.Ordinal);
             Assert.DoesNotContain(artifact.Gaps, gap => gap.Contains("sparse signal", StringComparison.Ordinal));
         }
         finally
@@ -115,7 +127,7 @@ public sealed class GenerateFromCurrentCommandTests
 
             if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
             {
-                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED"}]}""");
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
             }
 
             throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentRendererTests.cs
@@ -1,0 +1,36 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenResult_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentResult
+            {
+                Domain = "auth",
+                ArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                SourceRoot = "src/IntentSystem.Cli",
+                SelectedIssueScope = "114",
+                SelectedPrScope = "113",
+                SelectedAltitudes = ["means", "execution"],
+                SelectedPaths = ["src/IntentSystem.Cli/Program.cs"],
+                SourceRefs = ["code:src/IntentSystem.Cli/Program.cs"],
+                SamplingNotes = ["code:src/IntentSystem.Cli/Program.cs summary=namespace IntentSystem.Cli;"],
+                Gaps = ["Issue 114 has sparse signal."]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: .intent-cli/intake/auth.current-sources.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Selected issue scope: 114", output, StringComparison.Ordinal);
+        Assert.Contains("Selected altitudes:", output, StringComparison.Ordinal);
+        Assert.Contains("Source refs:", output, StringComparison.Ordinal);
+        Assert.Contains("Gaps:", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## What changed
- add top-level `intent-cli generate-from-current <domain> --from-path <path>` command wiring
- collect deterministic current-source signals from selected code paths, repo markdown docs, selected issues, selected PRs, and optional tests
- write `.intent-cli/intake/<domain>.current-sources.yaml` plus renderer, serializer, and router coverage

## Why
- Issue 114 requires a reverse-intake entry command that captures reconstruction-ready source bundles without mutating parent source-of-truth or queue state

## Impact
- selected domains can now produce a current-sources artifact from explicit path, issue, PR, and altitude scope
- the command stays read-only apart from writing the artifact and summary output

## Validation
- `dotnet test IntentSystem.sln`