### PR TITLE
[codex] add generate-from-current resubmit command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -76,6 +76,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "resubmit", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentResubmitCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "implement", StringComparison.Ordinal))
         {
             return GenerateFromCurrentImplementCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentResubmitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentResubmitCommand.cs
@@ -1,0 +1,108 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentResubmitCommand
+{
+    private static readonly string[] DeferredResubmitStages =
+    [
+        "resubmit-trace"
+    ];
+
+    public static Func<CliContext, string[], GenerateFromCurrentFixResult> FixExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentFixCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string, RunResubmitResult> RunResubmitExecutor { get; set; } =
+        (context, executionUnit) => RunResubmitCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentResubmitRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentResubmitResult ExecuteCore(CliContext context, string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current resubmit requires a domain.");
+        }
+
+        var fixResult = FixExecutor(context, args);
+        if (!string.Equals(fixResult.ReadinessStatus, "ready", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentResubmitResult
+            {
+                Domain = fixResult.Domain,
+                SourceBundleArtifactPath = fixResult.SourceBundleArtifactPath,
+                ReconstructedArtifactPaths = fixResult.ReconstructedArtifactPaths,
+                StandardIntakeArtifactPaths = fixResult.StandardIntakeArtifactPaths,
+                UpdatedSourceFilePaths = fixResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = fixResult.UpdatedExecutionFilePaths,
+                GeneratedIssueArtifactPaths = fixResult.GeneratedIssueArtifactPaths,
+                CreatedIssueRefs = fixResult.CreatedIssueRefs,
+                WorktreePaths = fixResult.WorktreePaths,
+                StartedExecutionUnits = fixResult.StartedExecutionUnits,
+                ImplementRequestArtifactPaths = fixResult.ImplementRequestArtifactPaths,
+                CreatedPrRefs = fixResult.CreatedPrRefs,
+                ReviewExecutionUnits = fixResult.ReviewExecutionUnits,
+                ReviewRequestArtifactPaths = fixResult.ReviewRequestArtifactPaths,
+                PostedCommentArtifactPaths = fixResult.PostedCommentArtifactPaths,
+                CommentRefs = fixResult.CommentRefs,
+                FixingExecutionUnits = fixResult.FixingExecutionUnits,
+                FixRequestArtifactPaths = fixResult.FixRequestArtifactPaths,
+                ResubmittedExecutionUnits = [],
+                ResubmittedPrRefs = [],
+                ReadinessStatus = fixResult.ReadinessStatus,
+                SkippedStages = fixResult.SkippedStages.Concat(DeferredResubmitStages).ToArray()
+            };
+        }
+
+        var resubmitResults = fixResult.FixingExecutionUnits
+            .Select(executionUnit => RunResubmitExecutor(context, executionUnit))
+            .ToArray();
+
+        var skippedStages = new List<string>(fixResult.SkippedStages);
+        if (resubmitResults.Length == 0)
+        {
+            skippedStages.Add("resubmit-trace");
+        }
+
+        return new GenerateFromCurrentResubmitResult
+        {
+            Domain = fixResult.Domain,
+            SourceBundleArtifactPath = fixResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = fixResult.ReconstructedArtifactPaths,
+            StandardIntakeArtifactPaths = fixResult.StandardIntakeArtifactPaths,
+            UpdatedSourceFilePaths = fixResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = fixResult.UpdatedExecutionFilePaths,
+            GeneratedIssueArtifactPaths = fixResult.GeneratedIssueArtifactPaths,
+            CreatedIssueRefs = fixResult.CreatedIssueRefs,
+            WorktreePaths = fixResult.WorktreePaths,
+            StartedExecutionUnits = fixResult.StartedExecutionUnits,
+            ImplementRequestArtifactPaths = fixResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = fixResult.CreatedPrRefs,
+            ReviewExecutionUnits = fixResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = fixResult.ReviewRequestArtifactPaths,
+            PostedCommentArtifactPaths = fixResult.PostedCommentArtifactPaths,
+            CommentRefs = fixResult.CommentRefs,
+            FixingExecutionUnits = fixResult.FixingExecutionUnits,
+            FixRequestArtifactPaths = fixResult.FixRequestArtifactPaths,
+            ResubmittedExecutionUnits = resubmitResults.Select(result => result.ExecutionUnit).ToArray(),
+            ResubmittedPrRefs = resubmitResults.Select(result => result.LinkedPr).ToArray(),
+            ReadinessStatus = fixResult.ReadinessStatus,
+            SkippedStages = skippedStages
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentResubmitRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentResubmitRenderer.cs
@@ -1,0 +1,66 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentResubmitRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentResubmitResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current resubmit processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine("Regenerated standard intake artifact paths:");
+        WriteList(writer, result.StandardIntakeArtifactPaths);
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Generated issue artifact paths:");
+        WriteList(writer, result.GeneratedIssueArtifactPaths);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Posted comment artifact paths:");
+        WriteList(writer, result.PostedCommentArtifactPaths);
+        writer.WriteLine("Comment refs:");
+        WriteList(writer, result.CommentRefs);
+        writer.WriteLine("Fixing execution units:");
+        WriteList(writer, result.FixingExecutionUnits);
+        writer.WriteLine("Fix request artifact paths:");
+        WriteList(writer, result.FixRequestArtifactPaths);
+        writer.WriteLine("Resubmitted execution units:");
+        WriteList(writer, result.ResubmittedExecutionUnits);
+        writer.WriteLine("Resubmitted PR refs:");
+        WriteList(writer, result.ResubmittedPrRefs);
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentResubmitResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentResubmitResult.cs
@@ -1,0 +1,48 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentResubmitResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StandardIntakeArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> GeneratedIssueArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> PostedCommentArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CommentRefs { get; init; }
+
+    public required IReadOnlyList<string> FixingExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> FixRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedPrRefs { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/RunResubmitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunResubmitCommand.cs
@@ -25,94 +25,13 @@ internal static class RunResubmitCommand
             return 1;
         }
 
-        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
-        if (queueState is null)
-        {
-            return 1;
-        }
-
-        var executionUnit = args[0];
-        var queueItem = queueState.Items.FirstOrDefault(item =>
-            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
-
-        if (queueItem is null)
-        {
-            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
-            return 1;
-        }
-
-        if (queueItem.State is not QueueItemState.Fixing)
-        {
-            writer.WriteLine($"Execution unit '{executionUnit}' must be fixing before run resubmit.");
-            return 1;
-        }
-
-        if (queueItem.LinkedIssue is null)
-        {
-            writer.WriteLine($"Execution unit '{executionUnit}' must have a linked issue before run resubmit.");
-            return 1;
-        }
-
-        var packetPath = Path.Combine(
-            context.RepoRoot,
-            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
-        if (!File.Exists(packetPath))
-        {
-            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
-            return 1;
-        }
-
-        var runLogPath = context.GetRunLogPath();
-        if (!File.Exists(runLogPath))
-        {
-            writer.WriteLine($"Run log was not found at {runLogPath}");
-            return 1;
-        }
-
         try
         {
-            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
-            var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
-            if (string.IsNullOrWhiteSpace(childRepoRef))
-            {
-                throw new InvalidOperationException("Projection packet must contain a target repo.");
-            }
-
-            var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
-            if (!Directory.Exists(childRepoPath))
-            {
-                throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
-            }
-
-            var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
-            if (!Directory.Exists(worktreePath))
-            {
-                throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
-            }
-
-            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
-            var linkedPr = LatestLinkedPrResolver.Resolve(runEvents, executionUnit);
-
-            var branchName = RunStartCommand.ResolveBranchName(executionUnit, queueItem.LinkedIssue);
-            var gitRunner = GitCommandRunnerFactory();
-            EnsureBranchMatches(worktreePath, branchName, gitRunner);
-            PushBranch(worktreePath, branchName, gitRunner);
-
-            PersistRunEvent(
-                runLogPath,
-                new RunEvent
-                {
-                    Ts = TimestampFactory(),
-                    ExecutionUnit = executionUnit,
-                    Event = "resubmitted",
-                    By = EventActor,
-                    LinkedPr = linkedPr
-                });
-
-            writer.WriteLine($"Run resubmitted for {executionUnit}.");
-            writer.WriteLine($"Branch: {branchName}");
-            writer.WriteLine($"Worktree path: {worktreePath}");
-            writer.WriteLine($"Latest linked PR: {linkedPr}");
+            var result = ExecuteCore(context, args[0]);
+            writer.WriteLine($"Run resubmitted for {result.ExecutionUnit}.");
+            writer.WriteLine($"Branch: {result.Branch}");
+            writer.WriteLine($"Worktree path: {result.WorktreePath}");
+            writer.WriteLine($"Latest linked PR: {result.LinkedPr}");
             return 0;
         }
         catch (InvalidOperationException exception)
@@ -120,6 +39,97 @@ internal static class RunResubmitCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static RunResubmitResult ExecuteCore(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var queueStatePath = context.GetQueueStatePath();
+        var queueState = QueueCommandSupport.LoadQueueState(context, TextWriter.Null);
+        if (queueState is null)
+        {
+            throw new InvalidOperationException($"No queue state found at {queueStatePath}");
+        }
+
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            throw new InvalidOperationException($"Execution unit '{executionUnit}' was not found in queue state.");
+        }
+
+        if (queueItem.State is not QueueItemState.Fixing)
+        {
+            throw new InvalidOperationException($"Execution unit '{executionUnit}' must be fixing before run resubmit.");
+        }
+
+        if (queueItem.LinkedIssue is null)
+        {
+            throw new InvalidOperationException($"Execution unit '{executionUnit}' must have a linked issue before run resubmit.");
+        }
+
+        var packetPath = Path.Combine(
+            context.RepoRoot,
+            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(packetPath))
+        {
+            throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
+        }
+
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            throw new InvalidOperationException($"Run log was not found at {runLogPath}");
+        }
+
+        var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
+        var childRepoRef = packet.ImplementationIssuePacket.TargetRepo;
+        if (string.IsNullOrWhiteSpace(childRepoRef))
+        {
+            throw new InvalidOperationException("Projection packet must contain a target repo.");
+        }
+
+        var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
+        if (!Directory.Exists(childRepoPath))
+        {
+            throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+        }
+
+        var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
+        if (!Directory.Exists(worktreePath))
+        {
+            throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
+        }
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        var linkedPr = LatestLinkedPrResolver.Resolve(runEvents, executionUnit);
+
+        var branchName = RunStartCommand.ResolveBranchName(executionUnit, queueItem.LinkedIssue);
+        var gitRunner = GitCommandRunnerFactory();
+        EnsureBranchMatches(worktreePath, branchName, gitRunner);
+        PushBranch(worktreePath, branchName, gitRunner);
+
+        PersistRunEvent(
+            runLogPath,
+            new RunEvent
+            {
+                Ts = TimestampFactory(),
+                ExecutionUnit = executionUnit,
+                Event = "resubmitted",
+                By = EventActor,
+                LinkedPr = linkedPr
+            });
+
+        return new RunResubmitResult
+        {
+            ExecutionUnit = executionUnit,
+            Branch = branchName,
+            WorktreePath = worktreePath,
+            LinkedPr = linkedPr
+        };
     }
 
     private static string ResolveChildRepoPath(string repoRoot, string childRepoRef)

--- a/src/IntentSystem.Cli/Commands/RunResubmitResult.cs
+++ b/src/IntentSystem.Cli/Commands/RunResubmitResult.cs
@@ -1,0 +1,12 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record RunResubmitResult
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required string Branch { get; init; }
+
+    public required string WorktreePath { get; init; }
+
+    public required string LinkedPr { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -338,6 +338,35 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentResubmitCommand_DispatchesToResubmitRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("repo", "repair-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "resubmit", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution", "--from-file", "repair-comment.md"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current resubmit processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentResubmitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentResubmitCommandTests.cs
@@ -1,0 +1,201 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentResubmitCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_NotReadyAfterBridge_DefersResubmitTrace()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("repo", "repair-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["resubmit", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution", "--from-file", "repair-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current resubmit processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+            Assert.Contains("Resubmitted execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- resubmit-trace", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenReadyStageResults_ComposesToResubmitSummary()
+    {
+        using var writer = new StringWriter();
+        var originalFixExecutor = GenerateFromCurrentResubmitCommand.FixExecutor;
+        var originalRunResubmitExecutor = GenerateFromCurrentResubmitCommand.RunResubmitExecutor;
+
+        try
+        {
+            GenerateFromCurrentResubmitCommand.FixExecutor = (_, _) => new GenerateFromCurrentFixResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G136/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/136"],
+                WorktreePaths = [".intent-cli/worktrees/G136"],
+                StartedExecutionUnits = ["G136"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G136.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/136"],
+                ReviewExecutionUnits = ["G136"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G136.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/G136.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/136#issuecomment-1"],
+                FixingExecutionUnits = ["G136"],
+                FixRequestArtifactPaths = [".intent-cli/fix/G136.request.md"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+            GenerateFromCurrentResubmitCommand.RunResubmitExecutor = (_, executionUnit) => new RunResubmitResult
+            {
+                ExecutionUnit = executionUnit,
+                Branch = $"issue-136-{executionUnit.ToLowerInvariant()}",
+                WorktreePath = $".intent-cli/worktrees/{executionUnit}",
+                LinkedPr = $"https://github.com/J-Tech-Japan/intent-system/pull/{executionUnit[1..]}"
+            };
+
+            var exitCode = GenerateFromCurrentResubmitCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature", "--from-file", "repair-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/fix/G136.request.md", output, StringComparison.Ordinal);
+            Assert.Contains("Resubmitted execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- G136", output, StringComparison.Ordinal);
+            Assert.Contains("Resubmitted PR refs:", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/136", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentResubmitCommand.FixExecutor = originalFixExecutor;
+            GenerateFromCurrentResubmitCommand.RunResubmitExecutor = originalRunResubmitExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentResubmitCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-resubmit-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentResubmitRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentResubmitRendererTests.cs
@@ -1,0 +1,93 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentResubmitRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenResubmitResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentResubmitRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentResubmitResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G136/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/136"],
+                WorktreePaths = [".intent-cli/worktrees/G136"],
+                StartedExecutionUnits = ["G136"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G136.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/136"],
+                ReviewExecutionUnits = ["G136"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G136.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/G136.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/136#issuecomment-1"],
+                FixingExecutionUnits = ["G136"],
+                FixRequestArtifactPaths = [".intent-cli/fix/G136.request.md"],
+                ResubmittedExecutionUnits = ["G136"],
+                ResubmittedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/136"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current resubmit processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Resubmitted execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("- G136", output, StringComparison.Ordinal);
+        Assert.Contains("Resubmitted PR refs:", output, StringComparison.Ordinal);
+        Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/136", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_RendersNoneEntries()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentResubmitRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentResubmitResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                StandardIntakeArtifactPaths = [],
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                StartedExecutionUnits = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ResubmittedExecutionUnits = [],
+                ResubmittedPrRefs = [],
+                ReadinessStatus = "not-ready",
+                SkippedStages = ["fix-handoff", "resubmit-trace"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+        Assert.Contains("- resubmit-trace", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current resubmit <domain> --from-path <path> --from-file <path>` as the thin composition from current-source selection through fix handoff to same-PR resubmit trace append
- factor `run resubmit` into an internal reusable core result so the new generate-from-current command can reuse the existing push-only resubmit behavior without changing the public command contract
- add deterministic CLI coverage for the new resubmit command, renderer, and router dispatch

## Why
Issue 136 requires a deterministic top-level command that carries the selected current-source scope through reverse-intake, launch, review comment return, fix handoff, and same linked PR resubmit trace without expanding into rereview, accept, merge, or workflow execution.

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentResubmit|FullyQualifiedName~RunResubmit|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`
