### PR TITLE
[G53] Add generate-from-current comment command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -64,6 +64,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "comment", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentCommentCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "implement", StringComparison.Ordinal))
         {
             return GenerateFromCurrentImplementCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommentCommand.cs
@@ -1,0 +1,135 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentCommentCommand
+{
+    private static readonly string[] DeferredCommentStages =
+    [
+        "review-comment"
+    ];
+
+    public static Func<CliContext, string[], GenerateFromCurrentReviewResult> ReviewExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentReviewCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string, string, ReviewCommentResult> ReviewCommentExecutor { get; set; } =
+        (context, executionUnit, bodyPath) => ReviewCommentCommand.ExecuteCore(context, executionUnit, bodyPath);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentCommentRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentCommentResult ExecuteCore(CliContext context, string[] args)
+    {
+        var (pipelineArgs, bodyPath) = ParseArgs(args);
+        var reviewResult = ReviewExecutor(context, pipelineArgs);
+        if (!string.Equals(reviewResult.ReadinessStatus, "ready", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentCommentResult
+            {
+                Domain = reviewResult.Domain,
+                SourceBundleArtifactPath = reviewResult.SourceBundleArtifactPath,
+                ReconstructedArtifactPaths = reviewResult.ReconstructedArtifactPaths,
+                StandardIntakeArtifactPaths = reviewResult.StandardIntakeArtifactPaths,
+                UpdatedSourceFilePaths = reviewResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = reviewResult.UpdatedExecutionFilePaths,
+                GeneratedIssueArtifactPaths = reviewResult.GeneratedIssueArtifactPaths,
+                CreatedIssueRefs = reviewResult.CreatedIssueRefs,
+                WorktreePaths = reviewResult.WorktreePaths,
+                StartedExecutionUnits = reviewResult.StartedExecutionUnits,
+                ImplementRequestArtifactPaths = reviewResult.ImplementRequestArtifactPaths,
+                CreatedPrRefs = reviewResult.CreatedPrRefs,
+                ReviewExecutionUnits = reviewResult.ReviewExecutionUnits,
+                ReviewRequestArtifactPaths = reviewResult.ReviewRequestArtifactPaths,
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                ReadinessStatus = reviewResult.ReadinessStatus,
+                SkippedStages = reviewResult.SkippedStages.Concat(DeferredCommentStages).ToArray()
+            };
+        }
+
+        var commentResults = reviewResult.ReviewExecutionUnits
+            .Select(executionUnit => ReviewCommentExecutor(context, executionUnit, bodyPath))
+            .ToArray();
+
+        var skippedStages = new List<string>(reviewResult.SkippedStages);
+        if (commentResults.Length == 0)
+        {
+            skippedStages.Add("review-comment");
+        }
+
+        return new GenerateFromCurrentCommentResult
+        {
+            Domain = reviewResult.Domain,
+            SourceBundleArtifactPath = reviewResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = reviewResult.ReconstructedArtifactPaths,
+            StandardIntakeArtifactPaths = reviewResult.StandardIntakeArtifactPaths,
+            UpdatedSourceFilePaths = reviewResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = reviewResult.UpdatedExecutionFilePaths,
+            GeneratedIssueArtifactPaths = reviewResult.GeneratedIssueArtifactPaths,
+            CreatedIssueRefs = reviewResult.CreatedIssueRefs,
+            WorktreePaths = reviewResult.WorktreePaths,
+            StartedExecutionUnits = reviewResult.StartedExecutionUnits,
+            ImplementRequestArtifactPaths = reviewResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = reviewResult.CreatedPrRefs,
+            ReviewExecutionUnits = reviewResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = reviewResult.ReviewRequestArtifactPaths,
+            PostedCommentArtifactPaths = commentResults.Select(result => result.ArtifactPath).ToArray(),
+            CommentRefs = commentResults.Select(result => result.CommentRef).ToArray(),
+            FixingExecutionUnits = commentResults.Select(result => result.ExecutionUnit).ToArray(),
+            ReadinessStatus = reviewResult.ReadinessStatus,
+            SkippedStages = skippedStages
+        };
+    }
+
+    private static (string[] PipelineArgs, string BodyPath) ParseArgs(string[] args)
+    {
+        if (args.Length < 3 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException(
+                "Generate-from-current comment requires a domain, source selection args, and '--from-file <path>'.");
+        }
+
+        string? bodyPath = null;
+        var pipelineArgs = new List<string>();
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            if (string.Equals(argument, "--from-file", StringComparison.Ordinal))
+            {
+                if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                {
+                    throw new InvalidOperationException("--from-file requires a value.");
+                }
+
+                bodyPath = args[index + 1];
+                index++;
+                continue;
+            }
+
+            pipelineArgs.Add(argument);
+        }
+
+        if (string.IsNullOrWhiteSpace(bodyPath))
+        {
+            throw new InvalidOperationException("Generate-from-current comment requires '--from-file <path>'.");
+        }
+
+        return (pipelineArgs.ToArray(), bodyPath);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommentRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommentRenderer.cs
@@ -1,0 +1,60 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentCommentRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentCommentResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current comment processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine("Regenerated standard intake artifact paths:");
+        WriteList(writer, result.StandardIntakeArtifactPaths);
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Generated issue artifact paths:");
+        WriteList(writer, result.GeneratedIssueArtifactPaths);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Posted comment artifact paths:");
+        WriteList(writer, result.PostedCommentArtifactPaths);
+        writer.WriteLine("Comment refs:");
+        WriteList(writer, result.CommentRefs);
+        writer.WriteLine("Fixing execution units:");
+        WriteList(writer, result.FixingExecutionUnits);
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommentResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommentResult.cs
@@ -1,0 +1,42 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentCommentResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StandardIntakeArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> GeneratedIssueArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> PostedCommentArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CommentRefs { get; init; }
+
+    public required IReadOnlyList<string> FixingExecutionUnits { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/ReviewCommentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCommentCommand.cs
@@ -29,20 +29,38 @@ internal static class ReviewCommentCommand
             return 1;
         }
 
-        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
-        if (queueState is null)
+        try
         {
+            var result = ExecuteCore(context, args[0], args[2]);
+            writer.WriteLine($"Review comment posted for {result.ExecutionUnit}.");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
             return 1;
         }
+    }
 
-        var executionUnit = args[0];
+    internal static ReviewCommentResult ExecuteCore(CliContext context, string executionUnit, string bodyPathArg)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(bodyPathArg);
+
+        var queueStatePath = context.GetQueueStatePath();
+        var queueState = QueueCommandSupport.LoadQueueState(context, TextWriter.Null);
+        if (queueState is null)
+        {
+            throw new InvalidOperationException($"No queue state found at {queueStatePath}");
+        }
+
         var queueItem = queueState.Items.FirstOrDefault(item =>
             string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
 
         if (queueItem is null)
         {
-            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
-            return 1;
+            throw new InvalidOperationException($"Execution unit '{executionUnit}' was not found in queue state.");
         }
 
         var reviewRequestRef = ReviewArtifactPathResolver.Resolve(executionUnit);
@@ -51,75 +69,68 @@ internal static class ReviewCommentCommand
             reviewRequestRef.Replace('/', Path.DirectorySeparatorChar));
         if (!File.Exists(reviewRequestPath))
         {
-            writer.WriteLine($"Review request artifact was not found at {reviewRequestPath}");
-            return 1;
+            throw new InvalidOperationException($"Review request artifact was not found at {reviewRequestPath}");
         }
 
-        var bodyPath = ResolveBodyPath(context.RepoRoot, args[2]);
+        var bodyPath = ResolveBodyPath(context.RepoRoot, bodyPathArg);
         if (!File.Exists(bodyPath))
         {
-            writer.WriteLine($"Review comment body file was not found at {bodyPath}");
-            return 1;
+            throw new InvalidOperationException($"Review comment body file was not found at {bodyPath}");
         }
 
         var body = File.ReadAllText(bodyPath);
         if (string.IsNullOrWhiteSpace(body))
         {
-            writer.WriteLine("Review comment body file must not be empty.");
-            return 1;
+            throw new InvalidOperationException("Review comment body file must not be empty.");
         }
 
-        try
+        var request = ReviewRequestSerializer.Deserialize(File.ReadAllText(reviewRequestPath));
+        if (!string.Equals(request.ExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
         {
-            var request = ReviewRequestSerializer.Deserialize(File.ReadAllText(reviewRequestPath));
-            if (!string.Equals(request.ExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"Review request execution unit '{request.ExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.LinkedPr))
+        {
+            throw new InvalidOperationException("Review request must contain a linked PR.");
+        }
+
+        var commentRef = PublisherFactory().PostComment(request.LinkedPr, body);
+        var artifact = new ReviewCommentArtifact
+        {
+            ExecutionUnit = executionUnit,
+            ReviewRequestRef = reviewRequestRef,
+            LinkedPr = request.LinkedPr,
+            CommentRef = commentRef,
+            BodyPath = bodyPath
+        };
+
+        ReviewCommentArtifactWriter.Write(artifact, executionUnit, context.RepoRoot, overwrite: true);
+
+        var transition = QueueManager.RequestFix(
+            queueState,
+            executionUnit,
+            TransitionActor,
+            TimestampFactory());
+
+        PersistTransition(
+            context,
+            transition with
             {
-                throw new InvalidOperationException(
-                    $"Review request execution unit '{request.ExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
-            }
-
-            if (string.IsNullOrWhiteSpace(request.LinkedPr))
-            {
-                throw new InvalidOperationException("Review request must contain a linked PR.");
-            }
-
-            var commentRef = PublisherFactory().PostComment(request.LinkedPr, body);
-            var artifact = new ReviewCommentArtifact
-            {
-                ExecutionUnit = executionUnit,
-                ReviewRequestRef = reviewRequestRef,
-                LinkedPr = request.LinkedPr,
-                CommentRef = commentRef,
-                BodyPath = bodyPath
-            };
-
-            ReviewCommentArtifactWriter.Write(artifact, executionUnit, context.RepoRoot, overwrite: true);
-
-            var transition = QueueManager.RequestFix(
-                queueState,
-                executionUnit,
-                TransitionActor,
-                TimestampFactory());
-
-            PersistTransition(
-                context,
-                transition with
+                Event = transition.Event with
                 {
-                    Event = transition.Event with
-                    {
-                        LinkedPr = request.LinkedPr,
-                        CommentRef = commentRef
-                    }
-                });
+                    LinkedPr = request.LinkedPr,
+                    CommentRef = commentRef
+                }
+            });
 
-            writer.WriteLine($"Review comment posted for {executionUnit}.");
-            return 0;
-        }
-        catch (InvalidOperationException exception)
+        return new ReviewCommentResult
         {
-            writer.WriteLine(exception.Message);
-            return 1;
-        }
+            ExecutionUnit = executionUnit,
+            ArtifactPath = Review.ReviewCommentArtifactPathResolver.Resolve(executionUnit),
+            CommentRef = commentRef
+        };
     }
 
     private static string ResolveBodyPath(string repoRoot, string rawPath)

--- a/src/IntentSystem.Cli/Commands/ReviewCommentResult.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCommentResult.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record ReviewCommentResult
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required string ArtifactPath { get; init; }
+
+    public required string CommentRef { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -280,6 +280,35 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentCommentCommand_DispatchesToCommentRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("repo", "repair-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "comment", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution", "--from-file", "repair-comment.md"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current comment processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCommentCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCommentCommandTests.cs
@@ -1,0 +1,199 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentCommentCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_NotReadyAfterBridge_DefersReviewComment()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("repo", "repair-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["comment", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution", "--from-file", "repair-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current comment processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+            Assert.Contains("Posted comment artifact paths:", output, StringComparison.Ordinal);
+            Assert.Contains("- review-comment", output, StringComparison.Ordinal);
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "reviews", "G132.comment.json")));
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenReadyStageResults_ComposesToFixingSummary()
+    {
+        using var writer = new StringWriter();
+        var originalReviewExecutor = GenerateFromCurrentCommentCommand.ReviewExecutor;
+        var originalReviewCommentExecutor = GenerateFromCurrentCommentCommand.ReviewCommentExecutor;
+
+        try
+        {
+            GenerateFromCurrentCommentCommand.ReviewExecutor = (_, _) => new GenerateFromCurrentReviewResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G132/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/132"],
+                WorktreePaths = [".intent-cli/worktrees/G132"],
+                StartedExecutionUnits = ["G132"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G132.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/132"],
+                ReviewExecutionUnits = ["G132"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G132.request.json"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+            GenerateFromCurrentCommentCommand.ReviewCommentExecutor = (_, executionUnit, _) => new ReviewCommentResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.comment.json",
+                CommentRef = $"https://github.com/J-Tech-Japan/intent-system/pull/{executionUnit[1..]}#issuecomment-1"
+            };
+
+            var exitCode = GenerateFromCurrentCommentCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature", "--from-file", "repair-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/reviews/G132.comment.json", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/132#issuecomment-1", output, StringComparison.Ordinal);
+            Assert.Contains("Fixing execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- G132", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommentCommand.ReviewExecutor = originalReviewExecutor;
+            GenerateFromCurrentCommentCommand.ReviewCommentExecutor = originalReviewCommentExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFromFile_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentCommentCommand.Execute(
+            CreateContext("/tmp/intent-system"),
+            ["auth", "--from-path", "src/feature"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-file", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-comment-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCommentRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCommentRendererTests.cs
@@ -1,0 +1,87 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentCommentRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenCommentResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentCommentRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentCommentResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G132/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/132"],
+                WorktreePaths = [".intent-cli/worktrees/G132"],
+                StartedExecutionUnits = ["G132"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G132.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/132"],
+                ReviewExecutionUnits = ["G132"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G132.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/G132.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/132#issuecomment-1"],
+                FixingExecutionUnits = ["G132"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current comment processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Posted comment artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Comment refs:", output, StringComparison.Ordinal);
+        Assert.Contains("Fixing execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("- G132", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_RendersNoneEntries()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentCommentRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentCommentResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                StandardIntakeArtifactPaths = [],
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                StartedExecutionUnits = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                ReadinessStatus = "not-ready",
+                SkippedStages = ["review-request", "review-comment"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+        Assert.Contains("- review-comment", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current comment <domain> --from-path <path> --from-file <path>` to compose source bundle, reconstruction, bridge, advance, launch, implement handoff, submit, review request generation, and review comment return
- reuse `review comment` through an internal core result so composed flows can return deterministic comment artifact refs and comment refs without changing the outward command contract
- add renderer, router, and composition tests for ready and not-ready comment paths

## Testing
- dotnet test IntentSystem.sln