### PR TITLE
[G49] Add generate-from-current implement command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -46,6 +46,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "implement", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentImplementCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "bridge", StringComparison.Ordinal))
         {
             return GenerateFromCurrentBridgeCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentImplementCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentImplementCommand.cs
@@ -1,0 +1,98 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentImplementCommand
+{
+    private static readonly string[] DeferredActivationStages =
+    [
+        "issue-generation",
+        "launch",
+        "implement-handoff"
+    ];
+
+    public static Func<CliContext, string[], GenerateFromCurrentAdvanceResult> AdvanceExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentAdvanceCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string, TextWriter, IntakeStartResult> StartExecutor { get; set; } =
+        (context, domain, writer) => IntakeStartCommand.ExecuteCore(context, domain, writer);
+
+    public static Func<CliContext, string, RunImplementResult> RunImplementExecutor { get; set; } =
+        (context, executionUnit) => RunImplementCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentImplementRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentImplementResult ExecuteCore(CliContext context, string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current implement requires a domain.");
+        }
+
+        var domain = args[0].Trim();
+        var advanceResult = AdvanceExecutor(context, args);
+
+        if (!string.Equals(advanceResult.ReadinessStatus, "ready", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentImplementResult
+            {
+                Domain = domain,
+                SourceBundleArtifactPath = advanceResult.SourceBundleArtifactPath,
+                ReconstructedArtifactPaths = advanceResult.ReconstructedArtifactPaths,
+                StandardIntakeArtifactPaths = advanceResult.StandardIntakeArtifactPaths,
+                UpdatedSourceFilePaths = advanceResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = advanceResult.UpdatedExecutionFilePaths,
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                StartedExecutionUnits = [],
+                ImplementRequestArtifactPaths = [],
+                ReadinessStatus = advanceResult.ReadinessStatus,
+                SkippedStages = advanceResult.SkippedStages.Concat(DeferredActivationStages).ToArray()
+            };
+        }
+
+        var startResult = StartExecutor(context, domain, TextWriter.Null);
+        var implementArtifactPaths = startResult.StartedExecutionUnits
+            .Select(executionUnit => RunImplementExecutor(context, executionUnit).ArtifactPath)
+            .ToArray();
+
+        var skippedStages = new List<string>(advanceResult.SkippedStages);
+        if (implementArtifactPaths.Length == 0)
+        {
+            skippedStages.Add("implement-handoff");
+        }
+
+        return new GenerateFromCurrentImplementResult
+        {
+            Domain = domain,
+            SourceBundleArtifactPath = advanceResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = advanceResult.ReconstructedArtifactPaths,
+            StandardIntakeArtifactPaths = advanceResult.StandardIntakeArtifactPaths,
+            UpdatedSourceFilePaths = advanceResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = advanceResult.UpdatedExecutionFilePaths,
+            GeneratedIssueArtifactPaths = startResult.GeneratedArtifactPaths,
+            CreatedIssueRefs = startResult.CreatedIssueRefs,
+            WorktreePaths = startResult.WorktreePaths,
+            StartedExecutionUnits = startResult.StartedExecutionUnits,
+            ImplementRequestArtifactPaths = implementArtifactPaths,
+            ReadinessStatus = advanceResult.ReadinessStatus,
+            SkippedStages = skippedStages
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentImplementRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentImplementRenderer.cs
@@ -1,0 +1,48 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentImplementRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentImplementResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current implement processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine("Regenerated standard intake artifact paths:");
+        WriteList(writer, result.StandardIntakeArtifactPaths);
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Generated issue artifact paths:");
+        WriteList(writer, result.GeneratedIssueArtifactPaths);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentImplementResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentImplementResult.cs
@@ -1,0 +1,30 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentImplementResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StandardIntakeArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> GeneratedIssueArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
@@ -19,90 +19,10 @@ internal static class RunImplementCommand
             return 1;
         }
 
-        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
-        if (queueState is null)
-        {
-            return 1;
-        }
-
-        var executionUnit = args[0];
-        var queueItem = queueState.Items.FirstOrDefault(item =>
-            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
-
-        if (queueItem is null)
-        {
-            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
-            return 1;
-        }
-
-        if (queueItem.State is not (QueueItemState.Active or QueueItemState.Fixing))
-        {
-            writer.WriteLine(
-                $"Execution unit '{executionUnit}' must be active or fixing before run implement.");
-            return 1;
-        }
-
-        if (queueItem.LinkedIssue is null)
-        {
-            writer.WriteLine($"Execution unit '{executionUnit}' must have a linked issue before run implement.");
-            return 1;
-        }
-
-        var packetPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.Yaml);
-        if (!File.Exists(packetPath))
-        {
-            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
-            return 1;
-        }
-
-        var reviewContextPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.ReviewContext);
-        if (!File.Exists(reviewContextPath))
-        {
-            writer.WriteLine($"Review context artifact was not found at {reviewContextPath}");
-            return 1;
-        }
-
         try
         {
-            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
-            var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
-            if (string.IsNullOrWhiteSpace(childRepoRef))
-            {
-                throw new InvalidOperationException("Projection packet must contain a target repo.");
-            }
-
-            var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
-            if (!Directory.Exists(childRepoPath))
-            {
-                throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
-            }
-
-            var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
-            if (!Directory.Exists(worktreePath))
-            {
-                throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
-            }
-
-            var reviewContext = ReviewContextMarkdownParser.Parse(File.ReadAllText(reviewContextPath));
-            if (!string.Equals(reviewContext.SourceExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"Review context execution unit '{reviewContext.SourceExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
-            }
-
-            var latestLinkedPr = ResolveLatestLinkedPr(context, executionUnit);
-            var request = BuildRequest(
-                context,
-                queueItem,
-                packet,
-                reviewContext,
-                worktreePath,
-                childRepoPath,
-                latestLinkedPr);
-            var markdown = RunImplementRenderer.RenderMarkdown(request);
-            var artifactPath = RunImplementArtifactWriter.Write(markdown, executionUnit, context.RepoRoot, overwrite: true);
-            RunImplementRenderer.WriteSummary(writer, request, artifactPath);
-
+            var result = ExecuteCore(context, args[0]);
+            RunImplementRenderer.WriteSummary(writer, result.Request, result.ArtifactPath);
             return 0;
         }
         catch (InvalidOperationException exception)
@@ -110,6 +30,95 @@ internal static class RunImplementCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static RunImplementResult ExecuteCore(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var queueStatePath = context.GetQueueStatePath();
+        var queueState = QueueCommandSupport.LoadQueueState(context, TextWriter.Null);
+        if (queueState is null)
+        {
+            throw new InvalidOperationException($"No queue state found at {queueStatePath}");
+        }
+
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            throw new InvalidOperationException($"Execution unit '{executionUnit}' was not found in queue state.");
+        }
+
+        if (queueItem.State is not (QueueItemState.Active or QueueItemState.Fixing))
+        {
+            throw new InvalidOperationException(
+                $"Execution unit '{executionUnit}' must be active or fixing before run implement.");
+        }
+
+        if (queueItem.LinkedIssue is null)
+        {
+            throw new InvalidOperationException(
+                $"Execution unit '{executionUnit}' must have a linked issue before run implement.");
+        }
+
+        var packetPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.Yaml);
+        if (!File.Exists(packetPath))
+        {
+            throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
+        }
+
+        var reviewContextPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.ReviewContext);
+        if (!File.Exists(reviewContextPath))
+        {
+            throw new InvalidOperationException($"Review context artifact was not found at {reviewContextPath}");
+        }
+
+        var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+        var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
+        if (string.IsNullOrWhiteSpace(childRepoRef))
+        {
+            throw new InvalidOperationException("Projection packet must contain a target repo.");
+        }
+
+        var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
+        if (!Directory.Exists(childRepoPath))
+        {
+            throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+        }
+
+        var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
+        if (!Directory.Exists(worktreePath))
+        {
+            throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
+        }
+
+        var reviewContext = ReviewContextMarkdownParser.Parse(File.ReadAllText(reviewContextPath));
+        if (!string.Equals(reviewContext.SourceExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Review context execution unit '{reviewContext.SourceExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
+        }
+
+        var latestLinkedPr = ResolveLatestLinkedPr(context, executionUnit);
+        var request = BuildRequest(
+            context,
+            queueItem,
+            packet,
+            reviewContext,
+            worktreePath,
+            childRepoPath,
+            latestLinkedPr);
+        var markdown = RunImplementRenderer.RenderMarkdown(request);
+        var artifactPath = RunImplementArtifactWriter.Write(markdown, executionUnit, context.RepoRoot, overwrite: true);
+
+        return new RunImplementResult
+        {
+            Request = request,
+            ArtifactPath = ToRelativePath(context.RepoRoot, artifactPath)
+        };
     }
 
     private static RunImplementRequest BuildRequest(
@@ -179,5 +188,10 @@ internal static class RunImplementCommand
             QueueItemState.ClarifyBlocked => "clarify-blocked",
             _ => state.ToString().ToLowerInvariant()
         };
+    }
+
+    private static string ToRelativePath(string repoRoot, string absolutePath)
+    {
+        return Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
     }
 }

