### PR TITLE
[codex] Add generate-from-current best-practice command

### DIFF
--- a/src/IntentSystem.Cli/CliContext.cs
+++ b/src/IntentSystem.Cli/CliContext.cs
@@ -49,4 +49,20 @@ internal sealed record CliContext
 
         return Path.GetFullPath(Path.Combine(RepoRoot, worktreeRoot));
     }
+
+    public string? ResolveParentIntentRepoRootPath()
+    {
+        var parentIntentRepoRoot = Config.Project.ParentIntentRepoRoot;
+        if (string.IsNullOrWhiteSpace(parentIntentRepoRoot))
+        {
+            return null;
+        }
+
+        if (Path.IsPathRooted(parentIntentRepoRoot))
+        {
+            return parentIntentRepoRoot;
+        }
+
+        return Path.GetFullPath(Path.Combine(RepoRoot, parentIntentRepoRoot));
+    }
 }

--- a/src/IntentSystem.Cli/CliRuntimeContracts.cs
+++ b/src/IntentSystem.Cli/CliRuntimeContracts.cs
@@ -12,6 +12,7 @@ internal static class CliRuntimeContracts
     public const string WorkflowEngineKey = "workflow_engine";
     public const string ArtifactRootKey = "artifact_root";
     public const string WorktreeRootKey = "worktree_root";
+    public const string ParentIntentRepoRootKey = "parent_intent_repo_root";
     public const string RolesSectionName = "roles";
     public const string ImplementRoleKey = "implement";
     public const string ReviewRoleKey = "review";

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentBestPracticeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentBestPracticeCommand.cs
@@ -15,13 +15,13 @@ internal static class GenerateFromCurrentBestPracticeCommand
 
     private static readonly string[] ParentRuleSpecCandidates =
     [
-        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/intent-cli/specs/04-concept-intake-and-interview.md",
-        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/intent-cli/specs/05-intent-cli-surface.md",
-        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/intent-cli/specs/10-generate-from-current-and-historical-signals.md",
-        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md",
-        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/intent-cli/intent-tree/means/02-tooling-strategy.md",
-        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/rules/reconstruction-feedback-loop.md",
-        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/rules/issue-lifecycle-and-landing.md"
+        "intents/intent-cli/specs/04-concept-intake-and-interview.md",
+        "intents/intent-cli/specs/05-intent-cli-surface.md",
+        "intents/intent-cli/specs/10-generate-from-current-and-historical-signals.md",
+        "intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md",
+        "intents/intent-cli/intent-tree/means/02-tooling-strategy.md",
+        "intents/rules/reconstruction-feedback-loop.md",
+        "intents/rules/issue-lifecycle-and-landing.md"
     ];
 
     private static readonly string[] ModelRegistryDirectories =
@@ -51,8 +51,8 @@ internal static class GenerateFromCurrentBestPracticeCommand
     public static Func<string, IReadOnlyList<string>> KnowledgeRefProvider { get; set; } =
         repoRoot => ReadProjectRefs(repoRoot, KnowledgeBaseDirectories);
 
-    public static Func<IReadOnlyList<string>> ParentRuleSpecRefProvider { get; set; } =
-        () => ParentRuleSpecCandidates.Where(File.Exists).ToArray();
+    public static Func<string?, IReadOnlyList<string>> ParentRuleSpecRefProvider { get; set; } =
+        parentRepoRoot => ReadParentRuleSpecRefs(parentRepoRoot, ParentRuleSpecCandidates);
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -85,34 +85,39 @@ internal static class GenerateFromCurrentBestPracticeCommand
         var reconstructionResult = ReconstructionExecutor(context, domain);
         var modelRefs = ModelRefProvider(context.RepoRoot);
         var knowledgeRefs = KnowledgeRefProvider(context.RepoRoot);
-        var parentRefs = ParentRuleSpecRefProvider();
+        var parentRefs = ParentRuleSpecRefProvider(context.ResolveParentIntentRepoRootPath());
         var reviewedDimensions = BuildReviewedDimensions(
             sourceBundleResult,
             reconstructionResult,
             modelRefs,
-            knowledgeRefs);
+            knowledgeRefs,
+            parentRefs);
         var recommendedIntentAdditions = BuildRecommendedIntentAdditions(
             domain,
             reconstructionResult,
             modelRefs,
-            knowledgeRefs);
+            knowledgeRefs,
+            parentRefs);
         var recommendedClarifications = BuildRecommendedClarifications(
             domain,
             reconstructionResult,
             modelRefs,
-            knowledgeRefs);
+            knowledgeRefs,
+            parentRefs);
         var developerConfirmationItems = BuildDeveloperConfirmationItems(
             domain,
             recommendedIntentAdditions,
             recommendedClarifications,
             modelRefs,
-            knowledgeRefs);
+            knowledgeRefs,
+            parentRefs);
         var confidenceDeltas = BuildConfidenceDeltas(
             reconstructionResult.ConfidenceByAltitude,
             modelRefs,
-            knowledgeRefs);
-        var readinessStatus = DetermineReadinessStatus(modelRefs, knowledgeRefs, recommendedClarifications);
-        var skippedStages = BuildSkippedStages(modelRefs, knowledgeRefs);
+            knowledgeRefs,
+            parentRefs);
+        var readinessStatus = DetermineReadinessStatus(modelRefs, knowledgeRefs, parentRefs, recommendedClarifications);
+        var skippedStages = BuildSkippedStages(modelRefs, knowledgeRefs, parentRefs);
 
         var artifactPath = WriteArtifact(
             context.RepoRoot,
@@ -180,25 +185,40 @@ internal static class GenerateFromCurrentBestPracticeCommand
         return refs.Distinct(StringComparer.Ordinal).ToArray();
     }
 
