### PR TITLE
[G71] Add generate-from-current confirmed-fix command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -160,6 +160,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "confirmed-fix", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentConfirmedFixCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "clarify", StringComparison.Ordinal))
         {
             return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedFixCommand.cs
@@ -1,9 +1,16 @@
+using IntentSystem.Review;
+using IntentSystem.Review.Serialization;
+using IntentSystem.Supervisor.Models;
+
 namespace IntentSystem.Cli.Commands;
 
 internal static class GenerateFromCurrentConfirmedFixCommand
 {
-    public static Func<CliContext, string[], TextWriter, GenerateFromCurrentConfirmedCommentResult> ConfirmedCommentExecutor { get; set; } =
-        (context, args, writer) => GenerateFromCurrentConfirmedCommentCommand.ExecuteCore(context, args, writer);
+    public static Func<CliContext, string[], TextWriter, GenerateFromCurrentConfirmedReviewResult> ConfirmedReviewExecutor { get; set; } =
+        (context, args, writer) => GenerateFromCurrentConfirmedReviewCommand.ExecuteCore(context, args, writer);
+
+    public static Func<CliContext, IReadOnlyList<string>, ConfirmedCommentHandoff> ExistingCommentHandoffResolver { get; set; } =
+        ResolveExistingCommentHandoff;
 
     public static Func<CliContext, string, RunFixResult> RunFixExecutor { get; set; } =
         (context, executionUnit) => RunFixCommand.ExecuteCore(context, executionUnit);
@@ -33,64 +40,159 @@ internal static class GenerateFromCurrentConfirmedFixCommand
         TextWriter writer)
     {
         var domain = ParseDomain(args);
-        var confirmedCommentResult = ConfirmedCommentExecutor(context, args, writer);
+        var confirmedReviewResult = ConfirmedReviewExecutor(context, args, writer);
 
-        if (!string.Equals(confirmedCommentResult.Domain, domain, StringComparison.Ordinal))
+        if (!string.Equals(confirmedReviewResult.Domain, domain, StringComparison.Ordinal))
         {
             throw new InvalidOperationException(
-                $"Confirmed comment result domain '{confirmedCommentResult.Domain}' does not match requested domain '{domain}'.");
+                $"Confirmed review result domain '{confirmedReviewResult.Domain}' does not match requested domain '{domain}'.");
         }
 
-        if (string.Equals(confirmedCommentResult.Route, "clarification-return", StringComparison.Ordinal))
+        if (string.Equals(confirmedReviewResult.Route, "clarification-return", StringComparison.Ordinal))
         {
-            return CreateResult(domain, "clarification-return", confirmedCommentResult, []);
+            return CreateResult(
+                domain,
+                "clarification-return",
+                confirmedReviewResult,
+                new ConfirmedCommentHandoff
+                {
+                    PostedCommentArtifactPaths = [],
+                    CommentRefs = [],
+                    FixingExecutionUnits = []
+                },
+                []);
         }
 
-        if (!string.Equals(confirmedCommentResult.DownstreamReadiness, "ready", StringComparison.Ordinal))
+        if (!string.Equals(confirmedReviewResult.DownstreamReadiness, "ready", StringComparison.Ordinal))
         {
-            return CreateResult(domain, "reconciliation-required", confirmedCommentResult, []);
+            return CreateResult(
+                domain,
+                "reconciliation-required",
+                confirmedReviewResult,
+                new ConfirmedCommentHandoff
+                {
+                    PostedCommentArtifactPaths = [],
+                    CommentRefs = [],
+                    FixingExecutionUnits = []
+                },
+                []);
         }
 
-        var fixResults = confirmedCommentResult.FixingExecutionUnits
+        var commentHandoff = ExistingCommentHandoffResolver(context, confirmedReviewResult.ReviewExecutionUnits);
+
+        var fixResults = commentHandoff.FixingExecutionUnits
             .Select(executionUnit => RunFixExecutor(context, executionUnit))
             .ToArray();
 
         return CreateResult(
             domain,
             "confirmed-fix",
-            confirmedCommentResult,
+            confirmedReviewResult,
+            commentHandoff,
             fixResults.Select(result => result.ArtifactPath).ToArray());
     }
 
     private static GenerateFromCurrentConfirmedFixResult CreateResult(
         string domain,
         string route,
-        GenerateFromCurrentConfirmedCommentResult confirmedCommentResult,
+        GenerateFromCurrentConfirmedReviewResult confirmedReviewResult,
+        ConfirmedCommentHandoff commentHandoff,
         IReadOnlyList<string> fixRequestArtifactPaths)
     {
         return new GenerateFromCurrentConfirmedFixResult
         {
             Domain = domain,
             Route = route,
-            ClarificationReturnArtifactPath = confirmedCommentResult.ClarificationReturnArtifactPath,
-            ConfirmedReconstructionArtifactPath = confirmedCommentResult.ConfirmedReconstructionArtifactPath,
-            UpdatedSourceFilePaths = confirmedCommentResult.UpdatedSourceFilePaths,
-            UpdatedExecutionFilePaths = confirmedCommentResult.UpdatedExecutionFilePaths,
-            RegeneratedArtifactPaths = confirmedCommentResult.RegeneratedArtifactPaths,
-            StartedExecutionUnits = confirmedCommentResult.StartedExecutionUnits,
-            CreatedIssueRefs = confirmedCommentResult.CreatedIssueRefs,
-            WorktreePaths = confirmedCommentResult.WorktreePaths,
-            ImplementRequestArtifactPaths = confirmedCommentResult.ImplementRequestArtifactPaths,
-            CreatedPrRefs = confirmedCommentResult.CreatedPrRefs,
-            ReviewExecutionUnits = confirmedCommentResult.ReviewExecutionUnits,
-            ReviewRequestArtifactPaths = confirmedCommentResult.ReviewRequestArtifactPaths,
-            PostedCommentArtifactPaths = confirmedCommentResult.PostedCommentArtifactPaths,
-            CommentRefs = confirmedCommentResult.CommentRefs,
-            FixingExecutionUnits = confirmedCommentResult.FixingExecutionUnits,
+            ClarificationReturnArtifactPath = confirmedReviewResult.ClarificationReturnArtifactPath,
+            ConfirmedReconstructionArtifactPath = confirmedReviewResult.ConfirmedReconstructionArtifactPath,
+            UpdatedSourceFilePaths = confirmedReviewResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = confirmedReviewResult.UpdatedExecutionFilePaths,
+            RegeneratedArtifactPaths = confirmedReviewResult.RegeneratedArtifactPaths,
+            StartedExecutionUnits = confirmedReviewResult.StartedExecutionUnits,
+            CreatedIssueRefs = confirmedReviewResult.CreatedIssueRefs,
+            WorktreePaths = confirmedReviewResult.WorktreePaths,
+            ImplementRequestArtifactPaths = confirmedReviewResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = confirmedReviewResult.CreatedPrRefs,
+            ReviewExecutionUnits = confirmedReviewResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = confirmedReviewResult.ReviewRequestArtifactPaths,
+            PostedCommentArtifactPaths = commentHandoff.PostedCommentArtifactPaths,
+            CommentRefs = commentHandoff.CommentRefs,
+            FixingExecutionUnits = commentHandoff.FixingExecutionUnits,
             FixRequestArtifactPaths = fixRequestArtifactPaths,
-            ConfirmedItems = confirmedCommentResult.ConfirmedItems,
-            BlockedItems = confirmedCommentResult.BlockedItems,
-            DownstreamReadiness = confirmedCommentResult.DownstreamReadiness
+            ConfirmedItems = confirmedReviewResult.ConfirmedItems,
+            BlockedItems = confirmedReviewResult.BlockedItems,
+            DownstreamReadiness = confirmedReviewResult.DownstreamReadiness
+        };
+    }
+
+    private static ConfirmedCommentHandoff ResolveExistingCommentHandoff(
+        CliContext context,
+        IReadOnlyList<string> reviewExecutionUnits)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(reviewExecutionUnits);
+
+        if (reviewExecutionUnits.Count == 0)
+        {
+            return new ConfirmedCommentHandoff
+            {
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = []
+            };
+        }
+
+        var queueState = QueueCommandSupport.LoadQueueState(context, TextWriter.Null)
+            ?? throw new InvalidOperationException($"No queue state found at {context.GetQueueStatePath()}");
+
+        var postedCommentArtifactPaths = new List<string>();
+        var commentRefs = new List<string>();
+        var fixingExecutionUnits = new List<string>();
+
+        foreach (var executionUnit in reviewExecutionUnits)
+        {
+            var queueItem = queueState.Items.FirstOrDefault(item =>
+                string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+            if (queueItem is null)
+            {
+                throw new InvalidOperationException(
+                    $"Execution unit '{executionUnit}' was not found in queue state for confirmed-fix.");
+            }
+
+            if (queueItem.State is not QueueItemState.Fixing)
+            {
+                throw new InvalidOperationException(
+                    $"Execution unit '{executionUnit}' must be fixing before confirmed-fix can continue.");
+            }
+
+            var artifactRef = ReviewCommentArtifactPathResolver.Resolve(executionUnit);
+            var artifactPath = Path.Combine(
+                context.RepoRoot,
+                artifactRef.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(artifactPath))
+            {
+                throw new InvalidOperationException(
+                    $"Review comment artifact was not found at {artifactPath}");
+            }
+
+            var artifact = ReviewCommentArtifactSerializer.Deserialize(File.ReadAllText(artifactPath));
+            if (!string.Equals(artifact.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Review comment artifact execution unit '{artifact.ExecutionUnit}' must match '{executionUnit}'.");
+            }
+
+            postedCommentArtifactPaths.Add(artifactRef);
+            commentRefs.Add(artifact.CommentRef);
+            fixingExecutionUnits.Add(executionUnit);
+        }
+
+        return new ConfirmedCommentHandoff
+        {
+            PostedCommentArtifactPaths = postedCommentArtifactPaths,
+            CommentRefs = commentRefs,
+            FixingExecutionUnits = fixingExecutionUnits
         };
     }
 
@@ -103,4 +205,13 @@ internal static class GenerateFromCurrentConfirmedFixCommand
 
         return args[0].Trim();
     }
