### PR TITLE
[G67] Add generate-from-current confirmed-submit command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -136,6 +136,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "confirmed-submit", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentConfirmedSubmitCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "clarify", StringComparison.Ordinal))
         {
             return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedSubmitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedSubmitCommand.cs
@@ -1,0 +1,103 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedSubmitCommand
+{
+    public static Func<CliContext, string[], TextWriter, GenerateFromCurrentConfirmedImplementResult> ConfirmedImplementExecutor { get; set; } =
+        (context, args, writer) => GenerateFromCurrentConfirmedImplementCommand.ExecuteCore(context, args, writer);
+
+    public static Func<CliContext, string, RunSubmitResult> RunSubmitExecutor { get; set; } =
+        (context, executionUnit) => RunSubmitCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args, writer);
+            GenerateFromCurrentConfirmedSubmitRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentConfirmedSubmitResult ExecuteCore(
+        CliContext context,
+        string[] args,
+        TextWriter writer)
+    {
+        var domain = ParseDomain(args);
+        var confirmedImplementResult = ConfirmedImplementExecutor(context, args, writer);
+
+        if (!string.Equals(confirmedImplementResult.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed implement result domain '{confirmedImplementResult.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        if (string.Equals(confirmedImplementResult.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "clarification-return", confirmedImplementResult, [], []);
+        }
+
+        if (!string.Equals(confirmedImplementResult.DownstreamReadiness, "ready", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "reconciliation-required", confirmedImplementResult, [], []);
+        }
+
+        var submitResults = confirmedImplementResult.StartedExecutionUnits
+            .Select(executionUnit => RunSubmitExecutor(context, executionUnit))
+            .ToArray();
+
+        return CreateResult(
+            domain,
+            "confirmed-submit",
+            confirmedImplementResult,
+            submitResults.Select(result => result.LinkedPr).ToArray(),
+            submitResults.Select(result => result.ExecutionUnit).ToArray());
+    }
+
+    private static GenerateFromCurrentConfirmedSubmitResult CreateResult(
+        string domain,
+        string route,
+        GenerateFromCurrentConfirmedImplementResult confirmedImplementResult,
+        IReadOnlyList<string> createdPrRefs,
+        IReadOnlyList<string> reviewExecutionUnits)
+    {
+        return new GenerateFromCurrentConfirmedSubmitResult
+        {
+            Domain = domain,
+            Route = route,
+            ClarificationReturnArtifactPath = confirmedImplementResult.ClarificationReturnArtifactPath,
+            ConfirmedReconstructionArtifactPath = confirmedImplementResult.ConfirmedReconstructionArtifactPath,
+            UpdatedSourceFilePaths = confirmedImplementResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = confirmedImplementResult.UpdatedExecutionFilePaths,
+            RegeneratedArtifactPaths = confirmedImplementResult.RegeneratedArtifactPaths,
+            StartedExecutionUnits = confirmedImplementResult.StartedExecutionUnits,
+            CreatedIssueRefs = confirmedImplementResult.CreatedIssueRefs,
+            WorktreePaths = confirmedImplementResult.WorktreePaths,
+            ImplementRequestArtifactPaths = confirmedImplementResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = createdPrRefs,
+            ReviewExecutionUnits = reviewExecutionUnits,
+            ConfirmedItems = confirmedImplementResult.ConfirmedItems,
+            BlockedItems = confirmedImplementResult.BlockedItems,
+            DownstreamReadiness = confirmedImplementResult.DownstreamReadiness
+        };
+    }
+
+    private static string ParseDomain(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current confirmed-submit requires a domain.");
+        }
+
+        return args[0].Trim();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedSubmitRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedSubmitRenderer.cs
@@ -1,0 +1,60 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedSubmitRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentConfirmedSubmitResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current confirmed-submit processed for domain '{result.Domain}'.");
+
+        if (string.Equals(result.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+        }
+        else if (string.Equals(result.Route, "reconciliation-required", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Confirmed reconstruction artifact path: {result.ConfirmedReconstructionArtifactPath}");
+            writer.WriteLine("Confirmed submit did not run because reconciliation is not ready.");
+        }
+
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Generated implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedSubmitResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedSubmitResult.cs
@@ -1,0 +1,36 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentConfirmedSubmitResult
+{
+    public required string Domain { get; init; }
+
+    public required string Route { get; init; }
+
+    public string? ClarificationReturnArtifactPath { get; init; }
+
+    public string? ConfirmedReconstructionArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -791,6 +791,48 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentConfirmedSubmitCommand_DispatchesToConfirmedSubmitRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalImplementExecutor = GenerateFromCurrentConfirmedSubmitCommand.ConfirmedImplementExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedSubmitCommand.ConfirmedImplementExecutor = (_, _, _) => new GenerateFromCurrentConfirmedImplementResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirmed-submit", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current confirmed-submit processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedSubmitCommand.ConfirmedImplementExecutor = originalImplementExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedSubmitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedSubmitCommandTests.cs
@@ -1,0 +1,209 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentConfirmedSubmitCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyConfirmedImplement_SubmitsStartedExecutionUnits()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalImplementExecutor = GenerateFromCurrentConfirmedSubmitCommand.ConfirmedImplementExecutor;
+        var originalRunSubmitExecutor = GenerateFromCurrentConfirmedSubmitCommand.RunSubmitExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedSubmitCommand.ConfirmedImplementExecutor = (_, _, _) => new GenerateFromCurrentConfirmedImplementResult
+            {
+                Domain = "auth",
+                Route = "confirmed-implement",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                CreatedIssueRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/issues/501",
+                    "https://github.com/J-Tech-Japan/intent-system/issues/502"
+                ],
+                WorktreePaths =
+                [
+                    "/tmp/worktrees/AUTH-01",
+                    "/tmp/worktrees/AUTH-02"
+                ],
+                ImplementRequestArtifactPaths =
+                [
+                    ".intent-cli/implement/AUTH-01.request.md",
+                    ".intent-cli/implement/AUTH-02.request.md"
+                ],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            };
+            GenerateFromCurrentConfirmedSubmitCommand.RunSubmitExecutor = (_, executionUnit) => new RunSubmitResult
+            {
+                ExecutionUnit = executionUnit,
+                LinkedPr = executionUnit switch
+                {
+                    "AUTH-01" => "https://github.com/J-Tech-Japan/intent-system/pull/501",
+                    "AUTH-02" => "https://github.com/J-Tech-Japan/intent-system/pull/502",
+                    _ => throw new InvalidOperationException($"Unexpected execution unit '{executionUnit}'.")
+                }
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedSubmitCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current confirmed-submit processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/implement/AUTH-01.request.md", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/501", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/502", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedSubmitCommand.ConfirmedImplementExecutor = originalImplementExecutor;
+            GenerateFromCurrentConfirmedSubmitCommand.RunSubmitExecutor = originalRunSubmitExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationReturnRoute_StopsWithoutSubmit()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalImplementExecutor = GenerateFromCurrentConfirmedSubmitCommand.ConfirmedImplementExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedSubmitCommand.ConfirmedImplementExecutor = (_, _, _) => new GenerateFromCurrentConfirmedImplementResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                ConfirmedReconstructionArtifactPath = null,
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before review-entry treatment."],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedSubmitCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(".intent-cli/intake/auth.clarification-return.yaml", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedSubmitCommand.ConfirmedImplementExecutor = originalImplementExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyConfirmedImplement_StopsAtReconciliationPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalImplementExecutor = GenerateFromCurrentConfirmedSubmitCommand.ConfirmedImplementExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedSubmitCommand.ConfirmedImplementExecutor = (_, _, _) => new GenerateFromCurrentConfirmedImplementResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedSubmitCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains(".intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("reconciliation is not ready", output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedSubmitCommand.ConfirmedImplementExecutor = originalImplementExecutor;
+        }
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-confirmed-submit-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedSubmitRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedSubmitRendererTests.cs
@@ -1,0 +1,75 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentConfirmedSubmitRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenConfirmedSubmit_WritesCreatedPrRefs()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedSubmitRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedSubmitResult
+            {
+                Domain = "auth",
+                Route = "confirmed-submit",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/501"],
+                WorktreePaths = ["/tmp/worktrees/AUTH-01"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/AUTH-01.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501"],
+                ReviewExecutionUnits = ["AUTH-01"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current confirmed-submit processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Created PR refs:", output, StringComparison.Ordinal);
+        Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/501", output, StringComparison.Ordinal);
+        Assert.Contains("Review execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenClarificationReturnRoute_WritesStopReason()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedSubmitRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedSubmitResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before review-entry treatment."],
+                DownstreamReadiness = "not-ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Clarification-return artifact path: .intent-cli/intake/auth.clarification-return.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: not-ready", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## What Changed
- added `generate-from-current confirmed-submit <domain> --from-path <path>` as the G67 compose command
- threaded `confirmed-implement` success output into `run submit` for each started execution unit
- preserved clarification-return and reconciliation stop paths so submit does not run on not-ready downstream handoff
- added command tests, renderer tests, and command-router coverage for the new command

## Why
Issue 160 requires a thin bridge from the confirmed downstream handoff flow through implement handoff into deterministic review entry without widening the existing command contracts.

## Impact
- users can now progress from current-source reconstruction through confirmed implement and directly create draft PR refs for the selected execution units with one command
- summaries now report updated source paths, execution paths, regenerated artifacts, started units, created issue refs, worktree paths, implement request artifact paths, created PR refs, review units, confirmed items, blocked items, and downstream readiness

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentConfirmedSubmit|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`

Closes #160
