### PR TITLE
[G62] Add generate-from-current reconcile command

### DIFF
--- a/src/IntentSystem.Cli/Commands/ConfirmedReconstructionArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/ConfirmedReconstructionArtifactYaml.cs
@@ -1,0 +1,223 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record ConfirmedReconstructionArtifact
+{
+    public required string DomainSlug { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required string ReviewArtifactPath { get; init; }
+
+    public required string DeveloperConfirmationArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> RejectedItems { get; init; }
+
+    public required IReadOnlyList<string> DeferredItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}
+
+internal static class ConfirmedReconstructionArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "domain_slug",
+        "source_bundle_artifact_path",
+        "reconstructed_artifact_paths",
+        "review_artifact_path",
+        "developer_confirmation_artifact_path",
+        "confirmed_items",
+        "rejected_items",
+        "deferred_items",
+        "blocked_items",
+        "return_to_intent_paths",
+        "downstream_readiness"
+    ];
+
+    public static string Serialize(ConfirmedReconstructionArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"domain_slug: {artifact.DomainSlug}",
+            $"source_bundle_artifact_path: {Quote(artifact.SourceBundleArtifactPath)}",
+            $"review_artifact_path: {Quote(artifact.ReviewArtifactPath)}",
+            $"developer_confirmation_artifact_path: {Quote(artifact.DeveloperConfirmationArtifactPath)}",
+            $"downstream_readiness: {artifact.DownstreamReadiness}"
+        };
+
+        AppendList(lines, "reconstructed_artifact_paths", artifact.ReconstructedArtifactPaths);
+        AppendList(lines, "confirmed_items", artifact.ConfirmedItems);
+        AppendList(lines, "rejected_items", artifact.RejectedItems);
+        AppendList(lines, "deferred_items", artifact.DeferredItems);
+        AppendList(lines, "blocked_items", artifact.BlockedItems);
+        AppendList(lines, "return_to_intent_paths", artifact.ReturnToIntentPaths);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static ConfirmedReconstructionArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new ConfirmedReconstructionArtifact
+        {
+            DomainSlug = GetRequiredScalar(values, "domain_slug"),
+            SourceBundleArtifactPath = GetRequiredScalar(values, "source_bundle_artifact_path"),
+            ReconstructedArtifactPaths = GetRequiredList(values, "reconstructed_artifact_paths"),
+            ReviewArtifactPath = GetRequiredScalar(values, "review_artifact_path"),
+            DeveloperConfirmationArtifactPath = GetRequiredScalar(values, "developer_confirmation_artifact_path"),
+            ConfirmedItems = GetRequiredList(values, "confirmed_items"),
+            RejectedItems = GetRequiredList(values, "rejected_items"),
+            DeferredItems = GetRequiredList(values, "deferred_items"),
+            BlockedItems = GetRequiredList(values, "blocked_items"),
+            ReturnToIntentPaths = GetRequiredList(values, "return_to_intent_paths"),
+            DownstreamReadiness = GetRequiredScalar(values, "downstream_readiness")
+        };
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add($"{label}: []");
+            return;
+        }
+
+        lines.Add($"{label}:");
+        lines.AddRange(values.Select(value => $"  - {Quote(value)}"));
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("  - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !values.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException(
+                        $"Confirmed reconstruction YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[4..].TrimStart()));
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Confirmed reconstruction YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+
+            if (value.Length == 0)
+            {
+                values[key] = new List<string>();
+                currentListKey = key;
+                continue;
+            }
+
+            currentListKey = null;
+            values[key] = value switch
+            {
+                "[]" => Array.Empty<string>(),
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException(
+                    $"Confirmed reconstruction YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException(
+                $"Confirmed reconstruction YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static IReadOnlyList<string> GetRequiredList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed reconstruction YAML field '{key}' must be a list.");
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException(
+                $"Confirmed reconstruction YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -106,6 +106,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "reconcile", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentReconcileCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "clarify", StringComparison.Ordinal))
         {
             return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconcileCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconcileCommand.cs
@@ -1,0 +1,161 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentReconcileCommand
+{
+    public static Func<CliContext, string[], GenerateFromCurrentBestPracticeResult> BestPracticeExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentBestPracticeCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string[], GenerateFromCurrentClarifyResult> ClarifyExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentClarifyCommand.ExecuteCore(context, args);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentReconcileRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentReconcileResult ExecuteCore(CliContext context, string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current reconcile requires a domain.");
+        }
+
+        var domain = args[0].Trim();
+        var bestPracticeResult = BestPracticeExecutor(context, args);
+        var confirmationArtifactRef = $".intent-cli/intake/{domain}.developer-confirmation.yaml";
+        var confirmationArtifactPath = ResolvePath(context.RepoRoot, confirmationArtifactRef);
+
+        if (!File.Exists(confirmationArtifactPath))
+        {
+            throw new InvalidOperationException($"Developer confirmation artifact was not found at {confirmationArtifactPath}");
+        }
+
+        var confirmationArtifact = DeveloperConfirmationArtifactYaml.Deserialize(File.ReadAllText(confirmationArtifactPath));
+        ValidateDeveloperConfirmationArtifact(domain, bestPracticeResult, confirmationArtifact);
+
+        if (confirmationArtifact.ClarifyItems.Count > 0)
+        {
+            var clarifyResult = ClarifyExecutor(context, args);
+            return new GenerateFromCurrentReconcileResult
+            {
+                Domain = domain,
+                Route = "clarification-return",
+                SourceBundleArtifactPath = clarifyResult.SourceBundleArtifactPath,
+                ReconstructedArtifactPaths = clarifyResult.ReconstructedArtifactPaths,
+                ReviewArtifactPath = clarifyResult.ReviewArtifactPath,
+                DeveloperConfirmationArtifactPath = clarifyResult.DeveloperConfirmationArtifactPath,
+                ConfirmedItems = confirmationArtifact.ConfirmedItems,
+                RejectedItems = confirmationArtifact.RejectedItems,
+                DeferredItems = confirmationArtifact.DeferredItems,
+                BlockedItems = confirmationArtifact.BlockedItems,
+                ClarifyItems = clarifyResult.ClarifyItems,
+                ReturnToIntentPaths = clarifyResult.ReturnToIntentPaths,
+                DownstreamReadiness = confirmationArtifact.DownstreamReadiness,
+                ClarificationReturnArtifactPath = clarifyResult.ClarificationReturnArtifactPath
+            };
+        }
+
+        var confirmedArtifact = new ConfirmedReconstructionArtifact
+        {
+            DomainSlug = domain,
+            SourceBundleArtifactPath = bestPracticeResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = bestPracticeResult.ReconstructedArtifactPaths,
+            ReviewArtifactPath = bestPracticeResult.ReviewArtifactPath,
+            DeveloperConfirmationArtifactPath = confirmationArtifactRef,
+            ConfirmedItems = confirmationArtifact.ConfirmedItems,
+            RejectedItems = confirmationArtifact.RejectedItems,
+            DeferredItems = confirmationArtifact.DeferredItems,
+            BlockedItems = confirmationArtifact.BlockedItems,
+            ReturnToIntentPaths = confirmationArtifact.ReturnToIntentPaths,
+            DownstreamReadiness = confirmationArtifact.DownstreamReadiness
+        };
+
+        var artifactPath = WriteArtifact(context.RepoRoot, domain, ConfirmedReconstructionArtifactYaml.Serialize(confirmedArtifact));
+
+        return new GenerateFromCurrentReconcileResult
+        {
+            Domain = domain,
+            Route = "confirmed-handoff",
+            SourceBundleArtifactPath = bestPracticeResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = bestPracticeResult.ReconstructedArtifactPaths,
+            ReviewArtifactPath = bestPracticeResult.ReviewArtifactPath,
+            DeveloperConfirmationArtifactPath = confirmationArtifactRef,
+            ConfirmedReconstructionArtifactPath = ToRelativePath(context.RepoRoot, artifactPath),
+            ConfirmedItems = confirmationArtifact.ConfirmedItems,
+            RejectedItems = confirmationArtifact.RejectedItems,
+            DeferredItems = confirmationArtifact.DeferredItems,
+            BlockedItems = confirmationArtifact.BlockedItems,
+            ClarifyItems = Array.Empty<string>(),
+            ReturnToIntentPaths = confirmationArtifact.ReturnToIntentPaths,
+            DownstreamReadiness = confirmationArtifact.DownstreamReadiness
+        };
+    }
+
+    private static void ValidateDeveloperConfirmationArtifact(
+        string domain,
+        GenerateFromCurrentBestPracticeResult bestPracticeResult,
+        DeveloperConfirmationArtifact artifact)
+    {
+        if (!string.Equals(artifact.DomainSlug, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Developer confirmation artifact domain '{artifact.DomainSlug}' does not match requested domain '{domain}'.");
+        }
+
+        if (!string.Equals(artifact.SourceBundleArtifactPath, bestPracticeResult.SourceBundleArtifactPath, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Developer confirmation artifact source bundle path '{artifact.SourceBundleArtifactPath}' must match current source bundle path '{bestPracticeResult.SourceBundleArtifactPath}'.");
+        }
+
+        if (!artifact.ReconstructedArtifactPaths.SequenceEqual(bestPracticeResult.ReconstructedArtifactPaths, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Developer confirmation artifact reconstructed artifact paths must match the current reconstruction output.");
+        }
+
+        if (!string.Equals(artifact.ReviewArtifactPath, bestPracticeResult.ReviewArtifactPath, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Developer confirmation artifact review path '{artifact.ReviewArtifactPath}' must match current review path '{bestPracticeResult.ReviewArtifactPath}'.");
+        }
+    }
+
+    private static string ResolvePath(string repoRoot, string artifactRef)
+    {
+        return Path.GetFullPath(Path.Combine(repoRoot, artifactRef.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static string WriteArtifact(string repoRoot, string domain, string yaml)
+    {
+        var artifactPath = Path.Combine(
+            repoRoot,
+            ".intent-cli",
+            "intake",
+            $"{domain}.confirmed-reconstruction.yaml");
+        var directoryPath = Path.GetDirectoryName(artifactPath)
+            ?? throw new InvalidOperationException("Confirmed reconstruction artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(artifactPath, yaml);
+        return artifactPath;
+    }
+
+    private static string ToRelativePath(string repoRoot, string absolutePath)
+    {
+        return Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconcileRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconcileRenderer.cs
@@ -1,0 +1,54 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentReconcileRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentReconcileResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current reconcile processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine($"Best-practice review artifact path: {result.ReviewArtifactPath}");
+        writer.WriteLine($"Developer confirmation artifact path: {result.DeveloperConfirmationArtifactPath}");
+
+        if (string.Equals(result.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+            writer.WriteLine("Clarify items:");
+            WriteList(writer, result.ClarifyItems);
+        }
+        else
+        {
+            writer.WriteLine($"Confirmed reconstruction artifact path: {result.ConfirmedReconstructionArtifactPath}");
+        }
+
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Rejected items:");
+        WriteList(writer, result.RejectedItems);
+        writer.WriteLine("Deferred items:");
+        WriteList(writer, result.DeferredItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+        writer.WriteLine("Return-to-intent paths:");
+        WriteList(writer, result.ReturnToIntentPaths);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconcileResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentReconcileResult.cs
@@ -1,0 +1,34 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentReconcileResult
+{
+    public required string Domain { get; init; }
+
+    public required string Route { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required string ReviewArtifactPath { get; init; }
+
+    public required string DeveloperConfirmationArtifactPath { get; init; }
+
+    public string? ConfirmedReconstructionArtifactPath { get; init; }
+
+    public string? ClarificationReturnArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> RejectedItems { get; init; }
+
+    public required IReadOnlyList<string> DeferredItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required IReadOnlyList<string> ClarifyItems { get; init; }
+
+    public required IReadOnlyList<string> ReturnToIntentPaths { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -577,6 +577,56 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentReconcileCommand_DispatchesToReconcileRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var parentRepoRoot = tempDirectory.CreateDirectory("parent");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "model-registry"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent", "best-practices"));
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "model-registry", "auth-model.md"), "# auth model");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent", "best-practices", "security.md"), "# security");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        tempDirectory.CreateFile(Path.Combine("parent", "intents", "intent-cli", "specs", "11-reconstruction-review-and-confirmation.md"), "# review");
+        tempDirectory.CreateFile(Path.Combine("parent", "intents", "rules", "reconstruction-feedback-loop.md"), "# loop");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "prepared", "auth.decisions.md"),
+            """
+            # Current review decisions
+            - confirm: validate the best-practice review suggestions for 'auth' against parent rules/specs before any canonical mutation.
+            - reject: explicitly reject any suggested intent addition that conflicts with project rules or specs.
+            """);
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var confirmExitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirm", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution", "--from-file", "prepared/auth.decisions.md"],
+                CreateContext(repoRoot, parentRepoRoot),
+                TextWriter.Null);
+
+            Assert.Equal(0, confirmExitCode);
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "reconcile", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
+                CreateContext(repoRoot, parentRepoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current reconcile processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/ConfirmedReconstructionArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ConfirmedReconstructionArtifactYamlTests.cs
@@ -1,0 +1,66 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ConfirmedReconstructionArtifactYamlTests
+{
+    [Fact]
+    public void SerializeDeserialize_RoundTripsArtifact()
+    {
+        var artifact = new ConfirmedReconstructionArtifact
+        {
+            DomainSlug = "auth",
+            SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+            ReconstructedArtifactPaths =
+            [
+                ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                ".intent-cli/intake/auth.reconstructed-interview.md"
+            ],
+            ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+            DeveloperConfirmationArtifactPath = ".intent-cli/intake/auth.developer-confirmation.yaml",
+            ConfirmedItems = ["confirm: validate current auth boundary"],
+            RejectedItems = ["reject: do not rewrite current auth ownership model"],
+            DeferredItems = ["defer: return interface cleanup after clarification"],
+            BlockedItems = ["defer: return interface cleanup after clarification"],
+            ReturnToIntentPaths = ["intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md"],
+            DownstreamReadiness = "not-ready"
+        };
+
+        var yaml = ConfirmedReconstructionArtifactYaml.Serialize(artifact);
+        var roundTripped = ConfirmedReconstructionArtifactYaml.Deserialize(yaml);
+
+        Assert.Equal(artifact.DomainSlug, roundTripped.DomainSlug);
+        Assert.Equal(artifact.SourceBundleArtifactPath, roundTripped.SourceBundleArtifactPath);
+        Assert.Equal(artifact.ReconstructedArtifactPaths, roundTripped.ReconstructedArtifactPaths);
+        Assert.Equal(artifact.ReviewArtifactPath, roundTripped.ReviewArtifactPath);
+        Assert.Equal(artifact.DeveloperConfirmationArtifactPath, roundTripped.DeveloperConfirmationArtifactPath);
+        Assert.Equal(artifact.ConfirmedItems, roundTripped.ConfirmedItems);
+        Assert.Equal(artifact.RejectedItems, roundTripped.RejectedItems);
+        Assert.Equal(artifact.DeferredItems, roundTripped.DeferredItems);
+        Assert.Equal(artifact.BlockedItems, roundTripped.BlockedItems);
+        Assert.Equal(artifact.ReturnToIntentPaths, roundTripped.ReturnToIntentPaths);
+        Assert.Equal(artifact.DownstreamReadiness, roundTripped.DownstreamReadiness);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_Throws()
+    {
+        const string yaml =
+            """
+            domain_slug: auth
+            source_bundle_artifact_path: ".intent-cli/intake/auth.current-sources.yaml"
+            reconstructed_artifact_paths: []
+            review_artifact_path: ".intent-cli/intake/auth.best-practice-review.md"
+            developer_confirmation_artifact_path: ".intent-cli/intake/auth.developer-confirmation.yaml"
+            confirmed_items: []
+            rejected_items: []
+            deferred_items: []
+            blocked_items: []
+            downstream_readiness: ready
+            """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => ConfirmedReconstructionArtifactYaml.Deserialize(yaml));
+
+        Assert.Contains("return_to_intent_paths", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReconcileCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReconcileCommandTests.cs
@@ -1,0 +1,231 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentReconcileCommandTests
+{
+    [Fact]
+    public void Execute_GivenCurrentDeveloperConfirmationWithoutClarify_WritesConfirmedReconstructionArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.developer-confirmation.yaml"),
+            DeveloperConfirmationArtifactYaml.Serialize(
+                new DeveloperConfirmationArtifact
+                {
+                    DomainSlug = "auth",
+                    SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                    ReconstructedArtifactPaths =
+                    [
+                        ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                        ".intent-cli/intake/auth.reconstructed-interview.md"
+                    ],
+                    ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                    DecisionFilePath = "prepared/auth.decisions.md",
+                    ConfirmedItems = ["confirm: validate current auth boundary"],
+                    RejectedItems = ["reject: do not rewrite current auth ownership model"],
+                    ClarifyItems = [],
+                    DeferredItems = ["defer: return interface cleanup after clarification"],
+                    BlockedItems = ["defer: return interface cleanup after clarification"],
+                    DownstreamReadiness = "not-ready",
+                    ReturnToIntentPaths = ["intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md"]
+                }));
+        using var writer = new StringWriter();
+        var originalBestPracticeExecutor = GenerateFromCurrentReconcileCommand.BestPracticeExecutor;
+
+        try
+        {
+            GenerateFromCurrentReconcileCommand.BestPracticeExecutor = (_, _) => new GenerateFromCurrentBestPracticeResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                ReviewedDimensions = ["architecture: needs-confirmation"],
+                ModelRefs = [".intent/model-registry/auth-model.md"],
+                KnowledgeRefs = [".intent/best-practices/security.md"],
+                RecommendedIntentAdditions = [],
+                RecommendedClarifications = [],
+                DeveloperConfirmationItems = ["confirm: validate current auth boundary"],
+                ReturnToIntentPaths = ["intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md"],
+                ConfidenceDeltas = ["execution: medium -> high"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+
+            var exitCode = GenerateFromCurrentReconcileCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current reconcile processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+
+            var artifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.confirmed-reconstruction.yaml");
+            Assert.True(File.Exists(artifactPath));
+            var artifact = ConfirmedReconstructionArtifactYaml.Deserialize(File.ReadAllText(artifactPath));
+            Assert.Equal("auth", artifact.DomainSlug);
+            Assert.Single(artifact.ConfirmedItems);
+            Assert.Single(artifact.RejectedItems);
+            Assert.Single(artifact.DeferredItems);
+            Assert.Single(artifact.BlockedItems);
+            Assert.Equal("not-ready", artifact.DownstreamReadiness);
+        }
+        finally
+        {
+            GenerateFromCurrentReconcileCommand.BestPracticeExecutor = originalBestPracticeExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenCurrentDeveloperConfirmationWithClarify_GeneratesClarificationReturnInsteadOfConfirmedArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.developer-confirmation.yaml"),
+            DeveloperConfirmationArtifactYaml.Serialize(
+                new DeveloperConfirmationArtifact
+                {
+                    DomainSlug = "auth",
+                    SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                    ReconstructedArtifactPaths =
+                    [
+                        ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                        ".intent-cli/intake/auth.reconstructed-interview.md"
+                    ],
+                    ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                    DecisionFilePath = "prepared/auth.decisions.md",
+                    ConfirmedItems = ["confirm: validate current auth boundary"],
+                    RejectedItems = [],
+                    ClarifyItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                    DeferredItems = [],
+                    BlockedItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                    DownstreamReadiness = "not-ready",
+                    ReturnToIntentPaths = ["intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md"]
+                }));
+        using var writer = new StringWriter();
+        var originalBestPracticeExecutor = GenerateFromCurrentReconcileCommand.BestPracticeExecutor;
+        var originalClarifyExecutor = GenerateFromCurrentReconcileCommand.ClarifyExecutor;
+
+        try
+        {
+            GenerateFromCurrentReconcileCommand.BestPracticeExecutor = (_, _) => new GenerateFromCurrentBestPracticeResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                ReviewedDimensions = ["architecture: needs-confirmation"],
+                ModelRefs = [".intent/model-registry/auth-model.md"],
+                KnowledgeRefs = [".intent/best-practices/performance.md"],
+                RecommendedIntentAdditions = [],
+                RecommendedClarifications = ["Clarify the authn/authz model and trust boundary for 'auth'."],
+                DeveloperConfirmationItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                ReturnToIntentPaths = ["intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md"],
+                ConfidenceDeltas = ["execution: medium -> high"],
+                ReadinessStatus = "not-ready",
+                SkippedStages = []
+            };
+            GenerateFromCurrentReconcileCommand.ClarifyExecutor = (_, _) => new GenerateFromCurrentClarifyResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                DeveloperConfirmationArtifactPath = ".intent-cli/intake/auth.developer-confirmation.yaml",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                ClarifyItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                AffectedParentRefs = ["intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md"],
+                Reasons = ["Clarify the authn/authz model and trust boundary for 'auth'."],
+                Blockingness = ["blocking"],
+                ReturnToIntentPaths = ["intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentReconcileCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains(".intent-cli/intake/auth.clarification-return.yaml", output, StringComparison.Ordinal);
+            Assert.DoesNotContain(".intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.confirmed-reconstruction.yaml")));
+        }
+        finally
+        {
+            GenerateFromCurrentReconcileCommand.BestPracticeExecutor = originalBestPracticeExecutor;
+            GenerateFromCurrentReconcileCommand.ClarifyExecutor = originalClarifyExecutor;
+        }
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-reconcile-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReconcileRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentReconcileRendererTests.cs
@@ -1,0 +1,77 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentReconcileRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenConfirmedHandoff_WritesArtifactSummary()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentReconcileRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentReconcileResult
+            {
+                Domain = "auth",
+                Route = "confirmed-handoff",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                DeveloperConfirmationArtifactPath = ".intent-cli/intake/auth.developer-confirmation.yaml",
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                RejectedItems = ["reject: do not rewrite current auth ownership model"],
+                DeferredItems = ["defer: return interface cleanup after clarification"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                ClarifyItems = [],
+                ReturnToIntentPaths = ["intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md"],
+                DownstreamReadiness = "not-ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current reconcile processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Confirmed reconstruction artifact path: .intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Confirmed items:", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: not-ready", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenClarificationRoute_WritesClarificationSummary()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentReconcileRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentReconcileResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                DeveloperConfirmationArtifactPath = ".intent-cli/intake/auth.developer-confirmation.yaml",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                RejectedItems = [],
+                DeferredItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                ClarifyItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                ReturnToIntentPaths = ["intents/intent-cli/specs/11-reconstruction-review-and-confirmation.md"],
+                DownstreamReadiness = "not-ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Clarification-return artifact path: .intent-cli/intake/auth.clarification-return.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Clarify items:", output, StringComparison.Ordinal);
+        Assert.Contains("- clarify: resolve auth boundary before issue-cut-ready treatment.", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current reconcile <domain> --from-path <path>` as the confirmed downstream handoff entry
- generate `.intent-cli/intake/<domain>.confirmed-reconstruction.yaml` when no clarify items remain
- route remaining clarify items to the existing clarification-return path instead of silently advancing

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentReconcile|FullyQualifiedName~ConfirmedReconstructionArtifactYaml|FullyQualifiedName~CommandRouter"
- dotnet test IntentSystem.sln

Closes #150