+}
+
+internal sealed record ConfirmedCommentHandoff
+{
+    public required IReadOnlyList<string> PostedCommentArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CommentRefs { get; init; }
+
+    public required IReadOnlyList<string> FixingExecutionUnits { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedFixCommand.cs
@@ -1,0 +1,106 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedFixCommand
+{
+    public static Func<CliContext, string[], TextWriter, GenerateFromCurrentConfirmedCommentResult> ConfirmedCommentExecutor { get; set; } =
+        (context, args, writer) => GenerateFromCurrentConfirmedCommentCommand.ExecuteCore(context, args, writer);
+
+    public static Func<CliContext, string, RunFixResult> RunFixExecutor { get; set; } =
+        (context, executionUnit) => RunFixCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args, writer);
+            GenerateFromCurrentConfirmedFixRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentConfirmedFixResult ExecuteCore(
+        CliContext context,
+        string[] args,
+        TextWriter writer)
+    {
+        var domain = ParseDomain(args);
+        var confirmedCommentResult = ConfirmedCommentExecutor(context, args, writer);
+
+        if (!string.Equals(confirmedCommentResult.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed comment result domain '{confirmedCommentResult.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        if (string.Equals(confirmedCommentResult.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "clarification-return", confirmedCommentResult, []);
+        }
+
+        if (!string.Equals(confirmedCommentResult.DownstreamReadiness, "ready", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "reconciliation-required", confirmedCommentResult, []);
+        }
+
+        var fixResults = confirmedCommentResult.FixingExecutionUnits
+            .Select(executionUnit => RunFixExecutor(context, executionUnit))
+            .ToArray();
+
+        return CreateResult(
+            domain,
+            "confirmed-fix",
+            confirmedCommentResult,
+            fixResults.Select(result => result.ArtifactPath).ToArray());
+    }
+
+    private static GenerateFromCurrentConfirmedFixResult CreateResult(
+        string domain,
+        string route,
+        GenerateFromCurrentConfirmedCommentResult confirmedCommentResult,
+        IReadOnlyList<string> fixRequestArtifactPaths)
+    {
+        return new GenerateFromCurrentConfirmedFixResult
+        {
+            Domain = domain,
+            Route = route,
+            ClarificationReturnArtifactPath = confirmedCommentResult.ClarificationReturnArtifactPath,
+            ConfirmedReconstructionArtifactPath = confirmedCommentResult.ConfirmedReconstructionArtifactPath,
+            UpdatedSourceFilePaths = confirmedCommentResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = confirmedCommentResult.UpdatedExecutionFilePaths,
+            RegeneratedArtifactPaths = confirmedCommentResult.RegeneratedArtifactPaths,
+            StartedExecutionUnits = confirmedCommentResult.StartedExecutionUnits,
+            CreatedIssueRefs = confirmedCommentResult.CreatedIssueRefs,
+            WorktreePaths = confirmedCommentResult.WorktreePaths,
+            ImplementRequestArtifactPaths = confirmedCommentResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = confirmedCommentResult.CreatedPrRefs,
+            ReviewExecutionUnits = confirmedCommentResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = confirmedCommentResult.ReviewRequestArtifactPaths,
+            PostedCommentArtifactPaths = confirmedCommentResult.PostedCommentArtifactPaths,
+            CommentRefs = confirmedCommentResult.CommentRefs,
+            FixingExecutionUnits = confirmedCommentResult.FixingExecutionUnits,
+            FixRequestArtifactPaths = fixRequestArtifactPaths,
+            ConfirmedItems = confirmedCommentResult.ConfirmedItems,
+            BlockedItems = confirmedCommentResult.BlockedItems,
+            DownstreamReadiness = confirmedCommentResult.DownstreamReadiness
+        };
+    }
+
+    private static string ParseDomain(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current confirmed-fix requires a domain.");
+        }
+
+        return args[0].Trim();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedFixRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedFixRenderer.cs
@@ -1,0 +1,70 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedFixRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentConfirmedFixResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current confirmed-fix processed for domain '{result.Domain}'.");
+
+        if (string.Equals(result.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+        }
+        else if (string.Equals(result.Route, "reconciliation-required", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Confirmed reconstruction artifact path: {result.ConfirmedReconstructionArtifactPath}");
+            writer.WriteLine("Confirmed fix did not run because reconciliation is not ready.");
+        }
+
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Generated implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Posted comment artifact paths:");
+        WriteList(writer, result.PostedCommentArtifactPaths);
+        writer.WriteLine("Comment refs:");
+        WriteList(writer, result.CommentRefs);
+        writer.WriteLine("Fixing execution units:");
+        WriteList(writer, result.FixingExecutionUnits);
+        writer.WriteLine("Fix request artifact paths:");
+        WriteList(writer, result.FixRequestArtifactPaths);
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedFixResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedFixResult.cs
@@ -1,0 +1,46 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentConfirmedFixResult
+{
+    public required string Domain { get; init; }
+
+    public required string Route { get; init; }
+
+    public string? ClarificationReturnArtifactPath { get; init; }
+
+    public string? ConfirmedReconstructionArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> PostedCommentArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CommentRefs { get; init; }
+
+    public required IReadOnlyList<string> FixingExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> FixRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -967,6 +967,54 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentConfirmedFixCommand_DispatchesToConfirmedFixRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalCommentExecutor = GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = (_, _, _) => new GenerateFromCurrentConfirmedCommentResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirmed-fix", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution", "--from-file", "comment.md"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current confirmed-fix processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = originalCommentExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -972,11 +972,11 @@ public sealed class CommandRouterTests
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         using var writer = new StringWriter();
-        var originalCommentExecutor = GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor;
+        var originalReviewExecutor = GenerateFromCurrentConfirmedFixCommand.ConfirmedReviewExecutor;
 
         try
         {
-            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = (_, _, _) => new GenerateFromCurrentConfirmedCommentResult
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedReviewExecutor = (_, _, _) => new GenerateFromCurrentConfirmedReviewResult
             {
                 Domain = "auth",
                 Route = "reconciliation-required",
@@ -992,16 +992,13 @@ public sealed class CommandRouterTests
                 CreatedPrRefs = [],
                 ReviewExecutionUnits = [],
                 ReviewRequestArtifactPaths = [],
-                PostedCommentArtifactPaths = [],
-                CommentRefs = [],
-                FixingExecutionUnits = [],
                 ConfirmedItems = ["confirm: validate current auth boundary"],
                 BlockedItems = ["defer: return interface cleanup after clarification"],
                 DownstreamReadiness = "not-ready"
             };
 
             var exitCode = CommandRouter.Execute(
-                ["generate-from-current", "confirmed-fix", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution", "--from-file", "comment.md"],
+                ["generate-from-current", "confirmed-fix", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
                 CreateContext(repoRoot),
                 writer);
 
@@ -1010,7 +1007,7 @@ public sealed class CommandRouterTests
         }
         finally
         {
-            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = originalCommentExecutor;
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedReviewExecutor = originalReviewExecutor;
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedFixCommandTests.cs
@@ -1,5 +1,9 @@
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Review.Models;
+using IntentSystem.Review.Serialization;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -7,71 +11,91 @@ namespace IntentSystem.Cli.Tests;
 public sealed class GenerateFromCurrentConfirmedFixCommandTests
 {
     [Fact]
-    public void Execute_GivenReadyConfirmedComment_GeneratesFixRequestArtifacts()
+    public void Execute_GivenExistingFixingStateAndCommentArtifacts_GeneratesFixRequestArtifacts()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
+        string[]? confirmedReviewArgs = null;
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "AUTH-01.comment.json"),
+            ReviewCommentArtifactSerializer.Serialize(
+                new ReviewCommentArtifact
+                {
+                    ExecutionUnit = "AUTH-01",
+                    ReviewRequestRef = ".intent-cli/reviews/AUTH-01.request.json",
+                    LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/501",
+                    CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/501#issuecomment-1",
+                    BodyPath = "comment.md"
+                }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "AUTH-02.comment.json"),
+            ReviewCommentArtifactSerializer.Serialize(
+                new ReviewCommentArtifact
+                {
+                    ExecutionUnit = "AUTH-02",
+                    ReviewRequestRef = ".intent-cli/reviews/AUTH-02.request.json",
+                    LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/502",
+                    CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/502#issuecomment-2",
+                    BodyPath = "comment.md"
+                }));
         using var writer = new StringWriter();
-        var originalCommentExecutor = GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor;
+        var originalReviewExecutor = GenerateFromCurrentConfirmedFixCommand.ConfirmedReviewExecutor;
         var originalRunFixExecutor = GenerateFromCurrentConfirmedFixCommand.RunFixExecutor;
 
         try
         {
-            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = (_, _, _) => new GenerateFromCurrentConfirmedCommentResult
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedReviewExecutor = (_, args, _) =>
             {
-                Domain = "auth",
-                Route = "confirmed-comment",
-                ClarificationReturnArtifactPath = null,
-                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
-                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
-                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
-                RegeneratedArtifactPaths =
-                [
-                    ".intent-cli/intake/auth.concept.yaml",
-                    ".intent-cli/intake/auth.execution.md",
-                    ".intent-cli/issues/AUTH-01/packet.yaml"
-                ],
-                StartedExecutionUnits = ["AUTH-01", "AUTH-02"],
-                CreatedIssueRefs =
-                [
-                    "https://github.com/J-Tech-Japan/intent-system/issues/501",
-                    "https://github.com/J-Tech-Japan/intent-system/issues/502"
-                ],
-                WorktreePaths =
-                [
-                    "/tmp/worktrees/AUTH-01",
-                    "/tmp/worktrees/AUTH-02"
-                ],
-                ImplementRequestArtifactPaths =
-                [
-                    ".intent-cli/implement/AUTH-01.request.md",
-                    ".intent-cli/implement/AUTH-02.request.md"
-                ],
-                CreatedPrRefs =
-                [
-                    "https://github.com/J-Tech-Japan/intent-system/pull/501",
-                    "https://github.com/J-Tech-Japan/intent-system/pull/502"
-                ],
-                ReviewExecutionUnits = ["AUTH-01", "AUTH-02"],
-                ReviewRequestArtifactPaths =
-                [
-                    ".intent-cli/reviews/AUTH-01.request.json",
-                    ".intent-cli/reviews/AUTH-02.request.json"
-                ],
-                PostedCommentArtifactPaths =
-                [
-                    ".intent-cli/reviews/AUTH-01.comment.json",
-                    ".intent-cli/reviews/AUTH-02.comment.json"
-                ],
-                CommentRefs =
-                [
-                    "https://github.com/J-Tech-Japan/intent-system/pull/501#issuecomment-1",
-                    "https://github.com/J-Tech-Japan/intent-system/pull/502#issuecomment-2"
-                ],
-                FixingExecutionUnits = ["AUTH-01", "AUTH-02"],
-                ConfirmedItems = ["confirm: validate current auth boundary"],
-                BlockedItems = [],
-                DownstreamReadiness = "ready"
+                confirmedReviewArgs = args;
+
+                return new GenerateFromCurrentConfirmedReviewResult
+                {
+                    Domain = "auth",
+                    Route = "confirmed-review",
+                    ClarificationReturnArtifactPath = null,
+                    ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                    UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                    UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                    RegeneratedArtifactPaths =
+                    [
+                        ".intent-cli/intake/auth.concept.yaml",
+                        ".intent-cli/intake/auth.execution.md",
+                        ".intent-cli/issues/AUTH-01/packet.yaml"
+                    ],
+                    StartedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                    CreatedIssueRefs =
+                    [
+                        "https://github.com/J-Tech-Japan/intent-system/issues/501",
+                        "https://github.com/J-Tech-Japan/intent-system/issues/502"
+                    ],
+                    WorktreePaths =
+                    [
+                        "/tmp/worktrees/AUTH-01",
+                        "/tmp/worktrees/AUTH-02"
+                    ],
+                    ImplementRequestArtifactPaths =
+                    [
+                        ".intent-cli/implement/AUTH-01.request.md",
+                        ".intent-cli/implement/AUTH-02.request.md"
+                    ],
+                    CreatedPrRefs =
+                    [
+                        "https://github.com/J-Tech-Japan/intent-system/pull/501",
+                        "https://github.com/J-Tech-Japan/intent-system/pull/502"
+                    ],
+                    ReviewExecutionUnits = ["AUTH-01", "AUTH-02"],
+                    ReviewRequestArtifactPaths =
+                    [
+                        ".intent-cli/reviews/AUTH-01.request.json",
+                        ".intent-cli/reviews/AUTH-02.request.json"
+                    ],
+                    ConfirmedItems = ["confirm: validate current auth boundary"],
+                    BlockedItems = [],
+                    DownstreamReadiness = "ready"
+                };
             };
             GenerateFromCurrentConfirmedFixCommand.RunFixExecutor = (_, executionUnit) => new RunFixResult
             {
@@ -109,12 +133,16 @@ public sealed class GenerateFromCurrentConfirmedFixCommandTests
 
             var exitCode = GenerateFromCurrentConfirmedFixCommand.Execute(
                 CreateContext(repoRoot),
-                ["auth", "--from-path", "src/feature", "--from-file", "comment.md"],
+                ["auth", "--from-path", "src/feature"],
                 writer);
 
             Assert.Equal(0, exitCode);
             var output = writer.ToString();
             Assert.Contains("Generate-from-current confirmed-fix processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.NotNull(confirmedReviewArgs);
+            Assert.DoesNotContain("--from-file", confirmedReviewArgs!, StringComparer.Ordinal);
+            Assert.Contains("- .intent-cli/reviews/AUTH-01.comment.json", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/501#issuecomment-1", output, StringComparison.Ordinal);
             Assert.Contains("- .intent-cli/fix/AUTH-01.request.md", output, StringComparison.Ordinal);
             Assert.Contains("- .intent-cli/fix/AUTH-02.request.md", output, StringComparison.Ordinal);
             Assert.Contains("Fixing execution units:", output, StringComparison.Ordinal);
@@ -123,7 +151,7 @@ public sealed class GenerateFromCurrentConfirmedFixCommandTests
         }
         finally
         {
-            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = originalCommentExecutor;
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedReviewExecutor = originalReviewExecutor;
             GenerateFromCurrentConfirmedFixCommand.RunFixExecutor = originalRunFixExecutor;
         }
     }
@@ -134,11 +162,11 @@ public sealed class GenerateFromCurrentConfirmedFixCommandTests
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         using var writer = new StringWriter();
-        var originalCommentExecutor = GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor;
+        var originalReviewExecutor = GenerateFromCurrentConfirmedFixCommand.ConfirmedReviewExecutor;
 
         try
         {
-            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = (_, _, _) => new GenerateFromCurrentConfirmedCommentResult
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedReviewExecutor = (_, _, _) => new GenerateFromCurrentConfirmedReviewResult
             {
                 Domain = "auth",
                 Route = "clarification-return",
@@ -153,9 +181,6 @@ public sealed class GenerateFromCurrentConfirmedFixCommandTests
                 CreatedPrRefs = [],
                 ReviewExecutionUnits = [],
                 ReviewRequestArtifactPaths = [],
-                PostedCommentArtifactPaths = [],
-                CommentRefs = [],
-                FixingExecutionUnits = [],
                 ConfirmedItems = [],
                 BlockedItems = ["clarify: resolve auth boundary before repair worker handoff treatment."],
                 DownstreamReadiness = "not-ready"
@@ -163,7 +188,7 @@ public sealed class GenerateFromCurrentConfirmedFixCommandTests
 
             var exitCode = GenerateFromCurrentConfirmedFixCommand.Execute(
                 CreateContext(repoRoot),
-                ["auth", "--from-path", "src/feature", "--from-file", "comment.md"],
+                ["auth", "--from-path", "src/feature"],
                 writer);
 
             Assert.Equal(0, exitCode);
@@ -171,21 +196,21 @@ public sealed class GenerateFromCurrentConfirmedFixCommandTests
         }
         finally
         {
-            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = originalCommentExecutor;
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedReviewExecutor = originalReviewExecutor;
         }
     }
 
     [Fact]
-    public void Execute_GivenNotReadyConfirmedComment_StopsAtReconciliationPath()
+    public void Execute_GivenNotReadyConfirmedReview_StopsAtReconciliationPath()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         using var writer = new StringWriter();
-        var originalCommentExecutor = GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor;
+        var originalReviewExecutor = GenerateFromCurrentConfirmedFixCommand.ConfirmedReviewExecutor;
 
         try
         {
-            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = (_, _, _) => new GenerateFromCurrentConfirmedCommentResult
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedReviewExecutor = (_, _, _) => new GenerateFromCurrentConfirmedReviewResult
             {
                 Domain = "auth",
                 Route = "reconciliation-required",
@@ -201,9 +226,6 @@ public sealed class GenerateFromCurrentConfirmedFixCommandTests
                 CreatedPrRefs = [],
                 ReviewExecutionUnits = [],
                 ReviewRequestArtifactPaths = [],
-                PostedCommentArtifactPaths = [],
-                CommentRefs = [],
-                FixingExecutionUnits = [],
                 ConfirmedItems = ["confirm: validate current auth boundary"],
                 BlockedItems = ["defer: return interface cleanup after clarification"],
                 DownstreamReadiness = "not-ready"
@@ -211,7 +233,7 @@ public sealed class GenerateFromCurrentConfirmedFixCommandTests
 
             var exitCode = GenerateFromCurrentConfirmedFixCommand.Execute(
                 CreateContext(repoRoot),
-                ["auth", "--from-path", "src/feature", "--from-file", "comment.md"],
+                ["auth", "--from-path", "src/feature"],
                 writer);
 
             Assert.Equal(0, exitCode);
@@ -221,7 +243,7 @@ public sealed class GenerateFromCurrentConfirmedFixCommandTests
         }
         finally
         {
-            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = originalCommentExecutor;
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedReviewExecutor = originalReviewExecutor;
         }
     }
 
@@ -243,6 +265,50 @@ public sealed class GenerateFromCurrentConfirmedFixCommandTests
         };
     }
 
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-08T06:15:00Z"),
+            Items =
+            [
+                CreateItem("AUTH-01"),
+                CreateItem("AUTH-02")
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit)
+    {
+        var issueNumber = executionUnit == "AUTH-01" ? 501 : 502;
+
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Confirmed Fix",
+            State = QueueItemState.Fixing,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            LinkedIssue = new LinkedIssue
+            {
+                Repo = "J-Tech-Japan/intent-system",
+                Number = issueNumber,
+                Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{issueNumber}"
+            },
+            WorkerRole = "Claude",
+            ReviewRole = "Codex",
+            Priority = "high"
+        };
+    }
+
     private sealed class TemporaryDirectory : IDisposable
     {
         private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-confirmed-fix-tests-").FullName;
@@ -251,6 +317,19 @@ public sealed class GenerateFromCurrentConfirmedFixCommandTests
         {
             var fullPath = Path.Combine(rootPath, relativePath);
             Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
             return fullPath;
         }
 

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedFixCommandTests.cs
@@ -1,0 +1,265 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentConfirmedFixCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyConfirmedComment_GeneratesFixRequestArtifacts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalCommentExecutor = GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor;
+        var originalRunFixExecutor = GenerateFromCurrentConfirmedFixCommand.RunFixExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = (_, _, _) => new GenerateFromCurrentConfirmedCommentResult
+            {
+                Domain = "auth",
+                Route = "confirmed-comment",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                CreatedIssueRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/issues/501",
+                    "https://github.com/J-Tech-Japan/intent-system/issues/502"
+                ],
+                WorktreePaths =
+                [
+                    "/tmp/worktrees/AUTH-01",
+                    "/tmp/worktrees/AUTH-02"
+                ],
+                ImplementRequestArtifactPaths =
+                [
+                    ".intent-cli/implement/AUTH-01.request.md",
+                    ".intent-cli/implement/AUTH-02.request.md"
+                ],
+                CreatedPrRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/pull/501",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/502"
+                ],
+                ReviewExecutionUnits = ["AUTH-01", "AUTH-02"],
+                ReviewRequestArtifactPaths =
+                [
+                    ".intent-cli/reviews/AUTH-01.request.json",
+                    ".intent-cli/reviews/AUTH-02.request.json"
+                ],
+                PostedCommentArtifactPaths =
+                [
+                    ".intent-cli/reviews/AUTH-01.comment.json",
+                    ".intent-cli/reviews/AUTH-02.comment.json"
+                ],
+                CommentRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/pull/501#issuecomment-1",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/502#issuecomment-2"
+                ],
+                FixingExecutionUnits = ["AUTH-01", "AUTH-02"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            };
+            GenerateFromCurrentConfirmedFixCommand.RunFixExecutor = (_, executionUnit) => new RunFixResult
+            {
+                Request = new RunFixRequest
+                {
+                    ExecutionUnit = executionUnit,
+                    State = "fixing",
+                    ImplementRole = "Claude",
+                    QueueWorkerRole = "Claude",
+                    QueueReviewRole = "Codex",
+                    WorktreePath = $"/tmp/worktrees/{executionUnit}",
+                    ChildRepoPath = "/tmp/child",
+                    Branch = $"issue-500-{executionUnit.ToLowerInvariant()}",
+                    LinkedIssue = $"https://github.com/J-Tech-Japan/intent-system/issues/{(executionUnit == "AUTH-01" ? "501" : "502")}",
+                    LatestLinkedPr = $"https://github.com/J-Tech-Japan/intent-system/pull/{(executionUnit == "AUTH-01" ? "501" : "502")}",
+                    LatestCommentRef = $"https://github.com/J-Tech-Japan/intent-system/pull/{(executionUnit == "AUTH-01" ? "501" : "502")}#issuecomment-{(executionUnit == "AUTH-01" ? "1" : "2")}",
+                    PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                    ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                    ReviewCommentArtifactRef = $".intent-cli/reviews/{executionUnit}.comment.json",
+                    ReviewRequestRef = $".intent-cli/reviews/{executionUnit}.request.json",
+                    ReviewCommentBodyPath = "comment.md",
+                    IssueTitle = $"[{executionUnit}] Title",
+                    Goal = "Goal",
+                    TargetPart = "Target",
+                    TargetRepo = "submodules/intent-system",
+                    TargetPath = ".",
+                    InScope = [],
+                    OutOfScope = [],
+                    AcceptanceCriteria = [],
+                    DeterministicReviewChecks = [],
+                    ExpectedEvidence = []
+                },
+                ArtifactPath = $".intent-cli/fix/{executionUnit}.request.md"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedFixCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature", "--from-file", "comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current confirmed-fix processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/fix/AUTH-01.request.md", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/fix/AUTH-02.request.md", output, StringComparison.Ordinal);
+            Assert.Contains("Fixing execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = originalCommentExecutor;
+            GenerateFromCurrentConfirmedFixCommand.RunFixExecutor = originalRunFixExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationReturnRoute_StopsWithoutFixHandoff()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalCommentExecutor = GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = (_, _, _) => new GenerateFromCurrentConfirmedCommentResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before repair worker handoff treatment."],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedFixCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature", "--from-file", "comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(".intent-cli/intake/auth.clarification-return.yaml", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = originalCommentExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyConfirmedComment_StopsAtReconciliationPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalCommentExecutor = GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = (_, _, _) => new GenerateFromCurrentConfirmedCommentResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedFixCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature", "--from-file", "comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains(".intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("reconciliation is not ready", output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedFixCommand.ConfirmedCommentExecutor = originalCommentExecutor;
+        }
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-confirmed-fix-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedFixRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedFixRendererTests.cs
@@ -1,0 +1,83 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentConfirmedFixRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenConfirmedFix_WritesFixRequestArtifactPaths()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedFixRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedFixResult
+            {
+                Domain = "auth",
+                Route = "confirmed-fix",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/501"],
+                WorktreePaths = ["/tmp/worktrees/AUTH-01"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/AUTH-01.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501"],
+                ReviewExecutionUnits = ["AUTH-01"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/AUTH-01.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/AUTH-01.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501#issuecomment-1"],
+                FixingExecutionUnits = ["AUTH-01"],
+                FixRequestArtifactPaths = [".intent-cli/fix/AUTH-01.request.md"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current confirmed-fix processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Fix request artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/fix/AUTH-01.request.md", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenClarificationReturnRoute_WritesStopReason()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentConfirmedFixRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentConfirmedFixResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before repair worker handoff treatment."],
+                DownstreamReadiness = "not-ready"
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Clarification-return artifact path: .intent-cli/intake/auth.clarification-return.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream readiness: not-ready", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## What Changed
- added `generate-from-current confirmed-fix <domain> --from-path <path>` as the G71 compose command
- threaded `confirmed-comment` success output into `run fix` for each fixing execution unit
- preserved clarification-return and reconciliation stop paths so fix handoff generation does not run on not-ready downstream handoff
- added command tests, renderer tests, and command-router coverage for the new command

## Why
Issue 168 requires a thin bridge from the confirmed downstream handoff flow through repair-in-place review comment return into deterministic repair worker handoff generation without widening the existing command contracts.

## Impact
- users can now progress from current-source reconstruction through confirmed comment and directly generate fix request artifacts for the selected execution units with one command
- summaries now report updated source paths, execution paths, regenerated artifacts, started units, created issue refs, worktree paths, implement request artifact paths, created PR refs, review units, review request artifact paths, posted comment artifact paths, comment refs, fixing execution units, fix request artifact paths, confirmed items, blocked items, and downstream readiness

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentConfirmedFix|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`

Closes #168
