### PR TITLE
[G63] Add generate-from-current confirmed-bridge command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeCommand.cs
@@ -4,7 +4,7 @@ namespace IntentSystem.Cli.Commands;
 
 internal static class GenerateFromCurrentBridgeCommand
 {
-    private static readonly DateTimeOffset CreatedAtBase = DateTimeOffset.Parse("2026-01-01T00:00:00Z");
+    internal static readonly DateTimeOffset CreatedAtBase = DateTimeOffset.Parse("2026-01-01T00:00:00Z");
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -61,7 +61,7 @@ internal static class GenerateFromCurrentBridgeCommand
         };
     }
 
-    private static string ParseDomain(string[] args)
+    internal static string ParseDomain(string[] args)
     {
         if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
         {
@@ -71,7 +71,7 @@ internal static class GenerateFromCurrentBridgeCommand
         return args[0].Trim();
     }
 
-    private static ReconstructedConceptArtifact LoadReconstructedConcept(string repoRoot, string domain)
+    internal static ReconstructedConceptArtifact LoadReconstructedConcept(string repoRoot, string domain)
     {
         var artifactPath = Path.Combine(
             repoRoot,
@@ -91,7 +91,7 @@ internal static class GenerateFromCurrentBridgeCommand
         return artifact;
     }
 
-    private static ReconstructedInterviewArtifact LoadReconstructedInterview(string repoRoot, string domain)
+    internal static ReconstructedInterviewArtifact LoadReconstructedInterview(string repoRoot, string domain)
     {
         var artifactPath = Path.Combine(
             repoRoot,
@@ -111,7 +111,7 @@ internal static class GenerateFromCurrentBridgeCommand
         return artifact;
     }
 
-    private static IReadOnlyList<string> BuildRecommendedUpdates(ReconstructedInterviewArtifact reconstructedInterview)
+    internal static IReadOnlyList<string> BuildRecommendedUpdates(ReconstructedInterviewArtifact reconstructedInterview)
     {
         return reconstructedInterview.RootNearIntentCandidates
             .Concat(reconstructedInterview.ExecutionNearUpdateCandidates)
@@ -170,7 +170,7 @@ internal static class GenerateFromCurrentBridgeCommand
         return string.Join(Environment.NewLine, lines);
     }
 
-    private static IReadOnlyList<string> WriteInterviewArtifacts(
+    internal static IReadOnlyList<string> WriteInterviewArtifacts(
         string repoRoot,
         string domain,
         ReconstructedConceptArtifact reconstructedConcept,
@@ -288,7 +288,7 @@ internal static class GenerateFromCurrentBridgeCommand
         lines.AddRange(values.Select(value => $"- {value}"));
     }
 
-    private static string ToRelativePath(string repoRoot, string absolutePath)
+    internal static string ToRelativePath(string repoRoot, string absolutePath)
     {
         return Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
     }

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -112,6 +112,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "confirmed-bridge", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentConfirmedBridgeCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "clarify", StringComparison.Ordinal))
         {
             return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedBridgeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedBridgeCommand.cs
@@ -1,0 +1,252 @@
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedBridgeCommand
+{
+    public static Func<CliContext, string[], GenerateFromCurrentReconcileResult> ReconcileExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentReconcileCommand.ExecuteCore(context, args);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentConfirmedBridgeRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentConfirmedBridgeResult ExecuteCore(CliContext context, string[] args)
+    {
+        var domain = ParseDomain(args);
+        var reconcileResult = ReconcileExecutor(context, args);
+
+        if (!string.Equals(reconcileResult.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Reconciliation result domain '{reconcileResult.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        if (string.Equals(reconcileResult.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentConfirmedBridgeResult
+            {
+                Domain = domain,
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = reconcileResult.ClarificationReturnArtifactPath,
+                ConfirmedReconstructionArtifactPath = reconcileResult.ConfirmedReconstructionArtifactPath,
+                InterviewArtifactPaths = [],
+                RegeneratedArtifactPaths = [],
+                ConfirmedItems = reconcileResult.ConfirmedItems,
+                BlockedItems = reconcileResult.BlockedItems,
+                DownstreamReadiness = reconcileResult.DownstreamReadiness
+            };
+        }
+
+        if (!string.Equals(reconcileResult.DownstreamReadiness, "ready", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentConfirmedBridgeResult
+            {
+                Domain = domain,
+                Route = "reconciliation-required",
+                ConfirmedReconstructionArtifactPath = reconcileResult.ConfirmedReconstructionArtifactPath,
+                InterviewArtifactPaths = [],
+                RegeneratedArtifactPaths = reconcileResult.ConfirmedReconstructionArtifactPath is null
+                    ? []
+                    : [reconcileResult.ConfirmedReconstructionArtifactPath],
+                ConfirmedItems = reconcileResult.ConfirmedItems,
+                BlockedItems = reconcileResult.BlockedItems,
+                DownstreamReadiness = reconcileResult.DownstreamReadiness
+            };
+        }
+
+        if (string.IsNullOrWhiteSpace(reconcileResult.ConfirmedReconstructionArtifactPath))
+        {
+            throw new InvalidOperationException("Confirmed bridge requires a confirmed reconstruction artifact path.");
+        }
+
+        var confirmedArtifact = LoadConfirmedReconstruction(
+            context.RepoRoot,
+            reconcileResult.ConfirmedReconstructionArtifactPath,
+            domain);
+        ValidateConfirmedReconstructionArtifact(confirmedArtifact, reconcileResult);
+
+        var reconstructedConcept = GenerateFromCurrentBridgeCommand.LoadReconstructedConcept(context.RepoRoot, domain);
+        var reconstructedInterview = GenerateFromCurrentBridgeCommand.LoadReconstructedInterview(context.RepoRoot, domain);
+        var recommendedUpdates = GenerateFromCurrentBridgeCommand.BuildRecommendedUpdates(reconstructedInterview);
+        var conceptPacket = BuildConceptPacket(confirmedArtifact, reconstructedConcept, reconstructedInterview);
+
+        var conceptArtifactPath = IntakeConceptArtifactWriter.Write(
+            IntakeConceptArtifactYaml.Serialize(conceptPacket),
+            domain,
+            context.RepoRoot);
+
+        var interviewArtifactPaths = GenerateFromCurrentBridgeCommand.WriteInterviewArtifacts(
+            context.RepoRoot,
+            domain,
+            reconstructedConcept,
+            reconstructedInterview,
+            recommendedUpdates);
+
+        var regeneratedArtifactPaths = new List<string>
+        {
+            GenerateFromCurrentBridgeCommand.ToRelativePath(context.RepoRoot, conceptArtifactPath)
+        };
+        regeneratedArtifactPaths.AddRange(interviewArtifactPaths);
+
+        return new GenerateFromCurrentConfirmedBridgeResult
+        {
+            Domain = domain,
+            Route = "confirmed-bridge",
+            ConceptArtifactPath = GenerateFromCurrentBridgeCommand.ToRelativePath(context.RepoRoot, conceptArtifactPath),
+            InterviewArtifactPaths = interviewArtifactPaths,
+            ConfirmedReconstructionArtifactPath = reconcileResult.ConfirmedReconstructionArtifactPath,
+            RegeneratedArtifactPaths = regeneratedArtifactPaths,
+            ConfirmedItems = confirmedArtifact.ConfirmedItems,
+            BlockedItems = confirmedArtifact.BlockedItems,
+            DownstreamReadiness = confirmedArtifact.DownstreamReadiness
+        };
+    }
+
+    private static ConfirmedReconstructionArtifact LoadConfirmedReconstruction(
+        string repoRoot,
+        string artifactRef,
+        string domain)
+    {
+        var artifactPath = Path.Combine(repoRoot, artifactRef.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(artifactPath))
+        {
+            throw new InvalidOperationException($"Confirmed reconstruction artifact was not found at {artifactPath}");
+        }
+
+        var artifact = ConfirmedReconstructionArtifactYaml.Deserialize(File.ReadAllText(artifactPath));
+        if (!string.Equals(artifact.DomainSlug, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed reconstruction artifact domain '{artifact.DomainSlug}' does not match requested domain '{domain}'.");
+        }
+
+        return artifact;
+    }
+
+    private static string ParseDomain(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current confirmed-bridge requires a domain.");
+        }
+
+        return args[0].Trim();
+    }
+
+    private static void ValidateConfirmedReconstructionArtifact(
+        ConfirmedReconstructionArtifact artifact,
+        GenerateFromCurrentReconcileResult reconcileResult)
+    {
+        if (!string.Equals(artifact.SourceBundleArtifactPath, reconcileResult.SourceBundleArtifactPath, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed reconstruction artifact source bundle path '{artifact.SourceBundleArtifactPath}' must match current source bundle path '{reconcileResult.SourceBundleArtifactPath}'.");
+        }
+
+        if (!artifact.ReconstructedArtifactPaths.SequenceEqual(reconcileResult.ReconstructedArtifactPaths, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Confirmed reconstruction artifact reconstructed artifact paths must match the current reconstruction output.");
+        }
+
+        if (!string.Equals(artifact.ReviewArtifactPath, reconcileResult.ReviewArtifactPath, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed reconstruction artifact review path '{artifact.ReviewArtifactPath}' must match current review path '{reconcileResult.ReviewArtifactPath}'.");
+        }
+
+        if (!string.Equals(
+                artifact.DeveloperConfirmationArtifactPath,
+                reconcileResult.DeveloperConfirmationArtifactPath,
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Confirmed reconstruction artifact developer confirmation path must match the current reconciliation output.");
+        }
+    }
+
+    private static ConceptIntakePacket BuildConceptPacket(
+        ConfirmedReconstructionArtifact confirmedArtifact,
+        ReconstructedConceptArtifact reconstructedConcept,
+        ReconstructedInterviewArtifact reconstructedInterview)
+    {
+        return new ConceptIntakePacket
+        {
+            DomainSlug = confirmedArtifact.DomainSlug,
+            ConceptSource = "generate-from-current-confirmed-bridge",
+            ConceptText = BuildConceptText(confirmedArtifact, reconstructedConcept, reconstructedInterview),
+            UpstreamPaths = confirmedArtifact.ReturnToIntentPaths,
+            InitialGoal = reconstructedConcept.InitialGoal,
+            Constraints = reconstructedConcept.CandidateRules
+                .Concat(reconstructedConcept.CandidateSpecs)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray(),
+            KnownUnknowns = confirmedArtifact.DeferredItems
+                .Concat(confirmedArtifact.BlockedItems)
+                .Concat(reconstructedInterview.BridgeQuestions.Select(question => question.QuestionText))
+                .Concat(reconstructedInterview.Gaps)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .ToArray()
+        };
+    }
+
+    private static string BuildConceptText(
+        ConfirmedReconstructionArtifact confirmedArtifact,
+        ReconstructedConceptArtifact reconstructedConcept,
+        ReconstructedInterviewArtifact reconstructedInterview)
+    {
+        var lines = new List<string>
+        {
+            $"Confirmed reconstruction bridge for domain '{confirmedArtifact.DomainSlug}'."
+        };
+
+        AppendSection(lines, "confirmed_items", confirmedArtifact.ConfirmedItems);
+        AppendSection(lines, "rejected_items", confirmedArtifact.RejectedItems);
+        AppendSection(lines, "deferred_items", confirmedArtifact.DeferredItems);
+        AppendSection(lines, "blocked_items", confirmedArtifact.BlockedItems);
+        AppendSection(lines, "candidate_intent_nodes", reconstructedConcept.CandidateIntentNodes);
+        AppendSection(lines, "candidate_user_context", reconstructedConcept.CandidateUserContext);
+        AppendSection(lines, "candidate_means", reconstructedConcept.CandidateMeans);
+        AppendSection(lines, "candidate_execution_units", reconstructedConcept.CandidateExecutionUnits);
+        AppendSection(lines, "source_concept_refs", reconstructedConcept.SourceConceptRefs);
+        AppendSection(
+            lines,
+            "recommended_follow_up_questions",
+            reconstructedInterview.BridgeQuestions.Select(question => question.QuestionText).ToArray());
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static void AppendSection(List<string> lines, string title, IReadOnlyList<string> values)
+    {
+        lines.Add($"{title}:");
+        if (values.Count == 0)
+        {
+            lines.Add("- none");
+        }
+        else
+        {
+            lines.AddRange(values.Select(value => $"- {value}"));
+        }
+
+        lines.Add(string.Empty);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedBridgeRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedBridgeRenderer.cs
@@ -1,0 +1,50 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedBridgeRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentConfirmedBridgeResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current confirmed-bridge processed for domain '{result.Domain}'.");
+
+        if (string.Equals(result.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+        }
+        else if (string.Equals(result.Route, "reconciliation-required", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Confirmed reconstruction artifact path: {result.ConfirmedReconstructionArtifactPath}");
+            writer.WriteLine("Confirmed bridge did not run because reconciliation is not ready.");
+        }
+        else
+        {
+            writer.WriteLine($"Generated concept artifact: {result.ConceptArtifactPath}");
+            writer.WriteLine("Generated interview artifacts:");
+            WriteList(writer, result.InterviewArtifactPaths);
+        }
+
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedBridgeResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedBridgeResult.cs
@@ -1,0 +1,24 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentConfirmedBridgeResult
+{
+    public required string Domain { get; init; }
+
+    public required string Route { get; init; }
+
+    public string? ConceptArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> InterviewArtifactPaths { get; init; }
+
+    public string? ClarificationReturnArtifactPath { get; init; }
+
+    public string? ConfirmedReconstructionArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -627,6 +627,53 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentConfirmedBridgeCommand_DispatchesToConfirmedBridgeRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalExecutor = GenerateFromCurrentConfirmedBridgeCommand.ReconcileExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedBridgeCommand.ReconcileExecutor = (_, _) => new GenerateFromCurrentReconcileResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                DeveloperConfirmationArtifactPath = ".intent-cli/intake/auth.developer-confirmation.yaml",
+                ConfirmedReconstructionArtifactPath = null,
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                ConfirmedItems = [],
+                RejectedItems = [],
+                DeferredItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                ClarifyItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                ReturnToIntentPaths = ["README.md"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirmed-bridge", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current confirmed-bridge processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedBridgeCommand.ReconcileExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedBridgeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedBridgeCommandTests.cs
@@ -1,0 +1,294 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentConfirmedBridgeCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyConfirmedReconstruction_RegeneratesStandardIntakeArtifacts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.confirmed-reconstruction.yaml"),
+            ConfirmedReconstructionArtifactYaml.Serialize(
+                new ConfirmedReconstructionArtifact
+                {
+                    DomainSlug = "auth",
+                    SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                    ReconstructedArtifactPaths =
+                    [
+                        ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                        ".intent-cli/intake/auth.reconstructed-interview.md"
+                    ],
+                    ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                    DeveloperConfirmationArtifactPath = ".intent-cli/intake/auth.developer-confirmation.yaml",
+                    ConfirmedItems = ["confirm: validate current auth boundary"],
+                    RejectedItems = ["reject: do not rewrite current auth ownership model"],
+                    DeferredItems = [],
+                    BlockedItems = [],
+                    ReturnToIntentPaths = ["README.md", "AGENTS.md"],
+                    DownstreamReadiness = "ready"
+                }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.reconstructed-concept.yaml"),
+            ReconstructedConceptArtifactYaml.Serialize(
+                new ReconstructedConceptArtifact
+                {
+                    DomainSlug = "auth",
+                    InitialGoal = "Reconstruct auth domain intent.",
+                    CandidateIntentNodes = ["Clarify the auth domain mission."],
+                    CandidateUserContext = ["Validate expected auth personas."],
+                    CandidateMeans = ["Inspect OAuth entry points."],
+                    CandidateRules = ["Preserve repo-level auth guidance."],
+                    CandidateSpecs = ["Reconcile current auth public contract."],
+                    CandidateExecutionUnits = ["Execution candidate from src/Auth/Login.cs."],
+                    ConfidenceByAltitude = ["purpose: medium", "execution: high"],
+                    SourceConceptRefs = ["issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current"]
+                }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.reconstructed-interview.md"),
+            """
+            # Reconstructed Interview
+
+            ## Domain
+
+            `auth`
+
+            selected_altitudes:
+            - purpose
+            - execution
+
+            root_near_intent_candidates:
+            - Clarify the auth domain mission.
+
+            execution_near_update_candidates:
+            - Inspect OAuth entry points.
+
+            confidence_by_altitude:
+            - purpose: medium
+            - execution: high
+
+            source_concept_refs:
+            - issue:114 https://github.com/J-Tech-Japan/intent-system/issues/114 [G44] Generate From Current
+
+            recommended_follow_up_questions:
+            - Arbitrary text for the first bridge question.
+
+            bridge_questions:
+            - {"question_id":"iq-root","question_text":"Arbitrary text for the first bridge question.","reason":"Clarify root-near intent before standard intake resumes.","affects":["auth"],"blocking_or_nonblocking":"blocking"}
+
+            return_to_intent_paths:
+            - README.md
+            - AGENTS.md
+
+            gaps:
+            - Need stronger auth purpose signal.
+            """);
+        using var writer = new StringWriter();
+        var originalExecutor = GenerateFromCurrentConfirmedBridgeCommand.ReconcileExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedBridgeCommand.ReconcileExecutor = (_, _) => new GenerateFromCurrentReconcileResult
+            {
+                Domain = "auth",
+                Route = "confirmed-handoff",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                DeveloperConfirmationArtifactPath = ".intent-cli/intake/auth.developer-confirmation.yaml",
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                RejectedItems = ["reject: do not rewrite current auth ownership model"],
+                DeferredItems = [],
+                BlockedItems = [],
+                ClarifyItems = [],
+                ReturnToIntentPaths = ["README.md", "AGENTS.md"],
+                DownstreamReadiness = "ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedBridgeCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current confirmed-bridge processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/intake/auth.concept.yaml", output, StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/interviews/auth/iq-root.yaml", output, StringComparison.Ordinal);
+
+            var conceptPacket = IntakeConceptArtifactYaml.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "intake", "auth.concept.yaml")));
+            Assert.Equal("generate-from-current-confirmed-bridge", conceptPacket.ConceptSource);
+            Assert.Contains("confirmed_items:", conceptPacket.ConceptText, StringComparison.Ordinal);
+            Assert.Contains("confirm: validate current auth boundary", conceptPacket.ConceptText, StringComparison.Ordinal);
+            Assert.Equal(["README.md", "AGENTS.md"], conceptPacket.UpstreamPaths);
+
+            var interview = InterviewArtifactYaml.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-root.yaml")));
+            Assert.Equal("iq-root", interview.QuestionId);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedBridgeCommand.ReconcileExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationReturnRoute_StopsWithoutRegeneratingStandardIntakeArtifacts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalExecutor = GenerateFromCurrentConfirmedBridgeCommand.ReconcileExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedBridgeCommand.ReconcileExecutor = (_, _) => new GenerateFromCurrentReconcileResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                DeveloperConfirmationArtifactPath = ".intent-cli/intake/auth.developer-confirmation.yaml",
+                ConfirmedReconstructionArtifactPath = null,
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                ConfirmedItems = [],
+                RejectedItems = [],
+                DeferredItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                ClarifyItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                ReturnToIntentPaths = ["README.md"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedBridgeCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(".intent-cli/intake/auth.clarification-return.yaml", writer.ToString(), StringComparison.Ordinal);
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.concept.yaml")));
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedBridgeCommand.ReconcileExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyConfirmedReconstruction_StopsAtReconciliationPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalExecutor = GenerateFromCurrentConfirmedBridgeCommand.ReconcileExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedBridgeCommand.ReconcileExecutor = (_, _) => new GenerateFromCurrentReconcileResult
+            {
+                Domain = "auth",
+                Route = "confirmed-handoff",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                ReviewArtifactPath = ".intent-cli/intake/auth.best-practice-review.md",
+                DeveloperConfirmationArtifactPath = ".intent-cli/intake/auth.developer-confirmation.yaml",
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                RejectedItems = [],
+                DeferredItems = ["defer: return interface cleanup after clarification"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                ClarifyItems = [],
+                ReturnToIntentPaths = ["README.md"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedBridgeCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains(".intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("reconciliation is not ready", output, StringComparison.OrdinalIgnoreCase);
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.concept.yaml")));
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedBridgeCommand.ReconcileExecutor = originalExecutor;
+        }
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-confirmed-bridge-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedBridgeRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedBridgeRendererTests.cs
@@ -1,0 +1,66 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentConfirmedBridgeRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenConfirmedBridge_WritesRegeneratedArtifacts()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedBridgeRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedBridgeResult
+            {
+                Domain = "auth",
+                Route = "confirmed-bridge",
+                ConceptArtifactPath = ".intent-cli/intake/auth.concept.yaml",
+                InterviewArtifactPaths =
+                [
+                    ".intent-cli/interviews/auth/iq-root.yaml",
+                    ".intent-cli/interviews/auth/iq-root.md"
+                ],
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-root.yaml",
+                    ".intent-cli/interviews/auth/iq-root.md"
+                ],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current confirmed-bridge processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Generated concept artifact: .intent-cli/intake/auth.concept.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Regenerated artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenClarificationReturnRoute_WritesClarificationGuidance()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedBridgeRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedBridgeResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                InterviewArtifactPaths = [],
+                RegeneratedArtifactPaths = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                DownstreamReadiness = "not-ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Clarification-return artifact path: .intent-cli/intake/auth.clarification-return.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: not-ready", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current confirmed-bridge <domain> --from-path <path>` as the G62 to G46 handoff command
- stop on clarification-return or not-ready reconciliation instead of silently regenerating standard intake artifacts
- regenerate `.intent-cli/intake/<domain>.concept.yaml` and current interview artifacts only when the confirmed handoff is ready

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentConfirmedBridge|FullyQualifiedName~CommandRouter"
- dotnet test IntentSystem.sln

Closes #152
