### PR TITLE
[codex] add generate-from-current rereview command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -82,6 +82,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "rereview", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentRereviewCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "implement", StringComparison.Ordinal))
         {
             return GenerateFromCurrentImplementCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentRereviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentRereviewCommand.cs
@@ -1,0 +1,112 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentRereviewCommand
+{
+    private static readonly string[] DeferredRereviewStages =
+    [
+        "rereview-entry"
+    ];
+
+    public static Func<CliContext, string[], GenerateFromCurrentResubmitResult> ResubmitExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentResubmitCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string, RunRereviewResult> RunRereviewExecutor { get; set; } =
+        (context, executionUnit) => RunRereviewCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentRereviewRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentRereviewResult ExecuteCore(CliContext context, string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current rereview requires a domain.");
+        }
+
+        var resubmitResult = ResubmitExecutor(context, args);
+        if (!string.Equals(resubmitResult.ReadinessStatus, "ready", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentRereviewResult
+            {
+                Domain = resubmitResult.Domain,
+                SourceBundleArtifactPath = resubmitResult.SourceBundleArtifactPath,
+                ReconstructedArtifactPaths = resubmitResult.ReconstructedArtifactPaths,
+                StandardIntakeArtifactPaths = resubmitResult.StandardIntakeArtifactPaths,
+                UpdatedSourceFilePaths = resubmitResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = resubmitResult.UpdatedExecutionFilePaths,
+                GeneratedIssueArtifactPaths = resubmitResult.GeneratedIssueArtifactPaths,
+                CreatedIssueRefs = resubmitResult.CreatedIssueRefs,
+                WorktreePaths = resubmitResult.WorktreePaths,
+                StartedExecutionUnits = resubmitResult.StartedExecutionUnits,
+                ImplementRequestArtifactPaths = resubmitResult.ImplementRequestArtifactPaths,
+                CreatedPrRefs = resubmitResult.CreatedPrRefs,
+                ReviewExecutionUnits = resubmitResult.ReviewExecutionUnits,
+                ReviewRequestArtifactPaths = resubmitResult.ReviewRequestArtifactPaths,
+                PostedCommentArtifactPaths = resubmitResult.PostedCommentArtifactPaths,
+                CommentRefs = resubmitResult.CommentRefs,
+                FixingExecutionUnits = resubmitResult.FixingExecutionUnits,
+                FixRequestArtifactPaths = resubmitResult.FixRequestArtifactPaths,
+                ResubmittedExecutionUnits = resubmitResult.ResubmittedExecutionUnits,
+                ResubmittedPrRefs = resubmitResult.ResubmittedPrRefs,
+                RereviewedExecutionUnits = [],
+                RereviewedPrRefs = [],
+                ReadinessStatus = resubmitResult.ReadinessStatus,
+                SkippedStages = resubmitResult.SkippedStages.Concat(DeferredRereviewStages).ToArray()
+            };
+        }
+
+        var rereviewResults = resubmitResult.ResubmittedExecutionUnits
+            .Select(executionUnit => RunRereviewExecutor(context, executionUnit))
+            .ToArray();
+
+        var skippedStages = new List<string>(resubmitResult.SkippedStages);
+        if (rereviewResults.Length == 0)
+        {
+            skippedStages.Add("rereview-entry");
+        }
+
+        return new GenerateFromCurrentRereviewResult
+        {
+            Domain = resubmitResult.Domain,
+            SourceBundleArtifactPath = resubmitResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = resubmitResult.ReconstructedArtifactPaths,
+            StandardIntakeArtifactPaths = resubmitResult.StandardIntakeArtifactPaths,
+            UpdatedSourceFilePaths = resubmitResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = resubmitResult.UpdatedExecutionFilePaths,
+            GeneratedIssueArtifactPaths = resubmitResult.GeneratedIssueArtifactPaths,
+            CreatedIssueRefs = resubmitResult.CreatedIssueRefs,
+            WorktreePaths = resubmitResult.WorktreePaths,
+            StartedExecutionUnits = resubmitResult.StartedExecutionUnits,
+            ImplementRequestArtifactPaths = resubmitResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = resubmitResult.CreatedPrRefs,
+            ReviewExecutionUnits = resubmitResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = resubmitResult.ReviewRequestArtifactPaths,
+            PostedCommentArtifactPaths = resubmitResult.PostedCommentArtifactPaths,
+            CommentRefs = resubmitResult.CommentRefs,
+            FixingExecutionUnits = resubmitResult.FixingExecutionUnits,
+            FixRequestArtifactPaths = resubmitResult.FixRequestArtifactPaths,
+            ResubmittedExecutionUnits = resubmitResult.ResubmittedExecutionUnits,
+            ResubmittedPrRefs = resubmitResult.ResubmittedPrRefs,
+            RereviewedExecutionUnits = rereviewResults.Select(result => result.ExecutionUnit).ToArray(),
+            RereviewedPrRefs = rereviewResults.Select(result => result.LinkedPr).ToArray(),
+            ReadinessStatus = resubmitResult.ReadinessStatus,
+            SkippedStages = skippedStages
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentRereviewRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentRereviewRenderer.cs
@@ -1,0 +1,70 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentRereviewRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentRereviewResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current rereview processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine("Regenerated standard intake artifact paths:");
+        WriteList(writer, result.StandardIntakeArtifactPaths);
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Generated issue artifact paths:");
+        WriteList(writer, result.GeneratedIssueArtifactPaths);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Posted comment artifact paths:");
+        WriteList(writer, result.PostedCommentArtifactPaths);
+        writer.WriteLine("Comment refs:");
+        WriteList(writer, result.CommentRefs);
+        writer.WriteLine("Fixing execution units:");
+        WriteList(writer, result.FixingExecutionUnits);
+        writer.WriteLine("Fix request artifact paths:");
+        WriteList(writer, result.FixRequestArtifactPaths);
+        writer.WriteLine("Resubmitted execution units:");
+        WriteList(writer, result.ResubmittedExecutionUnits);
+        writer.WriteLine("Resubmitted PR refs:");
+        WriteList(writer, result.ResubmittedPrRefs);
+        writer.WriteLine("Rereviewed execution units:");
+        WriteList(writer, result.RereviewedExecutionUnits);
+        writer.WriteLine("Rereviewed PR refs:");
+        WriteList(writer, result.RereviewedPrRefs);
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentRereviewResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentRereviewResult.cs
@@ -1,0 +1,52 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentRereviewResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StandardIntakeArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> GeneratedIssueArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> PostedCommentArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CommentRefs { get; init; }
+
+    public required IReadOnlyList<string> FixingExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> FixRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> RereviewedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> RereviewedPrRefs { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/RunRereviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunRereviewCommand.cs
@@ -22,39 +22,10 @@ internal static class RunRereviewCommand
             return 1;
         }
 
-        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
-        if (queueState is null)
-        {
-            return 1;
-        }
-
-        var executionUnit = args[0];
-        if (!queueState.Items.Any(item => string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal)))
-        {
-            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
-            return 1;
-        }
-
-        var runLogPath = context.GetRunLogPath();
-        if (!File.Exists(runLogPath))
-        {
-            writer.WriteLine($"Run log was not found at {runLogPath}");
-            return 1;
-        }
-
         try
         {
-            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
-            var linkedPr = LatestLinkedPrResolver.Resolve(runEvents, executionUnit);
-            var transition = QueueManager.ResubmitForReview(
-                queueState,
-                executionUnit,
-                TransitionActor,
-                TimestampFactory(),
-                linkedPr);
-
-            PersistRereview(context, transition);
-            writer.WriteLine($"Run rereviewed for {executionUnit}.");
+            var result = ExecuteCore(context, args[0]);
+            writer.WriteLine($"Run rereviewed for {result.ExecutionUnit}.");
             return 0;
         }
         catch (InvalidOperationException exception)
@@ -62,6 +33,46 @@ internal static class RunRereviewCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static RunRereviewResult ExecuteCore(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var queueStatePath = context.GetQueueStatePath();
+        var queueState = QueueCommandSupport.LoadQueueState(context, TextWriter.Null);
+        if (queueState is null)
+        {
+            throw new InvalidOperationException($"No queue state found at {queueStatePath}");
+        }
+
+        if (!queueState.Items.Any(item => string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal)))
+        {
+            throw new InvalidOperationException($"Execution unit '{executionUnit}' was not found in queue state.");
+        }
+
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            throw new InvalidOperationException($"Run log was not found at {runLogPath}");
+        }
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        var linkedPr = LatestLinkedPrResolver.Resolve(runEvents, executionUnit);
+        var transition = QueueManager.ResubmitForReview(
+            queueState,
+            executionUnit,
+            TransitionActor,
+            TimestampFactory(),
+            linkedPr);
+
+        PersistRereview(context, transition);
+        return new RunRereviewResult
+        {
+            ExecutionUnit = executionUnit,
+            LinkedPr = linkedPr
+        };
     }
 
     private static void PersistRereview(CliContext context, QueueTransitionResult result)

--- a/src/IntentSystem.Cli/Commands/RunRereviewResult.cs
+++ b/src/IntentSystem.Cli/Commands/RunRereviewResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record RunRereviewResult
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required string LinkedPr { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -367,6 +367,35 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentRereviewCommand_DispatchesToRereviewRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("repo", "repair-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "rereview", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution", "--from-file", "repair-comment.md"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current rereview processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentRereviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentRereviewCommandTests.cs
@@ -1,0 +1,201 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentRereviewCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_NotReadyAfterBridge_DefersRereviewEntry()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("repo", "repair-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["rereview", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution", "--from-file", "repair-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current rereview processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+            Assert.Contains("Rereviewed execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- rereview-entry", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenReadyStageResults_ComposesToRereviewSummary()
+    {
+        using var writer = new StringWriter();
+        var originalResubmitExecutor = GenerateFromCurrentRereviewCommand.ResubmitExecutor;
+        var originalRunRereviewExecutor = GenerateFromCurrentRereviewCommand.RunRereviewExecutor;
+
+        try
+        {
+            GenerateFromCurrentRereviewCommand.ResubmitExecutor = (_, _) => new GenerateFromCurrentResubmitResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G138/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/138"],
+                WorktreePaths = [".intent-cli/worktrees/G138"],
+                StartedExecutionUnits = ["G138"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G138.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/138"],
+                ReviewExecutionUnits = ["G138"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G138.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/G138.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/138#issuecomment-1"],
+                FixingExecutionUnits = ["G138"],
+                FixRequestArtifactPaths = [".intent-cli/fix/G138.request.md"],
+                ResubmittedExecutionUnits = ["G138"],
+                ResubmittedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/138"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+            GenerateFromCurrentRereviewCommand.RunRereviewExecutor = (_, executionUnit) => new RunRereviewResult
+            {
+                ExecutionUnit = executionUnit,
+                LinkedPr = $"https://github.com/J-Tech-Japan/intent-system/pull/{executionUnit[1..]}"
+            };
+
+            var exitCode = GenerateFromCurrentRereviewCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature", "--from-file", "repair-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/fix/G138.request.md", output, StringComparison.Ordinal);
+            Assert.Contains("Rereviewed execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- G138", output, StringComparison.Ordinal);
+            Assert.Contains("Rereviewed PR refs:", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/138", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentRereviewCommand.ResubmitExecutor = originalResubmitExecutor;
+            GenerateFromCurrentRereviewCommand.RunRereviewExecutor = originalRunRereviewExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentRereviewCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-rereview-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentRereviewRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentRereviewRendererTests.cs
@@ -1,0 +1,97 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentRereviewRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenRereviewResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentRereviewRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentRereviewResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G138/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/138"],
+                WorktreePaths = [".intent-cli/worktrees/G138"],
+                StartedExecutionUnits = ["G138"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G138.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/138"],
+                ReviewExecutionUnits = ["G138"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G138.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/G138.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/138#issuecomment-1"],
+                FixingExecutionUnits = ["G138"],
+                FixRequestArtifactPaths = [".intent-cli/fix/G138.request.md"],
+                ResubmittedExecutionUnits = ["G138"],
+                ResubmittedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/138"],
+                RereviewedExecutionUnits = ["G138"],
+                RereviewedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/138"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current rereview processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Rereviewed execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("- G138", output, StringComparison.Ordinal);
+        Assert.Contains("Rereviewed PR refs:", output, StringComparison.Ordinal);
+        Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/138", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_RendersNoneEntries()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentRereviewRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentRereviewResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                StandardIntakeArtifactPaths = [],
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                StartedExecutionUnits = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ResubmittedExecutionUnits = [],
+                ResubmittedPrRefs = [],
+                RereviewedExecutionUnits = [],
+                RereviewedPrRefs = [],
+                ReadinessStatus = "not-ready",
+                SkippedStages = ["resubmit-trace", "rereview-entry"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+        Assert.Contains("- rereview-entry", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current rereview <domain> --from-path <path> --from-file <path>` as the thin composition from current-source selection through resubmit trace to rereview entry
- factor `run rereview` into an internal reusable core result so the new generate-from-current command can reuse the existing review-return behavior without changing the public command contract
- add deterministic CLI coverage for the new rereview command, renderer, and router dispatch

## Why
Issue 138 requires a deterministic top-level command that carries the selected current-source scope through reverse-intake, launch, review comment return, fix handoff, resubmit, and same linked PR rereview return without expanding into accept, merge, or workflow execution.

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentRereview|FullyQualifiedName~RunRereview|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`
