### PR TITLE
[G52] Add generate-from-current accept command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentAcceptCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentAcceptCommand.cs
@@ -1,0 +1,102 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentAcceptCommand
+{
+    private static readonly string[] DeferredAcceptStages =
+    [
+        "accepted-closeout"
+    ];
+
+    public static Func<CliContext, string[], GenerateFromCurrentReviewResult> ReviewExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentReviewCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string, ReviewAcceptResult> ReviewAcceptExecutor { get; set; } =
+        (context, executionUnit) => ReviewAcceptCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentAcceptRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentAcceptResult ExecuteCore(CliContext context, string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current accept requires a domain.");
+        }
+
+        var reviewResult = ReviewExecutor(context, args);
+        if (!string.Equals(reviewResult.ReadinessStatus, "ready", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentAcceptResult
+            {
+                Domain = reviewResult.Domain,
+                SourceBundleArtifactPath = reviewResult.SourceBundleArtifactPath,
+                ReconstructedArtifactPaths = reviewResult.ReconstructedArtifactPaths,
+                StandardIntakeArtifactPaths = reviewResult.StandardIntakeArtifactPaths,
+                UpdatedSourceFilePaths = reviewResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = reviewResult.UpdatedExecutionFilePaths,
+                GeneratedIssueArtifactPaths = reviewResult.GeneratedIssueArtifactPaths,
+                CreatedIssueRefs = reviewResult.CreatedIssueRefs,
+                WorktreePaths = reviewResult.WorktreePaths,
+                StartedExecutionUnits = reviewResult.StartedExecutionUnits,
+                ImplementRequestArtifactPaths = reviewResult.ImplementRequestArtifactPaths,
+                CreatedPrRefs = reviewResult.CreatedPrRefs,
+                ReviewExecutionUnits = reviewResult.ReviewExecutionUnits,
+                ReviewRequestArtifactPaths = reviewResult.ReviewRequestArtifactPaths,
+                MergedPrRefs = [],
+                ClosedIssueRefs = [],
+                CompletedExecutionUnits = [],
+                ReadinessStatus = reviewResult.ReadinessStatus,
+                SkippedStages = reviewResult.SkippedStages.Concat(DeferredAcceptStages).ToArray()
+            };
+        }
+
+        var acceptResults = reviewResult.ReviewExecutionUnits
+            .Select(executionUnit => ReviewAcceptExecutor(context, executionUnit))
+            .ToArray();
+
+        var skippedStages = new List<string>(reviewResult.SkippedStages);
+        if (acceptResults.Length == 0)
+        {
+            skippedStages.Add("accepted-closeout");
+        }
+
+        return new GenerateFromCurrentAcceptResult
+        {
+            Domain = reviewResult.Domain,
+            SourceBundleArtifactPath = reviewResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = reviewResult.ReconstructedArtifactPaths,
+            StandardIntakeArtifactPaths = reviewResult.StandardIntakeArtifactPaths,
+            UpdatedSourceFilePaths = reviewResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = reviewResult.UpdatedExecutionFilePaths,
+            GeneratedIssueArtifactPaths = reviewResult.GeneratedIssueArtifactPaths,
+            CreatedIssueRefs = reviewResult.CreatedIssueRefs,
+            WorktreePaths = reviewResult.WorktreePaths,
+            StartedExecutionUnits = reviewResult.StartedExecutionUnits,
+            ImplementRequestArtifactPaths = reviewResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = reviewResult.CreatedPrRefs,
+            ReviewExecutionUnits = reviewResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = reviewResult.ReviewRequestArtifactPaths,
+            MergedPrRefs = acceptResults.Select(result => result.MergedPrRef).ToArray(),
+            ClosedIssueRefs = acceptResults.Select(result => result.ClosedIssueRef).ToArray(),
+            CompletedExecutionUnits = acceptResults.Select(result => result.ExecutionUnit).ToArray(),
+            ReadinessStatus = reviewResult.ReadinessStatus,
+            SkippedStages = skippedStages
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentAcceptRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentAcceptRenderer.cs
@@ -1,0 +1,60 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentAcceptRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentAcceptResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current accept processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine("Regenerated standard intake artifact paths:");
+        WriteList(writer, result.StandardIntakeArtifactPaths);
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Generated issue artifact paths:");
+        WriteList(writer, result.GeneratedIssueArtifactPaths);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Merged PR refs:");
+        WriteList(writer, result.MergedPrRefs);
+        writer.WriteLine("Closed issue refs:");
+        WriteList(writer, result.ClosedIssueRefs);
+        writer.WriteLine("Completed execution units:");
+        WriteList(writer, result.CompletedExecutionUnits);
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentAcceptResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentAcceptResult.cs
@@ -1,0 +1,42 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentAcceptResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StandardIntakeArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> GeneratedIssueArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> MergedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ClosedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> CompletedExecutionUnits { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -58,6 +58,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "accept", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentAcceptCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "implement", StringComparison.Ordinal))
         {
             return GenerateFromCurrentImplementCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/ReviewAcceptCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewAcceptCommand.cs
@@ -28,66 +28,10 @@ internal static class ReviewAcceptCommand
             return 1;
         }
 
-        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
-        if (queueState is null)
-        {
-            return 1;
-        }
-
-        var executionUnit = args[0];
-        var queueItem = queueState.Items.FirstOrDefault(item =>
-            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
-
-        if (queueItem is null)
-        {
-            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
-            return 1;
-        }
-
-        var runLogPath = context.GetRunLogPath();
-        if (!File.Exists(runLogPath))
-        {
-            writer.WriteLine($"Run log was not found at {runLogPath}");
-            return 1;
-        }
-
-        var packetPath = Path.Combine(
-            context.RepoRoot,
-            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
-        if (!File.Exists(packetPath))
-        {
-            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
-            return 1;
-        }
-
         try
         {
-            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
-            var linkedPr = LatestLinkedPrResolver.Resolve(runEvents, executionUnit);
-            var linkedIssue = LatestLinkedIssueResolver.Resolve(runEvents, executionUnit);
-            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
-            var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
-            if (string.IsNullOrWhiteSpace(childRepoRef))
-            {
-                throw new InvalidOperationException("Projection packet must contain a target repo.");
-            }
-
-            var acceptClient = AcceptClientFactory();
-            var mergedCommitSha = acceptClient.MergePullRequest(linkedPr);
-            acceptClient.CloseIssue(linkedIssue);
-
-            var gitRunner = GitCommandRunnerFactory();
-            ChildRepoMainSynchronizer.Sync(context.RepoRoot, childRepoRef, mergedCommitSha, gitRunner);
-            ParentSubmodulePointerUpdater.Stage(context.RepoRoot, childRepoRef, gitRunner);
-
-            var timestamp = TimestampFactory();
-            var transition = QueueManager.AcceptReview(queueState, executionUnit, TransitionActor, timestamp);
-            PersistCloseout(
-                context,
-                transition.UpdatedState,
-                CreateCloseoutEvents(executionUnit, linkedPr, linkedIssue, timestamp));
-
-            writer.WriteLine($"Review accepted for {executionUnit}.");
+            var result = ExecuteCore(context, args[0]);
+            writer.WriteLine($"Review accepted for {result.ExecutionUnit}.");
             return 0;
         }
         catch (InvalidOperationException exception)
@@ -95,6 +39,73 @@ internal static class ReviewAcceptCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static ReviewAcceptResult ExecuteCore(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var queueStatePath = context.GetQueueStatePath();
+        var queueState = QueueCommandSupport.LoadQueueState(context, TextWriter.Null);
+        if (queueState is null)
+        {
+            throw new InvalidOperationException($"No queue state found at {queueStatePath}");
+        }
+
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            throw new InvalidOperationException($"Execution unit '{executionUnit}' was not found in queue state.");
+        }
+
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            throw new InvalidOperationException($"Run log was not found at {runLogPath}");
+        }
+
+        var packetPath = Path.Combine(
+            context.RepoRoot,
+            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(packetPath))
+        {
+            throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
+        }
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        var linkedPr = LatestLinkedPrResolver.Resolve(runEvents, executionUnit);
+        var linkedIssue = LatestLinkedIssueResolver.Resolve(runEvents, executionUnit);
+        var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+        var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
+        if (string.IsNullOrWhiteSpace(childRepoRef))
+        {
+            throw new InvalidOperationException("Projection packet must contain a target repo.");
+        }
+
+        var acceptClient = AcceptClientFactory();
+        var mergedCommitSha = acceptClient.MergePullRequest(linkedPr);
+        acceptClient.CloseIssue(linkedIssue);
+
+        var gitRunner = GitCommandRunnerFactory();
+        ChildRepoMainSynchronizer.Sync(context.RepoRoot, childRepoRef, mergedCommitSha, gitRunner);
+        ParentSubmodulePointerUpdater.Stage(context.RepoRoot, childRepoRef, gitRunner);
+
+        var timestamp = TimestampFactory();
+        var transition = QueueManager.AcceptReview(queueState, executionUnit, TransitionActor, timestamp);
+        PersistCloseout(
+            context,
+            transition.UpdatedState,
+            CreateCloseoutEvents(executionUnit, linkedPr, linkedIssue, timestamp));
+
+        return new ReviewAcceptResult
+        {
+            ExecutionUnit = executionUnit,
+            MergedPrRef = linkedPr,
+            ClosedIssueRef = linkedIssue
+        };
     }
 
     private static IReadOnlyList<RunEvent> CreateCloseoutEvents(

--- a/src/IntentSystem.Cli/Commands/ReviewAcceptResult.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewAcceptResult.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record ReviewAcceptResult
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required string MergedPrRef { get; init; }
+
+    public required string ClosedIssueRef { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -252,6 +252,34 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentAcceptCommand_DispatchesToAcceptRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "accept", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current accept processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentAcceptCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentAcceptCommandTests.cs
@@ -1,0 +1,195 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentAcceptCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_NotReadyAfterBridge_DefersAcceptedCloseout()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["accept", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current accept processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+            Assert.Contains("Merged PR refs:", output, StringComparison.Ordinal);
+            Assert.Contains("Closed issue refs:", output, StringComparison.Ordinal);
+            Assert.Contains("- accepted-closeout", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenReadyStageResults_ComposesToCompletedSummary()
+    {
+        using var writer = new StringWriter();
+        var originalReviewExecutor = GenerateFromCurrentAcceptCommand.ReviewExecutor;
+        var originalReviewAcceptExecutor = GenerateFromCurrentAcceptCommand.ReviewAcceptExecutor;
+
+        try
+        {
+            GenerateFromCurrentAcceptCommand.ReviewExecutor = (_, _) => new GenerateFromCurrentReviewResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G130/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/130"],
+                WorktreePaths = [".intent-cli/worktrees/G130"],
+                StartedExecutionUnits = ["G130"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G130.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/130"],
+                ReviewExecutionUnits = ["G130"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G130.request.json"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+            GenerateFromCurrentAcceptCommand.ReviewAcceptExecutor = (_, executionUnit) => new ReviewAcceptResult
+            {
+                ExecutionUnit = executionUnit,
+                MergedPrRef = "https://github.com/J-Tech-Japan/intent-system/pull/130",
+                ClosedIssueRef = "https://github.com/J-Tech-Japan/intent-system/issues/130"
+            };
+
+            var exitCode = GenerateFromCurrentAcceptCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/130", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/issues/130", output, StringComparison.Ordinal);
+            Assert.Contains("Completed execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- G130", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentAcceptCommand.ReviewExecutor = originalReviewExecutor;
+            GenerateFromCurrentAcceptCommand.ReviewAcceptExecutor = originalReviewAcceptExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentAcceptCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-accept-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentAcceptRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentAcceptRendererTests.cs
@@ -1,0 +1,87 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentAcceptRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenAcceptResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentAcceptRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentAcceptResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G130/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/130"],
+                WorktreePaths = [".intent-cli/worktrees/G130"],
+                StartedExecutionUnits = ["G130"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G130.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/130"],
+                ReviewExecutionUnits = ["G130"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G130.request.json"],
+                MergedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/130"],
+                ClosedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/130"],
+                CompletedExecutionUnits = ["G130"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current accept processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Merged PR refs:", output, StringComparison.Ordinal);
+        Assert.Contains("Closed issue refs:", output, StringComparison.Ordinal);
+        Assert.Contains("Completed execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("- G130", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_RendersNoneEntries()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentAcceptRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentAcceptResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                StandardIntakeArtifactPaths = [],
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                StartedExecutionUnits = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                MergedPrRefs = [],
+                ClosedIssueRefs = [],
+                CompletedExecutionUnits = [],
+                ReadinessStatus = "not-ready",
+                SkippedStages = ["review-request", "accepted-closeout"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+        Assert.Contains("- accepted-closeout", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current accept <domain> --from-path <path>` to compose source bundle, reconstruction, bridge, advance, launch, implement handoff, submit, review request generation, and accepted closeout
- reuse `review accept` through an internal core result so composed flows can return deterministic merged PR refs and closed issue refs without changing the outward command contract
- add renderer, router, and composition tests for ready and not-ready accept paths

## Testing
- dotnet test IntentSystem.sln