### PR TITLE
[G50] Add generate-from-current submit command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -46,6 +46,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "submit", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentSubmitCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "implement", StringComparison.Ordinal))
         {
             return GenerateFromCurrentImplementCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentSubmitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentSubmitCommand.cs
@@ -1,0 +1,94 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentSubmitCommand
+{
+    private static readonly string[] DeferredSubmitStages =
+    [
+        "submit-review"
+    ];
+
+    public static Func<CliContext, string[], GenerateFromCurrentImplementResult> ImplementExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentImplementCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string, RunSubmitResult> RunSubmitExecutor { get; set; } =
+        (context, executionUnit) => RunSubmitCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentSubmitRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentSubmitResult ExecuteCore(CliContext context, string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current submit requires a domain.");
+        }
+
+        var implementResult = ImplementExecutor(context, args);
+        if (!string.Equals(implementResult.ReadinessStatus, "ready", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentSubmitResult
+            {
+                Domain = implementResult.Domain,
+                SourceBundleArtifactPath = implementResult.SourceBundleArtifactPath,
+                ReconstructedArtifactPaths = implementResult.ReconstructedArtifactPaths,
+                StandardIntakeArtifactPaths = implementResult.StandardIntakeArtifactPaths,
+                UpdatedSourceFilePaths = implementResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = implementResult.UpdatedExecutionFilePaths,
+                GeneratedIssueArtifactPaths = implementResult.GeneratedIssueArtifactPaths,
+                CreatedIssueRefs = implementResult.CreatedIssueRefs,
+                WorktreePaths = implementResult.WorktreePaths,
+                StartedExecutionUnits = implementResult.StartedExecutionUnits,
+                ImplementRequestArtifactPaths = implementResult.ImplementRequestArtifactPaths,
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReadinessStatus = implementResult.ReadinessStatus,
+                SkippedStages = implementResult.SkippedStages.Concat(DeferredSubmitStages).ToArray()
+            };
+        }
+
+        var submitResults = implementResult.StartedExecutionUnits
+            .Select(executionUnit => RunSubmitExecutor(context, executionUnit))
+            .ToArray();
+
+        var skippedStages = new List<string>(implementResult.SkippedStages);
+        if (submitResults.Length == 0)
+        {
+            skippedStages.Add("submit-review");
+        }
+
+        return new GenerateFromCurrentSubmitResult
+        {
+            Domain = implementResult.Domain,
+            SourceBundleArtifactPath = implementResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = implementResult.ReconstructedArtifactPaths,
+            StandardIntakeArtifactPaths = implementResult.StandardIntakeArtifactPaths,
+            UpdatedSourceFilePaths = implementResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = implementResult.UpdatedExecutionFilePaths,
+            GeneratedIssueArtifactPaths = implementResult.GeneratedIssueArtifactPaths,
+            CreatedIssueRefs = implementResult.CreatedIssueRefs,
+            WorktreePaths = implementResult.WorktreePaths,
+            StartedExecutionUnits = implementResult.StartedExecutionUnits,
+            ImplementRequestArtifactPaths = implementResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = submitResults.Select(result => result.LinkedPr).ToArray(),
+            ReviewExecutionUnits = submitResults.Select(result => result.ExecutionUnit).ToArray(),
+            ReadinessStatus = implementResult.ReadinessStatus,
+            SkippedStages = skippedStages
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentSubmitRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentSubmitRenderer.cs
@@ -1,0 +1,52 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentSubmitRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentSubmitResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current submit processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine("Regenerated standard intake artifact paths:");
+        WriteList(writer, result.StandardIntakeArtifactPaths);
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Generated issue artifact paths:");
+        WriteList(writer, result.GeneratedIssueArtifactPaths);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentSubmitResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentSubmitResult.cs
@@ -1,0 +1,34 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentSubmitResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StandardIntakeArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> GeneratedIssueArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/RunSubmitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSubmitCommand.cs
@@ -28,82 +28,10 @@ internal static class RunSubmitCommand
             return 1;
         }
 
-        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
-        if (queueState is null)
-        {
-            return 1;
-        }
-
-        var executionUnit = args[0];
-        var queueItem = queueState.Items.FirstOrDefault(item =>
-            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
-
-        if (queueItem is null)
-        {
-            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
-            return 1;
-        }
-
-        if (queueItem.LinkedIssue is null)
-        {
-            writer.WriteLine($"Execution unit '{executionUnit}' must have a linked issue before run submit.");
-            return 1;
-        }
-
-        var packetPath = Path.Combine(
-            context.RepoRoot,
-            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
-        if (!File.Exists(packetPath))
-        {
-            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
-            return 1;
-        }
-
         try
         {
-            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
-            var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
-            if (string.IsNullOrWhiteSpace(childRepoRef))
-            {
-                throw new InvalidOperationException("Projection packet must contain a target repo.");
-            }
-
-            var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
-            if (!Directory.Exists(childRepoPath))
-            {
-                throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
-            }
-
-            var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
-            if (!Directory.Exists(worktreePath))
-            {
-                throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
-            }
-
-            var branchName = RunStartCommand.ResolveBranchName(executionUnit, queueItem.LinkedIssue);
-            var gitRunner = GitCommandRunnerFactory();
-            EnsureBranchMatches(worktreePath, branchName, gitRunner);
-            PushBranch(worktreePath, branchName, gitRunner);
-
-            var targetRepo = ResolveGitHubTargetRepo(childRepoPath, gitRunner);
-            var pullRequestTitle = ResolvePullRequestTitle(queueItem);
-            var pullRequestBody = ResolvePullRequestBody(queueItem);
-            var linkedPr = PublisherFactory().CreateDraftPullRequest(
-                targetRepo,
-                branchName,
-                pullRequestTitle,
-                pullRequestBody);
-
-            var timestamp = TimestampFactory();
-            var transition = QueueManager.SubmitForReview(
-                queueState,
-                executionUnit,
-                TransitionActor,
-                timestamp,
-                linkedPr);
-            PersistSubmit(context, transition);
-
-            writer.WriteLine($"Run submitted for {executionUnit}.");
+            var result = ExecuteCore(context, args[0]);
+            writer.WriteLine($"Run submitted for {result.ExecutionUnit}.");
             return 0;
         }
         catch (InvalidOperationException exception)
@@ -111,6 +39,89 @@ internal static class RunSubmitCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static RunSubmitResult ExecuteCore(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var queueStatePath = context.GetQueueStatePath();
+        var queueState = QueueCommandSupport.LoadQueueState(context, TextWriter.Null);
+        if (queueState is null)
+        {
+            throw new InvalidOperationException($"No queue state found at {queueStatePath}");
+        }
+
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            throw new InvalidOperationException($"Execution unit '{executionUnit}' was not found in queue state.");
+        }
+
+        if (queueItem.LinkedIssue is null)
+        {
+            throw new InvalidOperationException(
+                $"Execution unit '{executionUnit}' must have a linked issue before run submit.");
+        }
+
+        var packetPath = Path.Combine(
+            context.RepoRoot,
+            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(packetPath))
+        {
+            throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
+        }
+
+        var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+        var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
+        if (string.IsNullOrWhiteSpace(childRepoRef))
+        {
+            throw new InvalidOperationException("Projection packet must contain a target repo.");
+        }
+
+        var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
+        if (!Directory.Exists(childRepoPath))
+        {
+            throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+        }
+
+        var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
+        if (!Directory.Exists(worktreePath))
+        {
+            throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
+        }
+
+        var branchName = RunStartCommand.ResolveBranchName(executionUnit, queueItem.LinkedIssue);
+        var gitRunner = GitCommandRunnerFactory();
+        EnsureBranchMatches(worktreePath, branchName, gitRunner);
+        PushBranch(worktreePath, branchName, gitRunner);
+
+        var targetRepo = ResolveGitHubTargetRepo(childRepoPath, gitRunner);
+        var pullRequestTitle = ResolvePullRequestTitle(queueItem);
+        var pullRequestBody = ResolvePullRequestBody(queueItem);
+        var linkedPr = PublisherFactory().CreateDraftPullRequest(
+            targetRepo,
+            branchName,
+            pullRequestTitle,
+            pullRequestBody);
+
+        var timestamp = TimestampFactory();
+        var transition = QueueManager.SubmitForReview(
+            queueState,
+            executionUnit,
+            TransitionActor,
+            timestamp,
+            linkedPr);
+        PersistSubmit(context, transition);
+
+        return new RunSubmitResult
+        {
+            ExecutionUnit = executionUnit,
+            LinkedPr = linkedPr
+        };
     }
 
     internal static string ResolvePullRequestTitle(QueueItem queueItem)

--- a/src/IntentSystem.Cli/Commands/RunSubmitResult.cs
+++ b/src/IntentSystem.Cli/Commands/RunSubmitResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record RunSubmitResult
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required string LinkedPr { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -196,6 +196,34 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentSubmitCommand_DispatchesToSubmitRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "submit", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current submit processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentSubmitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentSubmitCommandTests.cs
@@ -1,0 +1,210 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentSubmitCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_NotReadyAfterBridge_DefersSubmit()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["submit", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current submit processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+            Assert.Contains("Created PR refs:", output, StringComparison.Ordinal);
+            Assert.Contains("Review execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- submit-review", output, StringComparison.Ordinal);
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "implement", "G126.request.md")));
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenReadyStageResults_ComposesToReviewSummary()
+    {
+        using var writer = new StringWriter();
+        var originalImplementExecutor = GenerateFromCurrentSubmitCommand.ImplementExecutor;
+        var originalRunSubmitExecutor = GenerateFromCurrentSubmitCommand.RunSubmitExecutor;
+
+        try
+        {
+            GenerateFromCurrentSubmitCommand.ImplementExecutor = (_, _) => new GenerateFromCurrentImplementResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths =
+                [
+                    ".intent-cli/issues/G126/packet.yaml",
+                    ".intent-cli/issues/G127/packet.yaml"
+                ],
+                CreatedIssueRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/issues/126",
+                    "https://github.com/J-Tech-Japan/intent-system/issues/127"
+                ],
+                WorktreePaths =
+                [
+                    ".intent-cli/worktrees/G126",
+                    ".intent-cli/worktrees/G127"
+                ],
+                StartedExecutionUnits = ["G126", "G127"],
+                ImplementRequestArtifactPaths =
+                [
+                    ".intent-cli/implement/G126.request.md",
+                    ".intent-cli/implement/G127.request.md"
+                ],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+            GenerateFromCurrentSubmitCommand.RunSubmitExecutor = (_, executionUnit) => new RunSubmitResult
+            {
+                ExecutionUnit = executionUnit,
+                LinkedPr = $"https://github.com/J-Tech-Japan/intent-system/pull/{executionUnit[1..]}"
+            };
+
+            var exitCode = GenerateFromCurrentSubmitCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/implement/G126.request.md", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/126", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/127", output, StringComparison.Ordinal);
+            Assert.Contains("Review execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- G126", output, StringComparison.Ordinal);
+            Assert.Contains("- G127", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentSubmitCommand.ImplementExecutor = originalImplementExecutor;
+            GenerateFromCurrentSubmitCommand.RunSubmitExecutor = originalRunSubmitExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentSubmitCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-submit-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentSubmitRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentSubmitRendererTests.cs
@@ -1,0 +1,79 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentSubmitRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenSubmitResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentSubmitRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentSubmitResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G126/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/126"],
+                WorktreePaths = [".intent-cli/worktrees/G126"],
+                StartedExecutionUnits = ["G126"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G126.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/126"],
+                ReviewExecutionUnits = ["G126"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current submit processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Created PR refs:", output, StringComparison.Ordinal);
+        Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/126", output, StringComparison.Ordinal);
+        Assert.Contains("Review execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("- G126", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_RendersNoneEntries()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentSubmitRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentSubmitResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                StandardIntakeArtifactPaths = [],
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                StartedExecutionUnits = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReadinessStatus = "not-ready",
+                SkippedStages = ["issue-generation", "launch", "implement-handoff", "submit-review"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+        Assert.Contains("- submit-review", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current submit <domain> --from-path <path>` to compose source bundle, reconstruction, bridge, advance, launch, implement handoff, and review entry
- reuse `run submit` through an internal core result so composed flows can create deterministic PR refs without changing the outward command contract
- add renderer, router, and composition tests for ready and not-ready submit paths

## Testing
- dotnet test IntentSystem.sln