### PR TITLE
[G65] Add generate-from-current confirmed-activate command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -124,6 +124,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "confirmed-activate", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentConfirmedActivateCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "clarify", StringComparison.Ordinal))
         {
             return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedActivateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedActivateCommand.cs
@@ -1,0 +1,117 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedActivateCommand
+{
+    public static Func<CliContext, string[], GenerateFromCurrentConfirmedAdvanceResult> ConfirmedAdvanceExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentConfirmedAdvanceCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string, TextWriter, IntakeStartResult> IntakeStartExecutor { get; set; } =
+        (context, domain, writer) => IntakeStartCommand.ExecuteCore(context, domain, writer);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args, writer);
+            GenerateFromCurrentConfirmedActivateRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentConfirmedActivateResult ExecuteCore(
+        CliContext context,
+        string[] args,
+        TextWriter writer)
+    {
+        var domain = ParseDomain(args);
+        var confirmedAdvanceResult = ConfirmedAdvanceExecutor(context, args);
+
+        if (!string.Equals(confirmedAdvanceResult.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed advance result domain '{confirmedAdvanceResult.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        if (string.Equals(confirmedAdvanceResult.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentConfirmedActivateResult
+            {
+                Domain = domain,
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = confirmedAdvanceResult.ClarificationReturnArtifactPath,
+                ConfirmedReconstructionArtifactPath = confirmedAdvanceResult.ConfirmedReconstructionArtifactPath,
+                UpdatedSourceFilePaths = confirmedAdvanceResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = confirmedAdvanceResult.UpdatedExecutionFilePaths,
+                RegeneratedArtifactPaths = confirmedAdvanceResult.RegeneratedArtifactPaths,
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ConfirmedItems = confirmedAdvanceResult.ConfirmedItems,
+                BlockedItems = confirmedAdvanceResult.BlockedItems,
+                DownstreamReadiness = confirmedAdvanceResult.DownstreamReadiness
+            };
+        }
+
+        if (!string.Equals(confirmedAdvanceResult.DownstreamReadiness, "ready", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentConfirmedActivateResult
+            {
+                Domain = domain,
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = confirmedAdvanceResult.ClarificationReturnArtifactPath,
+                ConfirmedReconstructionArtifactPath = confirmedAdvanceResult.ConfirmedReconstructionArtifactPath,
+                UpdatedSourceFilePaths = confirmedAdvanceResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = confirmedAdvanceResult.UpdatedExecutionFilePaths,
+                RegeneratedArtifactPaths = confirmedAdvanceResult.RegeneratedArtifactPaths,
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ConfirmedItems = confirmedAdvanceResult.ConfirmedItems,
+                BlockedItems = confirmedAdvanceResult.BlockedItems,
+                DownstreamReadiness = confirmedAdvanceResult.DownstreamReadiness
+            };
+        }
+
+        var startResult = IntakeStartExecutor(context, domain, writer);
+        var regeneratedArtifactPaths = confirmedAdvanceResult.RegeneratedArtifactPaths
+            .Concat(startResult.GeneratedArtifactPaths)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return new GenerateFromCurrentConfirmedActivateResult
+        {
+            Domain = domain,
+            Route = "confirmed-activate",
+            ClarificationReturnArtifactPath = confirmedAdvanceResult.ClarificationReturnArtifactPath,
+            ConfirmedReconstructionArtifactPath = confirmedAdvanceResult.ConfirmedReconstructionArtifactPath,
+            UpdatedSourceFilePaths = confirmedAdvanceResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = confirmedAdvanceResult.UpdatedExecutionFilePaths,
+            RegeneratedArtifactPaths = regeneratedArtifactPaths,
+            StartedExecutionUnits = startResult.StartedExecutionUnits,
+            CreatedIssueRefs = startResult.CreatedIssueRefs,
+            WorktreePaths = startResult.WorktreePaths,
+            ConfirmedItems = confirmedAdvanceResult.ConfirmedItems,
+            BlockedItems = confirmedAdvanceResult.BlockedItems,
+            DownstreamReadiness = confirmedAdvanceResult.DownstreamReadiness
+        };
+    }
+
+    private static string ParseDomain(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current confirmed-activate requires a domain.");
+        }
+
+        return args[0].Trim();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedActivateRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedActivateRenderer.cs
@@ -1,0 +1,54 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedActivateRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentConfirmedActivateResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current confirmed-activate processed for domain '{result.Domain}'.");
+
+        if (string.Equals(result.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+        }
+        else if (string.Equals(result.Route, "reconciliation-required", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Confirmed reconstruction artifact path: {result.ConfirmedReconstructionArtifactPath}");
+            writer.WriteLine("Confirmed activate did not run because reconciliation is not ready.");
+        }
+
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedActivateResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedActivateResult.cs
@@ -1,0 +1,30 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentConfirmedActivateResult
+{
+    public required string Domain { get; init; }
+
+    public required string Route { get; init; }
+
+    public string? ClarificationReturnArtifactPath { get; init; }
+
+    public string? ConfirmedReconstructionArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -712,6 +712,44 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentConfirmedActivateCommand_DispatchesToConfirmedActivateRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalAdvanceExecutor = GenerateFromCurrentConfirmedActivateCommand.ConfirmedAdvanceExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedActivateCommand.ConfirmedAdvanceExecutor = (_, _) => new GenerateFromCurrentConfirmedAdvanceResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirmed-activate", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current confirmed-activate processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedActivateCommand.ConfirmedAdvanceExecutor = originalAdvanceExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedActivateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedActivateCommandTests.cs
@@ -1,0 +1,196 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentConfirmedActivateCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyConfirmedAdvance_StartsExecutionUnits()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalAdvanceExecutor = GenerateFromCurrentConfirmedActivateCommand.ConfirmedAdvanceExecutor;
+        var originalStartExecutor = GenerateFromCurrentConfirmedActivateCommand.IntakeStartExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedActivateCommand.ConfirmedAdvanceExecutor = (_, _) => new GenerateFromCurrentConfirmedAdvanceResult
+            {
+                Domain = "auth",
+                Route = "confirmed-advance",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md"
+                ],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            };
+            GenerateFromCurrentConfirmedActivateCommand.IntakeStartExecutor = (_, _, _) => new IntakeStartResult
+            {
+                Domain = "auth",
+                StartedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                GeneratedArtifactPaths =
+                [
+                    ".intent-cli/issues/AUTH-01/packet.yaml",
+                    ".intent-cli/issues/AUTH-02/github-body.md"
+                ],
+                CreatedIssueRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/issues/501",
+                    "https://github.com/J-Tech-Japan/intent-system/issues/502"
+                ],
+                WorktreePaths =
+                [
+                    "/tmp/worktrees/AUTH-01",
+                    "/tmp/worktrees/AUTH-02"
+                ],
+                SkippedUnits = []
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedActivateCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current confirmed-activate processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/issues/501", output, StringComparison.Ordinal);
+            Assert.Contains("- /tmp/worktrees/AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.concept.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/issues/AUTH-01/packet.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedActivateCommand.ConfirmedAdvanceExecutor = originalAdvanceExecutor;
+            GenerateFromCurrentConfirmedActivateCommand.IntakeStartExecutor = originalStartExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationReturnRoute_StopsWithoutStart()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalAdvanceExecutor = GenerateFromCurrentConfirmedActivateCommand.ConfirmedAdvanceExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedActivateCommand.ConfirmedAdvanceExecutor = (_, _) => new GenerateFromCurrentConfirmedAdvanceResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                ConfirmedReconstructionArtifactPath = null,
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedActivateCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(".intent-cli/intake/auth.clarification-return.yaml", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedActivateCommand.ConfirmedAdvanceExecutor = originalAdvanceExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyConfirmedAdvance_StopsAtReconciliationPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalAdvanceExecutor = GenerateFromCurrentConfirmedActivateCommand.ConfirmedAdvanceExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedActivateCommand.ConfirmedAdvanceExecutor = (_, _) => new GenerateFromCurrentConfirmedAdvanceResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedActivateCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains(".intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("reconciliation is not ready", output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedActivateCommand.ConfirmedAdvanceExecutor = originalAdvanceExecutor;
+        }
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-confirmed-activate-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedActivateRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedActivateRendererTests.cs
@@ -1,0 +1,69 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentConfirmedActivateRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenConfirmedActivate_WritesStartedUnitsAndRefs()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedActivateRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedActivateResult
+            {
+                Domain = "auth",
+                Route = "confirmed-activate",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/501"],
+                WorktreePaths = ["/tmp/worktrees/AUTH-01"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current confirmed-activate processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Started execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("Created issue refs:", output, StringComparison.Ordinal);
+        Assert.Contains("Worktree paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenClarificationReturnRoute_WritesStopReason()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedActivateRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedActivateResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                DownstreamReadiness = "not-ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Clarification-return artifact path: .intent-cli/intake/auth.clarification-return.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: not-ready", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `generate-from-current confirmed-activate <domain> --from-path <path>` as the G64 to launch compose command
- stop on clarification-return or not-ready reconciliation instead of silently starting execution units
- combine updated source/execution paths, regenerated artifacts, started execution units, issue refs, and worktree paths in the final summary

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentConfirmedActivate|FullyQualifiedName~CommandRouter"
- dotnet test IntentSystem.sln

Closes #156
