### PR TITLE
[codex] Add generate-from-current clarify command

### DIFF
--- a/src/IntentSystem.Cli/Commands/BestPracticeReviewArtifactMarkdown.cs
+++ b/src/IntentSystem.Cli/Commands/BestPracticeReviewArtifactMarkdown.cs
@@ -1,0 +1,121 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BestPracticeReviewArtifact
+{
+    public required string Domain { get; init; }
+
+    public required IReadOnlyList<string> ParentRuleSpecRefs { get; init; }
+
+    public required IReadOnlyList<string> RecommendedClarifications { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+}
+
+internal static class BestPracticeReviewArtifactMarkdown
+{
+    private static readonly string[] RequiredSections =
+    [
+        "reconstructed_artifact_paths",
+        "reviewed_dimensions",
+        "model_refs",
+        "knowledge_refs",
+        "parent_rule_spec_refs",
+        "recommended_intent_additions",
+        "recommended_clarifications",
+        "developer_confirmation_items",
+        "return_to_intent_paths",
+        "confidence_deltas",
+        "skipped_stages"
+    ];
+
+    public static BestPracticeReviewArtifact Deserialize(string markdown)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(markdown);
+
+        var lines = markdown.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n', StringSplitOptions.None);
+        var sawTitle = false;
+        var expectingDomain = false;
+        string? domain = null;
+        string? currentSection = null;
+        var sections = RequiredSections.ToDictionary(section => section, _ => new List<string>(), StringComparer.Ordinal);
+        var seenSections = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (string.Equals(line, "# Best Practice Review", StringComparison.Ordinal))
+            {
+                sawTitle = true;
+                currentSection = null;
+                continue;
+            }
+
+            if (string.Equals(line, "## Domain", StringComparison.Ordinal))
+            {
+                expectingDomain = true;
+                currentSection = null;
+                continue;
+            }
+
+            if (expectingDomain)
+            {
+                if (line.StartsWith('`') && line.EndsWith('`') && line.Length >= 2)
+                {
+                    domain = line[1..^1];
+                    expectingDomain = false;
+                    continue;
+                }
+
+                throw new InvalidOperationException("Best-practice review artifact must contain a backticked domain line.");
+            }
+
+            if (line.EndsWith(":", StringComparison.Ordinal) && sections.ContainsKey(line[..^1]))
+            {
+                currentSection = line[..^1];
+                seenSections.Add(currentSection);
+                continue;
+            }
+
+            if (!line.StartsWith("- ", StringComparison.Ordinal) || currentSection is null)
+            {
+                continue;
+            }
+
+            var value = line[2..];
+            if (!string.Equals(value, "none", StringComparison.Ordinal))
+            {
+                sections[currentSection].Add(value);
+            }
+        }
+
+        if (!sawTitle)
+        {
+            throw new InvalidOperationException("Best-practice review artifact must start with '# Best Practice Review'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            throw new InvalidOperationException("Best-practice review artifact must contain a domain.");
+        }
+
+        var missingSection = RequiredSections.FirstOrDefault(section => !seenSections.Contains(section));
+        if (missingSection is not null)
+        {
+            throw new InvalidOperationException(
+                $"Best-practice review artifact must contain section '{missingSection}:'.");
+        }
+
+        return new BestPracticeReviewArtifact
+        {
+            Domain = domain,
+            ParentRuleSpecRefs = sections["parent_rule_spec_refs"].ToArray(),
+            RecommendedClarifications = sections["recommended_clarifications"].ToArray(),
+            ReturnToIntentPaths = sections["return_to_intent_paths"].ToArray()
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ClarificationReturnArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/ClarificationReturnArtifactYaml.cs
@@ -1,0 +1,217 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record ClarificationReturnArtifact
+{
+    public required string DomainSlug { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required string ReviewArtifactPath { get; init; }
+
+    public required string DeveloperConfirmationArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ClarifyItems { get; init; }
+
+    public required IReadOnlyList<string> AffectedParentRefs { get; init; }
+
+    public required IReadOnlyList<string> Reasons { get; init; }
+
+    public required IReadOnlyList<string> Blockingness { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}
+
+internal static class ClarificationReturnArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "domain_slug",
+        "source_bundle_artifact_path",
+        "reconstructed_artifact_paths",
+        "review_artifact_path",
+        "developer_confirmation_artifact_path",
+        "clarify_items",
+        "affected_parent_refs",
+        "reasons",
+        "blockingness",
+        "return_to_intent_paths",
+        "downstream_readiness"
+    ];
+
+    public static string Serialize(ClarificationReturnArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"domain_slug: {artifact.DomainSlug}",
+            $"source_bundle_artifact_path: {Quote(artifact.SourceBundleArtifactPath)}",
+            $"review_artifact_path: {Quote(artifact.ReviewArtifactPath)}",
+            $"developer_confirmation_artifact_path: {Quote(artifact.DeveloperConfirmationArtifactPath)}",
+            $"downstream_readiness: {artifact.DownstreamReadiness}"
+        };
+
+        AppendList(lines, "reconstructed_artifact_paths", artifact.ReconstructedArtifactPaths);
+        AppendList(lines, "clarify_items", artifact.ClarifyItems);
+        AppendList(lines, "affected_parent_refs", artifact.AffectedParentRefs);
+        AppendList(lines, "reasons", artifact.Reasons);
+        AppendList(lines, "blockingness", artifact.Blockingness);
+        AppendList(lines, "return_to_intent_paths", artifact.ReturnToIntentPaths);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static ClarificationReturnArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new ClarificationReturnArtifact
+        {
+            DomainSlug = GetRequiredScalar(values, "domain_slug"),
+            SourceBundleArtifactPath = GetRequiredScalar(values, "source_bundle_artifact_path"),
+            ReconstructedArtifactPaths = GetRequiredList(values, "reconstructed_artifact_paths"),
+            ReviewArtifactPath = GetRequiredScalar(values, "review_artifact_path"),
+            DeveloperConfirmationArtifactPath = GetRequiredScalar(values, "developer_confirmation_artifact_path"),
+            ClarifyItems = GetRequiredList(values, "clarify_items"),
+            AffectedParentRefs = GetRequiredList(values, "affected_parent_refs"),
+            Reasons = GetRequiredList(values, "reasons"),
+            Blockingness = GetRequiredList(values, "blockingness"),
+            ReturnToIntentPaths = GetRequiredList(values, "return_to_intent_paths"),
+            DownstreamReadiness = GetRequiredScalar(values, "downstream_readiness")
+        };
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add($"{label}: []");
+            return;
+        }
+
+        lines.Add($"{label}:");
+        lines.AddRange(values.Select(value => $"  - {Quote(value)}"));
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("  - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !values.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException($"Clarification return YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[4..].TrimStart()));
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Clarification return YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+
+            if (value.Length == 0)
+            {
+                values[key] = new List<string>();
+                currentListKey = key;
+                continue;
+            }
+
+            currentListKey = null;
+            values[key] = value switch
+            {
+                "[]" => Array.Empty<string>(),
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Clarification return YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException($"Clarification return YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static IReadOnlyList<string> GetRequiredList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Clarification return YAML field '{key}' must be a list.");
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException($"Clarification return YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentClarifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentClarifyCommand.cs
@@ -1,0 +1,173 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentClarifyCommand
+{
+    public static Func<CliContext, string[], GenerateFromCurrentBestPracticeResult> BestPracticeExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentBestPracticeCommand.ExecuteCore(context, args);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentClarifyRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentClarifyResult ExecuteCore(CliContext context, string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current clarify requires a domain.");
+        }
+
+        var domain = args[0].Trim();
+        var bestPracticeResult = BestPracticeExecutor(context, args);
+        var confirmationArtifactRef = $".intent-cli/intake/{domain}.developer-confirmation.yaml";
+        var confirmationArtifactPath = ResolvePath(context.RepoRoot, confirmationArtifactRef);
+        if (!File.Exists(confirmationArtifactPath))
+        {
+            throw new InvalidOperationException($"Developer confirmation artifact was not found at {confirmationArtifactPath}");
+        }
+
+        var confirmationArtifact = DeveloperConfirmationArtifactYaml.Deserialize(File.ReadAllText(confirmationArtifactPath));
+        ValidateDeveloperConfirmationArtifact(domain, bestPracticeResult, confirmationArtifact, confirmationArtifactRef);
+
+        var clarifyItems = confirmationArtifact.ClarifyItems;
+        var affectedParentRefs = confirmationArtifact.ReturnToIntentPaths;
+        var reasons = BuildReasons(bestPracticeResult, clarifyItems);
+        var blockingness = BuildBlockingness(clarifyItems, confirmationArtifact);
+
+        var clarificationReturnArtifact = new ClarificationReturnArtifact
+        {
+            DomainSlug = domain,
+            SourceBundleArtifactPath = bestPracticeResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = bestPracticeResult.ReconstructedArtifactPaths,
+            ReviewArtifactPath = bestPracticeResult.ReviewArtifactPath,
+            DeveloperConfirmationArtifactPath = confirmationArtifactRef,
+            ClarifyItems = clarifyItems,
+            AffectedParentRefs = affectedParentRefs,
+            Reasons = reasons,
+            Blockingness = blockingness,
+            ReturnToIntentPaths = confirmationArtifact.ReturnToIntentPaths,
+            DownstreamReadiness = confirmationArtifact.DownstreamReadiness
+        };
+
+        var artifactPath = WriteArtifact(context.RepoRoot, domain, ClarificationReturnArtifactYaml.Serialize(clarificationReturnArtifact));
+
+        return new GenerateFromCurrentClarifyResult
+        {
+            Domain = domain,
+            SourceBundleArtifactPath = bestPracticeResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = bestPracticeResult.ReconstructedArtifactPaths,
+            ReviewArtifactPath = bestPracticeResult.ReviewArtifactPath,
+            DeveloperConfirmationArtifactPath = confirmationArtifactRef,
+            ClarificationReturnArtifactPath = ToRelativePath(context.RepoRoot, artifactPath),
+            ClarifyItems = clarifyItems,
+            AffectedParentRefs = affectedParentRefs,
+            Reasons = reasons,
+            Blockingness = blockingness,
+            ReturnToIntentPaths = confirmationArtifact.ReturnToIntentPaths,
+            DownstreamReadiness = confirmationArtifact.DownstreamReadiness
+        };
+    }
+
+    private static void ValidateDeveloperConfirmationArtifact(
+        string domain,
+        GenerateFromCurrentBestPracticeResult bestPracticeResult,
+        DeveloperConfirmationArtifact artifact,
+        string artifactRef)
+    {
+        if (!string.Equals(artifact.DomainSlug, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Developer confirmation artifact domain '{artifact.DomainSlug}' does not match requested domain '{domain}'.");
+        }
+
+        if (!string.Equals(artifact.SourceBundleArtifactPath, bestPracticeResult.SourceBundleArtifactPath, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Developer confirmation artifact source bundle path '{artifact.SourceBundleArtifactPath}' must match current source bundle path '{bestPracticeResult.SourceBundleArtifactPath}'.");
+        }
+
+        if (!artifact.ReconstructedArtifactPaths.SequenceEqual(bestPracticeResult.ReconstructedArtifactPaths, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Developer confirmation artifact reconstructed artifact paths must match the current reconstruction output.");
+        }
+
+        if (!string.Equals(artifact.ReviewArtifactPath, bestPracticeResult.ReviewArtifactPath, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Developer confirmation artifact review path '{artifact.ReviewArtifactPath}' must match current review path '{bestPracticeResult.ReviewArtifactPath}'.");
+        }
+
+        if (artifact.ClarifyItems.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Developer confirmation artifact at {artifactRef} does not contain any clarify items.");
+        }
+    }
+
+    private static IReadOnlyList<string> BuildReasons(
+        GenerateFromCurrentBestPracticeResult bestPracticeResult,
+        IReadOnlyList<string> clarifyItems)
+    {
+        if (bestPracticeResult.RecommendedClarifications.Count > 0)
+        {
+            return bestPracticeResult.RecommendedClarifications;
+        }
+
+        return clarifyItems
+            .Select(item => item.StartsWith("clarify:", StringComparison.Ordinal)
+                ? item["clarify:".Length..].TrimStart()
+                : item)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildBlockingness(
+        IReadOnlyList<string> clarifyItems,
+        DeveloperConfirmationArtifact artifact)
+    {
+        var isBlocking = !string.Equals(artifact.DownstreamReadiness, "ready", StringComparison.Ordinal);
+        return clarifyItems
+            .Select(item => artifact.BlockedItems.Contains(item, StringComparer.Ordinal) || isBlocking
+                ? $"{item} => blocking"
+                : $"{item} => nonblocking")
+            .ToArray();
+    }
+
+    private static string ResolvePath(string repoRoot, string artifactRef)
+    {
+        return Path.GetFullPath(Path.Combine(repoRoot, artifactRef.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static string WriteArtifact(string repoRoot, string domain, string yaml)
+    {
+        var artifactPath = Path.Combine(
+            repoRoot,
+            ".intent-cli",
+            "intake",
+            $"{domain}.clarification-return.yaml");
+        var directoryPath = Path.GetDirectoryName(artifactPath)
+            ?? throw new InvalidOperationException("Clarification-return artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(artifactPath, yaml);
+        return artifactPath;
+    }
+
+    private static string ToRelativePath(string repoRoot, string absolutePath)
+    {
+        return Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentClarifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentClarifyCommand.cs
@@ -35,17 +35,25 @@ internal static class GenerateFromCurrentClarifyCommand
         var bestPracticeResult = BestPracticeExecutor(context, args);
         var confirmationArtifactRef = $".intent-cli/intake/{domain}.developer-confirmation.yaml";
         var confirmationArtifactPath = ResolvePath(context.RepoRoot, confirmationArtifactRef);
+        var reviewArtifactPath = ResolvePath(context.RepoRoot, bestPracticeResult.ReviewArtifactPath);
         if (!File.Exists(confirmationArtifactPath))
         {
             throw new InvalidOperationException($"Developer confirmation artifact was not found at {confirmationArtifactPath}");
         }
 
+        if (!File.Exists(reviewArtifactPath))
+        {
+            throw new InvalidOperationException($"Best-practice review artifact was not found at {reviewArtifactPath}");
+        }
+
         var confirmationArtifact = DeveloperConfirmationArtifactYaml.Deserialize(File.ReadAllText(confirmationArtifactPath));
+        var reviewArtifact = BestPracticeReviewArtifactMarkdown.Deserialize(File.ReadAllText(reviewArtifactPath));
         ValidateDeveloperConfirmationArtifact(domain, bestPracticeResult, confirmationArtifact, confirmationArtifactRef);
+        ValidateBestPracticeReviewArtifact(domain, reviewArtifact);
 
         var clarifyItems = confirmationArtifact.ClarifyItems;
-        var affectedParentRefs = confirmationArtifact.ReturnToIntentPaths;
-        var reasons = BuildReasons(bestPracticeResult, clarifyItems);
+        var affectedParentRefs = reviewArtifact.ParentRuleSpecRefs;
+        var reasons = BuildReasons(reviewArtifact, clarifyItems);
         var blockingness = BuildBlockingness(clarifyItems, confirmationArtifact);
 
         var clarificationReturnArtifact = new ClarificationReturnArtifact
@@ -59,7 +67,7 @@ internal static class GenerateFromCurrentClarifyCommand
             AffectedParentRefs = affectedParentRefs,
             Reasons = reasons,
             Blockingness = blockingness,
-            ReturnToIntentPaths = confirmationArtifact.ReturnToIntentPaths,
+            ReturnToIntentPaths = reviewArtifact.ReturnToIntentPaths,
             DownstreamReadiness = confirmationArtifact.DownstreamReadiness
         };
 
@@ -77,7 +85,7 @@ internal static class GenerateFromCurrentClarifyCommand
             AffectedParentRefs = affectedParentRefs,
             Reasons = reasons,
             Blockingness = blockingness,
-            ReturnToIntentPaths = confirmationArtifact.ReturnToIntentPaths,
+            ReturnToIntentPaths = reviewArtifact.ReturnToIntentPaths,
             DownstreamReadiness = confirmationArtifact.DownstreamReadiness
         };
     }
@@ -119,19 +127,34 @@ internal static class GenerateFromCurrentClarifyCommand
         }
     }
 
+    private static void ValidateBestPracticeReviewArtifact(string domain, BestPracticeReviewArtifact artifact)
+    {
+        if (!string.Equals(artifact.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Best-practice review artifact domain '{artifact.Domain}' does not match requested domain '{domain}'.");
+        }
+    }
+
     private static IReadOnlyList<string> BuildReasons(
-        GenerateFromCurrentBestPracticeResult bestPracticeResult,
+        BestPracticeReviewArtifact reviewArtifact,
         IReadOnlyList<string> clarifyItems)
     {
-        if (bestPracticeResult.RecommendedClarifications.Count > 0)
+        if (reviewArtifact.RecommendedClarifications.Count == 0)
         {
-            return bestPracticeResult.RecommendedClarifications;
+            return clarifyItems
+                .Select(item => item.StartsWith("clarify:", StringComparison.Ordinal)
+                    ? item["clarify:".Length..].TrimStart()
+                    : item)
+                .ToArray();
         }
 
         return clarifyItems
-            .Select(item => item.StartsWith("clarify:", StringComparison.Ordinal)
-                ? item["clarify:".Length..].TrimStart()
-                : item)
+            .Select((item, index) => index < reviewArtifact.RecommendedClarifications.Count
+                ? reviewArtifact.RecommendedClarifications[index]
+                : item.StartsWith("clarify:", StringComparison.Ordinal)
+                    ? item["clarify:".Length..].TrimStart()
+                    : item)
             .ToArray();
     }
 
@@ -142,8 +165,8 @@ internal static class GenerateFromCurrentClarifyCommand
         var isBlocking = !string.Equals(artifact.DownstreamReadiness, "ready", StringComparison.Ordinal);
         return clarifyItems
             .Select(item => artifact.BlockedItems.Contains(item, StringComparer.Ordinal) || isBlocking
-                ? $"{item} => blocking"
-                : $"{item} => nonblocking")
+                ? "blocking"
+                : "nonblocking")
             .ToArray();
     }
 

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentClarifyRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentClarifyRenderer.cs
@@ -1,0 +1,43 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentClarifyRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentClarifyResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current clarify processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine($"Best-practice review artifact path: {result.ReviewArtifactPath}");
+        writer.WriteLine($"Developer confirmation artifact path: {result.DeveloperConfirmationArtifactPath}");
+        writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+        writer.WriteLine("Clarify items:");
+        WriteList(writer, result.ClarifyItems);
+        writer.WriteLine("Affected parent refs:");
+        WriteList(writer, result.AffectedParentRefs);
+        writer.WriteLine("Reasons:");
+        WriteList(writer, result.Reasons);
+        writer.WriteLine("Blockingness:");
+        WriteList(writer, result.Blockingness);
+        writer.WriteLine("Return-to-intent paths:");
+        WriteList(writer, result.ReturnToIntentPaths);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentClarifyResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentClarifyResult.cs
@@ -1,0 +1,28 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentClarifyResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required string ReviewArtifactPath { get; init; }
+
+    public required string DeveloperConfirmationArtifactPath { get; init; }
+
+    public required string ClarificationReturnArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ClarifyItems { get; init; }
+
+    public required IReadOnlyList<string> AffectedParentRefs { get; init; }
+
+    public required IReadOnlyList<string> Reasons { get; init; }
+
+    public required IReadOnlyList<string> Blockingness { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -106,6 +106,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "clarify", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "best-practice", StringComparison.Ordinal))
         {
             return GenerateFromCurrentBestPracticeCommand.Execute(context, args[1..], writer);

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -461,7 +461,7 @@ public sealed class CommandRouterTests
         tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "model-registry"));
         tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "best-practices"));
         tempDirectory.CreateFile(Path.Combine("repo", ".intent", "model-registry", "auth-model.md"), "# auth model");
-        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "best-practices", "security.md"), "# security");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "best-practices", "performance.md"), "# performance");
         tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
         tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
         tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
