### PR TITLE
[G70] Add generate-from-current confirmed-comment command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -154,6 +154,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "confirmed-comment", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentConfirmedCommentCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "clarify", StringComparison.Ordinal))
         {
             return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedCommentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedCommentCommand.cs
@@ -1,0 +1,142 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedCommentCommand
+{
+    public static Func<CliContext, string[], TextWriter, GenerateFromCurrentConfirmedReviewResult> ConfirmedReviewExecutor { get; set; } =
+        (context, args, writer) => GenerateFromCurrentConfirmedReviewCommand.ExecuteCore(context, args, writer);
+
+    public static Func<CliContext, string, string, ReviewCommentResult> ReviewCommentExecutor { get; set; } =
+        (context, executionUnit, bodyPath) => ReviewCommentCommand.ExecuteCore(context, executionUnit, bodyPath);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args, writer);
+            GenerateFromCurrentConfirmedCommentRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentConfirmedCommentResult ExecuteCore(
+        CliContext context,
+        string[] args,
+        TextWriter writer)
+    {
+        var (pipelineArgs, bodyPath) = ParseArgs(args);
+        var domain = pipelineArgs[0];
+        var confirmedReviewResult = ConfirmedReviewExecutor(context, pipelineArgs, writer);
+
+        if (!string.Equals(confirmedReviewResult.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed review result domain '{confirmedReviewResult.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        if (string.Equals(confirmedReviewResult.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "clarification-return", confirmedReviewResult, [], [], []);
+        }
+
+        if (!string.Equals(confirmedReviewResult.DownstreamReadiness, "ready", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "reconciliation-required", confirmedReviewResult, [], [], []);
+        }
+
+        var commentResults = confirmedReviewResult.ReviewExecutionUnits
+            .Select(executionUnit => ReviewCommentExecutor(context, executionUnit, bodyPath))
+            .ToArray();
+
+        return CreateResult(
+            domain,
+            "confirmed-comment",
+            confirmedReviewResult,
+            commentResults.Select(result => result.ArtifactPath).ToArray(),
+            commentResults.Select(result => result.CommentRef).ToArray(),
+            commentResults.Select(result => result.ExecutionUnit).ToArray());
+    }
+
+    private static GenerateFromCurrentConfirmedCommentResult CreateResult(
+        string domain,
+        string route,
+        GenerateFromCurrentConfirmedReviewResult confirmedReviewResult,
+        IReadOnlyList<string> postedCommentArtifactPaths,
+        IReadOnlyList<string> commentRefs,
+        IReadOnlyList<string> fixingExecutionUnits)
+    {
+        return new GenerateFromCurrentConfirmedCommentResult
+        {
+            Domain = domain,
+            Route = route,
+            ClarificationReturnArtifactPath = confirmedReviewResult.ClarificationReturnArtifactPath,
+            ConfirmedReconstructionArtifactPath = confirmedReviewResult.ConfirmedReconstructionArtifactPath,
+            UpdatedSourceFilePaths = confirmedReviewResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = confirmedReviewResult.UpdatedExecutionFilePaths,
+            RegeneratedArtifactPaths = confirmedReviewResult.RegeneratedArtifactPaths,
+            StartedExecutionUnits = confirmedReviewResult.StartedExecutionUnits,
+            CreatedIssueRefs = confirmedReviewResult.CreatedIssueRefs,
+            WorktreePaths = confirmedReviewResult.WorktreePaths,
+            ImplementRequestArtifactPaths = confirmedReviewResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = confirmedReviewResult.CreatedPrRefs,
+            ReviewExecutionUnits = confirmedReviewResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = confirmedReviewResult.ReviewRequestArtifactPaths,
+            PostedCommentArtifactPaths = postedCommentArtifactPaths,
+            CommentRefs = commentRefs,
+            FixingExecutionUnits = fixingExecutionUnits,
+            ConfirmedItems = confirmedReviewResult.ConfirmedItems,
+            BlockedItems = confirmedReviewResult.BlockedItems,
+            DownstreamReadiness = confirmedReviewResult.DownstreamReadiness
+        };
+    }
+
+    private static (string[] PipelineArgs, string BodyPath) ParseArgs(string[] args)
+    {
+        if (args.Length < 3 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException(
+                "Generate-from-current confirmed-comment requires a domain, source selection args, and '--from-file <path>'.");
+        }
+
+        string? bodyPath = null;
+        var pipelineArgs = new List<string>();
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            if (string.Equals(argument, "--from-file", StringComparison.Ordinal))
+            {
+                if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                {
+                    throw new InvalidOperationException("--from-file requires a value.");
+                }
+
+                bodyPath = args[index + 1];
+                index++;
+                continue;
+            }
+
+            pipelineArgs.Add(argument);
+        }
+
+        if (pipelineArgs.Count == 0 || string.IsNullOrWhiteSpace(pipelineArgs[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current confirmed-comment requires a domain.");
+        }
+
+        if (string.IsNullOrWhiteSpace(bodyPath))
+        {
+            throw new InvalidOperationException("Generate-from-current confirmed-comment requires '--from-file <path>'.");
+        }
+
+        return (pipelineArgs.ToArray(), bodyPath);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedCommentRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedCommentRenderer.cs
@@ -1,0 +1,68 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedCommentRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentConfirmedCommentResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current confirmed-comment processed for domain '{result.Domain}'.");
+
+        if (string.Equals(result.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+        }
+        else if (string.Equals(result.Route, "reconciliation-required", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Confirmed reconstruction artifact path: {result.ConfirmedReconstructionArtifactPath}");
+            writer.WriteLine("Confirmed comment did not run because reconciliation is not ready.");
+        }
+
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Generated implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Posted comment artifact paths:");
+        WriteList(writer, result.PostedCommentArtifactPaths);
+        writer.WriteLine("Comment refs:");
+        WriteList(writer, result.CommentRefs);
+        writer.WriteLine("Fixing execution units:");
+        WriteList(writer, result.FixingExecutionUnits);
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedCommentResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedCommentResult.cs
@@ -1,0 +1,44 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentConfirmedCommentResult
+{
+    public required string Domain { get; init; }
+
+    public required string Route { get; init; }
+
+    public string? ClarificationReturnArtifactPath { get; init; }
+
+    public string? ConfirmedReconstructionArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> PostedCommentArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CommentRefs { get; init; }
+
+    public required IReadOnlyList<string> FixingExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -922,6 +922,51 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentConfirmedCommentCommand_DispatchesToConfirmedCommentRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalReviewExecutor = GenerateFromCurrentConfirmedCommentCommand.ConfirmedReviewExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedCommentCommand.ConfirmedReviewExecutor = (_, _, _) => new GenerateFromCurrentConfirmedReviewResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirmed-comment", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution", "--from-file", "comment.md"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current confirmed-comment processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedCommentCommand.ConfirmedReviewExecutor = originalReviewExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedCommentCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedCommentCommandTests.cs
@@ -1,0 +1,235 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentConfirmedCommentCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyConfirmedReview_PostsRepairInPlaceComments()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalReviewExecutor = GenerateFromCurrentConfirmedCommentCommand.ConfirmedReviewExecutor;
+        var originalCommentExecutor = GenerateFromCurrentConfirmedCommentCommand.ReviewCommentExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedCommentCommand.ConfirmedReviewExecutor = (_, _, _) => new GenerateFromCurrentConfirmedReviewResult
+            {
+                Domain = "auth",
+                Route = "confirmed-review",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                CreatedIssueRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/issues/501",
+                    "https://github.com/J-Tech-Japan/intent-system/issues/502"
+                ],
+                WorktreePaths =
+                [
+                    "/tmp/worktrees/AUTH-01",
+                    "/tmp/worktrees/AUTH-02"
+                ],
+                ImplementRequestArtifactPaths =
+                [
+                    ".intent-cli/implement/AUTH-01.request.md",
+                    ".intent-cli/implement/AUTH-02.request.md"
+                ],
+                CreatedPrRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/pull/501",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/502"
+                ],
+                ReviewExecutionUnits = ["AUTH-01", "AUTH-02"],
+                ReviewRequestArtifactPaths =
+                [
+                    ".intent-cli/reviews/AUTH-01.request.json",
+                    ".intent-cli/reviews/AUTH-02.request.json"
+                ],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            };
+            GenerateFromCurrentConfirmedCommentCommand.ReviewCommentExecutor = (_, executionUnit, bodyPath) => new ReviewCommentResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.comment.json",
+                CommentRef = $"{bodyPath}#{executionUnit}"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedCommentCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature", "--from-file", "comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current confirmed-comment processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/reviews/AUTH-01.comment.json", output, StringComparison.Ordinal);
+            Assert.Contains("- comment.md#AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("Fixing execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedCommentCommand.ConfirmedReviewExecutor = originalReviewExecutor;
+            GenerateFromCurrentConfirmedCommentCommand.ReviewCommentExecutor = originalCommentExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationReturnRoute_StopsWithoutCommentPosting()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalReviewExecutor = GenerateFromCurrentConfirmedCommentCommand.ConfirmedReviewExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedCommentCommand.ConfirmedReviewExecutor = (_, _, _) => new GenerateFromCurrentConfirmedReviewResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before repair-in-place review comment treatment."],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedCommentCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature", "--from-file", "comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(".intent-cli/intake/auth.clarification-return.yaml", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedCommentCommand.ConfirmedReviewExecutor = originalReviewExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyConfirmedReview_StopsAtReconciliationPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalReviewExecutor = GenerateFromCurrentConfirmedCommentCommand.ConfirmedReviewExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedCommentCommand.ConfirmedReviewExecutor = (_, _, _) => new GenerateFromCurrentConfirmedReviewResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedCommentCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature", "--from-file", "comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains(".intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("reconciliation is not ready", output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedCommentCommand.ConfirmedReviewExecutor = originalReviewExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingBodyPath_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentConfirmedCommentCommand.Execute(
+            CreateContext("/tmp/intent-system"),
+            ["auth", "--from-path", "src/feature"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-file", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-confirmed-comment-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedCommentRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedCommentRendererTests.cs
@@ -1,0 +1,83 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentConfirmedCommentRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenConfirmedComment_WritesCommentArtifactsAndRefs()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedCommentRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedCommentResult
+            {
+                Domain = "auth",
+                Route = "confirmed-comment",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/501"],
+                WorktreePaths = ["/tmp/worktrees/AUTH-01"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/AUTH-01.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501"],
+                ReviewExecutionUnits = ["AUTH-01"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/AUTH-01.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/AUTH-01.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501#issuecomment-1"],
+                FixingExecutionUnits = ["AUTH-01"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current confirmed-comment processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Posted comment artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/reviews/AUTH-01.comment.json", output, StringComparison.Ordinal);
+        Assert.Contains("Comment refs:", output, StringComparison.Ordinal);
+        Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/501#issuecomment-1", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenClarificationReturnRoute_WritesStopReason()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedCommentRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedCommentResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before repair-in-place review comment treatment."],
+                DownstreamReadiness = "not-ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Clarification-return artifact path: .intent-cli/intake/auth.clarification-return.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: not-ready", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## What Changed
- added `generate-from-current confirmed-comment <domain> --from-path <path> --from-file <path>` as the G70 compose command
- threaded `confirmed-review` success output into `review comment` for each review execution unit
- preserved clarification-return and reconciliation stop paths so repair-in-place review comment posting does not run on not-ready downstream handoff
- added command tests, renderer tests, and command-router coverage for the new command

## Why
Issue 166 requires a thin bridge from the confirmed downstream handoff flow through review request generation into deterministic repair-in-place review comment return without widening the existing command contracts.

## Impact
- users can now progress from current-source reconstruction through confirmed review and directly post repair comments for the selected execution units with one command
- summaries now report updated source paths, execution paths, regenerated artifacts, started units, created issue refs, worktree paths, implement request artifact paths, created PR refs, review units, review request artifact paths, posted comment artifact paths, comment refs, fixing execution units, confirmed items, blocked items, and downstream readiness

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentConfirmedComment|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`

Closes #166
