### PR TITLE
[codex] Add generate-from-current bridge

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeCommand.cs
@@ -137,6 +137,7 @@ internal static class GenerateFromCurrentBridgeCommand
                 .OrderBy(value => value, StringComparer.Ordinal)
                 .ToArray(),
             KnownUnknowns = reconstructedInterview.RecommendedFollowUpQuestions
+                .Concat(reconstructedInterview.BridgeQuestions.Select(question => question.QuestionText))
                 .Concat(reconstructedInterview.Gaps)
                 .Distinct(StringComparer.Ordinal)
                 .OrderBy(value => value, StringComparer.Ordinal)
@@ -161,7 +162,10 @@ internal static class GenerateFromCurrentBridgeCommand
         AppendSection(lines, "candidate_execution_units", reconstructedConcept.CandidateExecutionUnits);
         AppendSection(lines, "confidence_by_altitude", reconstructedConcept.ConfidenceByAltitude);
         AppendSection(lines, "source_concept_refs", reconstructedConcept.SourceConceptRefs);
-        AppendSection(lines, "recommended_follow_up_questions", reconstructedInterview.RecommendedFollowUpQuestions);
+        AppendSection(
+            lines,
+            "recommended_follow_up_questions",
+            reconstructedInterview.BridgeQuestions.Select(question => question.QuestionText).ToArray());
 
         return string.Join(Environment.NewLine, lines);
     }

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeCommand.cs
@@ -184,7 +184,7 @@ internal static class GenerateFromCurrentBridgeCommand
             Directory.Delete(interviewsRoot, recursive: true);
         }
 
-        if (reconstructedInterview.RecommendedFollowUpQuestions.Count == 0)
+        if (reconstructedInterview.BridgeQuestions.Count == 0)
         {
             return [];
         }
@@ -192,20 +192,19 @@ internal static class GenerateFromCurrentBridgeCommand
         Directory.CreateDirectory(interviewsRoot);
         var artifactPaths = new List<string>();
 