@@ -496,7 +496,7 @@ public sealed class CommandRouterTests
         tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "model-registry"));
         tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "best-practices"));
         tempDirectory.CreateFile(Path.Combine("repo", ".intent", "model-registry", "auth-model.md"), "# auth model");
-        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "best-practices", "security.md"), "# security");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "best-practices", "performance.md"), "# performance");
         tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
         tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
         tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
@@ -521,6 +521,54 @@ public sealed class CommandRouterTests
 
             Assert.Equal(0, exitCode);
             Assert.Contains("Generate-from-current confirm processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenGenerateFromCurrentClarifyCommand_DispatchesToClarifyRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var parentRepoRoot = tempDirectory.CreateDirectory("parent");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "model-registry"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "best-practices"));
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "model-registry", "auth-model.md"), "# auth model");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "best-practices", "performance.md"), "# performance");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("parent", "intents", "intent-cli", "specs", "11-reconstruction-review-and-confirmation.md"), "# review");
+        tempDirectory.CreateFile(Path.Combine("parent", "intents", "rules", "reconstruction-feedback-loop.md"), "# loop");
+        tempDirectory.CreateFile(Path.Combine("repo", "prepared", "auth.decisions.md"), """
+            # Current review decisions
+            - confirm: validate the best-practice review suggestions for 'auth' against parent rules/specs before any canonical mutation.
+            - reject: explicitly reject any suggested intent addition that conflicts with project rules or specs.
+            - clarify: resolve 1 clarification candidate(s) before issue-cut-ready treatment.
+            """);
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var confirmExitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirm", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution", "--from-file", "prepared/auth.decisions.md"],
+                CreateContext(repoRoot, parentRepoRoot),
+                TextWriter.Null);
+            Assert.Equal(0, confirmExitCode);
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "clarify", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
+                CreateContext(repoRoot, parentRepoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current clarify processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentClarifyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentClarifyCommandTests.cs
@@ -1,0 +1,219 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentClarifyCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_GeneratesClarificationReturnArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var parentRepoRoot = tempDirectory.CreateDirectory("parent");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "model-registry"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "best-practices"));
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "model-registry", "auth-model.md"), "# auth model");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "best-practices", "performance.md"), "# performance");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("parent", "intents", "intent-cli", "specs", "11-reconstruction-review-and-confirmation.md"), "# review");
+        tempDirectory.CreateFile(Path.Combine("parent", "intents", "rules", "reconstruction-feedback-loop.md"), "# loop");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "prepared", "auth.decisions.md"),
+            """
+            # Current review decisions
+            - confirm: validate the best-practice review suggestions for 'auth' against parent rules/specs before any canonical mutation.
+            - reject: explicitly reject any suggested intent addition that conflicts with project rules or specs.
+            - clarify: resolve 1 clarification candidate(s) before issue-cut-ready treatment.
+            """);
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var confirmExitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot, parentRepoRoot),
+                ["confirm", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,rules,execution", "--from-file", "prepared/auth.decisions.md"],
+                TextWriter.Null);
+            Assert.Equal(0, confirmExitCode);
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot, parentRepoRoot),
+                ["clarify", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,rules,execution"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current clarify processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/intake/auth.clarification-return.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("Downstream readiness: not-ready", output, StringComparison.Ordinal);
+
+            var artifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.clarification-return.yaml");
+            Assert.True(File.Exists(artifactPath));
+            var artifact = ClarificationReturnArtifactYaml.Deserialize(File.ReadAllText(artifactPath));
+            Assert.Equal("auth", artifact.DomainSlug);
+            Assert.Single(artifact.ClarifyItems);
+            Assert.Equal(".intent-cli/intake/auth.developer-confirmation.yaml", artifact.DeveloperConfirmationArtifactPath);
+            Assert.Contains("README.md", artifact.AffectedParentRefs, StringComparer.Ordinal);
+            Assert.Contains("Clarify the authn/authz model and trust boundary for 'auth'.", artifact.Reasons, StringComparer.Ordinal);
+            Assert.Contains("=> blocking", artifact.Blockingness.Single(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenDeveloperConfirmationArtifactWithoutClarifyItems_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.developer-confirmation.yaml"),
+            DeveloperConfirmationArtifactYaml.Serialize(
+                new DeveloperConfirmationArtifact
+                {
+                    DomainSlug = "auth",
+                    SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                    ReconstructedArtifactPaths =
+                    [
+                        ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                        ".intent-cli/intake/auth.reconstructed-interview.md"
+                    ],
+                    ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                    DecisionFilePath = "prepared/auth.decisions.md",
+                    ConfirmedItems = ["confirm: validate current auth boundary"],
+                    RejectedItems = [],
+                    ClarifyItems = [],
+                    DeferredItems = [],
+                    BlockedItems = [],
+                    DownstreamReadiness = "ready",
+                    ReturnToIntentPaths = ["README.md"]
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = GenerateFromCurrentClarifyCommand.BestPracticeExecutor;
+
+        try
+        {
+            GenerateFromCurrentClarifyCommand.BestPracticeExecutor = (_, _) => new GenerateFromCurrentBestPracticeResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                ReviewedDimensions = ["architecture: needs-confirmation"],
+                ModelRefs = [".intent/model-registry/auth-model.md"],
+                KnowledgeRefs = [".intent/best-practices/security.md"],
+                RecommendedIntentAdditions = [],
+                RecommendedClarifications = ["Clarify the authn/authz model and trust boundary for 'auth'."],
+                DeveloperConfirmationItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                ReturnToIntentPaths = ["README.md"],
+                ConfidenceDeltas = ["execution: medium -> high"],
+                ReadinessStatus = "not-ready",
+                SkippedStages = []
+            };
+
+            var exitCode = GenerateFromCurrentClarifyCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("does not contain any clarify items", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentClarifyCommand.BestPracticeExecutor = originalExecutor;
+        }
+    }
+
+    private static CliContext CreateContext(string repoRoot, string? parentIntentRepoRoot = null)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                    ParentIntentRepoRoot = parentIntentRepoRoot ?? string.Empty
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-clarify-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentClarifyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentClarifyCommandTests.cs
@@ -59,9 +59,9 @@ public sealed class GenerateFromCurrentClarifyCommandTests
             Assert.Equal("auth", artifact.DomainSlug);
             Assert.Single(artifact.ClarifyItems);
             Assert.Equal(".intent-cli/intake/auth.developer-confirmation.yaml", artifact.DeveloperConfirmationArtifactPath);
-            Assert.Contains("README.md", artifact.AffectedParentRefs, StringComparer.Ordinal);
+            Assert.Contains("intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md", artifact.AffectedParentRefs, StringComparer.Ordinal);
             Assert.Contains("Clarify the authn/authz model and trust boundary for 'auth'.", artifact.Reasons, StringComparer.Ordinal);
-            Assert.Contains("=> blocking", artifact.Blockingness.Single(), StringComparison.Ordinal);
+            Assert.Equal("blocking", artifact.Blockingness.Single());
         }
         finally
         {
@@ -96,6 +96,47 @@ public sealed class GenerateFromCurrentClarifyCommandTests
                     DownstreamReadiness = "ready",
                     ReturnToIntentPaths = ["README.md"]
                 }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.best-practice-review.md"),
+            """
+            # Best Practice Review
+            ## Domain
+            `auth`
+
+            reconstructed_artifact_paths:
+            - .intent-cli/intake/auth.reconstructed-concept.yaml
+            - .intent-cli/intake/auth.reconstructed-interview.md
+
+            reviewed_dimensions:
+            - architecture: needs-confirmation
+
+            model_refs:
+            - .intent/model-registry/auth-model.md
+
+            knowledge_refs:
+            - .intent/best-practices/security.md
+
+            parent_rule_spec_refs:
+            - intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md
+
+            recommended_intent_additions:
+            - none
+
+            recommended_clarifications:
+            - Clarify the authn/authz model and trust boundary for 'auth'.
+
+            developer_confirmation_items:
+            - clarify: resolve auth boundary before issue-cut-ready treatment.
+
+            return_to_intent_paths:
+            - README.md
+
+            confidence_deltas:
+            - execution: medium -> high
+
+            skipped_stages:
+            - none
+            """);
         using var writer = new StringWriter();
         var originalExecutor = GenerateFromCurrentClarifyCommand.BestPracticeExecutor;
 

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentClarifyRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentClarifyRendererTests.cs
@@ -1,0 +1,66 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentClarifyRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenClarifyResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentClarifyRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentClarifyResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                DeveloperConfirmationArtifactPath = ".intent-cli/intake/auth.developer-confirmation.yaml",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                ClarifyItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                AffectedParentRefs = ["README.md"],
+                Reasons = ["Clarify the authn/authz model and trust boundary for 'auth'."],
+                Blockingness = ["clarify: resolve auth boundary before issue-cut-ready treatment. => blocking"],
+                ReturnToIntentPaths = ["README.md"],
+                DownstreamReadiness = "not-ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current clarify processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Clarification-return artifact path: .intent-cli/intake/auth.clarification-return.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Affected parent refs:", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: not-ready", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_RendersNoneEntries()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentClarifyRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentClarifyResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                DeveloperConfirmationArtifactPath = ".intent-cli/intake/auth.developer-confirmation.yaml",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                ClarifyItems = [],
+                AffectedParentRefs = [],
+                Reasons = [],
+                Blockingness = [],
+                ReturnToIntentPaths = [],
+                DownstreamReadiness = "ready"
+            });
+
+        Assert.Contains("- none", writer.ToString(), StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentClarifyRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentClarifyRendererTests.cs
@@ -26,7 +26,7 @@ public sealed class GenerateFromCurrentClarifyRendererTests
                 ClarifyItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
                 AffectedParentRefs = ["README.md"],
                 Reasons = ["Clarify the authn/authz model and trust boundary for 'auth'."],
-                Blockingness = ["clarify: resolve auth boundary before issue-cut-ready treatment. => blocking"],
+                Blockingness = ["blocking"],
                 ReturnToIntentPaths = ["README.md"],
                 DownstreamReadiness = "not-ready"
             });
@@ -35,6 +35,7 @@ public sealed class GenerateFromCurrentClarifyRendererTests
         Assert.Contains("Generate-from-current clarify processed for domain 'auth'.", output, StringComparison.Ordinal);
         Assert.Contains("Clarification-return artifact path: .intent-cli/intake/auth.clarification-return.yaml", output, StringComparison.Ordinal);
         Assert.Contains("Affected parent refs:", output, StringComparison.Ordinal);
+        Assert.Contains("- blocking", output, StringComparison.Ordinal);
         Assert.Contains("Downstream readiness: not-ready", output, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
## Summary
- add `generate-from-current clarify <domain> --from-path <path>` as a thin composition over current best-practice review plus current developer confirmation artifacts
- generate deterministic `.intent-cli/intake/<domain>.clarification-return.yaml` artifacts with clarify items, affected parent refs, reasons, blockingness, and downstream readiness
- cover the new clarify flow with command, renderer, and router tests

Closes #148