### PR TITLE
[codex] add generate-from-current closeout command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCloseoutCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCloseoutCommand.cs
@@ -1,0 +1,134 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentCloseoutCommand
+{
+    private const string AcceptedCloseoutPath = "accepted-closeout";
+    private const string RepairAcceptedCloseoutPath = "repair-in-place-accepted-closeout";
+
+    public static Func<CliContext, string[], GenerateFromCurrentAcceptResult> AcceptExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentAcceptCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string[], GenerateFromCurrentReacceptResult> ReacceptExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentReacceptCommand.ExecuteCore(context, args);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentCloseoutRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentCloseoutResult ExecuteCore(CliContext context, string[] args)
+    {
+        var (pipelineArgs, hasPreparedRepairComment) = ParseArgs(args);
+        if (hasPreparedRepairComment)
+        {
+            var reacceptResult = ReacceptExecutor(context, args);
+            return new GenerateFromCurrentCloseoutResult
+            {
+                Domain = reacceptResult.Domain,
+                SourceBundleArtifactPath = reacceptResult.SourceBundleArtifactPath,
+                ReconstructedArtifactPaths = reacceptResult.ReconstructedArtifactPaths,
+                StandardIntakeArtifactPaths = reacceptResult.StandardIntakeArtifactPaths,
+                UpdatedSourceFilePaths = reacceptResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = reacceptResult.UpdatedExecutionFilePaths,
+                GeneratedIssueArtifactPaths = reacceptResult.GeneratedIssueArtifactPaths,
+                CreatedIssueRefs = reacceptResult.CreatedIssueRefs,
+                WorktreePaths = reacceptResult.WorktreePaths,
+                StartedExecutionUnits = reacceptResult.StartedExecutionUnits,
+                ImplementRequestArtifactPaths = reacceptResult.ImplementRequestArtifactPaths,
+                CreatedPrRefs = reacceptResult.CreatedPrRefs,
+                ReviewExecutionUnits = reacceptResult.ReviewExecutionUnits,
+                ReviewRequestArtifactPaths = reacceptResult.ReviewRequestArtifactPaths,
+                PostedCommentArtifactPaths = reacceptResult.PostedCommentArtifactPaths,
+                CommentRefs = reacceptResult.CommentRefs,
+                FixingExecutionUnits = reacceptResult.FixingExecutionUnits,
+                FixRequestArtifactPaths = reacceptResult.FixRequestArtifactPaths,
+                ResubmittedExecutionUnits = reacceptResult.ResubmittedExecutionUnits,
+                ResubmittedPrRefs = reacceptResult.ResubmittedPrRefs,
+                RereviewedExecutionUnits = reacceptResult.RereviewedExecutionUnits,
+                CompletedExecutionUnits = reacceptResult.CompletedExecutionUnits,
+                ClosedIssueRefs = reacceptResult.ClosedIssueRefs,
+                MergedPrRefs = reacceptResult.MergedPrRefs,
+                ReadinessStatus = reacceptResult.ReadinessStatus,
+                SelectedCloseoutPath = RepairAcceptedCloseoutPath,
+                SkippedStages = reacceptResult.SkippedStages
+            };
+        }
+
+        var acceptResult = AcceptExecutor(context, pipelineArgs);
+        return new GenerateFromCurrentCloseoutResult
+        {
+            Domain = acceptResult.Domain,
+            SourceBundleArtifactPath = acceptResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = acceptResult.ReconstructedArtifactPaths,
+            StandardIntakeArtifactPaths = acceptResult.StandardIntakeArtifactPaths,
+            UpdatedSourceFilePaths = acceptResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = acceptResult.UpdatedExecutionFilePaths,
+            GeneratedIssueArtifactPaths = acceptResult.GeneratedIssueArtifactPaths,
+            CreatedIssueRefs = acceptResult.CreatedIssueRefs,
+            WorktreePaths = acceptResult.WorktreePaths,
+            StartedExecutionUnits = acceptResult.StartedExecutionUnits,
+            ImplementRequestArtifactPaths = acceptResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = acceptResult.CreatedPrRefs,
+            ReviewExecutionUnits = acceptResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = acceptResult.ReviewRequestArtifactPaths,
+            PostedCommentArtifactPaths = [],
+            CommentRefs = [],
+            FixingExecutionUnits = [],
+            FixRequestArtifactPaths = [],
+            ResubmittedExecutionUnits = [],
+            ResubmittedPrRefs = [],
+            RereviewedExecutionUnits = [],
+            CompletedExecutionUnits = acceptResult.CompletedExecutionUnits,
+            ClosedIssueRefs = acceptResult.ClosedIssueRefs,
+            MergedPrRefs = acceptResult.MergedPrRefs,
+            ReadinessStatus = acceptResult.ReadinessStatus,
+            SelectedCloseoutPath = AcceptedCloseoutPath,
+            SkippedStages = acceptResult.SkippedStages
+        };
+    }
+
+    private static (string[] PipelineArgs, bool HasPreparedRepairComment) ParseArgs(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current closeout requires a domain.");
+        }
+
+        var pipelineArgs = new List<string>();
+        var hasPreparedRepairComment = false;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            if (string.Equals(argument, "--from-file", StringComparison.Ordinal))
+            {
+                if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                {
+                    throw new InvalidOperationException("--from-file requires a value.");
+                }
+
+                hasPreparedRepairComment = true;
+                index++;
+                continue;
+            }
+
+            pipelineArgs.Add(argument);
+        }
+
+        return (pipelineArgs.ToArray(), hasPreparedRepairComment);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCloseoutRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCloseoutRenderer.cs
@@ -1,0 +1,75 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentCloseoutRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentCloseoutResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current closeout processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Selected closeout path: {result.SelectedCloseoutPath}");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine("Regenerated standard intake artifact paths:");
+        WriteList(writer, result.StandardIntakeArtifactPaths);
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Generated issue artifact paths:");
+        WriteList(writer, result.GeneratedIssueArtifactPaths);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Posted comment artifact paths:");
+        WriteList(writer, result.PostedCommentArtifactPaths);
+        writer.WriteLine("Comment refs:");
+        WriteList(writer, result.CommentRefs);
+        writer.WriteLine("Fixing execution units:");
+        WriteList(writer, result.FixingExecutionUnits);
+        writer.WriteLine("Fix request artifact paths:");
+        WriteList(writer, result.FixRequestArtifactPaths);
+        writer.WriteLine("Resubmitted execution units:");
+        WriteList(writer, result.ResubmittedExecutionUnits);
+        writer.WriteLine("Resubmitted PR refs:");
+        WriteList(writer, result.ResubmittedPrRefs);
+        writer.WriteLine("Rereviewed execution units:");
+        WriteList(writer, result.RereviewedExecutionUnits);
+        writer.WriteLine("Completed execution units:");
+        WriteList(writer, result.CompletedExecutionUnits);
+        writer.WriteLine("Closed issue refs:");
+        WriteList(writer, result.ClosedIssueRefs);
+        writer.WriteLine("Merged PR refs:");
+        WriteList(writer, result.MergedPrRefs);
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCloseoutResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCloseoutResult.cs
@@ -1,0 +1,58 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentCloseoutResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StandardIntakeArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> GeneratedIssueArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> PostedCommentArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CommentRefs { get; init; }
+
+    public required IReadOnlyList<string> FixingExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> FixRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> RereviewedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> CompletedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ClosedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> MergedPrRefs { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required string SelectedCloseoutPath { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -94,6 +94,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "closeout", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentCloseoutCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "implement", StringComparison.Ordinal))
         {
             return GenerateFromCurrentImplementCommand.Execute(context, args[1..], writer);

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -425,6 +425,34 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentCloseoutCommand_DispatchesToCloseoutRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "closeout", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current closeout processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCloseoutCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCloseoutCommandTests.cs
@@ -1,0 +1,248 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentCloseoutCommandTests
+{
+    [Fact]
+    public void Execute_GivenNoRepairComment_UsesAcceptedCloseoutPath()
+    {
+        using var writer = new StringWriter();
+        var originalAcceptExecutor = GenerateFromCurrentCloseoutCommand.AcceptExecutor;
+        var originalReacceptExecutor = GenerateFromCurrentCloseoutCommand.ReacceptExecutor;
+
+        try
+        {
+            GenerateFromCurrentCloseoutCommand.AcceptExecutor = (_, _) => new GenerateFromCurrentAcceptResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths = [".intent-cli/intake/auth.concept.yaml"],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G142/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/142"],
+                WorktreePaths = [".intent-cli/worktrees/G142"],
+                StartedExecutionUnits = ["G142"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G142.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/142"],
+                ReviewExecutionUnits = ["G142"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G142.request.json"],
+                MergedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/142"],
+                ClosedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/142"],
+                CompletedExecutionUnits = ["G142"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+            GenerateFromCurrentCloseoutCommand.ReacceptExecutor = (_, _) =>
+                throw new InvalidOperationException("reaccept path should not run");
+
+            var exitCode = GenerateFromCurrentCloseoutCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Selected closeout path: accepted-closeout", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCloseoutCommand.AcceptExecutor = originalAcceptExecutor;
+            GenerateFromCurrentCloseoutCommand.ReacceptExecutor = originalReacceptExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenRepairComment_UsesRepairAcceptedCloseoutPath()
+    {
+        using var writer = new StringWriter();
+        var originalAcceptExecutor = GenerateFromCurrentCloseoutCommand.AcceptExecutor;
+        var originalReacceptExecutor = GenerateFromCurrentCloseoutCommand.ReacceptExecutor;
+
+        try
+        {
+            GenerateFromCurrentCloseoutCommand.AcceptExecutor = (_, _) =>
+                throw new InvalidOperationException("accept path should not run");
+            GenerateFromCurrentCloseoutCommand.ReacceptExecutor = (_, _) => new GenerateFromCurrentReacceptResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths = [".intent-cli/intake/auth.concept.yaml"],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G142/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/142"],
+                WorktreePaths = [".intent-cli/worktrees/G142"],
+                StartedExecutionUnits = ["G142"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G142.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/142"],
+                ReviewExecutionUnits = ["G142"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G142.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/G142.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/142#issuecomment-1"],
+                FixingExecutionUnits = ["G142"],
+                FixRequestArtifactPaths = [".intent-cli/fix/G142.request.md"],
+                ResubmittedExecutionUnits = ["G142"],
+                ResubmittedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/142"],
+                RereviewedExecutionUnits = ["G142"],
+                RereviewedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/142"],
+                CompletedExecutionUnits = ["G142"],
+                ClosedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/142"],
+                MergedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/142"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+
+            var exitCode = GenerateFromCurrentCloseoutCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature", "--from-file", "repair-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Selected closeout path: repair-in-place-accepted-closeout", output, StringComparison.Ordinal);
+            Assert.Contains("Comment refs:", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCloseoutCommand.AcceptExecutor = originalAcceptExecutor;
+            GenerateFromCurrentCloseoutCommand.ReacceptExecutor = originalReacceptExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenRealPipeline_NotReadyAfterBridge_StaysOnAcceptedPathWhenNoRepairComment()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["closeout", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current closeout processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Selected closeout path: accepted-closeout", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentCloseoutCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-closeout-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCloseoutRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentCloseoutRendererTests.cs
@@ -1,0 +1,101 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentCloseoutRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenAcceptedCloseoutResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentCloseoutRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentCloseoutResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G142/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/142"],
+                WorktreePaths = [".intent-cli/worktrees/G142"],
+                StartedExecutionUnits = ["G142"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/G142.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/142"],
+                ReviewExecutionUnits = ["G142"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/G142.request.json"],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ResubmittedExecutionUnits = [],
+                ResubmittedPrRefs = [],
+                RereviewedExecutionUnits = [],
+                CompletedExecutionUnits = ["G142"],
+                ClosedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/142"],
+                MergedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/142"],
+                ReadinessStatus = "ready",
+                SelectedCloseoutPath = "accepted-closeout",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current closeout processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Selected closeout path: accepted-closeout", output, StringComparison.Ordinal);
+        Assert.Contains("Completed execution units:", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenRepairCloseoutResult_RendersRepairPath()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentCloseoutRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentCloseoutResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                StandardIntakeArtifactPaths = [],
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                StartedExecutionUnits = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/G142.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/142#issuecomment-1"],
+                FixingExecutionUnits = ["G142"],
+                FixRequestArtifactPaths = [".intent-cli/fix/G142.request.md"],
+                ResubmittedExecutionUnits = ["G142"],
+                ResubmittedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/142"],
+                RereviewedExecutionUnits = ["G142"],
+                CompletedExecutionUnits = ["G142"],
+                ClosedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/142"],
+                MergedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/142"],
+                ReadinessStatus = "ready",
+                SelectedCloseoutPath = "repair-in-place-accepted-closeout",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Selected closeout path: repair-in-place-accepted-closeout", output, StringComparison.Ordinal);
+        Assert.Contains("Comment refs:", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current closeout <domain> --from-path <path> [--from-file <path>]` as the thin composition that chooses accepted closeout or repair-in-place accepted closeout from the selected current-source scope
- keep the existing `accept` and `reaccept` contracts unchanged by branching only in the new closeout command and summary renderer
- add deterministic CLI coverage for both closeout paths and router dispatch

## Why
Issue 142 requires a single top-level closeout command that can deterministically finish either the accepted path or the repair-in-place accepted path depending on whether a prepared repair comment body is supplied.

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentCloseout|FullyQualifiedName~GenerateFromCurrentAccept|FullyQualifiedName~GenerateFromCurrentReaccept|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`
