### PR TITLE
[codex] add generate-from-current fix command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -70,6 +70,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "fix", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentFixCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "implement", StringComparison.Ordinal))
         {
             return GenerateFromCurrentImplementCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentFixCommand.cs
@@ -1,0 +1,104 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentFixCommand
+{
+    private static readonly string[] DeferredFixStages =
+    [
+        "fix-handoff"
+    ];
+
+    public static Func<CliContext, string[], GenerateFromCurrentCommentResult> CommentExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentCommentCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string, RunFixResult> RunFixExecutor { get; set; } =
+        (context, executionUnit) => RunFixCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentFixRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentFixResult ExecuteCore(CliContext context, string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current fix requires a domain.");
+        }
+
+        var commentResult = CommentExecutor(context, args);
+        if (!string.Equals(commentResult.ReadinessStatus, "ready", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentFixResult
+            {
+                Domain = commentResult.Domain,
+                SourceBundleArtifactPath = commentResult.SourceBundleArtifactPath,
+                ReconstructedArtifactPaths = commentResult.ReconstructedArtifactPaths,
+                StandardIntakeArtifactPaths = commentResult.StandardIntakeArtifactPaths,
+                UpdatedSourceFilePaths = commentResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = commentResult.UpdatedExecutionFilePaths,
+                GeneratedIssueArtifactPaths = commentResult.GeneratedIssueArtifactPaths,
+                CreatedIssueRefs = commentResult.CreatedIssueRefs,
+                WorktreePaths = commentResult.WorktreePaths,
+                StartedExecutionUnits = commentResult.StartedExecutionUnits,
+                ImplementRequestArtifactPaths = commentResult.ImplementRequestArtifactPaths,
+                CreatedPrRefs = commentResult.CreatedPrRefs,
+                ReviewExecutionUnits = commentResult.ReviewExecutionUnits,
+                ReviewRequestArtifactPaths = commentResult.ReviewRequestArtifactPaths,
+                PostedCommentArtifactPaths = commentResult.PostedCommentArtifactPaths,
+                CommentRefs = commentResult.CommentRefs,
+                FixingExecutionUnits = commentResult.FixingExecutionUnits,
+                FixRequestArtifactPaths = [],
+                ReadinessStatus = commentResult.ReadinessStatus,
+                SkippedStages = commentResult.SkippedStages.Concat(DeferredFixStages).ToArray()
+            };
+        }
+
+        var fixResults = commentResult.FixingExecutionUnits
+            .Select(executionUnit => RunFixExecutor(context, executionUnit))
+            .ToArray();
+
+        var skippedStages = new List<string>(commentResult.SkippedStages);
+        if (fixResults.Length == 0)
+        {
+            skippedStages.Add("fix-handoff");
+        }
+
+        return new GenerateFromCurrentFixResult
+        {
+            Domain = commentResult.Domain,
+            SourceBundleArtifactPath = commentResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = commentResult.ReconstructedArtifactPaths,
+            StandardIntakeArtifactPaths = commentResult.StandardIntakeArtifactPaths,
+            UpdatedSourceFilePaths = commentResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = commentResult.UpdatedExecutionFilePaths,
+            GeneratedIssueArtifactPaths = commentResult.GeneratedIssueArtifactPaths,
+            CreatedIssueRefs = commentResult.CreatedIssueRefs,
+            WorktreePaths = commentResult.WorktreePaths,
+            StartedExecutionUnits = commentResult.StartedExecutionUnits,
+            ImplementRequestArtifactPaths = commentResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = commentResult.CreatedPrRefs,
+            ReviewExecutionUnits = commentResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = commentResult.ReviewRequestArtifactPaths,
+            PostedCommentArtifactPaths = commentResult.PostedCommentArtifactPaths,
+            CommentRefs = commentResult.CommentRefs,
+            FixingExecutionUnits = commentResult.FixingExecutionUnits,
+            FixRequestArtifactPaths = fixResults.Select(result => result.ArtifactPath).ToArray(),
+            ReadinessStatus = commentResult.ReadinessStatus,
+            SkippedStages = skippedStages
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentFixRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentFixRenderer.cs
@@ -1,0 +1,62 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentFixRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentFixResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current fix processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine("Regenerated standard intake artifact paths:");
+        WriteList(writer, result.StandardIntakeArtifactPaths);
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Generated issue artifact paths:");
+        WriteList(writer, result.GeneratedIssueArtifactPaths);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Posted comment artifact paths:");
+        WriteList(writer, result.PostedCommentArtifactPaths);
+        writer.WriteLine("Comment refs:");
+        WriteList(writer, result.CommentRefs);
+        writer.WriteLine("Fixing execution units:");
+        WriteList(writer, result.FixingExecutionUnits);
+        writer.WriteLine("Fix request artifact paths:");
+        WriteList(writer, result.FixRequestArtifactPaths);
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentFixResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentFixResult.cs
@@ -1,0 +1,44 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentFixResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StandardIntakeArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> GeneratedIssueArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> PostedCommentArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CommentRefs { get; init; }
+
+    public required IReadOnlyList<string> FixingExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> FixRequestArtifactPaths { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/RunFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixCommand.cs
@@ -20,114 +20,10 @@ internal static class RunFixCommand
             return 1;
         }
 
-        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
-        if (queueState is null)
-        {
-            return 1;
-        }
-
-        var executionUnit = args[0];
-        var queueItem = queueState.Items.FirstOrDefault(item =>
-            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
-
-        if (queueItem is null)
-        {
-            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
-            return 1;
-        }
-
-        if (queueItem.State is not QueueItemState.Fixing)
-        {
-            writer.WriteLine(
-                $"Execution unit '{executionUnit}' must be fixing before run fix.");
-            return 1;
-        }
-
-        if (queueItem.LinkedIssue is null)
-        {
-            writer.WriteLine($"Execution unit '{executionUnit}' must have a linked issue before run fix.");
-            return 1;
-        }
-
-        var packetPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.Yaml);
-        if (!File.Exists(packetPath))
-        {
-            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
-            return 1;
-        }
-
-        var reviewContextPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.ReviewContext);
-        if (!File.Exists(reviewContextPath))
-        {
-            writer.WriteLine($"Review context artifact was not found at {reviewContextPath}");
-            return 1;
-        }
-
-        var reviewCommentArtifactRef = ReviewCommentArtifactPathResolver.Resolve(executionUnit);
-        var reviewCommentArtifactPath = ResolveArtifactPath(context.RepoRoot, reviewCommentArtifactRef);
-        if (!File.Exists(reviewCommentArtifactPath))
-        {
-            writer.WriteLine($"Review comment artifact was not found at {reviewCommentArtifactPath}");
-            return 1;
-        }
-
         try
         {
-            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
-            var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
-            if (string.IsNullOrWhiteSpace(childRepoRef))
-            {
-                throw new InvalidOperationException("Projection packet must contain a target repo.");
-            }
-
-            var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
-            if (!Directory.Exists(childRepoPath))
-            {
-                throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
-            }
-
-            var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
-            if (!Directory.Exists(worktreePath))
-            {
-                throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
-            }
-
-            var reviewContext = ReviewContextMarkdownParser.Parse(File.ReadAllText(reviewContextPath));
-            if (!string.Equals(reviewContext.SourceExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"Review context execution unit '{reviewContext.SourceExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
-            }
-
-            var reviewCommentArtifact = ReviewCommentArtifactSerializer.Deserialize(
-                File.ReadAllText(reviewCommentArtifactPath));
-            if (!string.Equals(reviewCommentArtifact.ExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"Review comment artifact execution unit '{reviewCommentArtifact.ExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
-            }
-
-            var latestLinkedPr = ResolveLatestLinkedPr(context, executionUnit);
-            if (!string.Equals(reviewCommentArtifact.LinkedPr, latestLinkedPr, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"Review comment artifact linked PR '{reviewCommentArtifact.LinkedPr}' must match latest linked PR '{latestLinkedPr}'.");
-            }
-
-            var request = BuildRequest(
-                context,
-                queueItem,
-                packet,
-                reviewContext,
-                reviewCommentArtifactRef,
-                reviewCommentArtifact,
-                worktreePath,
-                childRepoPath,
-                latestLinkedPr);
-            var markdown = RunFixRenderer.RenderMarkdown(request);
-            var artifactPath = RunFixArtifactWriter.Write(markdown, executionUnit, context.RepoRoot, overwrite: true);
-            RunFixRenderer.WriteSummary(writer, request, artifactPath);
-
+            var result = ExecuteCore(context, args[0]);
+            RunFixRenderer.WriteSummary(writer, result.Request, result.ArtifactPath);
             return 0;
         }
         catch (InvalidOperationException exception)
@@ -135,6 +31,118 @@ internal static class RunFixCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static RunFixResult ExecuteCore(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var queueStatePath = context.GetQueueStatePath();
+        var queueState = QueueCommandSupport.LoadQueueState(context, TextWriter.Null);
+        if (queueState is null)
+        {
+            throw new InvalidOperationException($"No queue state found at {queueStatePath}");
+        }
+
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            throw new InvalidOperationException($"Execution unit '{executionUnit}' was not found in queue state.");
+        }
+
+        if (queueItem.State is not QueueItemState.Fixing)
+        {
+            throw new InvalidOperationException(
+                $"Execution unit '{executionUnit}' must be fixing before run fix.");
+        }
+
+        if (queueItem.LinkedIssue is null)
+        {
+            throw new InvalidOperationException(
+                $"Execution unit '{executionUnit}' must have a linked issue before run fix.");
+        }
+
+        var packetPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.Yaml);
+        if (!File.Exists(packetPath))
+        {
+            throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
+        }
+
+        var reviewContextPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.ReviewContext);
+        if (!File.Exists(reviewContextPath))
+        {
+            throw new InvalidOperationException($"Review context artifact was not found at {reviewContextPath}");
+        }
+
+        var reviewCommentArtifactRef = ReviewCommentArtifactPathResolver.Resolve(executionUnit);
+        var reviewCommentArtifactPath = ResolveArtifactPath(context.RepoRoot, reviewCommentArtifactRef);
+        if (!File.Exists(reviewCommentArtifactPath))
+        {
+            throw new InvalidOperationException($"Review comment artifact was not found at {reviewCommentArtifactPath}");
+        }
+
+        var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+        var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
+        if (string.IsNullOrWhiteSpace(childRepoRef))
+        {
+            throw new InvalidOperationException("Projection packet must contain a target repo.");
+        }
+
+        var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
+        if (!Directory.Exists(childRepoPath))
+        {
+            throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+        }
+
+        var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
+        if (!Directory.Exists(worktreePath))
+        {
+            throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
+        }
+
+        var reviewContext = ReviewContextMarkdownParser.Parse(File.ReadAllText(reviewContextPath));
+        if (!string.Equals(reviewContext.SourceExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Review context execution unit '{reviewContext.SourceExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
+        }
+
+        var reviewCommentArtifact = ReviewCommentArtifactSerializer.Deserialize(
+            File.ReadAllText(reviewCommentArtifactPath));
+        if (!string.Equals(reviewCommentArtifact.ExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Review comment artifact execution unit '{reviewCommentArtifact.ExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
+        }
+
+        var latestLinkedPr = ResolveLatestLinkedPr(context, executionUnit);
+        if (!string.Equals(reviewCommentArtifact.LinkedPr, latestLinkedPr, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Review comment artifact linked PR '{reviewCommentArtifact.LinkedPr}' must match latest linked PR '{latestLinkedPr}'.");
+        }
+
+        var request = BuildRequest(
+            context,
+            queueItem,
+            packet,
+            reviewContext,
+            reviewCommentArtifactRef,
+            reviewCommentArtifact,
+            worktreePath,
+            childRepoPath,
+            latestLinkedPr);
+        var markdown = RunFixRenderer.RenderMarkdown(request);
+        var artifactPath = RunFixArtifactWriter.Write(markdown, executionUnit, context.RepoRoot, overwrite: true);
+
+        return new RunFixResult
+        {
+            Request = request,
+            ArtifactPath = ToRelativePath(context.RepoRoot, artifactPath)
+        };
     }
 
     private static RunFixRequest BuildRequest(
@@ -210,5 +218,10 @@ internal static class RunFixCommand
             QueueItemState.ClarifyBlocked => "clarify-blocked",
             _ => state.ToString().ToLowerInvariant()
         };
+    }
+
+    private static string ToRelativePath(string repoRoot, string absolutePath)
+    {
+        return Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
     }
 }

--- a/src/IntentSystem.Cli/Commands/RunFixResult.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record RunFixResult
+{
+    public required RunFixRequest Request { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -309,6 +309,35 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentFixCommand_DispatchesToFixRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("repo", "repair-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "fix", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution", "--from-file", "repair-comment.md"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current fix processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentFixCommandTests.cs
@@ -1,0 +1,226 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentFixCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_NotReadyAfterBridge_DefersFixHandoff()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("repo", "repair-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["fix", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution", "--from-file", "repair-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current fix processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+            Assert.Contains("Fix request artifact paths:", output, StringComparison.Ordinal);
+            Assert.Contains("- fix-handoff", output, StringComparison.Ordinal);
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "fix", "G134.request.md")));
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenReadyStageResults_ComposesToFixRequestSummary()
+    {
+        using var writer = new StringWriter();
+        var originalCommentExecutor = GenerateFromCurrentFixCommand.CommentExecutor;
+        var originalRunFixExecutor = GenerateFromCurrentFixCommand.RunFixExecutor;
+
+        try
+        {
+            GenerateFromCurrentFixCommand.CommentExecutor = (_, _) => new GenerateFromCurrentCommentResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G134/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/134"],
+                WorktreePaths = [".intent-cli/worktrees/G134"],
+                StartedExecutionUnits = ["G134"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G134.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/134"],
+                ReviewExecutionUnits = ["G134"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G134.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/G134.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/134#issuecomment-1"],
+                FixingExecutionUnits = ["G134"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+            GenerateFromCurrentFixCommand.RunFixExecutor = (_, executionUnit) => new RunFixResult
+            {
+                Request = new RunFixRequest
+                {
+                    ExecutionUnit = executionUnit,
+                    State = "fixing",
+                    ImplementRole = "Claude",
+                    QueueWorkerRole = "coder",
+                    QueueReviewRole = "reviewer",
+                    WorktreePath = $".intent-cli/worktrees/{executionUnit}",
+                    ChildRepoPath = "submodules/intent-system",
+                    Branch = $"issue-134-{executionUnit.ToLowerInvariant()}",
+                    LinkedIssue = $"https://github.com/J-Tech-Japan/intent-system/issues/{executionUnit[1..]}",
+                    LatestLinkedPr = $"https://github.com/J-Tech-Japan/intent-system/pull/{executionUnit[1..]}",
+                    LatestCommentRef = $"https://github.com/J-Tech-Japan/intent-system/pull/{executionUnit[1..]}#issuecomment-1",
+                    PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                    ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                    ReviewCommentArtifactRef = $".intent-cli/reviews/{executionUnit}.comment.json",
+                    ReviewRequestRef = $".intent-cli/reviews/{executionUnit}.request.json",
+                    ReviewCommentBodyPath = "/tmp/repair-comment.md",
+                    IssueTitle = $"[{executionUnit}] Fix",
+                    Goal = "Generate fix handoff.",
+                    TargetPart = "cli",
+                    TargetRepo = "submodules/intent-system",
+                    TargetPath = ".",
+                    InScope = ["fix handoff"],
+                    OutOfScope = ["resubmit"],
+                    AcceptanceCriteria = ["handoff exists"],
+                    DeterministicReviewChecks = ["deterministic summary"],
+                    ExpectedEvidence = ["dotnet test"]
+                },
+                ArtifactPath = $".intent-cli/fix/{executionUnit}.request.md"
+            };
+
+            var exitCode = GenerateFromCurrentFixCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature", "--from-file", "repair-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/reviews/G134.comment.json", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/fix/G134.request.md", output, StringComparison.Ordinal);
+            Assert.Contains("Fixing execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- G134", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentFixCommand.CommentExecutor = originalCommentExecutor;
+            GenerateFromCurrentFixCommand.RunFixExecutor = originalRunFixExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentFixCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-fix-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentFixRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentFixRendererTests.cs
@@ -1,0 +1,88 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentFixRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenFixResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentFixRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentFixResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G134/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/134"],
+                WorktreePaths = [".intent-cli/worktrees/G134"],
+                StartedExecutionUnits = ["G134"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G134.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/134"],
+                ReviewExecutionUnits = ["G134"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G134.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/G134.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/134#issuecomment-1"],
+                FixingExecutionUnits = ["G134"],
+                FixRequestArtifactPaths = [".intent-cli/fix/G134.request.md"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current fix processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Fix request artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/fix/G134.request.md", output, StringComparison.Ordinal);
+        Assert.Contains("Fixing execution units:", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_RendersNoneEntries()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentFixRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentFixResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                StandardIntakeArtifactPaths = [],
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                StartedExecutionUnits = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ReadinessStatus = "not-ready",
+                SkippedStages = ["review-comment", "fix-handoff"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+        Assert.Contains("- fix-handoff", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current fix <domain> --from-path <path> --from-file <path>` as the thin composition from current-source bundle through review comment to fix handoff
- factor `run fix` into an internal core result so the new composition can reuse the existing fix artifact generation without changing the public command contract
- add deterministic CLI coverage for the new generate-from-current fix renderer, command, and router dispatch

## Why
Issue 134 requires a deterministic top-level command that carries the selected current-source scope through reverse-intake, launch, review comment, and fix handoff generation without expanding unrelated command contracts.

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentFix|FullyQualifiedName~RunFix|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`
