### PR TITLE
[G51] Add generate-from-current review command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -52,6 +52,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "review", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentReviewCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "implement", StringComparison.Ordinal))
         {
             return GenerateFromCurrentImplementCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReviewCommand.cs
@@ -1,0 +1,96 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentReviewCommand
+{
+    private static readonly string[] DeferredReviewRequestStages =
+    [
+        "review-request"
+    ];
+
+    public static Func<CliContext, string[], GenerateFromCurrentSubmitResult> SubmitExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentSubmitCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string, ReviewRunResult> ReviewRunExecutor { get; set; } =
+        (context, executionUnit) => ReviewRunCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentReviewRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentReviewResult ExecuteCore(CliContext context, string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current review requires a domain.");
+        }
+
+        var submitResult = SubmitExecutor(context, args);
+        if (!string.Equals(submitResult.ReadinessStatus, "ready", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentReviewResult
+            {
+                Domain = submitResult.Domain,
+                SourceBundleArtifactPath = submitResult.SourceBundleArtifactPath,
+                ReconstructedArtifactPaths = submitResult.ReconstructedArtifactPaths,
+                StandardIntakeArtifactPaths = submitResult.StandardIntakeArtifactPaths,
+                UpdatedSourceFilePaths = submitResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = submitResult.UpdatedExecutionFilePaths,
+                GeneratedIssueArtifactPaths = submitResult.GeneratedIssueArtifactPaths,
+                CreatedIssueRefs = submitResult.CreatedIssueRefs,
+                WorktreePaths = submitResult.WorktreePaths,
+                StartedExecutionUnits = submitResult.StartedExecutionUnits,
+                ImplementRequestArtifactPaths = submitResult.ImplementRequestArtifactPaths,
+                CreatedPrRefs = submitResult.CreatedPrRefs,
+                ReviewExecutionUnits = submitResult.ReviewExecutionUnits,
+                ReviewRequestArtifactPaths = [],
+                ReadinessStatus = submitResult.ReadinessStatus,
+                SkippedStages = submitResult.SkippedStages.Concat(DeferredReviewRequestStages).ToArray()
+            };
+        }
+
+        var reviewResults = submitResult.ReviewExecutionUnits
+            .Select(executionUnit => ReviewRunExecutor(context, executionUnit))
+            .ToArray();
+
+        var skippedStages = new List<string>(submitResult.SkippedStages);
+        if (reviewResults.Length == 0)
+        {
+            skippedStages.Add("review-request");
+        }
+
+        return new GenerateFromCurrentReviewResult
+        {
+            Domain = submitResult.Domain,
+            SourceBundleArtifactPath = submitResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = submitResult.ReconstructedArtifactPaths,
+            StandardIntakeArtifactPaths = submitResult.StandardIntakeArtifactPaths,
+            UpdatedSourceFilePaths = submitResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = submitResult.UpdatedExecutionFilePaths,
+            GeneratedIssueArtifactPaths = submitResult.GeneratedIssueArtifactPaths,
+            CreatedIssueRefs = submitResult.CreatedIssueRefs,
+            WorktreePaths = submitResult.WorktreePaths,
+            StartedExecutionUnits = submitResult.StartedExecutionUnits,
+            ImplementRequestArtifactPaths = submitResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = submitResult.CreatedPrRefs,
+            ReviewExecutionUnits = submitResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = reviewResults.Select(result => result.ArtifactPath).ToArray(),
+            ReadinessStatus = submitResult.ReadinessStatus,
+            SkippedStages = skippedStages
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReviewRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReviewRenderer.cs
@@ -1,0 +1,54 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentReviewRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentReviewResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current review processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine("Regenerated standard intake artifact paths:");
+        WriteList(writer, result.StandardIntakeArtifactPaths);
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Generated issue artifact paths:");
+        WriteList(writer, result.GeneratedIssueArtifactPaths);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReviewResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReviewResult.cs
@@ -1,0 +1,36 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentReviewResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StandardIntakeArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> GeneratedIssueArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/ReviewRunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewRunCommand.cs
@@ -17,20 +17,37 @@ internal static class ReviewRunCommand
             return 1;
         }
 
-        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
-        if (queueState is null)
+        try
         {
+            var result = ExecuteCore(context, args[0]);
+            writer.WriteLine($"Review request artifact generated for {result.ExecutionUnit}.");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
             return 1;
         }
+    }
 
-        var executionUnit = args[0];
+    internal static ReviewRunResult ExecuteCore(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var queueStatePath = context.GetQueueStatePath();
+        var queueState = QueueCommandSupport.LoadQueueState(context, TextWriter.Null);
+        if (queueState is null)
+        {
+            throw new InvalidOperationException($"No queue state found at {queueStatePath}");
+        }
+
         var queueItem = queueState.Items.FirstOrDefault(item =>
             string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
 
         if (queueItem is null)
         {
-            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
-            return 1;
+            throw new InvalidOperationException($"Execution unit '{executionUnit}' was not found in queue state.");
         }
 
         var reviewContextRef = queueItem.PacketPaths.ReviewContext;
@@ -39,38 +56,32 @@ internal static class ReviewRunCommand
             reviewContextRef.Replace('/', Path.DirectorySeparatorChar));
         if (!File.Exists(reviewContextPath))
         {
-            writer.WriteLine($"Review context artifact was not found at {reviewContextPath}");
-            return 1;
+            throw new InvalidOperationException($"Review context artifact was not found at {reviewContextPath}");
         }
 
         var runLogPath = context.GetRunLogPath();
         if (!File.Exists(runLogPath))
         {
-            writer.WriteLine($"Run log was not found at {runLogPath}");
-            return 1;
+            throw new InvalidOperationException($"Run log was not found at {runLogPath}");
         }
 
-        try
+        var reviewContext = ReviewContextMarkdownParser.Parse(File.ReadAllText(reviewContextPath));
+        if (!string.Equals(reviewContext.SourceExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
         {
-            var reviewContext = ReviewContextMarkdownParser.Parse(File.ReadAllText(reviewContextPath));
-            if (!string.Equals(reviewContext.SourceExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"Review context execution unit '{reviewContext.SourceExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
-            }
-
-            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
-            var linkedPr = LatestLinkedPrResolver.Resolve(runEvents, executionUnit);
-            var request = ReviewRequestFactory.Create(executionUnit, reviewContextRef, linkedPr, reviewContext);
-            ReviewArtifactWriter.Write(request, executionUnit, context.RepoRoot, overwrite: true);
-
-            writer.WriteLine($"Review request artifact generated for {executionUnit}.");
-            return 0;
+            throw new InvalidOperationException(
+                $"Review context execution unit '{reviewContext.SourceExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
         }
-        catch (InvalidOperationException exception)
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        var linkedPr = LatestLinkedPrResolver.Resolve(runEvents, executionUnit);
+        var request = ReviewRequestFactory.Create(executionUnit, reviewContextRef, linkedPr, reviewContext);
+        ReviewArtifactWriter.Write(request, executionUnit, context.RepoRoot, overwrite: true);
+        var artifactPath = Review.ReviewArtifactPathResolver.Resolve(executionUnit);
+
+        return new ReviewRunResult
         {
-            writer.WriteLine(exception.Message);
-            return 1;
-        }
+            ExecutionUnit = executionUnit,
+            ArtifactPath = artifactPath
+        };
     }
 }

--- a/src/IntentSystem.Cli/Commands/ReviewRunResult.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewRunResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record ReviewRunResult
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -224,6 +224,34 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentReviewCommand_DispatchesToReviewRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "review", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current review processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReviewCommandTests.cs
@@ -1,0 +1,192 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentReviewCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_NotReadyAfterBridge_DefersReviewRequest()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["review", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current review processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+            Assert.Contains("Review request artifact paths:", output, StringComparison.Ordinal);
+            Assert.Contains("- review-request", output, StringComparison.Ordinal);
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "reviews", "G128.request.json")));
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenReadyStageResults_ComposesToReviewArtifactSummary()
+    {
+        using var writer = new StringWriter();
+        var originalSubmitExecutor = GenerateFromCurrentReviewCommand.SubmitExecutor;
+        var originalReviewRunExecutor = GenerateFromCurrentReviewCommand.ReviewRunExecutor;
+
+        try
+        {
+            GenerateFromCurrentReviewCommand.SubmitExecutor = (_, _) => new GenerateFromCurrentSubmitResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G128/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/128"],
+                WorktreePaths = [".intent-cli/worktrees/G128"],
+                StartedExecutionUnits = ["G128"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G128.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/128"],
+                ReviewExecutionUnits = ["G128"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+            GenerateFromCurrentReviewCommand.ReviewRunExecutor = (_, executionUnit) => new ReviewRunResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+            };
+
+            var exitCode = GenerateFromCurrentReviewCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/128", output, StringComparison.Ordinal);
+            Assert.Contains("- G128", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/reviews/G128.request.json", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentReviewCommand.SubmitExecutor = originalSubmitExecutor;
+            GenerateFromCurrentReviewCommand.ReviewRunExecutor = originalReviewRunExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentReviewCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-review-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReviewRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReviewRendererTests.cs
@@ -1,0 +1,80 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentReviewRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenReviewResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentReviewRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentReviewResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G128/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/128"],
+                WorktreePaths = [".intent-cli/worktrees/G128"],
+                StartedExecutionUnits = ["G128"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G128.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/128"],
+                ReviewExecutionUnits = ["G128"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G128.request.json"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current review processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Review request artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/reviews/G128.request.json", output, StringComparison.Ordinal);
+        Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/128", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_RendersNoneEntries()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentReviewRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentReviewResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                StandardIntakeArtifactPaths = [],
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                StartedExecutionUnits = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                ReadinessStatus = "not-ready",
+                SkippedStages = ["submit-review", "review-request"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+        Assert.Contains("- review-request", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current review <domain> --from-path <path>` to compose source bundle, reconstruction, bridge, advance, launch, implement handoff, submit, and review request generation
- reuse `review run` through an internal core result so composed flows can return deterministic review request artifact refs without changing the outward command contract
- add renderer, router, and composition tests for ready and not-ready review paths

## Testing
- dotnet test IntentSystem.sln