### PR TITLE
[codex] Add generate-from-current confirm command

### DIFF
--- a/src/IntentSystem.Cli/Commands/DeveloperConfirmationArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/DeveloperConfirmationArtifactYaml.cs
@@ -1,0 +1,222 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record DeveloperConfirmationArtifact
+{
+    public required string DomainSlug { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required string ReviewArtifactPath { get; init; }
+
+    public required string DecisionFilePath { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> RejectedItems { get; init; }
+
+    public required IReadOnlyList<string> ClarifyItems { get; init; }
+
+    public required IReadOnlyList<string> DeferredItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+}
+
+internal static class DeveloperConfirmationArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "domain_slug",
+        "source_bundle_artifact_path",
+        "reconstructed_artifact_paths",
+        "review_artifact_path",
+        "decision_file_path",
+        "confirmed_items",
+        "rejected_items",
+        "clarify_items",
+        "deferred_items",
+        "blocked_items",
+        "downstream_readiness",
+        "return_to_intent_paths"
+    ];
+
+    public static string Serialize(DeveloperConfirmationArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"domain_slug: {artifact.DomainSlug}",
+            $"source_bundle_artifact_path: {Quote(artifact.SourceBundleArtifactPath)}",
+            $"review_artifact_path: {Quote(artifact.ReviewArtifactPath)}",
+            $"decision_file_path: {Quote(artifact.DecisionFilePath)}",
+            $"downstream_readiness: {artifact.DownstreamReadiness}"
+        };
+
+        AppendList(lines, "reconstructed_artifact_paths", artifact.ReconstructedArtifactPaths);
+        AppendList(lines, "confirmed_items", artifact.ConfirmedItems);
+        AppendList(lines, "rejected_items", artifact.RejectedItems);
+        AppendList(lines, "clarify_items", artifact.ClarifyItems);
+        AppendList(lines, "deferred_items", artifact.DeferredItems);
+        AppendList(lines, "blocked_items", artifact.BlockedItems);
+        AppendList(lines, "return_to_intent_paths", artifact.ReturnToIntentPaths);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static DeveloperConfirmationArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new DeveloperConfirmationArtifact
+        {
+            DomainSlug = GetRequiredScalar(values, "domain_slug"),
+            SourceBundleArtifactPath = GetRequiredScalar(values, "source_bundle_artifact_path"),
+            ReconstructedArtifactPaths = GetRequiredList(values, "reconstructed_artifact_paths"),
+            ReviewArtifactPath = GetRequiredScalar(values, "review_artifact_path"),
+            DecisionFilePath = GetRequiredScalar(values, "decision_file_path"),
+            ConfirmedItems = GetRequiredList(values, "confirmed_items"),
+            RejectedItems = GetRequiredList(values, "rejected_items"),
+            ClarifyItems = GetRequiredList(values, "clarify_items"),
+            DeferredItems = GetRequiredList(values, "deferred_items"),
+            BlockedItems = GetRequiredList(values, "blocked_items"),
+            DownstreamReadiness = GetRequiredScalar(values, "downstream_readiness"),
+            ReturnToIntentPaths = GetRequiredList(values, "return_to_intent_paths")
+        };
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add($"{label}: []");
+            return;
+        }
+
+        lines.Add($"{label}:");
+        lines.AddRange(values.Select(value => $"  - {Quote(value)}"));
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("  - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !values.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException($"Developer confirmation YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[4..].TrimStart()));
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Developer confirmation YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+
+            if (value.Length == 0)
+            {
+                values[key] = new List<string>();
+                currentListKey = key;
+                continue;
+            }
+
+            currentListKey = null;
+            values[key] = value switch
+            {
+                "[]" => Array.Empty<string>(),
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Developer confirmation YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException($"Developer confirmation YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static IReadOnlyList<string> GetRequiredList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Developer confirmation YAML field '{key}' must be a list.");
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException($"Developer confirmation YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/DeveloperDecisionFileMarkdown.cs
+++ b/src/IntentSystem.Cli/Commands/DeveloperDecisionFileMarkdown.cs
@@ -1,0 +1,93 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record DeveloperDecisionFile
+{
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> RejectedItems { get; init; }
+
+    public required IReadOnlyList<string> ClarifyItems { get; init; }
+
+    public required IReadOnlyList<string> DeferredItems { get; init; }
+}
+
+internal static class DeveloperDecisionFileMarkdown
+{
+    private static readonly string[] RequiredSections =
+    [
+        "Confirm",
+        "Reject",
+        "Clarify",
+        "Defer"
+    ];
+
+    public static DeveloperDecisionFile Deserialize(string markdown)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(markdown);
+
+        var sections = RequiredSections.ToDictionary(section => section, _ => new List<string>(), StringComparer.Ordinal);
+        var seenSections = new HashSet<string>(StringComparer.Ordinal);
+        var lines = markdown.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n', StringSplitOptions.None);
+        var sawTitle = false;
+        string? currentSection = null;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (string.Equals(line, "# Developer Confirmation Decisions", StringComparison.Ordinal))
+            {
+                sawTitle = true;
+                currentSection = null;
+                continue;
+            }
+
+            if (line.StartsWith("## ", StringComparison.Ordinal))
+            {
+                var section = line[3..].Trim();
+                if (!sections.ContainsKey(section))
+                {
+                    throw new InvalidOperationException($"Developer decision file section '{section}' is not supported.");
+                }
+
+                currentSection = section;
+                seenSections.Add(section);
+                continue;
+            }
+
+            if (!line.StartsWith("- ", StringComparison.Ordinal) || currentSection is null)
+            {
+                continue;
+            }
+
+            var value = line[2..].Trim();
+            if (!string.Equals(value, "none", StringComparison.Ordinal))
+            {
+                sections[currentSection].Add(value);
+            }
+        }
+
+        if (!sawTitle)
+        {
+            throw new InvalidOperationException("Developer decision file must start with '# Developer Confirmation Decisions'.");
+        }
+
+        var missingSection = RequiredSections.FirstOrDefault(section => !seenSections.Contains(section));
+        if (missingSection is not null)
+        {
+            throw new InvalidOperationException($"Developer decision file must contain section '## {missingSection}'.");
+        }
+
+        return new DeveloperDecisionFile
+        {
+            ConfirmedItems = sections["Confirm"].ToArray(),
+            RejectedItems = sections["Reject"].ToArray(),
+            ClarifyItems = sections["Clarify"].ToArray(),
+            DeferredItems = sections["Defer"].ToArray()
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/DeveloperDecisionFileMarkdown.cs
+++ b/src/IntentSystem.Cli/Commands/DeveloperDecisionFileMarkdown.cs
@@ -13,81 +13,107 @@ internal sealed record DeveloperDecisionFile
 
 internal static class DeveloperDecisionFileMarkdown
 {
-    private static readonly string[] RequiredSections =
+    private static readonly string[] SupportedDecisionPrefixes =
     [
-        "Confirm",
-        "Reject",
-        "Clarify",
-        "Defer"
+        "confirm:",
+        "reject:",
+        "clarify:",
+        "defer:"
     ];
 
     public static DeveloperDecisionFile Deserialize(string markdown)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(markdown);
 
-        var sections = RequiredSections.ToDictionary(section => section, _ => new List<string>(), StringComparer.Ordinal);
-        var seenSections = new HashSet<string>(StringComparer.Ordinal);
+        var confirmedItems = new List<string>();
+        var rejectedItems = new List<string>();
+        var clarifyItems = new List<string>();
+        var deferredItems = new List<string>();
         var lines = markdown.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n', StringSplitOptions.None);
-        var sawTitle = false;
-        string? currentSection = null;
 
         foreach (var rawLine in lines)
         {
-            var line = rawLine.TrimEnd();
+            var line = NormalizeDecisionLine(rawLine);
             if (string.IsNullOrWhiteSpace(line))
             {
                 continue;
             }
 
-            if (string.Equals(line, "# Developer Confirmation Decisions", StringComparison.Ordinal))
+            if (TryReadDecision(line, out var decisionType, out var decisionValue))
             {
-                sawTitle = true;
-                currentSection = null;
-                continue;
-            }
-
-            if (line.StartsWith("## ", StringComparison.Ordinal))
-            {
-                var section = line[3..].Trim();
-                if (!sections.ContainsKey(section))
+                switch (decisionType)
                 {
-                    throw new InvalidOperationException($"Developer decision file section '{section}' is not supported.");
+                    case "confirm":
+                        confirmedItems.Add(decisionValue);
+                        break;
+                    case "reject":
+                        rejectedItems.Add(decisionValue);
+                        break;
+                    case "clarify":
+                        clarifyItems.Add(decisionValue);
+                        break;
+                    case "defer":
+                        deferredItems.Add(decisionValue);
+                        break;
                 }
-
-                currentSection = section;
-                seenSections.Add(section);
-                continue;
-            }
-
-            if (!line.StartsWith("- ", StringComparison.Ordinal) || currentSection is null)
-            {
-                continue;
-            }
-
-            var value = line[2..].Trim();
-            if (!string.Equals(value, "none", StringComparison.Ordinal))
-            {
-                sections[currentSection].Add(value);
             }
         }
 
-        if (!sawTitle)
+        if (confirmedItems.Count == 0
+            && rejectedItems.Count == 0
+            && clarifyItems.Count == 0
+            && deferredItems.Count == 0)
         {
-            throw new InvalidOperationException("Developer decision file must start with '# Developer Confirmation Decisions'.");
-        }
-
-        var missingSection = RequiredSections.FirstOrDefault(section => !seenSections.Contains(section));
-        if (missingSection is not null)
-        {
-            throw new InvalidOperationException($"Developer decision file must contain section '## {missingSection}'.");
+            throw new InvalidOperationException(
+                "Prepared developer decision file must contain at least one bounded decision line using 'confirm:', 'reject:', 'clarify:', or 'defer:'.");
         }
 
         return new DeveloperDecisionFile
         {
-            ConfirmedItems = sections["Confirm"].ToArray(),
-            RejectedItems = sections["Reject"].ToArray(),
-            ClarifyItems = sections["Clarify"].ToArray(),
-            DeferredItems = sections["Defer"].ToArray()
+            ConfirmedItems = confirmedItems,
+            RejectedItems = rejectedItems,
+            ClarifyItems = clarifyItems,
+            DeferredItems = deferredItems
         };
+    }
+
+    private static string NormalizeDecisionLine(string rawLine)
+    {
+        var line = rawLine.Trim();
+        if (line.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        if (line.StartsWith("- ", StringComparison.Ordinal)
+            || line.StartsWith("* ", StringComparison.Ordinal))
+        {
+            return line[2..].TrimStart();
+        }
+
+        var periodIndex = line.IndexOf(". ", StringComparison.Ordinal);
+        if (periodIndex > 0 && line[..periodIndex].All(char.IsDigit))
+        {
+            return line[(periodIndex + 2)..].TrimStart();
+        }
+
+        return line;
+    }
+
+    private static bool TryReadDecision(string line, out string decisionType, out string decisionValue)
+    {
+        foreach (var prefix in SupportedDecisionPrefixes)
+        {
+            if (line.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                decisionType = prefix[..^1];
+                decisionValue = line;
+                return true;
+            }
+        }
+
+        decisionType = string.Empty;
+        decisionValue = string.Empty;
+        return false;
     }
 }

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -100,6 +100,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "confirm", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentConfirmCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "best-practice", StringComparison.Ordinal))
         {
             return GenerateFromCurrentBestPracticeCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmCommand.cs
@@ -1,0 +1,207 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmCommand
+{
+    public static Func<CliContext, string[], GenerateFromCurrentBestPracticeResult> BestPracticeExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentBestPracticeCommand.ExecuteCore(context, args);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentConfirmRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentConfirmResult ExecuteCore(CliContext context, string[] args)
+    {
+        var (pipelineArgs, decisionFilePathArgument) = ParseArgs(args);
+        var domain = pipelineArgs[0].Trim();
+        var bestPracticeResult = BestPracticeExecutor(context, pipelineArgs);
+        var decisionFilePath = ResolveInputPath(context.RepoRoot, decisionFilePathArgument);
+        if (!File.Exists(decisionFilePath))
+        {
+            throw new InvalidOperationException($"Prepared developer decision file was not found at {decisionFilePath}");
+        }
+
+        var decisionFile = DeveloperDecisionFileMarkdown.Deserialize(File.ReadAllText(decisionFilePath));
+        ValidateDecisions(bestPracticeResult.DeveloperConfirmationItems, decisionFile);
+
+        var decidedItems = decisionFile.ConfirmedItems
+            .Concat(decisionFile.RejectedItems)
+            .Concat(decisionFile.ClarifyItems)
+            .Concat(decisionFile.DeferredItems)
+            .ToHashSet(StringComparer.Ordinal);
+        var blockedItems = BuildBlockedItems(bestPracticeResult, decisionFile, decidedItems);
+        var downstreamReadiness = string.Equals(bestPracticeResult.ReadinessStatus, "ready", StringComparison.Ordinal)
+            && blockedItems.Count == 0
+            ? "ready"
+            : "not-ready";
+
+        var artifact = new DeveloperConfirmationArtifact
+        {
+            DomainSlug = domain,
+            SourceBundleArtifactPath = bestPracticeResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = bestPracticeResult.ReconstructedArtifactPaths,
+            ReviewArtifactPath = bestPracticeResult.ReviewArtifactPath,
+            DecisionFilePath = ToDisplayPath(context.RepoRoot, decisionFilePath),
+            ConfirmedItems = decisionFile.ConfirmedItems,
+            RejectedItems = decisionFile.RejectedItems,
+            ClarifyItems = decisionFile.ClarifyItems,
+            DeferredItems = decisionFile.DeferredItems,
+            BlockedItems = blockedItems,
+            DownstreamReadiness = downstreamReadiness,
+            ReturnToIntentPaths = bestPracticeResult.ReturnToIntentPaths
+        };
+
+        var artifactPath = WriteArtifact(context.RepoRoot, domain, DeveloperConfirmationArtifactYaml.Serialize(artifact));
+
+        return new GenerateFromCurrentConfirmResult
+        {
+            Domain = domain,
+            SourceBundleArtifactPath = bestPracticeResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = bestPracticeResult.ReconstructedArtifactPaths,
+            ReviewArtifactPath = bestPracticeResult.ReviewArtifactPath,
+            DecisionFilePath = artifact.DecisionFilePath,
+            ConfirmationArtifactPath = ToRelativePath(context.RepoRoot, artifactPath),
+            ConfirmedItems = decisionFile.ConfirmedItems,
+            RejectedItems = decisionFile.RejectedItems,
+            ClarifyItems = decisionFile.ClarifyItems,
+            DeferredItems = decisionFile.DeferredItems,
+            BlockedItems = blockedItems,
+            DownstreamReadiness = downstreamReadiness,
+            ReturnToIntentPaths = bestPracticeResult.ReturnToIntentPaths
+        };
+    }
+
+    private static (string[] PipelineArgs, string DecisionFilePath) ParseArgs(string[] args)
+    {
+        if (args.Length < 3 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException(
+                "Generate-from-current confirm requires a domain, source selection args, and '--from-file <path>'.");
+        }
+
+        string? decisionFilePath = null;
+        var pipelineArgs = new List<string>();
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            if (string.Equals(argument, "--from-file", StringComparison.Ordinal))
+            {
+                if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                {
+                    throw new InvalidOperationException("--from-file requires a value.");
+                }
+
+                decisionFilePath = args[index + 1];
+                index++;
+                continue;
+            }
+
+            pipelineArgs.Add(argument);
+        }
+
+        if (string.IsNullOrWhiteSpace(decisionFilePath))
+        {
+            throw new InvalidOperationException("Generate-from-current confirm requires '--from-file <path>'.");
+        }
+
+        return (pipelineArgs.ToArray(), decisionFilePath);
+    }
+
+    private static void ValidateDecisions(
+        IReadOnlyList<string> currentItems,
+        DeveloperDecisionFile decisionFile)
+    {
+        var knownItems = currentItems.ToHashSet(StringComparer.Ordinal);
+        var seenItems = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var item in decisionFile.ConfirmedItems
+                     .Concat(decisionFile.RejectedItems)
+                     .Concat(decisionFile.ClarifyItems)
+                     .Concat(decisionFile.DeferredItems))
+        {
+            if (!knownItems.Contains(item))
+            {
+                throw new InvalidOperationException(
+                    $"Prepared developer decision item '{item}' does not match a current developer confirmation item.");
+            }
+
+            if (!seenItems.Add(item))
+            {
+                throw new InvalidOperationException(
+                    $"Prepared developer decision item '{item}' must not appear in more than one decision bucket.");
+            }
+        }
+    }
+
+    private static IReadOnlyList<string> BuildBlockedItems(
+        GenerateFromCurrentBestPracticeResult bestPracticeResult,
+        DeveloperDecisionFile decisionFile,
+        IReadOnlySet<string> decidedItems)
+    {
+        var blockedItems = new List<string>();
+
+        blockedItems.AddRange(decisionFile.ClarifyItems);
+        blockedItems.AddRange(decisionFile.DeferredItems);
+        blockedItems.AddRange(bestPracticeResult.DeveloperConfirmationItems
+            .Where(item => !decidedItems.Contains(item)));
+
+        if (!string.Equals(bestPracticeResult.ReadinessStatus, "ready", StringComparison.Ordinal))
+        {
+            blockedItems.Add($"Resolve upstream reconstruction review readiness '{bestPracticeResult.ReadinessStatus}' before downstream activation.");
+        }
+
+        blockedItems.AddRange(bestPracticeResult.SkippedStages
+            .Select(stage => $"Resolve upstream skipped stage '{stage}' before downstream activation."));
+
+        return blockedItems.Distinct(StringComparer.Ordinal).ToArray();
+    }
+
+    private static string ResolveInputPath(string repoRoot, string path)
+    {
+        return Path.IsPathRooted(path)
+            ? Path.GetFullPath(path)
+            : Path.GetFullPath(Path.Combine(repoRoot, path));
+    }
+
+    private static string ToDisplayPath(string repoRoot, string absolutePath)
+    {
+        var repoRootWithSeparator = repoRoot.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        return absolutePath.StartsWith(repoRootWithSeparator, StringComparison.Ordinal)
+            ? ToRelativePath(repoRoot, absolutePath)
+            : absolutePath;
+    }
+
+    private static string WriteArtifact(string repoRoot, string domain, string yaml)
+    {
+        var artifactPath = Path.Combine(
+            repoRoot,
+            ".intent-cli",
+            "intake",
+            $"{domain}.developer-confirmation.yaml");
+        var directoryPath = Path.GetDirectoryName(artifactPath)
+            ?? throw new InvalidOperationException("Developer confirmation artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(artifactPath, yaml);
+        return artifactPath;
+    }
+
+    private static string ToRelativePath(string repoRoot, string absolutePath)
+    {
+        return Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmRenderer.cs
@@ -1,0 +1,45 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentConfirmResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current confirm processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine($"Best-practice review artifact path: {result.ReviewArtifactPath}");
+        writer.WriteLine($"Prepared decision file path: {result.DecisionFilePath}");
+        writer.WriteLine($"Developer confirmation artifact path: {result.ConfirmationArtifactPath}");
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Rejected items:");
+        WriteList(writer, result.RejectedItems);
+        writer.WriteLine("Clarify items:");
+        WriteList(writer, result.ClarifyItems);
+        writer.WriteLine("Deferred items:");
+        WriteList(writer, result.DeferredItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+        writer.WriteLine("Return-to-intent paths:");
+        WriteList(writer, result.ReturnToIntentPaths);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmResult.cs
@@ -1,0 +1,30 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentConfirmResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required string ReviewArtifactPath { get; init; }
+
+    public required string DecisionFilePath { get; init; }
+
+    public required string ConfirmationArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> RejectedItems { get; init; }
+
+    public required IReadOnlyList<string> ClarifyItems { get; init; }
+
+    public required IReadOnlyList<string> DeferredItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -488,6 +488,57 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentConfirmCommand_DispatchesToConfirmRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var parentRepoRoot = tempDirectory.CreateDirectory("parent");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "model-registry"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "best-practices"));
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "model-registry", "auth-model.md"), "# auth model");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "best-practices", "security.md"), "# security");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("parent", "intents", "intent-cli", "specs", "11-reconstruction-review-and-confirmation.md"), "# review");
+        tempDirectory.CreateFile(Path.Combine("repo", "prepared", "auth.decisions.md"), """
+            # Developer Confirmation Decisions
+
+            ## Confirm
+            - confirm: validate the best-practice review suggestions for 'auth' against parent rules/specs before any canonical mutation.
+            - confirm: choose which of the 2 suggested intent additions should return to the parent intent tree.
+
+            ## Reject
+            - reject: explicitly reject any suggested intent addition that conflicts with project rules or specs.
+
+            ## Clarify
+            - none
+
+            ## Defer
+            - none
+            """);
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirm", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution", "--from-file", "prepared/auth.decisions.md"],
+                CreateContext(repoRoot, parentRepoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current confirm processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -502,20 +502,10 @@ public sealed class CommandRouterTests
         tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
         tempDirectory.CreateFile(Path.Combine("parent", "intents", "intent-cli", "specs", "11-reconstruction-review-and-confirmation.md"), "# review");
         tempDirectory.CreateFile(Path.Combine("repo", "prepared", "auth.decisions.md"), """
-            # Developer Confirmation Decisions
-
-            ## Confirm
+            # Current review decisions
             - confirm: validate the best-practice review suggestions for 'auth' against parent rules/specs before any canonical mutation.
             - confirm: choose which of the 2 suggested intent additions should return to the parent intent tree.
-
-            ## Reject
             - reject: explicitly reject any suggested intent addition that conflicts with project rules or specs.
-
-            ## Clarify
-            - none
-
-            ## Defer
-            - none
             """);
         using var writer = new StringWriter();
         var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmCommandTests.cs
@@ -1,0 +1,238 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentConfirmCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_GeneratesDeveloperConfirmationArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var parentRepoRoot = tempDirectory.CreateDirectory("parent");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "model-registry"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "best-practices"));
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "model-registry", "auth-model.md"), "# auth model");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "best-practices", "security.md"), "# security");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("parent", "intents", "intent-cli", "specs", "11-reconstruction-review-and-confirmation.md"), "# review");
+        tempDirectory.CreateFile(Path.Combine("parent", "intents", "rules", "reconstruction-feedback-loop.md"), "# loop");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "prepared", "auth.decisions.md"),
+            """
+            # Developer Confirmation Decisions
+
+            ## Confirm
+            - confirm: validate the best-practice review suggestions for 'auth' against parent rules/specs before any canonical mutation.
+            - confirm: choose which of the 2 suggested intent additions should return to the parent intent tree.
+
+            ## Reject
+            - reject: explicitly reject any suggested intent addition that conflicts with project rules or specs.
+
+            ## Clarify
+            - none
+
+            ## Defer
+            - none
+            """);
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot, parentRepoRoot),
+                ["confirm", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,rules,execution", "--from-file", "prepared/auth.decisions.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current confirm processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/intake/auth.developer-confirmation.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+
+            var artifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.developer-confirmation.yaml");
+            Assert.True(File.Exists(artifactPath));
+            var artifact = DeveloperConfirmationArtifactYaml.Deserialize(File.ReadAllText(artifactPath));
+            Assert.Equal("auth", artifact.DomainSlug);
+            Assert.Equal("prepared/auth.decisions.md", artifact.DecisionFilePath);
+            Assert.Equal("ready", artifact.DownstreamReadiness);
+            Assert.Equal(2, artifact.ConfirmedItems.Count);
+            Assert.Single(artifact.RejectedItems);
+            Assert.Empty(artifact.BlockedItems);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenUndecidedItems_ReturnsBlockedNotReadyArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "prepared", "auth.decisions.md"),
+            """
+            # Developer Confirmation Decisions
+
+            ## Confirm
+            - confirm: validate current auth boundary
+
+            ## Reject
+            - none
+
+            ## Clarify
+            - none
+
+            ## Defer
+            - none
+            """);
+        using var writer = new StringWriter();
+        var originalExecutor = GenerateFromCurrentConfirmCommand.BestPracticeExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmCommand.BestPracticeExecutor = (_, _) => new GenerateFromCurrentBestPracticeResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                ReviewedDimensions = ["architecture: needs-confirmation"],
+                ModelRefs = [".intent/model-registry/auth-model.md"],
+                KnowledgeRefs = [".intent/best-practices/security.md"],
+                RecommendedIntentAdditions = [],
+                RecommendedClarifications = [],
+                DeveloperConfirmationItems =
+                [
+                    "confirm: validate current auth boundary",
+                    "confirm: choose the parent return path"
+                ],
+                ReturnToIntentPaths = ["README.md"],
+                ConfidenceDeltas = ["execution: medium -> high"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+
+            var exitCode = GenerateFromCurrentConfirmCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature", "--from-file", "prepared/auth.decisions.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Downstream readiness: not-ready", output, StringComparison.Ordinal);
+            Assert.Contains("confirm: choose the parent return path", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmCommand.BestPracticeExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFromFileArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentConfirmCommand.Execute(
+            CreateContext("/tmp/intent-system"),
+            ["auth", "--from-path", "src/feature"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-file", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot, string? parentIntentRepoRoot = null)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                    ParentIntentRepoRoot = parentIntentRepoRoot ?? string.Empty
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-confirm-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmCommandTests.cs
@@ -24,20 +24,12 @@ public sealed class GenerateFromCurrentConfirmCommandTests
         tempDirectory.CreateFile(
             Path.Combine("repo", "prepared", "auth.decisions.md"),
             """
-            # Developer Confirmation Decisions
+            # Review Follow-up For Auth
 
-            ## Confirm
+            These are the bounded decisions for the current reconstruction review.
             - confirm: validate the best-practice review suggestions for 'auth' against parent rules/specs before any canonical mutation.
             - confirm: choose which of the 2 suggested intent additions should return to the parent intent tree.
-
-            ## Reject
-            - reject: explicitly reject any suggested intent addition that conflicts with project rules or specs.
-
-            ## Clarify
-            - none
-
-            ## Defer
-            - none
+            1. reject: explicitly reject any suggested intent addition that conflicts with project rules or specs.
             """);
         using var writer = new StringWriter();
         var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
@@ -81,19 +73,9 @@ public sealed class GenerateFromCurrentConfirmCommandTests
         tempDirectory.CreateFile(
             Path.Combine("repo", "prepared", "auth.decisions.md"),
             """
-            # Developer Confirmation Decisions
+            # Follow-up
 
-            ## Confirm
             - confirm: validate current auth boundary
-
-            ## Reject
-            - none
-
-            ## Clarify
-            - none
-
-            ## Defer
-            - none
             """);
         using var writer = new StringWriter();
         var originalExecutor = GenerateFromCurrentConfirmCommand.BestPracticeExecutor;
@@ -154,6 +136,59 @@ public sealed class GenerateFromCurrentConfirmCommandTests
 
         Assert.Equal(1, exitCode);
         Assert.Contains("--from-file", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenDecisionFileWithoutBoundedDecisionLines_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "prepared", "auth.decisions.md"),
+            """
+            # Notes
+
+            We should probably confirm the current auth approach later.
+            """);
+        using var writer = new StringWriter();
+        var originalExecutor = GenerateFromCurrentConfirmCommand.BestPracticeExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmCommand.BestPracticeExecutor = (_, _) => new GenerateFromCurrentBestPracticeResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                ReviewedDimensions = ["architecture: needs-confirmation"],
+                ModelRefs = [".intent/model-registry/auth-model.md"],
+                KnowledgeRefs = [".intent/best-practices/security.md"],
+                RecommendedIntentAdditions = [],
+                RecommendedClarifications = [],
+                DeveloperConfirmationItems = ["confirm: validate current auth boundary"],
+                ReturnToIntentPaths = ["README.md"],
+                ConfidenceDeltas = ["execution: medium -> high"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+
+            var exitCode = GenerateFromCurrentConfirmCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature", "--from-file", "prepared/auth.decisions.md"],
+                writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("bounded decision line", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmCommand.BestPracticeExecutor = originalExecutor;
+        }
     }
 
     private static CliContext CreateContext(string repoRoot, string? parentIntentRepoRoot = null)

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmRendererTests.cs
@@ -1,0 +1,70 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentConfirmRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenConfirmResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                DecisionFilePath = "prepared/auth.decisions.md",
+                ConfirmationArtifactPath = ".intent-cli/intake/auth.developer-confirmation.yaml",
+                ConfirmedItems = ["confirm: validate the best-practice review suggestions for 'auth' against parent rules/specs before any canonical mutation."],
+                RejectedItems = ["reject: explicitly reject any suggested intent addition that conflicts with project rules or specs."],
+                ClarifyItems = [],
+                DeferredItems = [],
+                BlockedItems = [],
+                DownstreamReadiness = "ready",
+                ReturnToIntentPaths = ["README.md"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current confirm processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Prepared decision file path: prepared/auth.decisions.md", output, StringComparison.Ordinal);
+        Assert.Contains("Developer confirmation artifact path: .intent-cli/intake/auth.developer-confirmation.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_RendersNoneEntries()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                DecisionFilePath = "prepared/auth.decisions.md",
+                ConfirmationArtifactPath = ".intent-cli/intake/auth.developer-confirmation.yaml",
+                ConfirmedItems = [],
+                RejectedItems = [],
+                ClarifyItems = [],
+                DeferredItems = [],
+                BlockedItems = ["clarify: resolve remaining auth boundary"],
+                DownstreamReadiness = "not-ready",
+                ReturnToIntentPaths = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+        Assert.Contains("Blocked items:", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current confirm <domain> --from-path <path> --from-file <path>` as a thin composition over best-practice review plus prepared developer decisions
- generate deterministic `.intent-cli/intake/<domain>.developer-confirmation.yaml` artifacts with confirmed, rejected, clarify, deferred, and blocked items
- cover the new confirm flow with command, renderer, and router tests

Closes #146