-        for (var index = 0; index < reconstructedInterview.RecommendedFollowUpQuestions.Count; index++)
+        for (var index = 0; index < reconstructedInterview.BridgeQuestions.Count; index++)
         {
-            var questionId = $"iq-{index + 1}";
-            var questionText = reconstructedInterview.RecommendedFollowUpQuestions[index];
+            var bridgeQuestion = reconstructedInterview.BridgeQuestions[index];
             var item = new InterviewQueueItem
             {
                 DomainSlug = domain,
                 SourceConceptRef = reconstructedConcept.SourceConceptRefs.FirstOrDefault()
                     ?? $"generate-from-current:{domain}",
-                QuestionId = questionId,
-                QuestionText = questionText,
-                Reason = ResolveReason(questionText),
-                Affects = [domain],
-                BlockingOrNonblocking = ResolveBlockingOrNonblocking(questionText),
+                QuestionId = bridgeQuestion.QuestionId,
+                QuestionText = bridgeQuestion.QuestionText,
+                Reason = bridgeQuestion.Reason,
+                Affects = bridgeQuestion.Affects,
+                BlockingOrNonblocking = bridgeQuestion.BlockingOrNonblocking,
                 Status = InterviewQueueItemStatus.Open,
                 ReturnToIntentPaths = reconstructedInterview.ReturnToIntentPaths,
                 CreatedAt = CreatedAtBase.AddMinutes(index),
@@ -213,8 +212,8 @@ internal static class GenerateFromCurrentBridgeCommand
                 RecommendedUpdates = recommendedUpdates
             };
 
-            var yamlPath = Path.Combine(interviewsRoot, $"{questionId}.yaml");
-            var markdownPath = Path.Combine(interviewsRoot, $"{questionId}.md");
+            var yamlPath = Path.Combine(interviewsRoot, $"{bridgeQuestion.QuestionId}.yaml");
+            var markdownPath = Path.Combine(interviewsRoot, $"{bridgeQuestion.QuestionId}.md");
             File.WriteAllText(yamlPath, InterviewArtifactYaml.Serialize(item));
             File.WriteAllText(
                 markdownPath,
@@ -283,25 +282,6 @@ internal static class GenerateFromCurrentBridgeCommand
         }
 
         lines.AddRange(values.Select(value => $"- {value}"));
-    }
-
-    private static string ResolveReason(string questionText)
-    {
-        if (questionText.StartsWith("What user-facing outcome", StringComparison.Ordinal)
-            || questionText.StartsWith("Which current rules or specs", StringComparison.Ordinal)
-            || questionText.StartsWith("Which missing intent detail", StringComparison.Ordinal))
-        {
-            return "Clarify root-near intent before standard intake resumes.";
-        }
-
-        return "Clarify execution-near detail before standard intake resumes.";
-    }
-
-    private static string ResolveBlockingOrNonblocking(string questionText)
-    {
-        return questionText.StartsWith("Which execution-ready change slice", StringComparison.Ordinal)
-            ? "nonblocking"
-            : "blocking";
     }
 
     private static string ToRelativePath(string repoRoot, string absolutePath)

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeCommand.cs
@@ -1,0 +1,311 @@
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentBridgeCommand
+{
+    private static readonly DateTimeOffset CreatedAtBase = DateTimeOffset.Parse("2026-01-01T00:00:00Z");
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentBridgeRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentBridgeResult ExecuteCore(CliContext context, string[] args)
+    {
+        var domain = ParseDomain(args);
+        var reconstructedConcept = LoadReconstructedConcept(context.RepoRoot, domain);
+        var reconstructedInterview = LoadReconstructedInterview(context.RepoRoot, domain);
+        var recommendedUpdates = BuildRecommendedUpdates(reconstructedInterview);
+        var conceptPacket = BuildConceptPacket(reconstructedConcept, reconstructedInterview);
+
+        var conceptArtifactPath = IntakeConceptArtifactWriter.Write(
+            IntakeConceptArtifactYaml.Serialize(conceptPacket),
+            domain,
+            context.RepoRoot);
+
+        var interviewArtifactPaths = WriteInterviewArtifacts(
+            context.RepoRoot,
+            domain,
+            reconstructedConcept,
+            reconstructedInterview,
+            recommendedUpdates);
+
+        IReadOnlyList<string> skippedBridgeSteps = interviewArtifactPaths.Count == 0
+            ? ["No reconstructed follow-up questions were present; interview artifact generation was skipped."]
+            : Array.Empty<string>();
+
+        return new GenerateFromCurrentBridgeResult
+        {
+            Domain = domain,
+            ConceptArtifactPath = ToRelativePath(context.RepoRoot, conceptArtifactPath),
+            InterviewArtifactPaths = interviewArtifactPaths,
+            RecommendedUpdates = recommendedUpdates,
+            ReturnToIntentPaths = reconstructedInterview.ReturnToIntentPaths,
+            Gaps = reconstructedInterview.Gaps,
+            SkippedBridgeSteps = skippedBridgeSteps
+        };
+    }
+
+    private static string ParseDomain(string[] args)
+    {
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current bridge requires a domain.");
+        }
+
+        return args[0].Trim();
+    }
+
+    private static ReconstructedConceptArtifact LoadReconstructedConcept(string repoRoot, string domain)
+    {
+        var artifactPath = Path.Combine(
+            repoRoot,
+            ReconstructedConceptArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(artifactPath))
+        {
+            throw new InvalidOperationException($"Reconstructed concept artifact was not found at {artifactPath}");
+        }
+
+        var artifact = ReconstructedConceptArtifactYaml.Deserialize(File.ReadAllText(artifactPath));
+        if (!string.Equals(artifact.DomainSlug, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Reconstructed concept artifact domain '{artifact.DomainSlug}' does not match requested domain '{domain}'.");
+        }
+
+        return artifact;
+    }
+
+    private static ReconstructedInterviewArtifact LoadReconstructedInterview(string repoRoot, string domain)
+    {
+        var artifactPath = Path.Combine(
+            repoRoot,
+            ReconstructedInterviewArtifactPathResolver.Resolve(domain).Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(artifactPath))
+        {
+            throw new InvalidOperationException($"Reconstructed interview artifact was not found at {artifactPath}");
+        }
+
+        var artifact = ReconstructedInterviewArtifactMarkdown.Deserialize(File.ReadAllText(artifactPath));
+        if (!string.Equals(artifact.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Reconstructed interview artifact domain '{artifact.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        return artifact;
+    }
+
+    private static IReadOnlyList<string> BuildRecommendedUpdates(ReconstructedInterviewArtifact reconstructedInterview)
+    {
+        return reconstructedInterview.RootNearIntentCandidates
+            .Concat(reconstructedInterview.ExecutionNearUpdateCandidates)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(value => value, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static ConceptIntakePacket BuildConceptPacket(
+        ReconstructedConceptArtifact reconstructedConcept,
+        ReconstructedInterviewArtifact reconstructedInterview)
+    {
+        return new ConceptIntakePacket
+        {
+            DomainSlug = reconstructedConcept.DomainSlug,
+            ConceptSource = "generate-from-current-bridge",
+            ConceptText = BuildConceptText(reconstructedConcept, reconstructedInterview),
+            UpstreamPaths = reconstructedInterview.ReturnToIntentPaths,
+            InitialGoal = reconstructedConcept.InitialGoal,
+            Constraints = reconstructedConcept.CandidateRules
+                .Concat(reconstructedConcept.CandidateSpecs)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray(),
+            KnownUnknowns = reconstructedInterview.RecommendedFollowUpQuestions
+                .Concat(reconstructedInterview.Gaps)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray()
+        };
+    }
+
+    private static string BuildConceptText(
+        ReconstructedConceptArtifact reconstructedConcept,
+        ReconstructedInterviewArtifact reconstructedInterview)
+    {
+        var lines = new List<string>
+        {
+            $"Reconstructed concept bridge for domain '{reconstructedConcept.DomainSlug}'."
+        };
+
+        AppendSection(lines, "candidate_intent_nodes", reconstructedConcept.CandidateIntentNodes);
+        AppendSection(lines, "candidate_user_context", reconstructedConcept.CandidateUserContext);
+        AppendSection(lines, "candidate_means", reconstructedConcept.CandidateMeans);
+        AppendSection(lines, "candidate_rules", reconstructedConcept.CandidateRules);
+        AppendSection(lines, "candidate_specs", reconstructedConcept.CandidateSpecs);
+        AppendSection(lines, "candidate_execution_units", reconstructedConcept.CandidateExecutionUnits);
+        AppendSection(lines, "confidence_by_altitude", reconstructedConcept.ConfidenceByAltitude);
+        AppendSection(lines, "source_concept_refs", reconstructedConcept.SourceConceptRefs);
+        AppendSection(lines, "recommended_follow_up_questions", reconstructedInterview.RecommendedFollowUpQuestions);
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static IReadOnlyList<string> WriteInterviewArtifacts(
+        string repoRoot,
+        string domain,
+        ReconstructedConceptArtifact reconstructedConcept,
+        ReconstructedInterviewArtifact reconstructedInterview,
+        IReadOnlyList<string> recommendedUpdates)
+    {
+        var interviewsRoot = Path.Combine(
+            repoRoot,
+            ".intent-cli",
+            "interviews",
+            domain.Replace('/', Path.DirectorySeparatorChar));
+
+        if (Directory.Exists(interviewsRoot))
+        {
+            Directory.Delete(interviewsRoot, recursive: true);
+        }
+
+        if (reconstructedInterview.RecommendedFollowUpQuestions.Count == 0)
+        {
+            return [];
+        }
+
+        Directory.CreateDirectory(interviewsRoot);
+        var artifactPaths = new List<string>();
+
+        for (var index = 0; index < reconstructedInterview.RecommendedFollowUpQuestions.Count; index++)
+        {
+            var questionId = $"iq-{index + 1}";
+            var questionText = reconstructedInterview.RecommendedFollowUpQuestions[index];
+            var item = new InterviewQueueItem
+            {
+                DomainSlug = domain,
+                SourceConceptRef = reconstructedConcept.SourceConceptRefs.FirstOrDefault()
+                    ?? $"generate-from-current:{domain}",
+                QuestionId = questionId,
+                QuestionText = questionText,
+                Reason = ResolveReason(questionText),
+                Affects = [domain],
+                BlockingOrNonblocking = ResolveBlockingOrNonblocking(questionText),
+                Status = InterviewQueueItemStatus.Open,
+                ReturnToIntentPaths = reconstructedInterview.ReturnToIntentPaths,
+                CreatedAt = CreatedAtBase.AddMinutes(index),
+                Answer = null,
+                RecommendedUpdates = recommendedUpdates
+            };
+
+            var yamlPath = Path.Combine(interviewsRoot, $"{questionId}.yaml");
+            var markdownPath = Path.Combine(interviewsRoot, $"{questionId}.md");
+            File.WriteAllText(yamlPath, InterviewArtifactYaml.Serialize(item));
+            File.WriteAllText(
+                markdownPath,
+                RenderInterviewMarkdown(item, recommendedUpdates, reconstructedInterview.Gaps));
+
+            artifactPaths.Add(ToRelativePath(repoRoot, yamlPath));
+            artifactPaths.Add(ToRelativePath(repoRoot, markdownPath));
+        }
+
+        return artifactPaths;
+    }
+
+    private static string RenderInterviewMarkdown(
+        InterviewQueueItem item,
+        IReadOnlyList<string> recommendedUpdates,
+        IReadOnlyList<string> gaps)
+    {
+        var lines = new List<string>
+        {
+            "# Interview Question",
+            string.Empty,
+            "## Domain",
+            string.Empty,
+            $"`{item.DomainSlug}`",
+            string.Empty,
+            $"question_id: {item.QuestionId}",
+            $"question_text: {item.QuestionText}",
+            $"reason: {item.Reason}",
+            $"blocking_or_nonblocking: {item.BlockingOrNonblocking}",
+            string.Empty,
+            "return_to_intent_paths:"
+        };
+
+        AppendBullets(lines, item.ReturnToIntentPaths);
+        lines.Add(string.Empty);
+        lines.Add("recommended_updates:");
+        AppendBullets(lines, recommendedUpdates);
+        lines.Add(string.Empty);
+        lines.Add("gaps:");
+        AppendBullets(lines, gaps);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    private static void AppendSection(List<string> lines, string title, IReadOnlyList<string> values)
+    {
+        lines.Add($"{title}:");
+        if (values.Count == 0)
+        {
+            lines.Add("- none");
+        }
+        else
+        {
+            lines.AddRange(values.Select(value => $"- {value}"));
+        }
+
+        lines.Add(string.Empty);
+    }
+
+    private static void AppendBullets(List<string> lines, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add("- none");
+            return;
+        }
+
+        lines.AddRange(values.Select(value => $"- {value}"));
+    }
+
+    private static string ResolveReason(string questionText)
+    {
+        if (questionText.StartsWith("What user-facing outcome", StringComparison.Ordinal)
+            || questionText.StartsWith("Which current rules or specs", StringComparison.Ordinal)
+            || questionText.StartsWith("Which missing intent detail", StringComparison.Ordinal))
+        {
+            return "Clarify root-near intent before standard intake resumes.";
+        }
+
+        return "Clarify execution-near detail before standard intake resumes.";
+    }
+
+    private static string ResolveBlockingOrNonblocking(string questionText)
+    {
+        return questionText.StartsWith("Which execution-ready change slice", StringComparison.Ordinal)
+            ? "nonblocking"
+            : "blocking";
+    }
+
+    private static string ToRelativePath(string repoRoot, string absolutePath)
+    {
+        return Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeRenderer.cs
@@ -1,0 +1,37 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentBridgeRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentBridgeResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current bridge processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Generated concept artifact: {result.ConceptArtifactPath}");
+        writer.WriteLine("Generated interview artifacts:");
+        WriteList(writer, result.InterviewArtifactPaths);
+        writer.WriteLine("Recommended updates:");
+        WriteList(writer, result.RecommendedUpdates);
+        writer.WriteLine("Return-to-intent paths:");
+        WriteList(writer, result.ReturnToIntentPaths);
+        writer.WriteLine("Gaps:");
+        WriteList(writer, result.Gaps);
+        writer.WriteLine("Skipped bridge steps:");
+        WriteList(writer, result.SkippedBridgeSteps);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeResult.cs
@@ -1,0 +1,18 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentBridgeResult
+{
+    public required string Domain { get; init; }
+
+    public required string ConceptArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> InterviewArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> RecommendedUpdates { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+
+    public required IReadOnlyList<string> Gaps { get; init; }
+
+    public required IReadOnlyList<string> SkippedBridgeSteps { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -39,6 +39,12 @@ internal static class GenerateFromCurrentCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
+        if (args.Length > 0
+            && string.Equals(args[0], "bridge", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentBridgeCommand.Execute(context, args[1..], writer);
+        }
+
         if (!args.Contains("--from-path", StringComparer.Ordinal))
         {
             return GenerateFromCurrentReconstructionCommand.Execute(context, args, writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconstructionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconstructionCommand.cs
@@ -34,7 +34,8 @@ internal static class GenerateFromCurrentReconstructionCommand
         var executionUnits = BuildExecutionUnits(currentSources);
         var confidenceByAltitude = BuildConfidenceByAltitude(currentSources);
         var sourceConceptRefs = BuildSourceConceptRefs(currentSources);
-        var interviewQuestions = BuildInterviewQuestions(currentSources);
+        var bridgeQuestions = BuildBridgeQuestions(currentSources);
+        var interviewQuestions = bridgeQuestions.Select(question => question.QuestionText).ToArray();
         var returnToIntentPaths = BuildReturnToIntentPaths(context.RepoRoot, currentSources);
 
         var conceptArtifact = new ReconstructedConceptArtifact
@@ -65,6 +66,7 @@ internal static class GenerateFromCurrentReconstructionCommand
             confidenceByAltitude,
             sourceConceptRefs,
             interviewQuestions,
+            bridgeQuestions,
             returnToIntentPaths,
             currentSources.Gaps);
         var interviewArtifactPath = ReconstructedInterviewArtifactWriter.Write(context.RepoRoot, domain, interviewMarkdown);
@@ -252,33 +254,71 @@ internal static class GenerateFromCurrentReconstructionCommand
             .ToArray();
     }
 
-    private static IReadOnlyList<string> BuildInterviewQuestions(CurrentSourcesArtifact artifact)
+    private static IReadOnlyList<ReconstructedBridgeQuestion> BuildBridgeQuestions(CurrentSourcesArtifact artifact)
     {
-        var questions = new List<string>();
+        var questions = new List<ReconstructedBridgeQuestion>();
+        var nextQuestionNumber = 1;
 
         if (artifact.SelectedAltitudes.Contains("purpose", StringComparer.Ordinal)
             || artifact.SelectedAltitudes.Contains("user-context", StringComparer.Ordinal))
         {
-            questions.Add($"What user-facing outcome should '{artifact.DomainSlug}' prioritize based on the selected current signals?");
+            questions.Add(CreateBridgeQuestion(
+                artifact.DomainSlug,
+                nextQuestionNumber++,
+                $"What user-facing outcome should '{artifact.DomainSlug}' prioritize based on the selected current signals?",
+                "Clarify root-near intent before standard intake resumes.",
+                "blocking"));
         }
 
         if (artifact.SelectedAltitudes.Contains("rules", StringComparer.Ordinal)
             || artifact.SelectedAltitudes.Contains("specs", StringComparer.Ordinal))
         {
-            questions.Add("Which current rules or specs are mandatory versus historical context only?");
+            questions.Add(CreateBridgeQuestion(
+                artifact.DomainSlug,
+                nextQuestionNumber++,
+                "Which current rules or specs are mandatory versus historical context only?",
+                "Clarify root-near rule and spec expectations before standard intake resumes.",
+                "blocking"));
         }
 
         if (artifact.SelectedAltitudes.Contains("execution", StringComparer.Ordinal))
         {
-            questions.Add("Which execution-ready change slice should be cut first from the selected current paths?");
+            questions.Add(CreateBridgeQuestion(
+                artifact.DomainSlug,
+                nextQuestionNumber++,
+                "Which execution-ready change slice should be cut first from the selected current paths?",
+                "Clarify execution-near detail before standard intake resumes.",
+                "nonblocking"));
         }
 
         if (questions.Count == 0)
         {
-            questions.Add($"Which missing intent detail should be clarified first for domain '{artifact.DomainSlug}'?");
+            questions.Add(CreateBridgeQuestion(
+                artifact.DomainSlug,
+                nextQuestionNumber,
+                $"Which missing intent detail should be clarified first for domain '{artifact.DomainSlug}'?",
+                "Clarify root-near intent before standard intake resumes.",
+                "blocking"));
         }
 
         return questions;
+    }
+
+    private static ReconstructedBridgeQuestion CreateBridgeQuestion(
+        string domain,
+        int questionNumber,
+        string questionText,
+        string reason,
+        string blockingOrNonblocking)
+    {
+        return new ReconstructedBridgeQuestion
+        {
+            QuestionId = $"iq-{questionNumber}",
+            QuestionText = questionText,
+            Reason = reason,
+            Affects = [domain],
+            BlockingOrNonblocking = blockingOrNonblocking
+        };
     }
 
     private static IReadOnlyList<string> BuildReturnToIntentPaths(string repoRoot, CurrentSourcesArtifact artifact)

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconstructionRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconstructionRenderer.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace IntentSystem.Cli.Commands;
 
 internal static class GenerateFromCurrentReconstructionRenderer
@@ -10,6 +12,7 @@ internal static class GenerateFromCurrentReconstructionRenderer
         IReadOnlyList<string> confidenceByAltitude,
         IReadOnlyList<string> sourceConceptRefs,
         IReadOnlyList<string> recommendedFollowUpQuestions,
+        IReadOnlyList<ReconstructedBridgeQuestion> bridgeQuestions,
         IReadOnlyList<string> returnToIntentPaths,
         IReadOnlyList<string> gaps)
     {
@@ -29,6 +32,7 @@ internal static class GenerateFromCurrentReconstructionRenderer
         AppendSection(lines, "confidence_by_altitude", confidenceByAltitude);
         AppendSection(lines, "source_concept_refs", sourceConceptRefs);
         AppendSection(lines, "recommended_follow_up_questions", recommendedFollowUpQuestions);
+        AppendJsonSection(lines, "bridge_questions", bridgeQuestions.Select(SerializeBridgeQuestion).ToArray());
         AppendSection(lines, "return_to_intent_paths", returnToIntentPaths);
         AppendSection(lines, "gaps", gaps);
 
@@ -76,6 +80,21 @@ internal static class GenerateFromCurrentReconstructionRenderer
         lines.Add(string.Empty);
     }
 
+    private static void AppendJsonSection(List<string> lines, string title, IReadOnlyList<string> values)
+    {
+        lines.Add($"{title}:");
+        if (values.Count == 0)
+        {
+            lines.Add("- none");
+        }
+        else
+        {
+            lines.AddRange(values.Select(value => $"- {value}"));
+        }
+
+        lines.Add(string.Empty);
+    }
+
     private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
     {
         if (values.Count == 0)
@@ -88,5 +107,18 @@ internal static class GenerateFromCurrentReconstructionRenderer
         {
             writer.WriteLine($"- {value}");
         }
+    }
+
+    private static string SerializeBridgeQuestion(ReconstructedBridgeQuestion question)
+    {
+        return JsonSerializer.Serialize(
+            new
+            {
+                question_id = question.QuestionId,
+                question_text = question.QuestionText,
+                reason = question.Reason,
+                affects = question.Affects,
+                blocking_or_nonblocking = question.BlockingOrNonblocking
+            });
     }
 }

--- a/src/IntentSystem.Cli/Commands/ReconstructedBridgeQuestion.cs
+++ b/src/IntentSystem.Cli/Commands/ReconstructedBridgeQuestion.cs
@@ -1,0 +1,14 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record ReconstructedBridgeQuestion
+{
+    public required string QuestionId { get; init; }
+
+    public required string QuestionText { get; init; }
+
+    public required string Reason { get; init; }
+
+    public required IReadOnlyList<string> Affects { get; init; }
+
+    public required string BlockingOrNonblocking { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifact.cs
+++ b/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifact.cs
@@ -16,6 +16,8 @@ internal sealed record ReconstructedInterviewArtifact
 
     public required IReadOnlyList<string> RecommendedFollowUpQuestions { get; init; }
 
+    public required IReadOnlyList<ReconstructedBridgeQuestion> BridgeQuestions { get; init; }
+
     public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
 
     public required IReadOnlyList<string> Gaps { get; init; }

--- a/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifact.cs
+++ b/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifact.cs
@@ -1,0 +1,22 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record ReconstructedInterviewArtifact
+{
+    public required string Domain { get; init; }
+
+    public required IReadOnlyList<string> SelectedAltitudes { get; init; }
+
+    public required IReadOnlyList<string> RootNearIntentCandidates { get; init; }
+
+    public required IReadOnlyList<string> ExecutionNearUpdateCandidates { get; init; }
+
+    public required IReadOnlyList<string> ConfidenceByAltitude { get; init; }
+
+    public required IReadOnlyList<string> SourceConceptRefs { get; init; }
+
+    public required IReadOnlyList<string> RecommendedFollowUpQuestions { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+
+    public required IReadOnlyList<string> Gaps { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifactMarkdown.cs
+++ b/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifactMarkdown.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace IntentSystem.Cli.Commands;
 
 internal static class ReconstructedInterviewArtifactMarkdown
@@ -10,6 +12,7 @@ internal static class ReconstructedInterviewArtifactMarkdown
         "confidence_by_altitude",
         "source_concept_refs",
         "recommended_follow_up_questions",
+        "bridge_questions",
         "return_to_intent_paths",
         "gaps"
     ];
@@ -108,8 +111,39 @@ internal static class ReconstructedInterviewArtifactMarkdown
             ConfidenceByAltitude = sections["confidence_by_altitude"].ToArray(),
             SourceConceptRefs = sections["source_concept_refs"].ToArray(),
             RecommendedFollowUpQuestions = sections["recommended_follow_up_questions"].ToArray(),
+            BridgeQuestions = sections["bridge_questions"].Select(ParseBridgeQuestion).ToArray(),
             ReturnToIntentPaths = sections["return_to_intent_paths"].ToArray(),
             Gaps = sections["gaps"].ToArray()
         };
+    }
+
+    private static ReconstructedBridgeQuestion ParseBridgeQuestion(string value)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(value);
+            var root = document.RootElement;
+            var affectsElement = root.GetProperty("affects");
+
+            return new ReconstructedBridgeQuestion
+            {
+                QuestionId = root.GetProperty("question_id").GetString()
+                    ?? throw new InvalidOperationException("Bridge question must contain question_id."),
+                QuestionText = root.GetProperty("question_text").GetString()
+                    ?? throw new InvalidOperationException("Bridge question must contain question_text."),
+                Reason = root.GetProperty("reason").GetString()
+                    ?? throw new InvalidOperationException("Bridge question must contain reason."),
+                Affects = affectsElement.EnumerateArray()
+                    .Select(element => element.GetString()
+                        ?? throw new InvalidOperationException("Bridge question affects entries must be strings."))
+                    .ToArray(),
+                BlockingOrNonblocking = root.GetProperty("blocking_or_nonblocking").GetString()
+                    ?? throw new InvalidOperationException("Bridge question must contain blocking_or_nonblocking.")
+            };
+        }
+        catch (Exception exception) when (exception is JsonException or KeyNotFoundException or InvalidOperationException)
+        {
+            throw new InvalidOperationException("Reconstructed interview artifact bridge_questions entries must be valid JSON objects.", exception);
+        }
     }
 }

--- a/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifactMarkdown.cs
+++ b/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifactMarkdown.cs
@@ -114,7 +114,9 @@ internal static class ReconstructedInterviewArtifactMarkdown
             BridgeQuestions = sections["bridge_questions"].Select(ParseBridgeQuestion).ToArray(),
             ReturnToIntentPaths = sections["return_to_intent_paths"].ToArray(),
             Gaps = sections["gaps"].ToArray()
-        };
+        } is var artifact
+            ? ValidateQuestionConsistency(artifact)
+            : throw new InvalidOperationException("Unreachable reconstructed interview artifact state.");
     }
 
     private static ReconstructedBridgeQuestion ParseBridgeQuestion(string value)
@@ -145,5 +147,28 @@ internal static class ReconstructedInterviewArtifactMarkdown
         {
             throw new InvalidOperationException("Reconstructed interview artifact bridge_questions entries must be valid JSON objects.", exception);
         }
+    }
+
+    private static ReconstructedInterviewArtifact ValidateQuestionConsistency(ReconstructedInterviewArtifact artifact)
+    {
+        if (artifact.RecommendedFollowUpQuestions.Count != artifact.BridgeQuestions.Count)
+        {
+            throw new InvalidOperationException(
+                "Reconstructed interview artifact must keep recommended_follow_up_questions and bridge_questions aligned one-to-one.");
+        }
+
+        for (var index = 0; index < artifact.RecommendedFollowUpQuestions.Count; index++)
+        {
+            if (!string.Equals(
+                artifact.RecommendedFollowUpQuestions[index],
+                artifact.BridgeQuestions[index].QuestionText,
+                StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    "Reconstructed interview artifact must keep recommended_follow_up_questions and bridge_questions question_text values aligned one-to-one.");
+            }
+        }
+
+        return artifact;
     }
 }

--- a/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifactMarkdown.cs
+++ b/src/IntentSystem.Cli/Commands/ReconstructedInterviewArtifactMarkdown.cs
@@ -1,0 +1,115 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class ReconstructedInterviewArtifactMarkdown
+{
+    private static readonly string[] RequiredSections =
+    [
+        "selected_altitudes",
+        "root_near_intent_candidates",
+        "execution_near_update_candidates",
+        "confidence_by_altitude",
+        "source_concept_refs",
+        "recommended_follow_up_questions",
+        "return_to_intent_paths",
+        "gaps"
+    ];
+
+    public static ReconstructedInterviewArtifact Deserialize(string markdown)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(markdown);
+
+        var lines = markdown
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.None);
+
+        var sawTitle = false;
+        string? domain = null;
+        var sections = RequiredSections.ToDictionary(section => section, _ => new List<string>(), StringComparer.Ordinal);
+        var seenSections = new HashSet<string>(StringComparer.Ordinal);
+        string? currentSection = null;
+        var expectingDomain = false;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (string.Equals(line, "# Reconstructed Interview", StringComparison.Ordinal))
+            {
+                sawTitle = true;
+                currentSection = null;
+                continue;
+            }
+
+            if (string.Equals(line, "## Domain", StringComparison.Ordinal))
+            {
+                expectingDomain = true;
+                currentSection = null;
+                continue;
+            }
+
+            if (expectingDomain)
+            {
+                if (line.StartsWith('`') && line.EndsWith('`') && line.Length >= 2)
+                {
+                    domain = line[1..^1];
+                    expectingDomain = false;
+                    continue;
+                }
+
+                throw new InvalidOperationException("Reconstructed interview artifact must contain a backticked domain line.");
+            }
+
+            if (line.EndsWith(":", StringComparison.Ordinal) && sections.ContainsKey(line[..^1]))
+            {
+                currentSection = line[..^1];
+                seenSections.Add(currentSection);
+                continue;
+            }
+
+            if (!line.StartsWith("- ", StringComparison.Ordinal) || currentSection is null)
+            {
+                continue;
+            }
+
+            var value = line[2..];
+            if (!string.Equals(value, "none", StringComparison.Ordinal))
+            {
+                sections[currentSection].Add(value);
+            }
+        }
+
+        if (!sawTitle)
+        {
+            throw new InvalidOperationException("Reconstructed interview artifact must start with '# Reconstructed Interview'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            throw new InvalidOperationException("Reconstructed interview artifact must contain a domain.");
+        }
+
+        var missingSection = RequiredSections.FirstOrDefault(section => !seenSections.Contains(section));
+        if (missingSection is not null)
+        {
+            throw new InvalidOperationException(
+                $"Reconstructed interview artifact must contain section '{missingSection}:'.");
+        }
+
+        return new ReconstructedInterviewArtifact
+        {
+            Domain = domain,
+            SelectedAltitudes = sections["selected_altitudes"].ToArray(),
+            RootNearIntentCandidates = sections["root_near_intent_candidates"].ToArray(),
+            ExecutionNearUpdateCandidates = sections["execution_near_update_candidates"].ToArray(),
+            ConfidenceByAltitude = sections["confidence_by_altitude"].ToArray(),
+            SourceConceptRefs = sections["source_concept_refs"].ToArray(),
+            RecommendedFollowUpQuestions = sections["recommended_follow_up_questions"].ToArray(),
+            ReturnToIntentPaths = sections["return_to_intent_paths"].ToArray(),
+            Gaps = sections["gaps"].ToArray()
+        };
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -117,6 +117,47 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentBridgeCommand_DispatchesToBridgeRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.reconstructed-concept.yaml"),
+            ReconstructedConceptArtifactYaml.Serialize(
+                new ReconstructedConceptArtifact
+                {
+                    DomainSlug = "auth",
+                    InitialGoal = "Reconstruct auth domain intent.",
+                    CandidateIntentNodes = [],
+                    CandidateUserContext = [],
+                    CandidateMeans = [],
+                    CandidateRules = [],
+                    CandidateSpecs = [],
+                    CandidateExecutionUnits = [],
+                    ConfidenceByAltitude = [],
+                    SourceConceptRefs = []
+                }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.reconstructed-interview.md"),
+            GenerateFromCurrentReconstructionRenderer.RenderInterviewMarkdown(
+                "auth",
+                [],
+                [],
+                [],
+                [],
+                [],
+                ["Which missing intent detail should be clarified first for domain 'auth'?"],
+                [],
+                []));
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["generate-from-current", "bridge", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Generate-from-current bridge processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenQueueListCommand_DispatchesToQueueRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -147,6 +147,16 @@ public sealed class CommandRouterTests
                 [],
                 [],
                 ["Which missing intent detail should be clarified first for domain 'auth'?"],
+                [
+                    new ReconstructedBridgeQuestion
+                    {
+                        QuestionId = "iq-1",
+                        QuestionText = "Which missing intent detail should be clarified first for domain 'auth'?",
+                        Reason = "Clarify root-near intent before standard intake resumes.",
+                        Affects = ["auth"],
+                        BlockingOrNonblocking = "blocking"
+                    }
+                ],
                 [],
                 []));
         using var writer = new StringWriter();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBridgeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBridgeCommandTests.cs
@@ -212,6 +212,71 @@ public sealed class GenerateFromCurrentBridgeCommandTests
         Assert.Contains("Reconstructed interview artifact was not found", writer.ToString(), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Execute_GivenConflictingReconstructedInterviewQuestions_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.reconstructed-concept.yaml"),
+            ReconstructedConceptArtifactYaml.Serialize(
+                new ReconstructedConceptArtifact
+                {
+                    DomainSlug = "auth",
+                    InitialGoal = "Reconstruct auth domain intent.",
+                    CandidateIntentNodes = [],
+                    CandidateUserContext = [],
+                    CandidateMeans = [],
+                    CandidateRules = [],
+                    CandidateSpecs = [],
+                    CandidateExecutionUnits = [],
+                    ConfidenceByAltitude = [],
+                    SourceConceptRefs = []
+                }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.reconstructed-interview.md"),
+            """
+            # Reconstructed Interview
+
+            ## Domain
+
+            `auth`
+
+            selected_altitudes:
+            - purpose
+
+            root_near_intent_candidates:
+            - Clarify the auth domain mission.
+
+            execution_near_update_candidates:
+            - none
+
+            confidence_by_altitude:
+            - purpose: medium
+
+            source_concept_refs:
+            - issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current
+
+            recommended_follow_up_questions:
+            - Human-facing question text.
+
+            bridge_questions:
+            - {"question_id":"iq-1","question_text":"Different bridge question text.","reason":"Clarify root-near intent before standard intake resumes.","affects":["auth"],"blocking_or_nonblocking":"blocking"}
+
+            return_to_intent_paths:
+            - README.md
+
+            gaps:
+            - none
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentCommand.Execute(CreateContext(repoRoot), ["bridge", "auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("aligned one-to-one", writer.ToString(), StringComparison.Ordinal);
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBridgeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBridgeCommandTests.cs
@@ -33,19 +33,45 @@ public sealed class GenerateFromCurrentBridgeCommandTests
                 }));
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "intake", "auth.reconstructed-interview.md"),
-            GenerateFromCurrentReconstructionRenderer.RenderInterviewMarkdown(
-                "auth",
-                ["purpose", "execution"],
-                ["Clarify the auth domain mission."],
-                ["Inspect OAuth entry points."],
-                ["purpose: medium", "execution: high"],
-                ["issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current"],
-                [
-                    "What user-facing outcome should 'auth' prioritize based on the selected current signals?",
-                    "Which execution-ready change slice should be cut first from the selected current paths?"
-                ],
-                ["README.md", "AGENTS.md"],
-                ["Need stronger auth purpose signal."]));
+            """
+            # Reconstructed Interview
+
+            ## Domain
+
+            `auth`
+
+            selected_altitudes:
+            - purpose
+            - execution
+
+            root_near_intent_candidates:
+            - Clarify the auth domain mission.
+
+            execution_near_update_candidates:
+            - Inspect OAuth entry points.
+
+            confidence_by_altitude:
+            - purpose: medium
+            - execution: high
+
+            source_concept_refs:
+            - issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current
+
+            recommended_follow_up_questions:
+            - Arbitrary text for the first bridge question.
+            - Arbitrary text for the second bridge question.
+
+            bridge_questions:
+            - {"question_id":"iq-root","question_text":"Arbitrary text for the first bridge question.","reason":"Clarify root-near intent before standard intake resumes.","affects":["auth"],"blocking_or_nonblocking":"blocking"}
+            - {"question_id":"iq-exec","question_text":"Arbitrary text for the second bridge question.","reason":"Clarify execution-near detail before standard intake resumes.","affects":["oauth"],"blocking_or_nonblocking":"nonblocking"}
+
+            return_to_intent_paths:
+            - README.md
+            - AGENTS.md
+
+            gaps:
+            - Need stronger auth purpose signal.
+            """);
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "interviews", "auth", "stale.yaml"),
             "stale");
@@ -60,8 +86,8 @@ public sealed class GenerateFromCurrentBridgeCommandTests
         var output = writer.ToString();
         Assert.Contains("Generate-from-current bridge processed for domain 'auth'.", output, StringComparison.Ordinal);
         Assert.Contains("Generated concept artifact: .intent-cli/intake/auth.concept.yaml", output, StringComparison.Ordinal);
-        Assert.Contains(".intent-cli/interviews/auth/iq-1.yaml", output, StringComparison.Ordinal);
-        Assert.Contains(".intent-cli/interviews/auth/iq-2.md", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/interviews/auth/iq-root.yaml", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/interviews/auth/iq-exec.md", output, StringComparison.Ordinal);
         Assert.Contains("Recommended updates:", output, StringComparison.Ordinal);
         Assert.Contains("- Clarify the auth domain mission.", output, StringComparison.Ordinal);
         Assert.Contains("- Inspect OAuth entry points.", output, StringComparison.Ordinal);
@@ -85,24 +111,27 @@ public sealed class GenerateFromCurrentBridgeCommandTests
         Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "interviews", "billing", "iq-1.yaml")));
 
         var firstInterview = InterviewArtifactYaml.Deserialize(File.ReadAllText(
-            Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-1.yaml")));
-        Assert.Equal("iq-1", firstInterview.QuestionId);
+            Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-root.yaml")));
+        Assert.Equal("iq-root", firstInterview.QuestionId);
         Assert.Equal("blocking", firstInterview.BlockingOrNonblocking);
         Assert.Equal("Clarify root-near intent before standard intake resumes.", firstInterview.Reason);
         Assert.Equal(DateTimeOffset.Parse("2026-01-01T00:00:00Z"), firstInterview.CreatedAt);
         Assert.Equal(["auth"], firstInterview.Affects);
+        Assert.Equal("Arbitrary text for the first bridge question.", firstInterview.QuestionText);
         Assert.Equal(
             ["Clarify the auth domain mission.", "Inspect OAuth entry points."],
             firstInterview.RecommendedUpdates);
 
         var secondInterview = InterviewArtifactYaml.Deserialize(File.ReadAllText(
-            Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-2.yaml")));
-        Assert.Equal("iq-2", secondInterview.QuestionId);
+            Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-exec.yaml")));
+        Assert.Equal("iq-exec", secondInterview.QuestionId);
         Assert.Equal("nonblocking", secondInterview.BlockingOrNonblocking);
         Assert.Equal("Clarify execution-near detail before standard intake resumes.", secondInterview.Reason);
         Assert.Equal(DateTimeOffset.Parse("2026-01-01T00:01:00Z"), secondInterview.CreatedAt);
+        Assert.Equal(["oauth"], secondInterview.Affects);
+        Assert.Equal("Arbitrary text for the second bridge question.", secondInterview.QuestionText);
 
-        var interviewMarkdown = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-1.md"));
+        var interviewMarkdown = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-root.md"));
         Assert.Contains("# Interview Question", interviewMarkdown, StringComparison.Ordinal);
         Assert.Contains("recommended_updates:", interviewMarkdown, StringComparison.Ordinal);
         Assert.Contains("gaps:", interviewMarkdown, StringComparison.Ordinal);
@@ -133,6 +162,7 @@ public sealed class GenerateFromCurrentBridgeCommandTests
             Path.Combine("repo", ".intent-cli", "intake", "auth.reconstructed-interview.md"),
             GenerateFromCurrentReconstructionRenderer.RenderInterviewMarkdown(
                 "auth",
+                [],
                 [],
                 [],
                 [],

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBridgeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBridgeCommandTests.cs
@@ -1,0 +1,235 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentBridgeCommandTests
+{
+    [Fact]
+    public void Execute_GivenReconstructedArtifacts_RegeneratesStandardIntakeAndInterviewArtifacts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.reconstructed-concept.yaml"),
+            ReconstructedConceptArtifactYaml.Serialize(
+                new ReconstructedConceptArtifact
+                {
+                    DomainSlug = "auth",
+                    InitialGoal = "Reconstruct auth domain intent.",
+                    CandidateIntentNodes = ["Clarify the auth domain mission."],
+                    CandidateUserContext = ["Validate expected auth personas."],
+                    CandidateMeans = ["Inspect OAuth entry points."],
+                    CandidateRules = ["Preserve repo-level auth guidance."],
+                    CandidateSpecs = ["Reconcile current auth public contract."],
+                    CandidateExecutionUnits = ["Execution candidate from src/Auth/Login.cs."],
+                    ConfidenceByAltitude = ["purpose: medium", "execution: high"],
+                    SourceConceptRefs =
+                    [
+                        "issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current",
+                        "pr:117 https://github.com/J-Tech-Japan/intent-system/pull/117 [codex] Add reconstruction stage"
+                    ]
+                }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.reconstructed-interview.md"),
+            GenerateFromCurrentReconstructionRenderer.RenderInterviewMarkdown(
+                "auth",
+                ["purpose", "execution"],
+                ["Clarify the auth domain mission."],
+                ["Inspect OAuth entry points."],
+                ["purpose: medium", "execution: high"],
+                ["issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current"],
+                [
+                    "What user-facing outcome should 'auth' prioritize based on the selected current signals?",
+                    "Which execution-ready change slice should be cut first from the selected current paths?"
+                ],
+                ["README.md", "AGENTS.md"],
+                ["Need stronger auth purpose signal."]));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "stale.yaml"),
+            "stale");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "billing", "iq-1.yaml"),
+            "kept");
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentCommand.Execute(CreateContext(repoRoot), ["bridge", "auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current bridge processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Generated concept artifact: .intent-cli/intake/auth.concept.yaml", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/interviews/auth/iq-1.yaml", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/interviews/auth/iq-2.md", output, StringComparison.Ordinal);
+        Assert.Contains("Recommended updates:", output, StringComparison.Ordinal);
+        Assert.Contains("- Clarify the auth domain mission.", output, StringComparison.Ordinal);
+        Assert.Contains("- Inspect OAuth entry points.", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped bridge steps:", output, StringComparison.Ordinal);
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+
+        var conceptArtifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.concept.yaml");
+        Assert.True(File.Exists(conceptArtifactPath));
+        var conceptPacket = IntakeConceptArtifactYaml.Deserialize(File.ReadAllText(conceptArtifactPath));
+        Assert.Equal("auth", conceptPacket.DomainSlug);
+        Assert.Equal("generate-from-current-bridge", conceptPacket.ConceptSource);
+        Assert.Equal("Reconstruct auth domain intent.", conceptPacket.InitialGoal);
+        Assert.Equal(["README.md", "AGENTS.md"], conceptPacket.UpstreamPaths);
+        Assert.Contains("candidate_intent_nodes:", conceptPacket.ConceptText, StringComparison.Ordinal);
+        Assert.Contains("recommended_follow_up_questions:", conceptPacket.ConceptText, StringComparison.Ordinal);
+        Assert.Contains("Preserve repo-level auth guidance.", conceptPacket.Constraints, StringComparer.Ordinal);
+        Assert.Contains("Reconcile current auth public contract.", conceptPacket.Constraints, StringComparer.Ordinal);
+        Assert.Contains("Need stronger auth purpose signal.", conceptPacket.KnownUnknowns, StringComparer.Ordinal);
+
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "stale.yaml")));
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "interviews", "billing", "iq-1.yaml")));
+
+        var firstInterview = InterviewArtifactYaml.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-1.yaml")));
+        Assert.Equal("iq-1", firstInterview.QuestionId);
+        Assert.Equal("blocking", firstInterview.BlockingOrNonblocking);
+        Assert.Equal("Clarify root-near intent before standard intake resumes.", firstInterview.Reason);
+        Assert.Equal(DateTimeOffset.Parse("2026-01-01T00:00:00Z"), firstInterview.CreatedAt);
+        Assert.Equal(["auth"], firstInterview.Affects);
+        Assert.Equal(
+            ["Clarify the auth domain mission.", "Inspect OAuth entry points."],
+            firstInterview.RecommendedUpdates);
+
+        var secondInterview = InterviewArtifactYaml.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-2.yaml")));
+        Assert.Equal("iq-2", secondInterview.QuestionId);
+        Assert.Equal("nonblocking", secondInterview.BlockingOrNonblocking);
+        Assert.Equal("Clarify execution-near detail before standard intake resumes.", secondInterview.Reason);
+        Assert.Equal(DateTimeOffset.Parse("2026-01-01T00:01:00Z"), secondInterview.CreatedAt);
+
+        var interviewMarkdown = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-1.md"));
+        Assert.Contains("# Interview Question", interviewMarkdown, StringComparison.Ordinal);
+        Assert.Contains("recommended_updates:", interviewMarkdown, StringComparison.Ordinal);
+        Assert.Contains("gaps:", interviewMarkdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNoFollowUpQuestions_SkipsInterviewArtifactGeneration()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.reconstructed-concept.yaml"),
+            ReconstructedConceptArtifactYaml.Serialize(
+                new ReconstructedConceptArtifact
+                {
+                    DomainSlug = "auth",
+                    InitialGoal = "Reconstruct auth domain intent.",
+                    CandidateIntentNodes = [],
+                    CandidateUserContext = [],
+                    CandidateMeans = [],
+                    CandidateRules = [],
+                    CandidateSpecs = [],
+                    CandidateExecutionUnits = [],
+                    ConfidenceByAltitude = [],
+                    SourceConceptRefs = []
+                }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.reconstructed-interview.md"),
+            GenerateFromCurrentReconstructionRenderer.RenderInterviewMarkdown(
+                "auth",
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                []));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "stale.yaml"),
+            "stale");
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentCommand.Execute(CreateContext(repoRoot), ["bridge", "auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("No reconstructed follow-up questions were present; interview artifact generation was skipped.", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(Directory.Exists(Path.Combine(repoRoot, ".intent-cli", "interviews", "auth")));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingReconstructedInterviewArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.reconstructed-concept.yaml"),
+            ReconstructedConceptArtifactYaml.Serialize(
+                new ReconstructedConceptArtifact
+                {
+                    DomainSlug = "auth",
+                    InitialGoal = "Reconstruct auth domain intent.",
+                    CandidateIntentNodes = [],
+                    CandidateUserContext = [],
+                    CandidateMeans = [],
+                    CandidateRules = [],
+                    CandidateSpecs = [],
+                    CandidateExecutionUnits = [],
+                    ConfidenceByAltitude = [],
+                    SourceConceptRefs = []
+                }));
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentCommand.Execute(CreateContext(repoRoot), ["bridge", "auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Reconstructed interview artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-bridge-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBridgeRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBridgeRendererTests.cs
@@ -1,0 +1,36 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentBridgeRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenResult_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentBridgeRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentBridgeResult
+            {
+                Domain = "auth",
+                ConceptArtifactPath = ".intent-cli/intake/auth.concept.yaml",
+                InterviewArtifactPaths =
+                [
+                    ".intent-cli/interviews/auth/iq-1.yaml",
+                    ".intent-cli/interviews/auth/iq-1.md"
+                ],
+                RecommendedUpdates = ["Clarify auth goal."],
+                ReturnToIntentPaths = ["README.md"],
+                Gaps = ["Need stronger auth purpose signal."],
+                SkippedBridgeSteps = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current bridge processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Generated concept artifact: .intent-cli/intake/auth.concept.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Generated interview artifacts:", output, StringComparison.Ordinal);
+        Assert.Contains("Recommended updates:", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped bridge steps:", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReconstructionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReconstructionCommandTests.cs
@@ -90,6 +90,9 @@ public sealed class GenerateFromCurrentReconstructionCommandTests
         var interviewMarkdown = File.ReadAllText(interviewArtifactPath);
         Assert.Contains("# Reconstructed Interview", interviewMarkdown, StringComparison.Ordinal);
         Assert.Contains("recommended_follow_up_questions:", interviewMarkdown, StringComparison.Ordinal);
+        Assert.Contains("bridge_questions:", interviewMarkdown, StringComparison.Ordinal);
+        Assert.Contains("\"question_id\":\"iq-1\"", interviewMarkdown, StringComparison.Ordinal);
+        Assert.Contains("\"blocking_or_nonblocking\":\"blocking\"", interviewMarkdown, StringComparison.Ordinal);
         Assert.Contains("What user-facing outcome should 'auth' prioritize based on the selected current signals?", interviewMarkdown, StringComparison.Ordinal);
         Assert.Contains("Which execution-ready change slice should be cut first from the selected current paths?", interviewMarkdown, StringComparison.Ordinal);
         Assert.Contains("return_to_intent_paths:", interviewMarkdown, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReconstructedInterviewArtifactMarkdownTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReconstructedInterviewArtifactMarkdownTests.cs
@@ -1,0 +1,52 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ReconstructedInterviewArtifactMarkdownTests
+{
+    [Fact]
+    public void Deserialize_GivenCanonicalMarkdown_ReturnsArtifact()
+    {
+        var markdown = GenerateFromCurrentReconstructionRenderer.RenderInterviewMarkdown(
+            "auth",
+            ["purpose", "execution"],
+            ["Clarify the auth domain mission."],
+            ["Inspect OAuth entry points."],
+            ["purpose: medium"],
+            ["issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current"],
+            ["Which execution-ready change slice should be cut first from the selected current paths?"],
+            ["README.md"],
+            ["Need stronger auth purpose signal."]);
+
+        var artifact = ReconstructedInterviewArtifactMarkdown.Deserialize(markdown);
+
+        Assert.Equal("auth", artifact.Domain);
+        Assert.Equal(["purpose", "execution"], artifact.SelectedAltitudes);
+        Assert.Equal(["Clarify the auth domain mission."], artifact.RootNearIntentCandidates);
+        Assert.Equal(["Inspect OAuth entry points."], artifact.ExecutionNearUpdateCandidates);
+        Assert.Equal(
+            ["Which execution-ready change slice should be cut first from the selected current paths?"],
+            artifact.RecommendedFollowUpQuestions);
+        Assert.Equal(["README.md"], artifact.ReturnToIntentPaths);
+        Assert.Equal(["Need stronger auth purpose signal."], artifact.Gaps);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingSection_Throws()
+    {
+        const string markdown = """
+            # Reconstructed Interview
+
+            ## Domain
+
+            `auth`
+
+            selected_altitudes:
+            - purpose
+            """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => ReconstructedInterviewArtifactMarkdown.Deserialize(markdown));
+
+        Assert.Contains("root_near_intent_candidates", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/ReconstructedInterviewArtifactMarkdownTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReconstructedInterviewArtifactMarkdownTests.cs
@@ -15,6 +15,16 @@ public sealed class ReconstructedInterviewArtifactMarkdownTests
             ["purpose: medium"],
             ["issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current"],
             ["Which execution-ready change slice should be cut first from the selected current paths?"],
+            [
+                new ReconstructedBridgeQuestion
+                {
+                    QuestionId = "iq-1",
+                    QuestionText = "Which execution-ready change slice should be cut first from the selected current paths?",
+                    Reason = "Clarify execution-near detail before standard intake resumes.",
+                    Affects = ["auth"],
+                    BlockingOrNonblocking = "nonblocking"
+                }
+            ],
             ["README.md"],
             ["Need stronger auth purpose signal."]);
 
@@ -27,6 +37,10 @@ public sealed class ReconstructedInterviewArtifactMarkdownTests
         Assert.Equal(
             ["Which execution-ready change slice should be cut first from the selected current paths?"],
             artifact.RecommendedFollowUpQuestions);
+        Assert.Single(artifact.BridgeQuestions);
+        Assert.Equal("iq-1", artifact.BridgeQuestions[0].QuestionId);
+        Assert.Equal("Clarify execution-near detail before standard intake resumes.", artifact.BridgeQuestions[0].Reason);
+        Assert.Equal("nonblocking", artifact.BridgeQuestions[0].BlockingOrNonblocking);
         Assert.Equal(["README.md"], artifact.ReturnToIntentPaths);
         Assert.Equal(["Need stronger auth purpose signal."], artifact.Gaps);
     }

--- a/tests/IntentSystem.Cli.Tests/ReconstructedInterviewArtifactMarkdownTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReconstructedInterviewArtifactMarkdownTests.cs
@@ -63,4 +63,47 @@ public sealed class ReconstructedInterviewArtifactMarkdownTests
 
         Assert.Contains("root_near_intent_candidates", exception.Message, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void Deserialize_GivenMismatchedQuestionSets_Throws()
+    {
+        const string markdown = """
+            # Reconstructed Interview
+
+            ## Domain
+
+            `auth`
+
+            selected_altitudes:
+            - purpose
+
+            root_near_intent_candidates:
+            - Clarify the auth domain mission.
+
+            execution_near_update_candidates:
+            - none
+
+            confidence_by_altitude:
+            - purpose: medium
+
+            source_concept_refs:
+            - issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current
+
+            recommended_follow_up_questions:
+            - Human-facing question text.
+
+            bridge_questions:
+            - {"question_id":"iq-1","question_text":"Different bridge question text.","reason":"Clarify root-near intent before standard intake resumes.","affects":["auth"],"blocking_or_nonblocking":"blocking"}
+
+            return_to_intent_paths:
+            - README.md
+
+            gaps:
+            - none
+            """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => ReconstructedInterviewArtifactMarkdown.Deserialize(markdown));
+
+        Assert.Contains("aligned one-to-one", exception.Message, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
## Summary
- add `generate-from-current bridge <domain>` as a thin bridge from reconstructed artifacts into the standard intake/interview flow
- regenerate `.intent-cli/intake/<domain>.concept.yaml` and `.intent-cli/interviews/<domain>/` deterministically for the selected domain only
- add parser, renderer, and router/runtime coverage for the bridge path

## Testing
- dotnet test IntentSystem.sln
