### PR TITLE
[codex] Add generate-from-current advance

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentAdvanceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentAdvanceCommand.cs
@@ -1,0 +1,83 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentAdvanceCommand
+{
+    public static Func<CliContext, string[], GenerateFromCurrentResult> SourceBundleExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentCommand.ExecuteSourceBundleCore(context, args);
+
+    public static Func<CliContext, string, GenerateFromCurrentReconstructionResult> ReconstructionExecutor { get; set; } =
+        (context, domain) => GenerateFromCurrentReconstructionCommand.ExecuteCore(context, [domain]);
+
+    public static Func<CliContext, string, GenerateFromCurrentBridgeResult> BridgeExecutor { get; set; } =
+        (context, domain) => GenerateFromCurrentBridgeCommand.ExecuteCore(context, [domain]);
+
+    public static Func<CliContext, string, IntakeAdvanceResult> IntakeAdvanceExecutor { get; set; } =
+        (context, domain) => IntakeAdvanceCommand.ExecuteCore(context, domain);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentAdvanceRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentAdvanceResult ExecuteCore(CliContext context, string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current advance requires a domain.");
+        }
+
+        var domain = args[0].Trim();
+        var sourceBundleResult = SourceBundleExecutor(context, args);
+        var reconstructionResult = ReconstructionExecutor(context, domain);
+        var bridgeResult = BridgeExecutor(context, domain);
+        var intakeAdvanceResult = IntakeAdvanceExecutor(context, domain);
+
+        return new GenerateFromCurrentAdvanceResult
+        {
+            Domain = domain,
+            SourceBundleArtifactPath = sourceBundleResult.ArtifactPath,
+            ReconstructedArtifactPaths =
+            [
+                reconstructionResult.ConceptArtifactPath,
+                reconstructionResult.InterviewArtifactPath
+            ],
+            StandardIntakeArtifactPaths =
+            [
+                bridgeResult.ConceptArtifactPath,
+                .. bridgeResult.InterviewArtifactPaths
+            ],
+            UpdatedSourceFilePaths = intakeAdvanceResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = intakeAdvanceResult.UpdatedExecutionFilePaths,
+            ReadinessStatus = intakeAdvanceResult.ReadinessStatus,
+            SkippedStages = BuildSkippedStages(bridgeResult, intakeAdvanceResult)
+        };
+    }
+
+    private static IReadOnlyList<string> BuildSkippedStages(
+        GenerateFromCurrentBridgeResult bridgeResult,
+        IntakeAdvanceResult intakeAdvanceResult)
+    {
+        var skippedStages = new List<string>();
+        if (bridgeResult.InterviewArtifactPaths.Count == 0)
+        {
+            skippedStages.Add("bridge-interviews");
+        }
+
+        skippedStages.AddRange(intakeAdvanceResult.SkippedStages);
+        return skippedStages;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentAdvanceRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentAdvanceRenderer.cs
@@ -1,0 +1,38 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentAdvanceRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentAdvanceResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current advance processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine("Regenerated standard intake artifact paths:");
+        WriteList(writer, result.StandardIntakeArtifactPaths);
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentAdvanceResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentAdvanceResult.cs
@@ -1,0 +1,20 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentAdvanceResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StandardIntakeArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -40,6 +40,12 @@ internal static class GenerateFromCurrentCommand
         ArgumentNullException.ThrowIfNull(writer);
 
         if (args.Length > 0
+            && string.Equals(args[0], "advance", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentAdvanceCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "bridge", StringComparison.Ordinal))
         {
             return GenerateFromCurrentBridgeCommand.Execute(context, args[1..], writer);

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -168,6 +168,34 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentAdvanceCommand_DispatchesToAdvanceRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "advance", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current advance processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenQueueListCommand_DispatchesToQueueRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentAdvanceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentAdvanceCommandTests.cs
@@ -1,0 +1,223 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentAdvanceCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_NotReadyAfterBridge_RendersDeterministicSummary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["advance", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current advance processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Source bundle artifact path: .intent-cli/intake/auth.current-sources.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.reconstructed-concept.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.reconstructed-interview.md", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.concept.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/interviews/auth/iq-1.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+            Assert.Contains("Skipped stages:", output, StringComparison.Ordinal);
+            Assert.Contains("- foldin", output, StringComparison.Ordinal);
+            Assert.Contains("- patch", output, StringComparison.Ordinal);
+            Assert.Contains("- apply", output, StringComparison.Ordinal);
+            Assert.Contains("- execution", output, StringComparison.Ordinal);
+            Assert.Contains("- execution-apply", output, StringComparison.Ordinal);
+
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.current-sources.yaml")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.reconstructed-concept.yaml")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.reconstructed-interview.md")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.concept.yaml")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-1.yaml")));
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.compile.md")));
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenReadyStageResults_ComposesToUpdatedExecutionSummary()
+    {
+        using var writer = new StringWriter();
+        var originalSourceBundleExecutor = GenerateFromCurrentAdvanceCommand.SourceBundleExecutor;
+        var originalReconstructionExecutor = GenerateFromCurrentAdvanceCommand.ReconstructionExecutor;
+        var originalBridgeExecutor = GenerateFromCurrentAdvanceCommand.BridgeExecutor;
+        var originalIntakeAdvanceExecutor = GenerateFromCurrentAdvanceCommand.IntakeAdvanceExecutor;
+
+        try
+        {
+            GenerateFromCurrentAdvanceCommand.SourceBundleExecutor = (_, _) => new GenerateFromCurrentResult
+            {
+                Domain = "auth",
+                ArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                SourceRoot = "src/feature",
+                SelectedIssueScope = "114",
+                SelectedPrScope = "113",
+                SelectedAltitudes = ["execution"],
+                SelectedPaths = ["src/feature/FeatureA.cs"],
+                SourceRefs = [],
+                SamplingNotes = [],
+                Gaps = []
+            };
+            GenerateFromCurrentAdvanceCommand.ReconstructionExecutor = (_, _) => new GenerateFromCurrentReconstructionResult
+            {
+                Domain = "auth",
+                ConceptArtifactPath = ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                InterviewArtifactPath = ".intent-cli/intake/auth.reconstructed-interview.md",
+                SelectedAltitudes = ["execution"],
+                CandidateIntentNodes = [],
+                CandidateExecutionUnits = ["Execution candidate from src/feature/FeatureA.cs."],
+                ConfidenceByAltitude = ["execution: high"],
+                SourceConceptRefs = [],
+                RecommendedFollowUpQuestions = [],
+                ReturnToIntentPaths = [],
+                Gaps = []
+            };
+            GenerateFromCurrentAdvanceCommand.BridgeExecutor = (_, _) => new GenerateFromCurrentBridgeResult
+            {
+                Domain = "auth",
+                ConceptArtifactPath = ".intent-cli/intake/auth.concept.yaml",
+                InterviewArtifactPaths = [".intent-cli/interviews/auth/iq-1.yaml"],
+                RecommendedUpdates = ["Align login UX wording"],
+                ReturnToIntentPaths = ["README.md"],
+                Gaps = [],
+                SkippedBridgeSteps = []
+            };
+            GenerateFromCurrentAdvanceCommand.IntakeAdvanceExecutor = (_, _) => new IntakeAdvanceResult
+            {
+                Domain = "auth",
+                ReadinessStatus = "ready",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.execution.md"],
+                SkippedStages = []
+            };
+
+            var exitCode = GenerateFromCurrentAdvanceCommand.Execute(CreateContext("/tmp/intent-system"), ["auth", "--from-path", "src/feature"], writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+            Assert.Contains("- intents/intent-cli/concepts/auth-oauth2.md", output, StringComparison.Ordinal);
+            Assert.Contains("- intents/intent-cli/execution/05-post-mvp-sub-slices.md", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.current-sources.yaml", output.Replace("Source bundle artifact path: ", "- ", StringComparison.Ordinal), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentAdvanceCommand.SourceBundleExecutor = originalSourceBundleExecutor;
+            GenerateFromCurrentAdvanceCommand.ReconstructionExecutor = originalReconstructionExecutor;
+            GenerateFromCurrentAdvanceCommand.BridgeExecutor = originalBridgeExecutor;
+            GenerateFromCurrentAdvanceCommand.IntakeAdvanceExecutor = originalIntakeAdvanceExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentAdvanceCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-advance-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentAdvanceRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentAdvanceRendererTests.cs
@@ -1,0 +1,44 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentAdvanceRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenResult_WritesDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentAdvanceRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentAdvanceResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current advance processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Source bundle artifact path: .intent-cli/intake/auth.current-sources.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Reconstructed artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Regenerated standard intake artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Updated source file paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Updated execution file paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped stages:", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current advance <domain> --from-path <path>` as a thin composition over source bundle, reconstruction, bridge, and intake advance
- return source bundle, reconstructed, and regenerated standard intake artifact paths together with updated source/execution paths, readiness, and skipped stages
- add runtime, renderer, and router coverage for both real not-ready composition and staged ready composition

## Testing
- dotnet test IntentSystem.sln