--- a/src/IntentSystem.Cli/Commands/RunImplementResult.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record RunImplementResult
+{
+    public required RunImplementRequest Request { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -196,6 +196,34 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "implement", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current implement processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenQueueListCommand_DispatchesToQueueRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentImplementCommandTests.cs
@@ -1,0 +1,245 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentImplementCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_NotReadyAfterBridge_DefersActivationAndImplement()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["implement", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current implement processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+            Assert.Contains("Generated issue artifact paths:", output, StringComparison.Ordinal);
+            Assert.Contains("Implement request artifact paths:", output, StringComparison.Ordinal);
+            Assert.Contains("- issue-generation", output, StringComparison.Ordinal);
+            Assert.Contains("- launch", output, StringComparison.Ordinal);
+            Assert.Contains("- implement-handoff", output, StringComparison.Ordinal);
+
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.current-sources.yaml")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.reconstructed-concept.yaml")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.reconstructed-interview.md")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.concept.yaml")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-1.yaml")));
+            Assert.False(Directory.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "G124")));
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "implement", "G124.request.md")));
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenReadyStageResults_ComposesToImplementHandoffSummary()
+    {
+        using var writer = new StringWriter();
+        var originalAdvanceExecutor = GenerateFromCurrentImplementCommand.AdvanceExecutor;
+        var originalStartExecutor = GenerateFromCurrentImplementCommand.StartExecutor;
+        var originalRunImplementExecutor = GenerateFromCurrentImplementCommand.RunImplementExecutor;
+
+        try
+        {
+            GenerateFromCurrentImplementCommand.AdvanceExecutor = (_, _) => new GenerateFromCurrentAdvanceResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+            GenerateFromCurrentImplementCommand.StartExecutor = (_, _, _) => new IntakeStartResult
+            {
+                Domain = "auth",
+                StartedExecutionUnits = ["G124", "G125"],
+                GeneratedArtifactPaths =
+                [
+                    ".intent-cli/issues/G124/packet.yaml",
+                    ".intent-cli/issues/G125/packet.yaml"
+                ],
+                CreatedIssueRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/issues/124",
+                    "https://github.com/J-Tech-Japan/intent-system/issues/125"
+                ],
+                WorktreePaths =
+                [
+                    ".intent-cli/worktrees/G124",
+                    ".intent-cli/worktrees/G125"
+                ],
+                SkippedUnits = []
+            };
+            GenerateFromCurrentImplementCommand.RunImplementExecutor = (_, executionUnit) => new RunImplementResult
+            {
+                Request = new RunImplementRequest
+                {
+                    ExecutionUnit = executionUnit,
+                    State = "active",
+                    ImplementRole = "Claude",
+                    QueueWorkerRole = "coder",
+                    QueueReviewRole = "reviewer",
+                    WorktreePath = $".intent-cli/worktrees/{executionUnit}",
+                    ChildRepoPath = "submodules/intent-system",
+                    Branch = $"issue-124-{executionUnit.ToLowerInvariant()}",
+                    LinkedIssue = $"https://github.com/J-Tech-Japan/intent-system/issues/{executionUnit[1..]}",
+                    LatestLinkedPr = null,
+                    PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                    ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                    IssueTitle = $"[{executionUnit}] Implement",
+                    Goal = "Generate implement handoff.",
+                    TargetPart = "cli",
+                    TargetRepo = "submodules/intent-system",
+                    TargetPath = ".",
+                    InScope = ["implement handoff"],
+                    OutOfScope = ["submit"],
+                    AcceptanceCriteria = ["handoff exists"],
+                    DeterministicReviewChecks = ["deterministic summary"],
+                    ExpectedEvidence = ["dotnet test"]
+                },
+                ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md"
+            };
+
+            var exitCode = GenerateFromCurrentImplementCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/issues/G124/packet.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/issues/124", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/worktrees/G124", output, StringComparison.Ordinal);
+            Assert.Contains("- G124", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/implement/G124.request.md", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/implement/G125.request.md", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentImplementCommand.AdvanceExecutor = originalAdvanceExecutor;
+            GenerateFromCurrentImplementCommand.StartExecutor = originalStartExecutor;
+            GenerateFromCurrentImplementCommand.RunImplementExecutor = originalRunImplementExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentImplementCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-implement-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentImplementRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentImplementRendererTests.cs
@@ -1,0 +1,75 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentImplementRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenImplementResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentImplementRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentImplementResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G124/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/124"],
+                WorktreePaths = [".intent-cli/worktrees/G124"],
+                StartedExecutionUnits = ["G124"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G124.request.md"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current implement processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Source bundle artifact path: .intent-cli/intake/auth.current-sources.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Implement request artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/implement/G124.request.md", output, StringComparison.Ordinal);
+        Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_RendersNoneEntries()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentImplementRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentImplementResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                StandardIntakeArtifactPaths = [],
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                StartedExecutionUnits = [],
+                ImplementRequestArtifactPaths = [],
+                ReadinessStatus = "not-ready",
+                SkippedStages = ["issue-generation", "launch", "implement-handoff"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+        Assert.Contains("- implement-handoff", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current implement <domain> --from-path <path>` to compose source bundle, reconstruction, bridge, advance, intake start, and implement handoff generation
- reuse `run implement` through an internal core result so composed flows can generate deterministic implement request artifacts without changing the outward command contract
- add renderer, router, and composition tests for ready and not-ready paths

## Testing
- dotnet test IntentSystem.sln