### PR TITLE
[G66] Add generate-from-current confirmed-implement command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -130,6 +130,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "confirmed-implement", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentConfirmedImplementCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "clarify", StringComparison.Ordinal))
         {
             return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedImplementCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedImplementCommand.cs
@@ -1,0 +1,95 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedImplementCommand
+{
+    public static Func<CliContext, string[], TextWriter, GenerateFromCurrentConfirmedActivateResult> ConfirmedActivateExecutor { get; set; } =
+        (context, args, writer) => GenerateFromCurrentConfirmedActivateCommand.ExecuteCore(context, args, writer);
+
+    public static Func<CliContext, string, RunImplementResult> RunImplementExecutor { get; set; } =
+        (context, executionUnit) => RunImplementCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args, writer);
+            GenerateFromCurrentConfirmedImplementRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentConfirmedImplementResult ExecuteCore(
+        CliContext context,
+        string[] args,
+        TextWriter writer)
+    {
+        var domain = ParseDomain(args);
+        var confirmedActivateResult = ConfirmedActivateExecutor(context, args, writer);
+
+        if (!string.Equals(confirmedActivateResult.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed activate result domain '{confirmedActivateResult.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        if (string.Equals(confirmedActivateResult.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            return CreateStopResult(domain, "clarification-return", confirmedActivateResult, []);
+        }
+
+        if (!string.Equals(confirmedActivateResult.DownstreamReadiness, "ready", StringComparison.Ordinal))
+        {
+            return CreateStopResult(domain, "reconciliation-required", confirmedActivateResult, []);
+        }
+
+        var implementArtifactPaths = confirmedActivateResult.StartedExecutionUnits
+            .Select(executionUnit => RunImplementExecutor(context, executionUnit).ArtifactPath)
+            .ToArray();
+
+        return CreateStopResult(domain, "confirmed-implement", confirmedActivateResult, implementArtifactPaths);
+    }
+
+    private static GenerateFromCurrentConfirmedImplementResult CreateStopResult(
+        string domain,
+        string route,
+        GenerateFromCurrentConfirmedActivateResult confirmedActivateResult,
+        IReadOnlyList<string> implementArtifactPaths)
+    {
+        return new GenerateFromCurrentConfirmedImplementResult
+        {
+            Domain = domain,
+            Route = route,
+            ClarificationReturnArtifactPath = confirmedActivateResult.ClarificationReturnArtifactPath,
+            ConfirmedReconstructionArtifactPath = confirmedActivateResult.ConfirmedReconstructionArtifactPath,
+            UpdatedSourceFilePaths = confirmedActivateResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = confirmedActivateResult.UpdatedExecutionFilePaths,
+            RegeneratedArtifactPaths = confirmedActivateResult.RegeneratedArtifactPaths,
+            StartedExecutionUnits = confirmedActivateResult.StartedExecutionUnits,
+            CreatedIssueRefs = confirmedActivateResult.CreatedIssueRefs,
+            WorktreePaths = confirmedActivateResult.WorktreePaths,
+            ImplementRequestArtifactPaths = implementArtifactPaths,
+            ConfirmedItems = confirmedActivateResult.ConfirmedItems,
+            BlockedItems = confirmedActivateResult.BlockedItems,
+            DownstreamReadiness = confirmedActivateResult.DownstreamReadiness
+        };
+    }
+
+    private static string ParseDomain(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current confirmed-implement requires a domain.");
+        }
+
+        return args[0].Trim();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedImplementRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedImplementRenderer.cs
@@ -1,0 +1,56 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedImplementRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentConfirmedImplementResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current confirmed-implement processed for domain '{result.Domain}'.");
+
+        if (string.Equals(result.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+        }
+        else if (string.Equals(result.Route, "reconciliation-required", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Confirmed reconstruction artifact path: {result.ConfirmedReconstructionArtifactPath}");
+            writer.WriteLine("Confirmed implement did not run because reconciliation is not ready.");
+        }
+
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Generated implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedImplementResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedImplementResult.cs
@@ -1,0 +1,32 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentConfirmedImplementResult
+{
+    public required string Domain { get; init; }
+
+    public required string Route { get; init; }
+
+    public string? ClarificationReturnArtifactPath { get; init; }
+
+    public string? ConfirmedReconstructionArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -750,6 +750,47 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentConfirmedImplementCommand_DispatchesToConfirmedImplementRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalActivateExecutor = GenerateFromCurrentConfirmedImplementCommand.ConfirmedActivateExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedImplementCommand.ConfirmedActivateExecutor = (_, _, _) => new GenerateFromCurrentConfirmedActivateResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirmed-implement", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current confirmed-implement processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedImplementCommand.ConfirmedActivateExecutor = originalActivateExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedImplementCommandTests.cs
@@ -1,0 +1,220 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentConfirmedImplementCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyConfirmedActivate_GeneratesImplementRequestArtifacts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalActivateExecutor = GenerateFromCurrentConfirmedImplementCommand.ConfirmedActivateExecutor;
+        var originalRunImplementExecutor = GenerateFromCurrentConfirmedImplementCommand.RunImplementExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedImplementCommand.ConfirmedActivateExecutor = (_, _, _) => new GenerateFromCurrentConfirmedActivateResult
+            {
+                Domain = "auth",
+                Route = "confirmed-activate",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                CreatedIssueRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/issues/501",
+                    "https://github.com/J-Tech-Japan/intent-system/issues/502"
+                ],
+                WorktreePaths =
+                [
+                    "/tmp/worktrees/AUTH-01",
+                    "/tmp/worktrees/AUTH-02"
+                ],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            };
+            GenerateFromCurrentConfirmedImplementCommand.RunImplementExecutor = (_, executionUnit) => new RunImplementResult
+            {
+                Request = new RunImplementRequest
+                {
+                    ExecutionUnit = executionUnit,
+                    State = "active",
+                    ImplementRole = "Claude",
+                    QueueWorkerRole = "Claude",
+                    QueueReviewRole = "Codex",
+                    WorktreePath = $"/tmp/worktrees/{executionUnit}",
+                    ChildRepoPath = "/tmp/child",
+                    Branch = $"issue-500-{executionUnit.ToLowerInvariant()}",
+                    LinkedIssue = $"https://github.com/J-Tech-Japan/intent-system/issues/{(executionUnit == "AUTH-01" ? "501" : "502")}",
+                    LatestLinkedPr = null,
+                    PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                    ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                    IssueTitle = $"[{executionUnit}] Title",
+                    Goal = "Goal",
+                    TargetPart = "Target",
+                    TargetRepo = "submodules/intent-system",
+                    TargetPath = ".",
+                    InScope = [],
+                    OutOfScope = [],
+                    AcceptanceCriteria = [],
+                    DeterministicReviewChecks = [],
+                    ExpectedEvidence = []
+                },
+                ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedImplementCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current confirmed-implement processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/implement/AUTH-01.request.md", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/implement/AUTH-02.request.md", output, StringComparison.Ordinal);
+            Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedImplementCommand.ConfirmedActivateExecutor = originalActivateExecutor;
+            GenerateFromCurrentConfirmedImplementCommand.RunImplementExecutor = originalRunImplementExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationReturnRoute_StopsWithoutImplementHandoff()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalActivateExecutor = GenerateFromCurrentConfirmedImplementCommand.ConfirmedActivateExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedImplementCommand.ConfirmedActivateExecutor = (_, _, _) => new GenerateFromCurrentConfirmedActivateResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                ConfirmedReconstructionArtifactPath = null,
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedImplementCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(".intent-cli/intake/auth.clarification-return.yaml", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedImplementCommand.ConfirmedActivateExecutor = originalActivateExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyConfirmedActivate_StopsAtReconciliationPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalActivateExecutor = GenerateFromCurrentConfirmedImplementCommand.ConfirmedActivateExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedImplementCommand.ConfirmedActivateExecutor = (_, _, _) => new GenerateFromCurrentConfirmedActivateResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedImplementCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains(".intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("reconciliation is not ready", output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedImplementCommand.ConfirmedActivateExecutor = originalActivateExecutor;
+        }
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-confirmed-implement-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedImplementRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedImplementRendererTests.cs
@@ -1,0 +1,70 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentConfirmedImplementRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenConfirmedImplement_WritesImplementArtifactPaths()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedImplementRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedImplementResult
+            {
+                Domain = "auth",
+                Route = "confirmed-implement",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/501"],
+                WorktreePaths = ["/tmp/worktrees/AUTH-01"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/AUTH-01.request.md"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current confirmed-implement processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Generated implement request artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/implement/AUTH-01.request.md", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenClarificationReturnRoute_WritesStopReason()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedImplementRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedImplementResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before issue-cut-ready treatment."],
+                DownstreamReadiness = "not-ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Clarification-return artifact path: .intent-cli/intake/auth.clarification-return.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: not-ready", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## What Changed
- added `generate-from-current confirmed-implement <domain> --from-path <path>` as the G66 compose command
- threaded `confirmed-activate` success output into `run implement` artifact generation for each started execution unit
- added stop-path handling so clarification-return and not-ready reconciliation halt before implement handoff
- covered the new command with command tests, renderer tests, and command-router coverage

## Why
Issue 158 requires a thin bridge from the confirmed downstream handoff flow into implement request artifact generation without widening the existing command contracts.

## Impact
- users can now progress from current-source reconstruction through confirmed activate and directly emit implement handoff artifacts with one command
- stop conditions remain explicit, and the summary reports regenerated artifacts, started units, issue refs, worktrees, confirmed items, blocked items, and generated implement requests

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentConfirmedImplement|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`

Closes #158
