### PR TITLE
[codex] Add generate-from-current reconstruction

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -39,9 +39,14 @@ internal static class GenerateFromCurrentCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
+        if (!args.Contains("--from-path", StringComparer.Ordinal))
+        {
+            return GenerateFromCurrentReconstructionCommand.Execute(context, args, writer);
+        }
+
         try
         {
-            var result = ExecuteCore(context, args);
+            var result = ExecuteSourceBundleCore(context, args);
             GenerateFromCurrentRenderer.WriteSummary(writer, result);
             return 0;
         }
@@ -52,7 +57,7 @@ internal static class GenerateFromCurrentCommand
         }
     }
 
-    internal static GenerateFromCurrentResult ExecuteCore(CliContext context, string[] args)
+    internal static GenerateFromCurrentResult ExecuteSourceBundleCore(CliContext context, string[] args)
     {
         var options = ParseOptions(args);
         var sourceRootRelativePath = ResolvePathWithinRepo(context.RepoRoot, options.FromPath);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconstructionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconstructionCommand.cs
@@ -1,0 +1,334 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentReconstructionCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentReconstructionRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentReconstructionResult ExecuteCore(CliContext context, string[] args)
+    {
+        var domain = ParseDomain(args);
+        var currentSources = LoadCurrentSources(context.RepoRoot, domain);
+
+        var intentNodes = BuildIntentNodes(currentSources);
+        var userContext = BuildUserContext(currentSources);
+        var means = BuildMeans(currentSources);
+        var rules = BuildRules(currentSources);
+        var specs = BuildSpecs(currentSources);
+        var executionUnits = BuildExecutionUnits(currentSources);
+        var confidenceByAltitude = BuildConfidenceByAltitude(currentSources);
+        var sourceConceptRefs = BuildSourceConceptRefs(currentSources);
+        var interviewQuestions = BuildInterviewQuestions(currentSources);
+        var returnToIntentPaths = BuildReturnToIntentPaths(context.RepoRoot, currentSources);
+
+        var conceptArtifact = new ReconstructedConceptArtifact
+        {
+            DomainSlug = domain,
+            InitialGoal = BuildInitialGoal(currentSources),
+            CandidateIntentNodes = intentNodes,
+            CandidateUserContext = userContext,
+            CandidateMeans = means,
+            CandidateRules = rules,
+            CandidateSpecs = specs,
+            CandidateExecutionUnits = executionUnits,
+            ConfidenceByAltitude = confidenceByAltitude,
+            SourceConceptRefs = sourceConceptRefs
+        };
+
+        var conceptArtifactPath = ReconstructedConceptArtifactWriter.Write(context.RepoRoot, domain, conceptArtifact);
+        var interviewMarkdown = GenerateFromCurrentReconstructionRenderer.RenderInterviewMarkdown(
+            domain,
+            currentSources.SelectedAltitudes,
+            intentNodes
+                .Concat(userContext)
+                .Concat(means)
+                .Concat(rules)
+                .Concat(specs)
+                .ToArray(),
+            executionUnits,
+            confidenceByAltitude,
+            sourceConceptRefs,
+            interviewQuestions,
+            returnToIntentPaths,
+            currentSources.Gaps);
+        var interviewArtifactPath = ReconstructedInterviewArtifactWriter.Write(context.RepoRoot, domain, interviewMarkdown);
+
+        return new GenerateFromCurrentReconstructionResult
+        {
+            Domain = domain,
+            ConceptArtifactPath = ToRelativePath(context.RepoRoot, conceptArtifactPath),
+            InterviewArtifactPath = ToRelativePath(context.RepoRoot, interviewArtifactPath),
+            SelectedAltitudes = currentSources.SelectedAltitudes,
+            CandidateIntentNodes = intentNodes.Concat(userContext).Concat(means).Concat(rules).Concat(specs).ToArray(),
+            CandidateExecutionUnits = executionUnits,
+            ConfidenceByAltitude = confidenceByAltitude,
+            SourceConceptRefs = sourceConceptRefs,
+            RecommendedFollowUpQuestions = interviewQuestions,
+            ReturnToIntentPaths = returnToIntentPaths,
+            Gaps = currentSources.Gaps
+        };
+    }
+
+    private static string ParseDomain(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current reconstruction requires a domain.");
+        }
+
+        if (args.Length != 1)
+        {
+            throw new InvalidOperationException(
+                "Generate-from-current reconstruction stage only accepts '<domain>' without source selection options.");
+        }
+
+        return args[0].Trim();
+    }
+
+    private static CurrentSourcesArtifact LoadCurrentSources(string repoRoot, string domain)
+    {
+        var artifactPath = Path.Combine(
+            repoRoot,
+            CurrentSourcesArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(artifactPath))
+        {
+            throw new InvalidOperationException($"Current sources artifact was not found at {artifactPath}");
+        }
+
+        var artifact = CurrentSourcesArtifactYaml.Deserialize(File.ReadAllText(artifactPath));
+        if (!string.Equals(artifact.DomainSlug, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Current sources artifact domain '{artifact.DomainSlug}' does not match requested domain '{domain}'.");
+        }
+
+        return artifact;
+    }
+
+    private static IReadOnlyList<string> BuildIntentNodes(CurrentSourcesArtifact artifact)
+    {
+        if (!artifact.SelectedAltitudes.Contains("purpose", StringComparer.Ordinal))
+        {
+            return [];
+        }
+
+        return
+        [
+            $"Clarify the primary purpose for domain '{artifact.DomainSlug}' from selected issue and PR signals."
+        ];
+    }
+
+    private static IReadOnlyList<string> BuildUserContext(CurrentSourcesArtifact artifact)
+    {
+        if (!artifact.SelectedAltitudes.Contains("user-context", StringComparer.Ordinal))
+        {
+            return [];
+        }
+
+        return
+        [
+            $"Validate the user-facing context for '{artifact.DomainSlug}' from selected issue and PR discussion."
+        ];
+    }
+
+    private static IReadOnlyList<string> BuildMeans(CurrentSourcesArtifact artifact)
+    {
+        if (!artifact.SelectedAltitudes.Contains("means", StringComparer.Ordinal))
+        {
+            return [];
+        }
+
+        return artifact.SelectedPaths
+            .Where(path => !path.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            .Take(3)
+            .Select(path => $"Inspect current implementation seam at {path}.")
+            .DefaultIfEmpty($"Inspect current implementation seams under '{artifact.SourceRoot}'.")
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildRules(CurrentSourcesArtifact artifact)
+    {
+        if (!artifact.SelectedAltitudes.Contains("rules", StringComparer.Ordinal))
+        {
+            return [];
+        }
+
+        return artifact.SelectedPaths
+            .Where(path => string.Equals(path, "AGENTS.md", StringComparison.Ordinal)
+                || string.Equals(path, "CLAUDE.md", StringComparison.Ordinal))
+            .Select(path => $"Preserve repo rule guidance captured in {path}.")
+            .DefaultIfEmpty("Clarify which repo-level rules remain mandatory for future changes.")
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildSpecs(CurrentSourcesArtifact artifact)
+    {
+        if (!artifact.SelectedAltitudes.Contains("specs", StringComparer.Ordinal))
+        {
+            return [];
+        }
+
+        return artifact.SelectedPaths
+            .Where(path => path.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            .Take(3)
+            .Select(path => $"Reconcile external contract and documentation signal from {path}.")
+            .DefaultIfEmpty("Reconstruct the current external surface and contract expectations.")
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildExecutionUnits(CurrentSourcesArtifact artifact)
+    {
+        if (!artifact.SelectedAltitudes.Contains("execution", StringComparer.Ordinal))
+        {
+            return [];
+        }
+
+        return artifact.SelectedPaths
+            .Where(path => !path.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            .Take(5)
+            .Select(path => $"Execution candidate from {path}.")
+            .DefaultIfEmpty($"Execution candidate from source root '{artifact.SourceRoot}'.")
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildConfidenceByAltitude(CurrentSourcesArtifact artifact)
+    {
+        return artifact.SelectedAltitudes
+            .Select(altitude => $"{altitude}: {ResolveConfidence(artifact, altitude)}")
+            .ToArray();
+    }
+
+    private static string ResolveConfidence(CurrentSourcesArtifact artifact, string altitude)
+    {
+        var relevantCount = altitude switch
+        {
+            "purpose" or "user-context" => artifact.SourceRefs.Count(reference =>
+                reference.StartsWith("issue:", StringComparison.Ordinal)
+                || reference.StartsWith("issue-comment:", StringComparison.Ordinal)
+                || reference.StartsWith("pr:", StringComparison.Ordinal)
+                || reference.StartsWith("pr-comment:", StringComparison.Ordinal)
+                || reference.StartsWith("pr-review:", StringComparison.Ordinal)),
+            "means" or "execution" => artifact.SourceRefs.Count(reference =>
+                reference.StartsWith("code:", StringComparison.Ordinal)
+                || reference.StartsWith("test:", StringComparison.Ordinal)),
+            "rules" or "specs" => artifact.SourceRefs.Count(reference =>
+                reference.StartsWith("doc:", StringComparison.Ordinal)
+                || reference.StartsWith("readme:", StringComparison.Ordinal)),
+            _ => 0
+        };
+
+        return relevantCount switch
+        {
+            >= 4 => "high",
+            >= 1 => "medium",
+            _ => "low"
+        };
+    }
+
+    private static IReadOnlyList<string> BuildSourceConceptRefs(CurrentSourcesArtifact artifact)
+    {
+        return artifact.SourceRefs
+            .Where(reference =>
+                !reference.StartsWith("code:", StringComparison.Ordinal)
+                && !reference.StartsWith("test:", StringComparison.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(reference => reference, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildInterviewQuestions(CurrentSourcesArtifact artifact)
+    {
+        var questions = new List<string>();
+
+        if (artifact.SelectedAltitudes.Contains("purpose", StringComparer.Ordinal)
+            || artifact.SelectedAltitudes.Contains("user-context", StringComparer.Ordinal))
+        {
+            questions.Add($"What user-facing outcome should '{artifact.DomainSlug}' prioritize based on the selected current signals?");
+        }
+
+        if (artifact.SelectedAltitudes.Contains("rules", StringComparer.Ordinal)
+            || artifact.SelectedAltitudes.Contains("specs", StringComparer.Ordinal))
+        {
+            questions.Add("Which current rules or specs are mandatory versus historical context only?");
+        }
+
+        if (artifact.SelectedAltitudes.Contains("execution", StringComparer.Ordinal))
+        {
+            questions.Add("Which execution-ready change slice should be cut first from the selected current paths?");
+        }
+
+        if (questions.Count == 0)
+        {
+            questions.Add($"Which missing intent detail should be clarified first for domain '{artifact.DomainSlug}'?");
+        }
+
+        return questions;
+    }
+
+    private static IReadOnlyList<string> BuildReturnToIntentPaths(string repoRoot, CurrentSourcesArtifact artifact)
+    {
+        var candidates = new List<string>();
+        AddIfExists(repoRoot, "README.md", candidates);
+
+        if (artifact.SelectedAltitudes.Contains("rules", StringComparer.Ordinal))
+        {
+            AddIfExists(repoRoot, "AGENTS.md", candidates);
+            AddIfExists(repoRoot, "CLAUDE.md", candidates);
+        }
+
+        return candidates
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static void AddIfExists(string repoRoot, string relativePath, List<string> values)
+    {
+        var absolutePath = Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        if (File.Exists(absolutePath))
+        {
+            values.Add(relativePath);
+        }
+    }
+
+    private static string BuildInitialGoal(CurrentSourcesArtifact artifact)
+    {
+        var firstIssueOrPr = artifact.SourceRefs.FirstOrDefault(reference =>
+            reference.StartsWith("issue:", StringComparison.Ordinal)
+            || reference.StartsWith("pr:", StringComparison.Ordinal));
+
+        if (firstIssueOrPr is not null)
+        {
+            var titleStart = firstIssueOrPr.IndexOf("] ", StringComparison.Ordinal);
+            if (titleStart >= 0 && titleStart + 2 < firstIssueOrPr.Length)
+            {
+                return firstIssueOrPr[(titleStart + 2)..];
+            }
+
+            return firstIssueOrPr;
+        }
+
+        return $"Reconstruct current intent for domain '{artifact.DomainSlug}' from source root '{artifact.SourceRoot}'.";
+    }
+
+    private static string ToRelativePath(string repoRoot, string absolutePath)
+    {
+        return Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconstructionRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconstructionRenderer.cs
@@ -1,0 +1,92 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentReconstructionRenderer
+{
+    public static string RenderInterviewMarkdown(
+        string domain,
+        IReadOnlyList<string> selectedAltitudes,
+        IReadOnlyList<string> rootNearIntentCandidates,
+        IReadOnlyList<string> executionNearUpdateCandidates,
+        IReadOnlyList<string> confidenceByAltitude,
+        IReadOnlyList<string> sourceConceptRefs,
+        IReadOnlyList<string> recommendedFollowUpQuestions,
+        IReadOnlyList<string> returnToIntentPaths,
+        IReadOnlyList<string> gaps)
+    {
+        var lines = new List<string>
+        {
+            "# Reconstructed Interview",
+            string.Empty,
+            "## Domain",
+            string.Empty,
+            $"`{domain}`",
+            string.Empty
+        };
+
+        AppendSection(lines, "selected_altitudes", selectedAltitudes);
+        AppendSection(lines, "root_near_intent_candidates", rootNearIntentCandidates);
+        AppendSection(lines, "execution_near_update_candidates", executionNearUpdateCandidates);
+        AppendSection(lines, "confidence_by_altitude", confidenceByAltitude);
+        AppendSection(lines, "source_concept_refs", sourceConceptRefs);
+        AppendSection(lines, "recommended_follow_up_questions", recommendedFollowUpQuestions);
+        AppendSection(lines, "return_to_intent_paths", returnToIntentPaths);
+        AppendSection(lines, "gaps", gaps);
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentReconstructionResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current reconstruction processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Reconstructed concept artifact: {result.ConceptArtifactPath}");
+        writer.WriteLine($"Reconstructed interview artifact: {result.InterviewArtifactPath}");
+        writer.WriteLine("Selected altitudes:");
+        WriteList(writer, result.SelectedAltitudes);
+        writer.WriteLine("Candidate intent nodes:");
+        WriteList(writer, result.CandidateIntentNodes);
+        writer.WriteLine("Candidate execution units:");
+        WriteList(writer, result.CandidateExecutionUnits);
+        writer.WriteLine("Confidence by altitude:");
+        WriteList(writer, result.ConfidenceByAltitude);
+        writer.WriteLine("Source concept refs:");
+        WriteList(writer, result.SourceConceptRefs);
+        writer.WriteLine("Recommended follow-up interview questions:");
+        WriteList(writer, result.RecommendedFollowUpQuestions);
+        writer.WriteLine("Return-to-intent paths:");
+        WriteList(writer, result.ReturnToIntentPaths);
+        writer.WriteLine("Gaps:");
+        WriteList(writer, result.Gaps);
+    }
+
+    private static void AppendSection(List<string> lines, string title, IReadOnlyList<string> values)
+    {
+        lines.Add($"{title}:");
+        if (values.Count == 0)
+        {
+            lines.Add("- none");
+        }
+        else
+        {
+            lines.AddRange(values.Select(value => $"- {value}"));
+        }
+
+        lines.Add(string.Empty);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconstructionResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconstructionResult.cs
@@ -1,0 +1,26 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentReconstructionResult
+{
+    public required string Domain { get; init; }
+
+    public required string ConceptArtifactPath { get; init; }
+
+    public required string InterviewArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> SelectedAltitudes { get; init; }
+
+    public required IReadOnlyList<string> CandidateIntentNodes { get; init; }
+
+    public required IReadOnlyList<string> CandidateExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ConfidenceByAltitude { get; init; }
+
+    public required IReadOnlyList<string> SourceConceptRefs { get; init; }
+
+    public required IReadOnlyList<string> RecommendedFollowUpQuestions { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+
+    public required IReadOnlyList<string> Gaps { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/ReconstructedConceptArtifact.cs
+++ b/src/IntentSystem.Cli/Commands/ReconstructedConceptArtifact.cs
@@ -1,0 +1,24 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record ReconstructedConceptArtifact
+{
+    public required string DomainSlug { get; init; }
+
+    public required string InitialGoal { get; init; }
+
+    public required IReadOnlyList<string> CandidateIntentNodes { get; init; }
+
+    public required IReadOnlyList<string> CandidateUserContext { get; init; }
+
+    public required IReadOnlyList<string> CandidateMeans { get; init; }
+
+    public required IReadOnlyList<string> CandidateRules { get; init; }
+
+    public required IReadOnlyList<string> CandidateSpecs { get; init; }
+
+    public required IReadOnlyList<string> CandidateExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ConfidenceByAltitude { get; init; }
+
+    public required IReadOnlyList<string> SourceConceptRefs { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/ReconstructedConceptArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/ReconstructedConceptArtifactPathResolver.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class ReconstructedConceptArtifactPathResolver
+{
+    public static string Resolve(string domain)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        return $".intent-cli/intake/{domain}.reconstructed-concept.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ReconstructedConceptArtifactWriter.cs
+++ b/src/IntentSystem.Cli/Commands/ReconstructedConceptArtifactWriter.cs
@@ -1,0 +1,19 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class ReconstructedConceptArtifactWriter
+{
+    public static string Write(string repoRoot, string domain, ReconstructedConceptArtifact artifact)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var relativePath = ReconstructedConceptArtifactPathResolver.Resolve(domain);
+        var artifactPath = Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        var directoryPath = Path.GetDirectoryName(artifactPath)
+            ?? throw new InvalidOperationException("Reconstructed concept artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(artifactPath, ReconstructedConceptArtifactYaml.Serialize(artifact));
+        return artifactPath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ReconstructedConceptArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/ReconstructedConceptArtifactYaml.cs
@@ -1,0 +1,195 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class ReconstructedConceptArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "domain_slug",
+        "initial_goal",
+        "candidate_intent_nodes",
+        "candidate_user_context",
+        "candidate_means",
+        "candidate_rules",
+        "candidate_specs",
+        "candidate_execution_units",
+        "confidence_by_altitude",
+        "source_concept_refs"
+    ];
+
+    public static string Serialize(ReconstructedConceptArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"domain_slug: {artifact.DomainSlug}",
+            $"initial_goal: {Quote(artifact.InitialGoal)}"
+        };
+
+        AppendList(lines, "candidate_intent_nodes", artifact.CandidateIntentNodes);
+        AppendList(lines, "candidate_user_context", artifact.CandidateUserContext);
+        AppendList(lines, "candidate_means", artifact.CandidateMeans);
+        AppendList(lines, "candidate_rules", artifact.CandidateRules);
+        AppendList(lines, "candidate_specs", artifact.CandidateSpecs);
+        AppendList(lines, "candidate_execution_units", artifact.CandidateExecutionUnits);
+        AppendList(lines, "confidence_by_altitude", artifact.ConfidenceByAltitude);
+        AppendList(lines, "source_concept_refs", artifact.SourceConceptRefs);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static ReconstructedConceptArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new ReconstructedConceptArtifact
+        {
+            DomainSlug = GetRequiredScalar(values, "domain_slug"),
+            InitialGoal = GetRequiredScalar(values, "initial_goal"),
+            CandidateIntentNodes = GetRequiredList(values, "candidate_intent_nodes"),
+            CandidateUserContext = GetRequiredList(values, "candidate_user_context"),
+            CandidateMeans = GetRequiredList(values, "candidate_means"),
+            CandidateRules = GetRequiredList(values, "candidate_rules"),
+            CandidateSpecs = GetRequiredList(values, "candidate_specs"),
+            CandidateExecutionUnits = GetRequiredList(values, "candidate_execution_units"),
+            ConfidenceByAltitude = GetRequiredList(values, "confidence_by_altitude"),
+            SourceConceptRefs = GetRequiredList(values, "source_concept_refs")
+        };
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add($"{label}: []");
+            return;
+        }
+
+        lines.Add($"{label}:");
+        lines.AddRange(values.Select(value => $"  - {Quote(value)}"));
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("  - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !values.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException(
+                        $"Reconstructed concept YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[4..].TrimStart()));
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Reconstructed concept YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+
+            if (value.Length == 0)
+            {
+                values[key] = new List<string>();
+                currentListKey = key;
+                continue;
+            }
+
+            currentListKey = null;
+            values[key] = value switch
+            {
+                "[]" => Array.Empty<string>(),
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException(
+                    $"Reconstructed concept YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException(
+                $"Reconstructed concept YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static IReadOnlyList<string> GetRequiredList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException(
+                $"Reconstructed concept YAML field '{key}' must be a list.");
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException(
+                $"Reconstructed concept YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifactPathResolver.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class ReconstructedInterviewArtifactPathResolver
+{
+    public static string Resolve(string domain)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        return $".intent-cli/intake/{domain}.reconstructed-interview.md";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifactWriter.cs
+++ b/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifactWriter.cs
@@ -1,0 +1,19 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class ReconstructedInterviewArtifactWriter
+{
+    public static string Write(string repoRoot, string domain, string markdown)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        ArgumentNullException.ThrowIfNull(markdown);
+
+        var relativePath = ReconstructedInterviewArtifactPathResolver.Resolve(domain);
+        var artifactPath = Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        var directoryPath = Path.GetDirectoryName(artifactPath)
+            ?? throw new InvalidOperationException("Reconstructed interview artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(artifactPath, markdown);
+        return artifactPath;
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -88,6 +88,35 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentReconstructionCommand_DispatchesToReconstructionRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.current-sources.yaml"),
+            CurrentSourcesArtifactYaml.Serialize(
+                new CurrentSourcesArtifact
+                {
+                    DomainSlug = "auth",
+                    SourceRoot = "src/feature",
+                    SelectedAltitudes = ["execution"],
+                    SelectedIssueScope = "none",
+                    SelectedPrScope = "none",
+                    SelectedPaths = ["src/feature/FeatureA.cs"],
+                    SourceRefs = ["code:src/feature/FeatureA.cs"],
+                    SamplingNotes = ["code:src/feature/FeatureA.cs summary=namespace FeatureA;"],
+                    Gaps = []
+                }));
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["generate-from-current", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Generate-from-current reconstruction processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenQueueListCommand_DispatchesToQueueRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCommandTests.cs
@@ -88,14 +88,14 @@ public sealed class GenerateFromCurrentCommandTests
     }
 
     [Fact]
-    public void Execute_GivenMissingFromPath_ReturnsExitCodeOne()
+    public void Execute_GivenSourceBundleModeWithoutFromPathValue_ReturnsExitCodeOne()
     {
         using var writer = new StringWriter();
 
-        var exitCode = GenerateFromCurrentCommand.Execute(CreateContext("/tmp/intent-system"), ["auth"], writer);
+        var exitCode = GenerateFromCurrentCommand.Execute(CreateContext("/tmp/intent-system"), ["auth", "--from-path"], writer);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("--from-path", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--from-path requires a value", writer.ToString(), StringComparison.Ordinal);
     }
 
     private static CliContext CreateContext(string repoRoot)

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReconstructionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReconstructionCommandTests.cs
@@ -1,0 +1,165 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentReconstructionCommandTests
+{
+    [Fact]
+    public void Execute_GivenCurrentSourcesArtifact_GeneratesReconstructedArtifacts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.current-sources.yaml"),
+            CurrentSourcesArtifactYaml.Serialize(
+                new CurrentSourcesArtifact
+                {
+                    DomainSlug = "auth",
+                    SourceRoot = "src/feature",
+                    SelectedAltitudes = ["purpose", "rules", "execution"],
+                    SelectedIssueScope = "114",
+                    SelectedPrScope = "113",
+                    SelectedPaths = ["src/feature/FeatureA.cs", "README.md", "AGENTS.md"],
+                    SourceRefs =
+                    [
+                        "issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current",
+                        "issue-comment:114#1 Need deterministic output.",
+                        "pr:113 https://github.com/J-Tech-Japan/intent-system/pull/113 [codex] Add intake activate command",
+                        "pr-review:113#1 state=COMMENTED Scope stayed thin.",
+                        "code:src/feature/FeatureA.cs",
+                        "readme:README.md",
+                        "doc:AGENTS.md"
+                    ],
+                    SamplingNotes =
+                    [
+                        "issue-comment:114#1 body=Need deterministic output.",
+                        "pr-review:113#1 state=COMMENTED body=Scope stayed thin."
+                    ],
+                    Gaps =
+                    [
+                        "Need stronger purpose signal."
+                    ]
+                }));
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current reconstruction processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/intake/auth.reconstructed-concept.yaml", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/intake/auth.reconstructed-interview.md", output, StringComparison.Ordinal);
+        Assert.Contains("Selected altitudes:", output, StringComparison.Ordinal);
+        Assert.Contains("- purpose", output, StringComparison.Ordinal);
+        Assert.Contains("- rules", output, StringComparison.Ordinal);
+        Assert.Contains("- execution", output, StringComparison.Ordinal);
+        Assert.Contains("Candidate intent nodes:", output, StringComparison.Ordinal);
+        Assert.Contains("Candidate execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("Confidence by altitude:", output, StringComparison.Ordinal);
+        Assert.Contains("Recommended follow-up interview questions:", output, StringComparison.Ordinal);
+        Assert.Contains("Return-to-intent paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Gaps:", output, StringComparison.Ordinal);
+
+        var conceptArtifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.reconstructed-concept.yaml");
+        var interviewArtifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.reconstructed-interview.md");
+        Assert.True(File.Exists(conceptArtifactPath));
+        Assert.True(File.Exists(interviewArtifactPath));
+
+        var conceptArtifact = ReconstructedConceptArtifactYaml.Deserialize(File.ReadAllText(conceptArtifactPath));
+        Assert.Equal("auth", conceptArtifact.DomainSlug);
+        Assert.Equal("Generate From Current", conceptArtifact.InitialGoal);
+        Assert.Contains(
+            "Clarify the primary purpose for domain 'auth' from selected issue and PR signals.",
+            conceptArtifact.CandidateIntentNodes,
+            StringComparer.Ordinal);
+        Assert.Contains(
+            "Execution candidate from src/feature/FeatureA.cs.",
+            conceptArtifact.CandidateExecutionUnits,
+            StringComparer.Ordinal);
+        Assert.Contains("purpose: high", conceptArtifact.ConfidenceByAltitude, StringComparer.Ordinal);
+        Assert.Contains("rules: medium", conceptArtifact.ConfidenceByAltitude, StringComparer.Ordinal);
+        Assert.Contains("execution: medium", conceptArtifact.ConfidenceByAltitude, StringComparer.Ordinal);
+        Assert.Contains(
+            "issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current",
+            conceptArtifact.SourceConceptRefs,
+            StringComparer.Ordinal);
+
+        var interviewMarkdown = File.ReadAllText(interviewArtifactPath);
+        Assert.Contains("# Reconstructed Interview", interviewMarkdown, StringComparison.Ordinal);
+        Assert.Contains("recommended_follow_up_questions:", interviewMarkdown, StringComparison.Ordinal);
+        Assert.Contains("What user-facing outcome should 'auth' prioritize based on the selected current signals?", interviewMarkdown, StringComparison.Ordinal);
+        Assert.Contains("Which execution-ready change slice should be cut first from the selected current paths?", interviewMarkdown, StringComparison.Ordinal);
+        Assert.Contains("return_to_intent_paths:", interviewMarkdown, StringComparison.Ordinal);
+        Assert.Contains("- README.md", interviewMarkdown, StringComparison.Ordinal);
+        Assert.Contains("- AGENTS.md", interviewMarkdown, StringComparison.Ordinal);
+        Assert.Contains("gaps:", interviewMarkdown, StringComparison.Ordinal);
+        Assert.Contains("- Need stronger purpose signal.", interviewMarkdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingCurrentSourcesArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Current sources artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-reconstruction-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReconstructionRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReconstructionRendererTests.cs
@@ -1,0 +1,37 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentReconstructionRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenResult_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentReconstructionRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentReconstructionResult
+            {
+                Domain = "auth",
+                ConceptArtifactPath = ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                InterviewArtifactPath = ".intent-cli/intake/auth.reconstructed-interview.md",
+                SelectedAltitudes = ["purpose", "execution"],
+                CandidateIntentNodes = ["Clarify the primary purpose for domain 'auth' from selected issue and PR signals."],
+                CandidateExecutionUnits = ["Execution candidate from src/feature/FeatureA.cs."],
+                ConfidenceByAltitude = ["purpose: medium", "execution: high"],
+                SourceConceptRefs = ["issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current"],
+                RecommendedFollowUpQuestions = ["Which execution-ready change slice should be cut first from the selected current paths?"],
+                ReturnToIntentPaths = ["README.md"],
+                Gaps = ["Need stronger purpose signal."]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current reconstruction processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Reconstructed concept artifact: .intent-cli/intake/auth.reconstructed-concept.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Candidate intent nodes:", output, StringComparison.Ordinal);
+        Assert.Contains("Candidate execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("Recommended follow-up interview questions:", output, StringComparison.Ordinal);
+        Assert.Contains("Return-to-intent paths:", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/ReconstructedConceptArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReconstructedConceptArtifactYamlTests.cs
@@ -1,0 +1,34 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ReconstructedConceptArtifactYamlTests
+{
+    [Fact]
+    public void SerializeAndDeserialize_GivenArtifact_RoundTripsDeterministically()
+    {
+        var artifact = new ReconstructedConceptArtifact
+        {
+            DomainSlug = "auth",
+            InitialGoal = "Generate From Current",
+            CandidateIntentNodes = ["Clarify purpose from issue and PR signals."],
+            CandidateUserContext = ["Validate user-facing context from discussion."],
+            CandidateMeans = ["Inspect current implementation seam at src/FeatureA.cs."],
+            CandidateRules = ["Preserve repo rule guidance captured in AGENTS.md."],
+            CandidateSpecs = ["Reconcile external contract and documentation signal from README.md."],
+            CandidateExecutionUnits = ["Execution candidate from src/FeatureA.cs."],
+            ConfidenceByAltitude = ["purpose: medium", "execution: high"],
+            SourceConceptRefs = ["issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current"]
+        };
+
+        var yaml = ReconstructedConceptArtifactYaml.Serialize(artifact);
+        var parsed = ReconstructedConceptArtifactYaml.Deserialize(yaml);
+
+        Assert.Equal(artifact.DomainSlug, parsed.DomainSlug);
+        Assert.Equal(artifact.InitialGoal, parsed.InitialGoal);
+        Assert.Equal(artifact.CandidateIntentNodes, parsed.CandidateIntentNodes);
+        Assert.Equal(artifact.CandidateExecutionUnits, parsed.CandidateExecutionUnits);
+        Assert.Equal(artifact.ConfidenceByAltitude, parsed.ConfidenceByAltitude);
+        Assert.Equal(artifact.SourceConceptRefs, parsed.SourceConceptRefs);
+    }
+}


### PR DESCRIPTION
## What changed
- extend top-level `generate-from-current` so the no-`--from-path` form runs the G45 reconstruction stage
- read and validate `.intent-cli/intake/<domain>.current-sources.yaml`, then generate reconstructed concept and interview artifacts deterministically
- add serializers, writers, renderers, and CLI coverage for root-near intent inference, execution-near inference, confidence, follow-up questions, return-to-intent paths, and gaps

## Why
- Issue 116 requires the reverse-intake reconstruction stage that turns the G44 current source bundle into reconstruction-ready concept and interview artifacts without mutating parent source-of-truth or queue state

## Impact
- `intent-cli generate-from-current <domain>` now emits `.intent-cli/intake/<domain>.reconstructed-concept.yaml` and `.intent-cli/intake/<domain>.reconstructed-interview.md`
- the existing `generate-from-current <domain> --from-path <path>` source-bundle path remains intact

## Validation
- `dotnet test IntentSystem.sln`