### PR TITLE
[codex] add generate-from-current reaccept command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -88,6 +88,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "reaccept", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentReacceptCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "implement", StringComparison.Ordinal))
         {
             return GenerateFromCurrentImplementCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReacceptCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReacceptCommand.cs
@@ -1,0 +1,118 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentReacceptCommand
+{
+    private static readonly string[] DeferredReacceptStages =
+    [
+        "accepted-closeout"
+    ];
+
+    public static Func<CliContext, string[], GenerateFromCurrentRereviewResult> RereviewExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentRereviewCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string, ReviewAcceptResult> ReviewAcceptExecutor { get; set; } =
+        (context, executionUnit) => ReviewAcceptCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentReacceptRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentReacceptResult ExecuteCore(CliContext context, string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current reaccept requires a domain.");
+        }
+
+        var rereviewResult = RereviewExecutor(context, args);
+        if (!string.Equals(rereviewResult.ReadinessStatus, "ready", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentReacceptResult
+            {
+                Domain = rereviewResult.Domain,
+                SourceBundleArtifactPath = rereviewResult.SourceBundleArtifactPath,
+                ReconstructedArtifactPaths = rereviewResult.ReconstructedArtifactPaths,
+                StandardIntakeArtifactPaths = rereviewResult.StandardIntakeArtifactPaths,
+                UpdatedSourceFilePaths = rereviewResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = rereviewResult.UpdatedExecutionFilePaths,
+                GeneratedIssueArtifactPaths = rereviewResult.GeneratedIssueArtifactPaths,
+                CreatedIssueRefs = rereviewResult.CreatedIssueRefs,
+                WorktreePaths = rereviewResult.WorktreePaths,
+                StartedExecutionUnits = rereviewResult.StartedExecutionUnits,
+                ImplementRequestArtifactPaths = rereviewResult.ImplementRequestArtifactPaths,
+                CreatedPrRefs = rereviewResult.CreatedPrRefs,
+                ReviewExecutionUnits = rereviewResult.ReviewExecutionUnits,
+                ReviewRequestArtifactPaths = rereviewResult.ReviewRequestArtifactPaths,
+                PostedCommentArtifactPaths = rereviewResult.PostedCommentArtifactPaths,
+                CommentRefs = rereviewResult.CommentRefs,
+                FixingExecutionUnits = rereviewResult.FixingExecutionUnits,
+                FixRequestArtifactPaths = rereviewResult.FixRequestArtifactPaths,
+                ResubmittedExecutionUnits = rereviewResult.ResubmittedExecutionUnits,
+                ResubmittedPrRefs = rereviewResult.ResubmittedPrRefs,
+                RereviewedExecutionUnits = rereviewResult.RereviewedExecutionUnits,
+                RereviewedPrRefs = rereviewResult.RereviewedPrRefs,
+                CompletedExecutionUnits = [],
+                ClosedIssueRefs = [],
+                MergedPrRefs = [],
+                ReadinessStatus = rereviewResult.ReadinessStatus,
+                SkippedStages = rereviewResult.SkippedStages.Concat(DeferredReacceptStages).ToArray()
+            };
+        }
+
+        var acceptResults = rereviewResult.RereviewedExecutionUnits
+            .Select(executionUnit => ReviewAcceptExecutor(context, executionUnit))
+            .ToArray();
+
+        var skippedStages = new List<string>(rereviewResult.SkippedStages);
+        if (acceptResults.Length == 0)
+        {
+            skippedStages.Add("accepted-closeout");
+        }
+
+        return new GenerateFromCurrentReacceptResult
+        {
+            Domain = rereviewResult.Domain,
+            SourceBundleArtifactPath = rereviewResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = rereviewResult.ReconstructedArtifactPaths,
+            StandardIntakeArtifactPaths = rereviewResult.StandardIntakeArtifactPaths,
+            UpdatedSourceFilePaths = rereviewResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = rereviewResult.UpdatedExecutionFilePaths,
+            GeneratedIssueArtifactPaths = rereviewResult.GeneratedIssueArtifactPaths,
+            CreatedIssueRefs = rereviewResult.CreatedIssueRefs,
+            WorktreePaths = rereviewResult.WorktreePaths,
+            StartedExecutionUnits = rereviewResult.StartedExecutionUnits,
+            ImplementRequestArtifactPaths = rereviewResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = rereviewResult.CreatedPrRefs,
+            ReviewExecutionUnits = rereviewResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = rereviewResult.ReviewRequestArtifactPaths,
+            PostedCommentArtifactPaths = rereviewResult.PostedCommentArtifactPaths,
+            CommentRefs = rereviewResult.CommentRefs,
+            FixingExecutionUnits = rereviewResult.FixingExecutionUnits,
+            FixRequestArtifactPaths = rereviewResult.FixRequestArtifactPaths,
+            ResubmittedExecutionUnits = rereviewResult.ResubmittedExecutionUnits,
+            ResubmittedPrRefs = rereviewResult.ResubmittedPrRefs,
+            RereviewedExecutionUnits = rereviewResult.RereviewedExecutionUnits,
+            RereviewedPrRefs = rereviewResult.RereviewedPrRefs,
+            CompletedExecutionUnits = acceptResults.Select(result => result.ExecutionUnit).ToArray(),
+            ClosedIssueRefs = acceptResults.Select(result => result.ClosedIssueRef).ToArray(),
+            MergedPrRefs = acceptResults.Select(result => result.MergedPrRef).ToArray(),
+            ReadinessStatus = rereviewResult.ReadinessStatus,
+            SkippedStages = skippedStages
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReacceptRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReacceptRenderer.cs
@@ -1,0 +1,76 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentReacceptRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentReacceptResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current reaccept processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine("Regenerated standard intake artifact paths:");
+        WriteList(writer, result.StandardIntakeArtifactPaths);
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Generated issue artifact paths:");
+        WriteList(writer, result.GeneratedIssueArtifactPaths);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Posted comment artifact paths:");
+        WriteList(writer, result.PostedCommentArtifactPaths);
+        writer.WriteLine("Comment refs:");
+        WriteList(writer, result.CommentRefs);
+        writer.WriteLine("Fixing execution units:");
+        WriteList(writer, result.FixingExecutionUnits);
+        writer.WriteLine("Fix request artifact paths:");
+        WriteList(writer, result.FixRequestArtifactPaths);
+        writer.WriteLine("Resubmitted execution units:");
+        WriteList(writer, result.ResubmittedExecutionUnits);
+        writer.WriteLine("Resubmitted PR refs:");
+        WriteList(writer, result.ResubmittedPrRefs);
+        writer.WriteLine("Rereviewed execution units:");
+        WriteList(writer, result.RereviewedExecutionUnits);
+        writer.WriteLine("Rereviewed PR refs:");
+        WriteList(writer, result.RereviewedPrRefs);
+        writer.WriteLine("Completed execution units:");
+        WriteList(writer, result.CompletedExecutionUnits);
+        writer.WriteLine("Closed issue refs:");
+        WriteList(writer, result.ClosedIssueRefs);
+        writer.WriteLine("Merged PR refs:");
+        WriteList(writer, result.MergedPrRefs);
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReacceptResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReacceptResult.cs
@@ -1,0 +1,58 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentReacceptResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StandardIntakeArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> GeneratedIssueArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> PostedCommentArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CommentRefs { get; init; }
+
+    public required IReadOnlyList<string> FixingExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> FixRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> RereviewedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> RereviewedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> CompletedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ClosedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> MergedPrRefs { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -396,6 +396,35 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentReacceptCommand_DispatchesToReacceptRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("repo", "repair-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "reaccept", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution", "--from-file", "repair-comment.md"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current reaccept processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReacceptCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReacceptCommandTests.cs
@@ -1,0 +1,206 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentReacceptCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_NotReadyAfterBridge_DefersAcceptedCloseout()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("repo", "repair-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["reaccept", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution", "--from-file", "repair-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current reaccept processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+            Assert.Contains("Completed execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- accepted-closeout", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenReadyStageResults_ComposesToReacceptSummary()
+    {
+        using var writer = new StringWriter();
+        var originalRereviewExecutor = GenerateFromCurrentReacceptCommand.RereviewExecutor;
+        var originalReviewAcceptExecutor = GenerateFromCurrentReacceptCommand.ReviewAcceptExecutor;
+
+        try
+        {
+            GenerateFromCurrentReacceptCommand.RereviewExecutor = (_, _) => new GenerateFromCurrentRereviewResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G140/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/140"],
+                WorktreePaths = [".intent-cli/worktrees/G140"],
+                StartedExecutionUnits = ["G140"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G140.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/140"],
+                ReviewExecutionUnits = ["G140"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G140.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/G140.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/140#issuecomment-1"],
+                FixingExecutionUnits = ["G140"],
+                FixRequestArtifactPaths = [".intent-cli/fix/G140.request.md"],
+                ResubmittedExecutionUnits = ["G140"],
+                ResubmittedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/140"],
+                RereviewedExecutionUnits = ["G140"],
+                RereviewedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/140"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+            GenerateFromCurrentReacceptCommand.ReviewAcceptExecutor = (_, executionUnit) => new ReviewAcceptResult
+            {
+                ExecutionUnit = executionUnit,
+                MergedPrRef = $"https://github.com/J-Tech-Japan/intent-system/pull/{executionUnit[1..]}",
+                ClosedIssueRef = $"https://github.com/J-Tech-Japan/intent-system/issues/{executionUnit[1..]}"
+            };
+
+            var exitCode = GenerateFromCurrentReacceptCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature", "--from-file", "repair-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/fix/G140.request.md", output, StringComparison.Ordinal);
+            Assert.Contains("Completed execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- G140", output, StringComparison.Ordinal);
+            Assert.Contains("Closed issue refs:", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/issues/140", output, StringComparison.Ordinal);
+            Assert.Contains("Merged PR refs:", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/140", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentReacceptCommand.RereviewExecutor = originalRereviewExecutor;
+            GenerateFromCurrentReacceptCommand.ReviewAcceptExecutor = originalReviewAcceptExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentReacceptCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-reaccept-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReacceptRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReacceptRendererTests.cs
@@ -1,0 +1,103 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentReacceptRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenReacceptResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentReacceptRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentReacceptResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G140/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/140"],
+                WorktreePaths = [".intent-cli/worktrees/G140"],
+                StartedExecutionUnits = ["G140"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G140.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/140"],
+                ReviewExecutionUnits = ["G140"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G140.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/G140.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/140#issuecomment-1"],
+                FixingExecutionUnits = ["G140"],
+                FixRequestArtifactPaths = [".intent-cli/fix/G140.request.md"],
+                ResubmittedExecutionUnits = ["G140"],
+                ResubmittedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/140"],
+                RereviewedExecutionUnits = ["G140"],
+                RereviewedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/140"],
+                CompletedExecutionUnits = ["G140"],
+                ClosedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/140"],
+                MergedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/140"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current reaccept processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Completed execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("- G140", output, StringComparison.Ordinal);
+        Assert.Contains("Closed issue refs:", output, StringComparison.Ordinal);
+        Assert.Contains("Merged PR refs:", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_RendersNoneEntries()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentReacceptRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentReacceptResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                StandardIntakeArtifactPaths = [],
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                StartedExecutionUnits = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ResubmittedExecutionUnits = [],
+                ResubmittedPrRefs = [],
+                RereviewedExecutionUnits = [],
+                RereviewedPrRefs = [],
+                CompletedExecutionUnits = [],
+                ClosedIssueRefs = [],
+                MergedPrRefs = [],
+                ReadinessStatus = "not-ready",
+                SkippedStages = ["rereview-entry", "accepted-closeout"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+        Assert.Contains("- accepted-closeout", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current reaccept <domain> --from-path <path> --from-file <path>` as the thin composition from current-source selection through rereview entry to accepted closeout
- reuse the existing `review accept` core so the new top-level flow closes out the selected execution units without changing the generic accept contract
- add deterministic CLI coverage for the new reaccept command, renderer, and router dispatch

## Why
Issue 140 requires a deterministic top-level command that carries the selected current-source scope through reverse-intake, launch, repair review loop, rereview return, and accepted closeout without expanding into diff review, next-issue creation, or workflow execution.

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentReaccept|FullyQualifiedName~ReviewAccept|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`