+    private static IReadOnlyList<string> ReadParentRuleSpecRefs(string? parentRepoRoot, IReadOnlyList<string> relativePaths)
+    {
+        if (string.IsNullOrWhiteSpace(parentRepoRoot) || !Directory.Exists(parentRepoRoot))
+        {
+            return [];
+        }
+
+        return relativePaths
+            .Where(relativePath => File.Exists(Path.Combine(parentRepoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar))))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
     private static IReadOnlyList<string> BuildReviewedDimensions(
         GenerateFromCurrentResult sourceBundleResult,
         GenerateFromCurrentReconstructionResult reconstructionResult,
         IReadOnlyList<string> modelRefs,
-        IReadOnlyList<string> knowledgeRefs)
+        IReadOnlyList<string> knowledgeRefs,
+        IReadOnlyList<string> parentRefs)
     {
         var hasModelRefs = modelRefs.Count > 0;
         var hasKnowledgeRefs = knowledgeRefs.Count > 0;
+        var hasParentRefs = parentRefs.Count > 0;
         var hasAuthKnowledge = knowledgeRefs.Any(reference => reference.Contains("auth", StringComparison.OrdinalIgnoreCase)
             || reference.Contains("security", StringComparison.OrdinalIgnoreCase));
         var hasTestSignals = sourceBundleResult.SourceRefs.Any(reference => reference.StartsWith("test:", StringComparison.Ordinal));
 
         return ReviewedDimensions.Select(dimension => dimension switch
         {
-            "architecture" => $"{dimension}: {(hasModelRefs ? "needs-confirmation" : "missing-model-registry")}",
-            "security" => $"{dimension}: {(hasKnowledgeRefs ? "needs-confirmation" : "missing-knowledge-base")}",
-            "auth" => $"{dimension}: {(hasAuthKnowledge ? "clarify" : "missing-auth-guidance")}",
-            "data-modeling" => $"{dimension}: {(hasModelRefs ? "clarify" : "missing-model-registry")}",
-            "error-handling" => $"{dimension}: {(hasKnowledgeRefs ? "needs-confirmation" : "missing-knowledge-base")}",
+            "architecture" => $"{dimension}: {(hasParentRefs && hasModelRefs ? "needs-confirmation" : hasParentRefs ? "missing-model-registry" : "missing-parent-rules-specs")}",
+            "security" => $"{dimension}: {(hasParentRefs && hasKnowledgeRefs ? "needs-confirmation" : hasParentRefs ? "missing-knowledge-base" : "missing-parent-rules-specs")}",
+            "auth" => $"{dimension}: {(hasParentRefs && hasAuthKnowledge ? "clarify" : hasParentRefs ? "missing-auth-guidance" : "missing-parent-rules-specs")}",
+            "data-modeling" => $"{dimension}: {(hasParentRefs && hasModelRefs ? "clarify" : hasParentRefs ? "missing-model-registry" : "missing-parent-rules-specs")}",
+            "error-handling" => $"{dimension}: {(hasParentRefs && hasKnowledgeRefs ? "needs-confirmation" : hasParentRefs ? "missing-knowledge-base" : "missing-parent-rules-specs")}",
             "performance" => $"{dimension}: {(reconstructionResult.CandidateExecutionUnits.Count > 0 ? "defer" : "needs-confirmation")}",
             "testability" => $"{dimension}: {(hasTestSignals ? "needs-confirmation" : "missing-test-signal")}",
             _ => $"{dimension}: needs-confirmation"
@@ -209,16 +229,17 @@ internal static class GenerateFromCurrentBestPracticeCommand
         string domain,
         GenerateFromCurrentReconstructionResult reconstructionResult,
         IReadOnlyList<string> modelRefs,
-        IReadOnlyList<string> knowledgeRefs)
+        IReadOnlyList<string> knowledgeRefs,
+        IReadOnlyList<string> parentRefs)
     {
         var suggestions = new List<string>();
 
-        if (reconstructionResult.CandidateIntentNodes.Count > 0)
+        if (parentRefs.Count > 0 && reconstructionResult.CandidateIntentNodes.Count > 0)
         {
             suggestions.Add($"Promote reconstructed intent candidates for '{domain}' into explicit parent intent additions after confirmation.");
         }
 
-        if (reconstructionResult.CandidateExecutionUnits.Count > 0)
+        if (parentRefs.Count > 0 && reconstructionResult.CandidateExecutionUnits.Count > 0)
         {
             suggestions.Add($"Add execution-near intent for '{domain}' before issue-cut based on the reconstructed execution candidates.");
         }
@@ -240,11 +261,17 @@ internal static class GenerateFromCurrentBestPracticeCommand
         string domain,
         GenerateFromCurrentReconstructionResult reconstructionResult,
         IReadOnlyList<string> modelRefs,
-        IReadOnlyList<string> knowledgeRefs)
+        IReadOnlyList<string> knowledgeRefs,
+        IReadOnlyList<string> parentRefs)
     {
         var clarifications = reconstructionResult.Gaps
             .Select(gap => $"Clarify: {gap}")
             .ToList();
+
+        if (parentRefs.Count == 0)
+        {
+            clarifications.Add($"Clarify the runtime parent intent repo root and required parent rules/spec refs for '{domain}' before best-practice review is treated as complete.");
+        }
 
         if (modelRefs.Count == 0)
         {
@@ -270,7 +297,8 @@ internal static class GenerateFromCurrentBestPracticeCommand
         IReadOnlyList<string> recommendedIntentAdditions,
         IReadOnlyList<string> recommendedClarifications,
         IReadOnlyList<string> modelRefs,
-        IReadOnlyList<string> knowledgeRefs)
+        IReadOnlyList<string> knowledgeRefs,
+        IReadOnlyList<string> parentRefs)
     {
         var items = new List<string>
         {
@@ -283,9 +311,9 @@ internal static class GenerateFromCurrentBestPracticeCommand
             items.Add($"clarify: resolve {recommendedClarifications.Count} clarification candidate(s) before issue-cut-ready treatment.");
         }
 
-        if (modelRefs.Count == 0 || knowledgeRefs.Count == 0)
+        if (modelRefs.Count == 0 || knowledgeRefs.Count == 0 || parentRefs.Count == 0)
         {
-            items.Add("defer: keep the reconstructed result out of issue-cut and source-of-truth mutation until project-local model registry and knowledge base coverage improve.");
+            items.Add("defer: keep the reconstructed result out of issue-cut and source-of-truth mutation until parent rules/specs, project-local model registry, and knowledge base coverage are resolved.");
         }
 
         if (recommendedIntentAdditions.Count > 0)
@@ -299,9 +327,10 @@ internal static class GenerateFromCurrentBestPracticeCommand
     private static IReadOnlyList<string> BuildConfidenceDeltas(
         IReadOnlyList<string> confidenceByAltitude,
         IReadOnlyList<string> modelRefs,
-        IReadOnlyList<string> knowledgeRefs)
+        IReadOnlyList<string> knowledgeRefs,
+        IReadOnlyList<string> parentRefs)
     {
-        var hasCompleteReviewInputs = modelRefs.Count > 0 && knowledgeRefs.Count > 0;
+        var hasCompleteReviewInputs = modelRefs.Count > 0 && knowledgeRefs.Count > 0 && parentRefs.Count > 0;
         return confidenceByAltitude
             .Select(entry =>
             {
@@ -342,10 +371,12 @@ internal static class GenerateFromCurrentBestPracticeCommand
     private static string DetermineReadinessStatus(
         IReadOnlyList<string> modelRefs,
         IReadOnlyList<string> knowledgeRefs,
+        IReadOnlyList<string> parentRefs,
         IReadOnlyList<string> recommendedClarifications)
     {
         return modelRefs.Count > 0
             && knowledgeRefs.Count > 0
+            && parentRefs.Count > 0
             && recommendedClarifications.Count == 0
             ? "ready"
             : "not-ready";
@@ -353,9 +384,15 @@ internal static class GenerateFromCurrentBestPracticeCommand
 
     private static IReadOnlyList<string> BuildSkippedStages(
         IReadOnlyList<string> modelRefs,
-        IReadOnlyList<string> knowledgeRefs)
+        IReadOnlyList<string> knowledgeRefs,
+        IReadOnlyList<string> parentRefs)
     {
         var skippedStages = new List<string>();
+        if (parentRefs.Count == 0)
+        {
+            skippedStages.Add("parent-rule-spec-review");
+        }
+
         if (modelRefs.Count == 0)
         {
             skippedStages.Add("model-registry-review");

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentBestPracticeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentBestPracticeCommand.cs
@@ -1,0 +1,468 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentBestPracticeCommand
+{
+    private static readonly string[] ReviewedDimensions =
+    [
+        "architecture",
+        "security",
+        "auth",
+        "data-modeling",
+        "error-handling",
+        "performance",
+        "testability"
+    ];
+
+    private static readonly string[] ParentRuleSpecCandidates =
+    [
+        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/intent-cli/specs/04-concept-intake-and-interview.md",
+        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/intent-cli/specs/05-intent-cli-surface.md",
+        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/intent-cli/specs/10-generate-from-current-and-historical-signals.md",
+        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md",
+        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/intent-cli/intent-tree/means/02-tooling-strategy.md",
+        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/rules/reconstruction-feedback-loop.md",
+        "/Users/tomohisa/dev/GitHub/MyIntentHost/intents/rules/issue-lifecycle-and-landing.md"
+    ];
+
+    private static readonly string[] ModelRegistryDirectories =
+    [
+        ".intent/model-registry",
+        ".intent/models",
+        ".intent-cli/model-registry"
+    ];
+
+    private static readonly string[] KnowledgeBaseDirectories =
+    [
+        ".intent/best-practices",
+        ".intent/best-practice",
+        ".intent-cli/best-practices",
+        "docs/best-practices"
+    ];
+
+    public static Func<CliContext, string[], GenerateFromCurrentResult> SourceBundleExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentCommand.ExecuteSourceBundleCore(context, args);
+
+    public static Func<CliContext, string, GenerateFromCurrentReconstructionResult> ReconstructionExecutor { get; set; } =
+        (context, domain) => GenerateFromCurrentReconstructionCommand.ExecuteCore(context, [domain]);
+
+    public static Func<string, IReadOnlyList<string>> ModelRefProvider { get; set; } =
+        repoRoot => ReadProjectRefs(repoRoot, ModelRegistryDirectories);
+
+    public static Func<string, IReadOnlyList<string>> KnowledgeRefProvider { get; set; } =
+        repoRoot => ReadProjectRefs(repoRoot, KnowledgeBaseDirectories);
+
+    public static Func<IReadOnlyList<string>> ParentRuleSpecRefProvider { get; set; } =
+        () => ParentRuleSpecCandidates.Where(File.Exists).ToArray();
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentBestPracticeRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentBestPracticeResult ExecuteCore(CliContext context, string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current best-practice requires a domain.");
+        }
+
+        var domain = args[0].Trim();
+        var sourceBundleResult = SourceBundleExecutor(context, args);
+        var reconstructionResult = ReconstructionExecutor(context, domain);
+        var modelRefs = ModelRefProvider(context.RepoRoot);
+        var knowledgeRefs = KnowledgeRefProvider(context.RepoRoot);
+        var parentRefs = ParentRuleSpecRefProvider();
+        var reviewedDimensions = BuildReviewedDimensions(
+            sourceBundleResult,
+            reconstructionResult,
+            modelRefs,
+            knowledgeRefs);
+        var recommendedIntentAdditions = BuildRecommendedIntentAdditions(
+            domain,
+            reconstructionResult,
+            modelRefs,
+            knowledgeRefs);
+        var recommendedClarifications = BuildRecommendedClarifications(
+            domain,
+            reconstructionResult,
+            modelRefs,
+            knowledgeRefs);
+        var developerConfirmationItems = BuildDeveloperConfirmationItems(
+            domain,
+            recommendedIntentAdditions,
+            recommendedClarifications,
+            modelRefs,
+            knowledgeRefs);
+        var confidenceDeltas = BuildConfidenceDeltas(
+            reconstructionResult.ConfidenceByAltitude,
+            modelRefs,
+            knowledgeRefs);
+        var readinessStatus = DetermineReadinessStatus(modelRefs, knowledgeRefs, recommendedClarifications);
+        var skippedStages = BuildSkippedStages(modelRefs, knowledgeRefs);
+
+        var artifactPath = WriteArtifact(
+            context.RepoRoot,
+            domain,
+            RenderArtifact(
+                domain,
+                sourceBundleResult.ArtifactPath,
+                [
+                    reconstructionResult.ConceptArtifactPath,
+                    reconstructionResult.InterviewArtifactPath
+                ],
+                reviewedDimensions,
+                modelRefs,
+                knowledgeRefs,
+                parentRefs,
+                recommendedIntentAdditions,
+                recommendedClarifications,
+                developerConfirmationItems,
+                reconstructionResult.ReturnToIntentPaths,
+                confidenceDeltas,
+                readinessStatus,
+                skippedStages));
+
+        return new GenerateFromCurrentBestPracticeResult
+        {
+            Domain = domain,
+            SourceBundleArtifactPath = sourceBundleResult.ArtifactPath,
+            ReconstructedArtifactPaths =
+            [
+                reconstructionResult.ConceptArtifactPath,
+                reconstructionResult.InterviewArtifactPath
+            ],
+            ReviewArtifactPath = ToRelativePath(context.RepoRoot, artifactPath),
+            ReviewedDimensions = reviewedDimensions,
+            ModelRefs = modelRefs,
+            KnowledgeRefs = knowledgeRefs,
+            RecommendedIntentAdditions = recommendedIntentAdditions,
+            RecommendedClarifications = recommendedClarifications,
+            DeveloperConfirmationItems = developerConfirmationItems,
+            ReturnToIntentPaths = reconstructionResult.ReturnToIntentPaths,
+            ConfidenceDeltas = confidenceDeltas,
+            ReadinessStatus = readinessStatus,
+            SkippedStages = skippedStages
+        };
+    }
+
+    private static IReadOnlyList<string> ReadProjectRefs(string repoRoot, IReadOnlyList<string> relativeDirectories)
+    {
+        var refs = new List<string>();
+
+        foreach (var relativeDirectory in relativeDirectories)
+        {
+            var fullDirectory = Path.Combine(repoRoot, relativeDirectory.Replace('/', Path.DirectorySeparatorChar));
+            if (!Directory.Exists(fullDirectory))
+            {
+                continue;
+            }
+
+            refs.AddRange(
+                Directory.EnumerateFiles(fullDirectory, "*", SearchOption.AllDirectories)
+                    .OrderBy(path => path, StringComparer.Ordinal)
+                    .Select(path => ToRelativePath(repoRoot, path)));
+        }
+
+        return refs.Distinct(StringComparer.Ordinal).ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildReviewedDimensions(
+        GenerateFromCurrentResult sourceBundleResult,
+        GenerateFromCurrentReconstructionResult reconstructionResult,
+        IReadOnlyList<string> modelRefs,
+        IReadOnlyList<string> knowledgeRefs)
+    {
+        var hasModelRefs = modelRefs.Count > 0;
+        var hasKnowledgeRefs = knowledgeRefs.Count > 0;
+        var hasAuthKnowledge = knowledgeRefs.Any(reference => reference.Contains("auth", StringComparison.OrdinalIgnoreCase)
+            || reference.Contains("security", StringComparison.OrdinalIgnoreCase));
+        var hasTestSignals = sourceBundleResult.SourceRefs.Any(reference => reference.StartsWith("test:", StringComparison.Ordinal));
+
+        return ReviewedDimensions.Select(dimension => dimension switch
+        {
+            "architecture" => $"{dimension}: {(hasModelRefs ? "needs-confirmation" : "missing-model-registry")}",
+            "security" => $"{dimension}: {(hasKnowledgeRefs ? "needs-confirmation" : "missing-knowledge-base")}",
+            "auth" => $"{dimension}: {(hasAuthKnowledge ? "clarify" : "missing-auth-guidance")}",
+            "data-modeling" => $"{dimension}: {(hasModelRefs ? "clarify" : "missing-model-registry")}",
+            "error-handling" => $"{dimension}: {(hasKnowledgeRefs ? "needs-confirmation" : "missing-knowledge-base")}",
+            "performance" => $"{dimension}: {(reconstructionResult.CandidateExecutionUnits.Count > 0 ? "defer" : "needs-confirmation")}",
+            "testability" => $"{dimension}: {(hasTestSignals ? "needs-confirmation" : "missing-test-signal")}",
+            _ => $"{dimension}: needs-confirmation"
+        }).ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildRecommendedIntentAdditions(
+        string domain,
+        GenerateFromCurrentReconstructionResult reconstructionResult,
+        IReadOnlyList<string> modelRefs,
+        IReadOnlyList<string> knowledgeRefs)
+    {
+        var suggestions = new List<string>();
+
+        if (reconstructionResult.CandidateIntentNodes.Count > 0)
+        {
+            suggestions.Add($"Promote reconstructed intent candidates for '{domain}' into explicit parent intent additions after confirmation.");
+        }
+
+        if (reconstructionResult.CandidateExecutionUnits.Count > 0)
+        {
+            suggestions.Add($"Add execution-near intent for '{domain}' before issue-cut based on the reconstructed execution candidates.");
+        }
+
+        if (modelRefs.Count == 0)
+        {
+            suggestions.Add($"Add project-local model registry entries for '{domain}' covering aggregate, read model, API, infrastructure, or auth model seams.");
+        }
+
+        if (knowledgeRefs.Count == 0)
+        {
+            suggestions.Add($"Add project-local best-practice knowledge entries for '{domain}' covering security, error-handling, and testability expectations.");
+        }
+
+        return suggestions.Distinct(StringComparer.Ordinal).ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildRecommendedClarifications(
+        string domain,
+        GenerateFromCurrentReconstructionResult reconstructionResult,
+        IReadOnlyList<string> modelRefs,
+        IReadOnlyList<string> knowledgeRefs)
+    {
+        var clarifications = reconstructionResult.Gaps
+            .Select(gap => $"Clarify: {gap}")
+            .ToList();
+
+        if (modelRefs.Count == 0)
+        {
+            clarifications.Add($"Clarify the aggregate boundary and data ownership model for '{domain}' before canonical mutation.");
+        }
+
+        if (knowledgeRefs.Count == 0)
+        {
+            clarifications.Add($"Clarify the security/auth and retry/error-handling expectations for '{domain}' before issue-cut.");
+        }
+
+        if (!knowledgeRefs.Any(reference => reference.Contains("auth", StringComparison.OrdinalIgnoreCase)
+            || reference.Contains("security", StringComparison.OrdinalIgnoreCase)))
+        {
+            clarifications.Add($"Clarify the authn/authz model and trust boundary for '{domain}'.");
+        }
+
+        return clarifications.Distinct(StringComparer.Ordinal).ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildDeveloperConfirmationItems(
+        string domain,
+        IReadOnlyList<string> recommendedIntentAdditions,
+        IReadOnlyList<string> recommendedClarifications,
+        IReadOnlyList<string> modelRefs,
+        IReadOnlyList<string> knowledgeRefs)
+    {
+        var items = new List<string>
+        {
+            $"confirm: validate the best-practice review suggestions for '{domain}' against parent rules/specs before any canonical mutation.",
+            "reject: explicitly reject any suggested intent addition that conflicts with project rules or specs."
+        };
+
+        if (recommendedClarifications.Count > 0)
+        {
+            items.Add($"clarify: resolve {recommendedClarifications.Count} clarification candidate(s) before issue-cut-ready treatment.");
+        }
+
+        if (modelRefs.Count == 0 || knowledgeRefs.Count == 0)
+        {
+            items.Add("defer: keep the reconstructed result out of issue-cut and source-of-truth mutation until project-local model registry and knowledge base coverage improve.");
+        }
+
+        if (recommendedIntentAdditions.Count > 0)
+        {
+            items.Add($"confirm: choose which of the {recommendedIntentAdditions.Count} suggested intent additions should return to the parent intent tree.");
+        }
+
+        return items.ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildConfidenceDeltas(
+        IReadOnlyList<string> confidenceByAltitude,
+        IReadOnlyList<string> modelRefs,
+        IReadOnlyList<string> knowledgeRefs)
+    {
+        var hasCompleteReviewInputs = modelRefs.Count > 0 && knowledgeRefs.Count > 0;
+        return confidenceByAltitude
+            .Select(entry =>
+            {
+                var parts = entry.Split(':', 2, StringSplitOptions.TrimEntries);
+                if (parts.Length != 2)
+                {
+                    return $"{entry} -> {entry}";
+                }
+
+                var nextConfidence = hasCompleteReviewInputs
+                    ? RaiseConfidence(parts[1])
+                    : LowerConfidence(parts[1]);
+                return $"{parts[0]}: {parts[1]} -> {nextConfidence}";
+            })
+            .ToArray();
+    }
+
+    private static string RaiseConfidence(string confidence)
+    {
+        return confidence switch
+        {
+            "low" => "medium",
+            "medium" => "high",
+            _ => "high"
+        };
+    }
+
+    private static string LowerConfidence(string confidence)
+    {
+        return confidence switch
+        {
+            "high" => "medium",
+            "medium" => "low",
+            _ => "low"
+        };
+    }
+
+    private static string DetermineReadinessStatus(
+        IReadOnlyList<string> modelRefs,
+        IReadOnlyList<string> knowledgeRefs,
+        IReadOnlyList<string> recommendedClarifications)
+    {
+        return modelRefs.Count > 0
+            && knowledgeRefs.Count > 0
+            && recommendedClarifications.Count == 0
+            ? "ready"
+            : "not-ready";
+    }
+
+    private static IReadOnlyList<string> BuildSkippedStages(
+        IReadOnlyList<string> modelRefs,
+        IReadOnlyList<string> knowledgeRefs)
+    {
+        var skippedStages = new List<string>();
+        if (modelRefs.Count == 0)
+        {
+            skippedStages.Add("model-registry-review");
+        }
+
+        if (knowledgeRefs.Count == 0)
+        {
+            skippedStages.Add("best-practice-knowledge-review");
+        }
+
+        return skippedStages;
+    }
+
+    private static string RenderArtifact(
+        string domain,
+        string sourceBundleArtifactPath,
+        IReadOnlyList<string> reconstructedArtifactPaths,
+        IReadOnlyList<string> reviewedDimensions,
+        IReadOnlyList<string> modelRefs,
+        IReadOnlyList<string> knowledgeRefs,
+        IReadOnlyList<string> parentRuleSpecRefs,
+        IReadOnlyList<string> recommendedIntentAdditions,
+        IReadOnlyList<string> recommendedClarifications,
+        IReadOnlyList<string> developerConfirmationItems,
+        IReadOnlyList<string> returnToIntentPaths,
+        IReadOnlyList<string> confidenceDeltas,
+        string readinessStatus,
+        IReadOnlyList<string> skippedStages)
+    {
+        var lines = new List<string>
+        {
+            "# Best Practice Review",
+            string.Empty,
+            "## Domain",
+            string.Empty,
+            $"`{domain}`",
+            string.Empty,
+            $"source_bundle_artifact_path: {sourceBundleArtifactPath}",
+            "reconstructed_artifact_paths:"
+        };
+
+        AppendBullets(lines, reconstructedArtifactPaths);
+        lines.Add(string.Empty);
+        lines.Add("reviewed_dimensions:");
+        AppendBullets(lines, reviewedDimensions);
+        lines.Add(string.Empty);
+        lines.Add("model_refs:");
+        AppendBullets(lines, modelRefs);
+        lines.Add(string.Empty);
+        lines.Add("knowledge_refs:");
+        AppendBullets(lines, knowledgeRefs);
+        lines.Add(string.Empty);
+        lines.Add("parent_rule_spec_refs:");
+        AppendBullets(lines, parentRuleSpecRefs);
+        lines.Add(string.Empty);
+        lines.Add("recommended_intent_additions:");
+        AppendBullets(lines, recommendedIntentAdditions);
+        lines.Add(string.Empty);
+        lines.Add("recommended_clarifications:");
+        AppendBullets(lines, recommendedClarifications);
+        lines.Add(string.Empty);
+        lines.Add("developer_confirmation_items:");
+        AppendBullets(lines, developerConfirmationItems);
+        lines.Add(string.Empty);
+        lines.Add("return_to_intent_paths:");
+        AppendBullets(lines, returnToIntentPaths);
+        lines.Add(string.Empty);
+        lines.Add("confidence_deltas:");
+        AppendBullets(lines, confidenceDeltas);
+        lines.Add(string.Empty);
+        lines.Add($"readiness_status: {readinessStatus}");
+        lines.Add("skipped_stages:");
+        AppendBullets(lines, skippedStages);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    private static void AppendBullets(List<string> lines, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            lines.Add($"- {value}");
+        }
+    }
+
+    private static string WriteArtifact(string repoRoot, string domain, string markdown)
+    {
+        var artifactPath = Path.Combine(
+            repoRoot,
+            ".intent-cli",
+            "intake",
+            $"{domain}.best-practice-review.md");
+        var directoryPath = Path.GetDirectoryName(artifactPath)
+            ?? throw new InvalidOperationException("Best-practice review artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(artifactPath, markdown);
+        return artifactPath;
+    }
+
+    private static string ToRelativePath(string repoRoot, string absolutePath)
+    {
+        return Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentBestPracticeRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentBestPracticeRenderer.cs
@@ -1,0 +1,49 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentBestPracticeRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentBestPracticeResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current best-practice processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine($"Best-practice review artifact path: {result.ReviewArtifactPath}");
+        writer.WriteLine("Reviewed dimensions:");
+        WriteList(writer, result.ReviewedDimensions);
+        writer.WriteLine("Model refs:");
+        WriteList(writer, result.ModelRefs);
+        writer.WriteLine("Knowledge refs:");
+        WriteList(writer, result.KnowledgeRefs);
+        writer.WriteLine("Recommended intent additions:");
+        WriteList(writer, result.RecommendedIntentAdditions);
+        writer.WriteLine("Recommended clarifications:");
+        WriteList(writer, result.RecommendedClarifications);
+        writer.WriteLine("Developer confirmation items:");
+        WriteList(writer, result.DeveloperConfirmationItems);
+        writer.WriteLine("Return-to-intent paths:");
+        WriteList(writer, result.ReturnToIntentPaths);
+        writer.WriteLine("Confidence deltas:");
+        WriteList(writer, result.ConfidenceDeltas);
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentBestPracticeResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentBestPracticeResult.cs
@@ -1,0 +1,32 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentBestPracticeResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required string ReviewArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReviewedDimensions { get; init; }
+
+    public required IReadOnlyList<string> ModelRefs { get; init; }
+
+    public required IReadOnlyList<string> KnowledgeRefs { get; init; }
+
+    public required IReadOnlyList<string> RecommendedIntentAdditions { get; init; }
+
+    public required IReadOnlyList<string> RecommendedClarifications { get; init; }
+
+    public required IReadOnlyList<string> DeveloperConfirmationItems { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+
+    public required IReadOnlyList<string> ConfidenceDeltas { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -100,6 +100,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "best-practice", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentBestPracticeCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "implement", StringComparison.Ordinal))
         {
             return GenerateFromCurrentImplementCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
+++ b/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
@@ -51,9 +51,11 @@ internal static class CliConfigLoader
 
         var worktreeRoot = TryGetOptionalString(rootTable, CliRuntimeContracts.WorktreeRootKey)
             ?? CliRuntimeContracts.DefaultWorktreeRoot;
+        var parentIntentRepoRoot = TryGetOptionalString(rootTable, CliRuntimeContracts.ParentIntentRepoRootKey)
+            ?? string.Empty;
         var roles = ReadRoles(rootTable);
 
-        config = CreateConfig(domain, workflowEngine, artifactRoot, worktreeRoot, roles);
+        config = CreateConfig(domain, workflowEngine, artifactRoot, worktreeRoot, parentIntentRepoRoot, roles);
         return true;
     }
 
@@ -78,9 +80,11 @@ internal static class CliConfigLoader
 
         var worktreeRoot = TryGetOptionalString(projectTable, CliRuntimeContracts.WorktreeRootKey)
             ?? CliRuntimeContracts.DefaultWorktreeRoot;
+        var parentIntentRepoRoot = TryGetOptionalString(projectTable, CliRuntimeContracts.ParentIntentRepoRootKey)
+            ?? string.Empty;
         var roles = ReadRoles(rootTable);
 
-        config = CreateConfig(domain, workflowEngine, artifactRoot, worktreeRoot, roles);
+        config = CreateConfig(domain, workflowEngine, artifactRoot, worktreeRoot, parentIntentRepoRoot, roles);
         return true;
     }
 
@@ -89,6 +93,7 @@ internal static class CliConfigLoader
         string workflowEngine,
         string artifactRoot,
         string worktreeRoot,
+        string parentIntentRepoRoot,
         RoleMappings roles)
     {
         return new CliConfig
@@ -98,7 +103,8 @@ internal static class CliConfigLoader
                 Domain = domain,
                 WorkflowEngine = workflowEngine,
                 ArtifactRoot = artifactRoot,
-                WorktreeRoot = worktreeRoot
+                WorktreeRoot = worktreeRoot,
+                ParentIntentRepoRoot = parentIntentRepoRoot
             },
             Roles = roles
         };

--- a/src/IntentSystem.Cli/Models/CliConfig.cs
+++ b/src/IntentSystem.Cli/Models/CliConfig.cs
@@ -16,6 +16,8 @@ internal sealed record ProjectConfig
     public required string ArtifactRoot { get; init; }
 
     public string WorktreeRoot { get; init; } = ".intent-cli/worktrees";
+
+    public string ParentIntentRepoRoot { get; init; } = string.Empty;
 }
 
 internal sealed record RoleMappings

--- a/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
@@ -12,6 +12,7 @@ public sealed class CliConfigLoaderTests
         workflow_engine = "takt"
         artifact_root = ".intent-cli"
         worktree_root = ".intent-cli/worktrees"
+        parent_intent_repo_root = "../MyIntentHost"
         """;
 
         var config = CliConfigLoader.Load(toml);
@@ -20,6 +21,7 @@ public sealed class CliConfigLoaderTests
         Assert.Equal("takt", config.Project.WorkflowEngine);
         Assert.Equal(".intent-cli", config.Project.ArtifactRoot);
         Assert.Equal(".intent-cli/worktrees", config.Project.WorktreeRoot);
+        Assert.Equal("../MyIntentHost", config.Project.ParentIntentRepoRoot);
         Assert.Equal("Claude", config.Roles.Implement);
         Assert.Equal("Codex", config.Roles.Review);
     }
@@ -35,6 +37,7 @@ public sealed class CliConfigLoaderTests
             workflow_engine = "takt"
             artifact_root = ".intent-cli"
             worktree_root = ".intent-cli/worktrees"
+            parent_intent_repo_root = "../MyIntentHost"
             """);
 
         var config = CliConfigLoader.LoadFromFile(configPath);
@@ -43,6 +46,7 @@ public sealed class CliConfigLoaderTests
         Assert.Equal("takt", config.Project.WorkflowEngine);
         Assert.Equal(".intent-cli", config.Project.ArtifactRoot);
         Assert.Equal(".intent-cli/worktrees", config.Project.WorktreeRoot);
+        Assert.Equal("../MyIntentHost", config.Project.ParentIntentRepoRoot);
         Assert.Equal("Claude", config.Roles.Implement);
     }
 
@@ -55,6 +59,7 @@ public sealed class CliConfigLoaderTests
         workflow_engine = "takt"
         artifact_root = ".intent-cli"
         worktree_root = ".intent-cli/worktrees"
+        parent_intent_repo_root = "../MyIntentHost"
         """;
 
         var config = CliConfigLoader.Load(toml);
@@ -63,6 +68,7 @@ public sealed class CliConfigLoaderTests
         Assert.Equal("takt", config.Project.WorkflowEngine);
         Assert.Equal(".intent-cli", config.Project.ArtifactRoot);
         Assert.Equal(".intent-cli/worktrees", config.Project.WorktreeRoot);
+        Assert.Equal("../MyIntentHost", config.Project.ParentIntentRepoRoot);
         Assert.Equal("Claude", config.Roles.Implement);
     }
 

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -457,6 +457,7 @@ public sealed class CommandRouterTests
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
+        var parentRepoRoot = tempDirectory.CreateDirectory("parent");
         tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "model-registry"));
         tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "best-practices"));
         tempDirectory.CreateFile(Path.Combine("repo", ".intent", "model-registry", "auth-model.md"), "# auth model");
@@ -464,21 +465,17 @@ public sealed class CommandRouterTests
         tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
         tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
         tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("parent", "intents", "intent-cli", "specs", "11-reconstruction-review-and-confirmation.md"), "# review");
         using var writer = new StringWriter();
         var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
-        var originalParentRefProvider = GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider;
 
         try
         {
             GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
-            GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider = () =>
-            [
-                "intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md"
-            ];
 
             var exitCode = CommandRouter.Execute(
                 ["generate-from-current", "best-practice", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
-                CreateContext(repoRoot),
+                CreateContext(repoRoot, parentRepoRoot),
                 writer);
 
             Assert.Equal(0, exitCode);
@@ -487,7 +484,6 @@ public sealed class CommandRouterTests
         finally
         {
             GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
-            GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider = originalParentRefProvider;
         }
     }
 
@@ -1899,7 +1895,7 @@ public sealed class CommandRouterTests
         Assert.Contains("Execution unit: G22", writer.ToString(), StringComparison.Ordinal);
     }
 
-    private static CliContext CreateContext(string repoRoot)
+    private static CliContext CreateContext(string repoRoot, string? parentIntentRepoRoot = null)
     {
         return new CliContext
         {
@@ -1910,7 +1906,8 @@ public sealed class CommandRouterTests
                 {
                     Domain = "intent-cli",
                     WorkflowEngine = "takt",
-                    ArtifactRoot = ".intent-cli"
+                    ArtifactRoot = ".intent-cli",
+                    ParentIntentRepoRoot = parentIntentRepoRoot ?? string.Empty
                 }
             }
         };

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -453,6 +453,45 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentBestPracticeCommand_DispatchesToBestPracticeRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "model-registry"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "best-practices"));
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "model-registry", "auth-model.md"), "# auth model");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "best-practices", "security.md"), "# security");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+        var originalParentRefProvider = GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+            GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider = () =>
+            [
+                "intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md"
+            ];
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "best-practice", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current best-practice processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+            GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider = originalParentRefProvider;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBestPracticeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBestPracticeCommandTests.cs
@@ -11,6 +11,7 @@ public sealed class GenerateFromCurrentBestPracticeCommandTests
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
+        var parentRepoRoot = tempDirectory.CreateDirectory("parent");
         tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "model-registry"));
         tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "best-practices"));
         tempDirectory.CreateFile(Path.Combine("repo", ".intent", "model-registry", "auth-model.md"), "# auth model");
@@ -20,19 +21,15 @@ public sealed class GenerateFromCurrentBestPracticeCommandTests
         tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
         using var writer = new StringWriter();
         var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
-        var originalParentRefProvider = GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider;
 
         try
         {
             GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
-            GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider = () =>
-            [
-                "intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md",
-                "intents/rules/reconstruction-feedback-loop.md"
-            ];
+            tempDirectory.CreateFile(Path.Combine("parent", "intents", "intent-cli", "specs", "11-reconstruction-review-and-confirmation.md"), "# review");
+            tempDirectory.CreateFile(Path.Combine("parent", "intents", "rules", "reconstruction-feedback-loop.md"), "# loop");
 
             var exitCode = GenerateFromCurrentCommand.Execute(
-                CreateContext(repoRoot),
+                CreateContext(repoRoot, parentRepoRoot),
                 ["best-practice", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,rules,execution"],
                 writer);
 
@@ -53,18 +50,19 @@ public sealed class GenerateFromCurrentBestPracticeCommandTests
             Assert.Contains("knowledge_refs:", artifact, StringComparison.Ordinal);
             Assert.Contains("- .intent/best-practices/security.md", artifact, StringComparison.Ordinal);
             Assert.Contains("parent_rule_spec_refs:", artifact, StringComparison.Ordinal);
+            Assert.Contains("- intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md", artifact, StringComparison.Ordinal);
+            Assert.Contains("- intents/rules/reconstruction-feedback-loop.md", artifact, StringComparison.Ordinal);
             Assert.Contains("recommended_intent_additions:", artifact, StringComparison.Ordinal);
             Assert.Contains("developer_confirmation_items:", artifact, StringComparison.Ordinal);
         }
         finally
         {
             GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
-            GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider = originalParentRefProvider;
         }
     }
 
     [Fact]
-    public void Execute_GivenMissingProjectInputs_ReturnsNotReadyReview()
+    public void Execute_GivenMissingParentRuleSpecInputs_ReturnsNotReadyReview()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -73,7 +71,6 @@ public sealed class GenerateFromCurrentBestPracticeCommandTests
         var originalReconstructionExecutor = GenerateFromCurrentBestPracticeCommand.ReconstructionExecutor;
         var originalModelRefProvider = GenerateFromCurrentBestPracticeCommand.ModelRefProvider;
         var originalKnowledgeRefProvider = GenerateFromCurrentBestPracticeCommand.KnowledgeRefProvider;
-        var originalParentRefProvider = GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider;
 
         try
         {
@@ -104,9 +101,8 @@ public sealed class GenerateFromCurrentBestPracticeCommandTests
                 ReturnToIntentPaths = ["README.md"],
                 Gaps = ["Need stronger auth signal."]
             };
-            GenerateFromCurrentBestPracticeCommand.ModelRefProvider = _ => [];
-            GenerateFromCurrentBestPracticeCommand.KnowledgeRefProvider = _ => [];
-            GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider = () => [];
+            GenerateFromCurrentBestPracticeCommand.ModelRefProvider = _ => [".intent/model-registry/auth-model.md"];
+            GenerateFromCurrentBestPracticeCommand.KnowledgeRefProvider = _ => [".intent/best-practices/security.md"];
 
             var exitCode = GenerateFromCurrentBestPracticeCommand.Execute(
                 CreateContext(repoRoot),
@@ -116,8 +112,10 @@ public sealed class GenerateFromCurrentBestPracticeCommandTests
             Assert.Equal(0, exitCode);
             var output = writer.ToString();
             Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
-            Assert.Contains("- model-registry-review", output, StringComparison.Ordinal);
-            Assert.Contains("- best-practice-knowledge-review", output, StringComparison.Ordinal);
+            Assert.Contains("- parent-rule-spec-review", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("- model-registry-review", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("- best-practice-knowledge-review", output, StringComparison.Ordinal);
+            Assert.Contains("runtime parent intent repo root", output, StringComparison.Ordinal);
         }
         finally
         {
@@ -125,7 +123,6 @@ public sealed class GenerateFromCurrentBestPracticeCommandTests
             GenerateFromCurrentBestPracticeCommand.ReconstructionExecutor = originalReconstructionExecutor;
             GenerateFromCurrentBestPracticeCommand.ModelRefProvider = originalModelRefProvider;
             GenerateFromCurrentBestPracticeCommand.KnowledgeRefProvider = originalKnowledgeRefProvider;
-            GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider = originalParentRefProvider;
         }
     }
 
@@ -140,7 +137,7 @@ public sealed class GenerateFromCurrentBestPracticeCommandTests
         Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
     }
 
-    private static CliContext CreateContext(string repoRoot)
+    private static CliContext CreateContext(string repoRoot, string? parentIntentRepoRoot = null)
     {
         return new CliContext
         {
@@ -152,7 +149,8 @@ public sealed class GenerateFromCurrentBestPracticeCommandTests
                     Domain = "intent-system",
                     WorkflowEngine = "intent-cli",
                     ArtifactRoot = ".intent-cli",
-                    WorktreeRoot = ".intent-cli/worktrees"
+                    WorktreeRoot = ".intent-cli/worktrees",
+                    ParentIntentRepoRoot = parentIntentRepoRoot ?? string.Empty
                 }
             }
         };

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBestPracticeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBestPracticeCommandTests.cs
@@ -1,0 +1,221 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentBestPracticeCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_GeneratesBestPracticeReviewArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "model-registry"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "best-practices"));
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "model-registry", "auth-model.md"), "# auth model");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "best-practices", "security.md"), "# security");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+        var originalParentRefProvider = GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+            GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider = () =>
+            [
+                "intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md",
+                "intents/rules/reconstruction-feedback-loop.md"
+            ];
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["best-practice", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,rules,execution"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current best-practice processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/intake/auth.best-practice-review.md", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+            Assert.Contains("Model refs:", output, StringComparison.Ordinal);
+            Assert.Contains("Knowledge refs:", output, StringComparison.Ordinal);
+
+            var artifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.best-practice-review.md");
+            Assert.True(File.Exists(artifactPath));
+            var artifact = File.ReadAllText(artifactPath);
+            Assert.Contains("# Best Practice Review", artifact, StringComparison.Ordinal);
+            Assert.Contains("model_refs:", artifact, StringComparison.Ordinal);
+            Assert.Contains("- .intent/model-registry/auth-model.md", artifact, StringComparison.Ordinal);
+            Assert.Contains("knowledge_refs:", artifact, StringComparison.Ordinal);
+            Assert.Contains("- .intent/best-practices/security.md", artifact, StringComparison.Ordinal);
+            Assert.Contains("parent_rule_spec_refs:", artifact, StringComparison.Ordinal);
+            Assert.Contains("recommended_intent_additions:", artifact, StringComparison.Ordinal);
+            Assert.Contains("developer_confirmation_items:", artifact, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+            GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider = originalParentRefProvider;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingProjectInputs_ReturnsNotReadyReview()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalSourceBundleExecutor = GenerateFromCurrentBestPracticeCommand.SourceBundleExecutor;
+        var originalReconstructionExecutor = GenerateFromCurrentBestPracticeCommand.ReconstructionExecutor;
+        var originalModelRefProvider = GenerateFromCurrentBestPracticeCommand.ModelRefProvider;
+        var originalKnowledgeRefProvider = GenerateFromCurrentBestPracticeCommand.KnowledgeRefProvider;
+        var originalParentRefProvider = GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider;
+
+        try
+        {
+            GenerateFromCurrentBestPracticeCommand.SourceBundleExecutor = (_, _) => new GenerateFromCurrentResult
+            {
+                Domain = "auth",
+                ArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                SourceRoot = "src/feature",
+                SelectedIssueScope = "none",
+                SelectedPrScope = "none",
+                SelectedAltitudes = ["execution"],
+                SelectedPaths = ["src/feature/FeatureA.cs"],
+                SourceRefs = ["code:src/feature/FeatureA.cs"],
+                SamplingNotes = [],
+                Gaps = []
+            };
+            GenerateFromCurrentBestPracticeCommand.ReconstructionExecutor = (_, _) => new GenerateFromCurrentReconstructionResult
+            {
+                Domain = "auth",
+                ConceptArtifactPath = ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                InterviewArtifactPath = ".intent-cli/intake/auth.reconstructed-interview.md",
+                SelectedAltitudes = ["execution"],
+                CandidateIntentNodes = [],
+                CandidateExecutionUnits = ["Execution candidate from src/feature/FeatureA.cs."],
+                ConfidenceByAltitude = ["execution: medium"],
+                SourceConceptRefs = [],
+                RecommendedFollowUpQuestions = [],
+                ReturnToIntentPaths = ["README.md"],
+                Gaps = ["Need stronger auth signal."]
+            };
+            GenerateFromCurrentBestPracticeCommand.ModelRefProvider = _ => [];
+            GenerateFromCurrentBestPracticeCommand.KnowledgeRefProvider = _ => [];
+            GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider = () => [];
+
+            var exitCode = GenerateFromCurrentBestPracticeCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+            Assert.Contains("- model-registry-review", output, StringComparison.Ordinal);
+            Assert.Contains("- best-practice-knowledge-review", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentBestPracticeCommand.SourceBundleExecutor = originalSourceBundleExecutor;
+            GenerateFromCurrentBestPracticeCommand.ReconstructionExecutor = originalReconstructionExecutor;
+            GenerateFromCurrentBestPracticeCommand.ModelRefProvider = originalModelRefProvider;
+            GenerateFromCurrentBestPracticeCommand.KnowledgeRefProvider = originalKnowledgeRefProvider;
+            GenerateFromCurrentBestPracticeCommand.ParentRuleSpecRefProvider = originalParentRefProvider;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentBestPracticeCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-best-practice-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBestPracticeRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentBestPracticeRendererTests.cs
@@ -1,0 +1,72 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentBestPracticeRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenBestPracticeResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentBestPracticeRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentBestPracticeResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                ReviewedDimensions = ["architecture: needs-confirmation", "security: needs-confirmation"],
+                ModelRefs = [".intent/model-registry/auth-model.md"],
+                KnowledgeRefs = [".intent/best-practices/security.md"],
+                RecommendedIntentAdditions = ["Promote reconstructed intent candidates for 'auth' into explicit parent intent additions after confirmation."],
+                RecommendedClarifications = ["Clarify the authn/authz model and trust boundary for 'auth'."],
+                DeveloperConfirmationItems = ["confirm: validate the best-practice review suggestions for 'auth' against parent rules/specs before any canonical mutation."],
+                ReturnToIntentPaths = ["README.md", "AGENTS.md"],
+                ConfidenceDeltas = ["purpose: medium -> high", "execution: medium -> high"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current best-practice processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Best-practice review artifact path: .intent-cli/intake/auth.best-practice-review.md", output, StringComparison.Ordinal);
+        Assert.Contains("Reviewed dimensions:", output, StringComparison.Ordinal);
+        Assert.Contains("Confidence deltas:", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_RendersNoneEntries()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentBestPracticeRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentBestPracticeResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                ReviewedDimensions = [],
+                ModelRefs = [],
+                KnowledgeRefs = [],
+                RecommendedIntentAdditions = [],
+                RecommendedClarifications = [],
+                DeveloperConfirmationItems = [],
+                ReturnToIntentPaths = [],
+                ConfidenceDeltas = [],
+                ReadinessStatus = "not-ready",
+                SkippedStages = ["model-registry-review", "best-practice-knowledge-review"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+        Assert.Contains("- model-registry-review", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current best-practice <domain> --from-path <path>` as a thin composition over source bundle and reconstruction
- generate deterministic `.intent-cli/intake/<domain>.best-practice-review.md` artifacts from project-local model registry, best-practice knowledge refs, and parent rule/spec inputs
- cover the new command with command, renderer, and router tests

Closes #144