### PR TITLE
[G68] Add generate-from-current confirmed-review command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -142,6 +142,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "confirmed-review", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentConfirmedReviewCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "clarify", StringComparison.Ordinal))
         {
             return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedReviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedReviewCommand.cs
@@ -1,0 +1,102 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedReviewCommand
+{
+    public static Func<CliContext, string[], TextWriter, GenerateFromCurrentConfirmedSubmitResult> ConfirmedSubmitExecutor { get; set; } =
+        (context, args, writer) => GenerateFromCurrentConfirmedSubmitCommand.ExecuteCore(context, args, writer);
+
+    public static Func<CliContext, string, ReviewRunResult> ReviewRunExecutor { get; set; } =
+        (context, executionUnit) => ReviewRunCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args, writer);
+            GenerateFromCurrentConfirmedReviewRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentConfirmedReviewResult ExecuteCore(
+        CliContext context,
+        string[] args,
+        TextWriter writer)
+    {
+        var domain = ParseDomain(args);
+        var confirmedSubmitResult = ConfirmedSubmitExecutor(context, args, writer);
+
+        if (!string.Equals(confirmedSubmitResult.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed submit result domain '{confirmedSubmitResult.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        if (string.Equals(confirmedSubmitResult.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "clarification-return", confirmedSubmitResult, []);
+        }
+
+        if (!string.Equals(confirmedSubmitResult.DownstreamReadiness, "ready", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "reconciliation-required", confirmedSubmitResult, []);
+        }
+
+        var reviewResults = confirmedSubmitResult.ReviewExecutionUnits
+            .Select(executionUnit => ReviewRunExecutor(context, executionUnit))
+            .ToArray();
+
+        return CreateResult(
+            domain,
+            "confirmed-review",
+            confirmedSubmitResult,
+            reviewResults.Select(result => result.ArtifactPath).ToArray());
+    }
+
+    private static GenerateFromCurrentConfirmedReviewResult CreateResult(
+        string domain,
+        string route,
+        GenerateFromCurrentConfirmedSubmitResult confirmedSubmitResult,
+        IReadOnlyList<string> reviewRequestArtifactPaths)
+    {
+        return new GenerateFromCurrentConfirmedReviewResult
+        {
+            Domain = domain,
+            Route = route,
+            ClarificationReturnArtifactPath = confirmedSubmitResult.ClarificationReturnArtifactPath,
+            ConfirmedReconstructionArtifactPath = confirmedSubmitResult.ConfirmedReconstructionArtifactPath,
+            UpdatedSourceFilePaths = confirmedSubmitResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = confirmedSubmitResult.UpdatedExecutionFilePaths,
+            RegeneratedArtifactPaths = confirmedSubmitResult.RegeneratedArtifactPaths,
+            StartedExecutionUnits = confirmedSubmitResult.StartedExecutionUnits,
+            CreatedIssueRefs = confirmedSubmitResult.CreatedIssueRefs,
+            WorktreePaths = confirmedSubmitResult.WorktreePaths,
+            ImplementRequestArtifactPaths = confirmedSubmitResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = confirmedSubmitResult.CreatedPrRefs,
+            ReviewExecutionUnits = confirmedSubmitResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = reviewRequestArtifactPaths,
+            ConfirmedItems = confirmedSubmitResult.ConfirmedItems,
+            BlockedItems = confirmedSubmitResult.BlockedItems,
+            DownstreamReadiness = confirmedSubmitResult.DownstreamReadiness
+        };
+    }
+
+    private static string ParseDomain(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current confirmed-review requires a domain.");
+        }
+
+        return args[0].Trim();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedReviewRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedReviewRenderer.cs
@@ -1,0 +1,62 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedReviewRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentConfirmedReviewResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current confirmed-review processed for domain '{result.Domain}'.");
+
+        if (string.Equals(result.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+        }
+        else if (string.Equals(result.Route, "reconciliation-required", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Confirmed reconstruction artifact path: {result.ConfirmedReconstructionArtifactPath}");
+            writer.WriteLine("Confirmed review did not run because reconciliation is not ready.");
+        }
+
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Generated implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedReviewResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedReviewResult.cs
@@ -1,0 +1,38 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentConfirmedReviewResult
+{
+    public required string Domain { get; init; }
+
+    public required string Route { get; init; }
+
+    public string? ClarificationReturnArtifactPath { get; init; }
+
+    public string? ConfirmedReconstructionArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -833,6 +833,50 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentConfirmedReviewCommand_DispatchesToConfirmedReviewRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalSubmitExecutor = GenerateFromCurrentConfirmedReviewCommand.ConfirmedSubmitExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedReviewCommand.ConfirmedSubmitExecutor = (_, _, _) => new GenerateFromCurrentConfirmedSubmitResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirmed-review", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current confirmed-review processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedReviewCommand.ConfirmedSubmitExecutor = originalSubmitExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedReviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedReviewCommandTests.cs
@@ -1,0 +1,214 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentConfirmedReviewCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyConfirmedSubmit_GeneratesReviewRequestArtifacts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalSubmitExecutor = GenerateFromCurrentConfirmedReviewCommand.ConfirmedSubmitExecutor;
+        var originalReviewRunExecutor = GenerateFromCurrentConfirmedReviewCommand.ReviewRunExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedReviewCommand.ConfirmedSubmitExecutor = (_, _, _) => new GenerateFromCurrentConfirmedSubmitResult
+            {
+                Domain = "auth",
+                Route = "confirmed-submit",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                CreatedIssueRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/issues/501",
+                    "https://github.com/J-Tech-Japan/intent-system/issues/502"
+                ],
+                WorktreePaths =
+                [
+                    "/tmp/worktrees/AUTH-01",
+                    "/tmp/worktrees/AUTH-02"
+                ],
+                ImplementRequestArtifactPaths =
+                [
+                    ".intent-cli/implement/AUTH-01.request.md",
+                    ".intent-cli/implement/AUTH-02.request.md"
+                ],
+                CreatedPrRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/pull/501",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/502"
+                ],
+                ReviewExecutionUnits = ["AUTH-01", "AUTH-02"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            };
+            GenerateFromCurrentConfirmedReviewCommand.ReviewRunExecutor = (_, executionUnit) => new ReviewRunResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedReviewCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current confirmed-review processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/reviews/AUTH-01.request.json", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/reviews/AUTH-02.request.json", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/501", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedReviewCommand.ConfirmedSubmitExecutor = originalSubmitExecutor;
+            GenerateFromCurrentConfirmedReviewCommand.ReviewRunExecutor = originalReviewRunExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationReturnRoute_StopsWithoutReviewRequestGeneration()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalSubmitExecutor = GenerateFromCurrentConfirmedReviewCommand.ConfirmedSubmitExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedReviewCommand.ConfirmedSubmitExecutor = (_, _, _) => new GenerateFromCurrentConfirmedSubmitResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                ConfirmedReconstructionArtifactPath = null,
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before review-request treatment."],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedReviewCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(".intent-cli/intake/auth.clarification-return.yaml", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedReviewCommand.ConfirmedSubmitExecutor = originalSubmitExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyConfirmedSubmit_StopsAtReconciliationPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalSubmitExecutor = GenerateFromCurrentConfirmedReviewCommand.ConfirmedSubmitExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedReviewCommand.ConfirmedSubmitExecutor = (_, _, _) => new GenerateFromCurrentConfirmedSubmitResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedReviewCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains(".intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("reconciliation is not ready", output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedReviewCommand.ConfirmedSubmitExecutor = originalSubmitExecutor;
+        }
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-confirmed-review-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedReviewRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedReviewRendererTests.cs
@@ -1,0 +1,76 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentConfirmedReviewRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenConfirmedReview_WritesReviewRequestArtifactPaths()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedReviewRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedReviewResult
+            {
+                Domain = "auth",
+                Route = "confirmed-review",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/501"],
+                WorktreePaths = ["/tmp/worktrees/AUTH-01"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/AUTH-01.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501"],
+                ReviewExecutionUnits = ["AUTH-01"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/AUTH-01.request.json"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current confirmed-review processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Review request artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/reviews/AUTH-01.request.json", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenClarificationReturnRoute_WritesStopReason()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedReviewRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedReviewResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before review-request treatment."],
+                DownstreamReadiness = "not-ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Clarification-return artifact path: .intent-cli/intake/auth.clarification-return.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: not-ready", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## What Changed
- added `generate-from-current confirmed-review <domain> --from-path <path>` as the G68 compose command
- threaded `confirmed-submit` success output into `review run` for each review execution unit
- preserved clarification-return and reconciliation stop paths so review request generation does not run on not-ready downstream handoff
- added command tests, renderer tests, and command-router coverage for the new command

## Why
Issue 162 requires a thin bridge from the confirmed downstream handoff flow through review entry into deterministic review request artifact generation without widening the existing command contracts.

## Impact
- users can now progress from current-source reconstruction through confirmed submit and directly generate review request artifacts for the selected execution units with one command
- summaries now report updated source paths, execution paths, regenerated artifacts, started units, created issue refs, worktree paths, implement request artifact paths, created PR refs, review units, review request artifact paths, confirmed items, blocked items, and downstream readiness

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentConfirmedReview|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`

Closes #162
