### PR TITLE
[G64] Add generate-from-current confirmed-advance command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -118,6 +118,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "confirmed-advance", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentConfirmedAdvanceCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "clarify", StringComparison.Ordinal))
         {
             return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedAdvanceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedAdvanceCommand.cs
@@ -1,0 +1,105 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedAdvanceCommand
+{
+    public static Func<CliContext, string[], GenerateFromCurrentConfirmedBridgeResult> ConfirmedBridgeExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentConfirmedBridgeCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string, IntakeAdvanceResult> IntakeAdvanceExecutor { get; set; } =
+        (context, domain) => IntakeAdvanceCommand.ExecuteCore(context, domain);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            GenerateFromCurrentConfirmedAdvanceRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentConfirmedAdvanceResult ExecuteCore(CliContext context, string[] args)
+    {
+        var domain = ParseDomain(args);
+        var confirmedBridgeResult = ConfirmedBridgeExecutor(context, args);
+
+        if (!string.Equals(confirmedBridgeResult.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed bridge result domain '{confirmedBridgeResult.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        if (string.Equals(confirmedBridgeResult.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentConfirmedAdvanceResult
+            {
+                Domain = domain,
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = confirmedBridgeResult.ClarificationReturnArtifactPath,
+                ConfirmedReconstructionArtifactPath = confirmedBridgeResult.ConfirmedReconstructionArtifactPath,
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = confirmedBridgeResult.RegeneratedArtifactPaths,
+                ConfirmedItems = confirmedBridgeResult.ConfirmedItems,
+                BlockedItems = confirmedBridgeResult.BlockedItems,
+                DownstreamReadiness = confirmedBridgeResult.DownstreamReadiness
+            };
+        }
+
+        if (!string.Equals(confirmedBridgeResult.DownstreamReadiness, "ready", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentConfirmedAdvanceResult
+            {
+                Domain = domain,
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = confirmedBridgeResult.ClarificationReturnArtifactPath,
+                ConfirmedReconstructionArtifactPath = confirmedBridgeResult.ConfirmedReconstructionArtifactPath,
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = confirmedBridgeResult.RegeneratedArtifactPaths,
+                ConfirmedItems = confirmedBridgeResult.ConfirmedItems,
+                BlockedItems = confirmedBridgeResult.BlockedItems,
+                DownstreamReadiness = confirmedBridgeResult.DownstreamReadiness
+            };
+        }
+
+        var intakeAdvanceResult = IntakeAdvanceExecutor(context, domain);
+        var regeneratedArtifactPaths = confirmedBridgeResult.RegeneratedArtifactPaths
+            .Concat(intakeAdvanceResult.RegeneratedArtifactPaths)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return new GenerateFromCurrentConfirmedAdvanceResult
+        {
+            Domain = domain,
+            Route = "confirmed-advance",
+            ClarificationReturnArtifactPath = confirmedBridgeResult.ClarificationReturnArtifactPath,
+            ConfirmedReconstructionArtifactPath = confirmedBridgeResult.ConfirmedReconstructionArtifactPath,
+            UpdatedSourceFilePaths = intakeAdvanceResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = intakeAdvanceResult.UpdatedExecutionFilePaths,
+            RegeneratedArtifactPaths = regeneratedArtifactPaths,
+            ConfirmedItems = confirmedBridgeResult.ConfirmedItems,
+            BlockedItems = confirmedBridgeResult.BlockedItems,
+            DownstreamReadiness = intakeAdvanceResult.ReadinessStatus
+        };
+    }
+
+    private static string ParseDomain(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current confirmed-advance requires a domain.");
+        }
+
+        return args[0].Trim();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedAdvanceRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedAdvanceRenderer.cs
@@ -1,0 +1,48 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedAdvanceRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentConfirmedAdvanceResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current confirmed-advance processed for domain '{result.Domain}'.");
+
+        if (string.Equals(result.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+        }
+        else if (string.Equals(result.Route, "reconciliation-required", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Confirmed reconstruction artifact path: {result.ConfirmedReconstructionArtifactPath}");
+            writer.WriteLine("Confirmed advance did not run because reconciliation is not ready.");
+        }
+
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedAdvanceResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedAdvanceResult.cs
@@ -1,0 +1,24 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentConfirmedAdvanceResult
+{
+    public required string Domain { get; init; }
+
+    public required string Route { get; init; }
+
+    public string? ClarificationReturnArtifactPath { get; init; }
+
+    public string? ConfirmedReconstructionArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -674,6 +674,44 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentConfirmedAdvanceCommand_DispatchesToConfirmedAdvanceRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalBridgeExecutor = GenerateFromCurrentConfirmedAdvanceCommand.ConfirmedBridgeExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedAdvanceCommand.ConfirmedBridgeExecutor = (_, _) => new GenerateFromCurrentConfirmedBridgeResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ConceptArtifactPath = null,
+                InterviewArtifactPaths = [],
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirmed-advance", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current confirmed-advance processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedAdvanceCommand.ConfirmedBridgeExecutor = originalBridgeExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedAdvanceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedAdvanceCommandTests.cs
@@ -1,0 +1,194 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentConfirmedAdvanceCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyConfirmedBridge_AdvancesToUpdatedExecutionSourceOfTruth()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalBridgeExecutor = GenerateFromCurrentConfirmedAdvanceCommand.ConfirmedBridgeExecutor;
+        var originalAdvanceExecutor = GenerateFromCurrentConfirmedAdvanceCommand.IntakeAdvanceExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedAdvanceCommand.ConfirmedBridgeExecutor = (_, _) => new GenerateFromCurrentConfirmedBridgeResult
+            {
+                Domain = "auth",
+                Route = "confirmed-bridge",
+                ConceptArtifactPath = ".intent-cli/intake/auth.concept.yaml",
+                InterviewArtifactPaths =
+                [
+                    ".intent-cli/interviews/auth/iq-root.yaml",
+                    ".intent-cli/interviews/auth/iq-root.md"
+                ],
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-root.yaml",
+                    ".intent-cli/interviews/auth/iq-root.md"
+                ],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            };
+            GenerateFromCurrentConfirmedAdvanceCommand.IntakeAdvanceExecutor = (_, _) => new IntakeAdvanceResult
+            {
+                Domain = "auth",
+                ReadinessStatus = "ready",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.compile.md",
+                    ".intent-cli/intake/auth.foldin.md",
+                    ".intent-cli/intake/auth.patch.md",
+                    ".intent-cli/intake/auth.execution.md"
+                ],
+                SkippedStages = []
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedAdvanceCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current confirmed-advance processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("- intents/intent-cli/concepts/auth-oauth2.md", output, StringComparison.Ordinal);
+            Assert.Contains("- intents/intent-cli/execution/05-post-mvp-sub-slices.md", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.concept.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.execution.md", output, StringComparison.Ordinal);
+            Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedAdvanceCommand.ConfirmedBridgeExecutor = originalBridgeExecutor;
+            GenerateFromCurrentConfirmedAdvanceCommand.IntakeAdvanceExecutor = originalAdvanceExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationReturnRoute_StopsWithoutAdvance()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalBridgeExecutor = GenerateFromCurrentConfirmedAdvanceCommand.ConfirmedBridgeExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedAdvanceCommand.ConfirmedBridgeExecutor = (_, _) => new GenerateFromCurrentConfirmedBridgeResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ConceptArtifactPath = null,
+                InterviewArtifactPaths = [],
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                ConfirmedReconstructionArtifactPath = null,
+                RegeneratedArtifactPaths = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedAdvanceCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(".intent-cli/intake/auth.clarification-return.yaml", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedAdvanceCommand.ConfirmedBridgeExecutor = originalBridgeExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyConfirmedBridge_StopsAtReconciliationPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalBridgeExecutor = GenerateFromCurrentConfirmedAdvanceCommand.ConfirmedBridgeExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedAdvanceCommand.ConfirmedBridgeExecutor = (_, _) => new GenerateFromCurrentConfirmedBridgeResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ConceptArtifactPath = null,
+                InterviewArtifactPaths = [],
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedAdvanceCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains(".intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("reconciliation is not ready", output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedAdvanceCommand.ConfirmedBridgeExecutor = originalBridgeExecutor;
+        }
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-confirmed-advance-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedAdvanceRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedAdvanceRendererTests.cs
@@ -1,0 +1,63 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentConfirmedAdvanceRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenConfirmedAdvance_WritesUpdatedPaths()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedAdvanceRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedAdvanceResult
+            {
+                Domain = "auth",
+                Route = "confirmed-advance",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.compile.md",
+                    ".intent-cli/intake/auth.execution.md"
+                ],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current confirmed-advance processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Updated source file paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Updated execution file paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Regenerated artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenReconciliationRequired_WritesStopReason()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedAdvanceRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedAdvanceResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Confirmed reconstruction artifact path: .intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("reconciliation is not ready", output, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current confirmed-advance <domain> --from-path <path>` as the G63 to G42 compose command
- stop on clarification-return or not-ready reconciliation instead of silently advancing source-of-truth updates
- combine regenerated intake artifacts with updated source and execution file paths in the final summary

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentConfirmedAdvance|FullyQualifiedName~CommandRouter"
- dotnet test IntentSystem.sln

Closes #154
