### PR TITLE
[codex] Add confirmed-resubmit generate-from-current command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -166,6 +166,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "confirmed-resubmit", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentConfirmedResubmitCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "clarify", StringComparison.Ordinal))
         {
             return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedResubmitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedResubmitCommand.cs
@@ -1,0 +1,110 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedResubmitCommand
+{
+    public static Func<CliContext, string[], TextWriter, GenerateFromCurrentConfirmedFixResult> ConfirmedFixExecutor { get; set; } =
+        (context, args, writer) => GenerateFromCurrentConfirmedFixCommand.ExecuteCore(context, args, writer);
+
+    public static Func<CliContext, string, RunResubmitResult> RunResubmitExecutor { get; set; } =
+        (context, executionUnit) => RunResubmitCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args, writer);
+            GenerateFromCurrentConfirmedResubmitRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentConfirmedResubmitResult ExecuteCore(
+        CliContext context,
+        string[] args,
+        TextWriter writer)
+    {
+        var domain = ParseDomain(args);
+        var confirmedFixResult = ConfirmedFixExecutor(context, args, writer);
+
+        if (!string.Equals(confirmedFixResult.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed fix result domain '{confirmedFixResult.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        if (string.Equals(confirmedFixResult.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "clarification-return", confirmedFixResult, [], []);
+        }
+
+        if (!string.Equals(confirmedFixResult.DownstreamReadiness, "ready", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "reconciliation-required", confirmedFixResult, [], []);
+        }
+
+        var resubmitResults = confirmedFixResult.FixingExecutionUnits
+            .Select(executionUnit => RunResubmitExecutor(context, executionUnit))
+            .ToArray();
+
+        return CreateResult(
+            domain,
+            "confirmed-resubmit",
+            confirmedFixResult,
+            resubmitResults.Select(result => result.ExecutionUnit).ToArray(),
+            resubmitResults.Select(result => result.LinkedPr).ToArray());
+    }
+
+    private static GenerateFromCurrentConfirmedResubmitResult CreateResult(
+        string domain,
+        string route,
+        GenerateFromCurrentConfirmedFixResult confirmedFixResult,
+        IReadOnlyList<string> resubmittedExecutionUnits,
+        IReadOnlyList<string> resubmittedPrRefs)
+    {
+        return new GenerateFromCurrentConfirmedResubmitResult
+        {
+            Domain = domain,
+            Route = route,
+            ClarificationReturnArtifactPath = confirmedFixResult.ClarificationReturnArtifactPath,
+            ConfirmedReconstructionArtifactPath = confirmedFixResult.ConfirmedReconstructionArtifactPath,
+            UpdatedSourceFilePaths = confirmedFixResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = confirmedFixResult.UpdatedExecutionFilePaths,
+            RegeneratedArtifactPaths = confirmedFixResult.RegeneratedArtifactPaths,
+            StartedExecutionUnits = confirmedFixResult.StartedExecutionUnits,
+            CreatedIssueRefs = confirmedFixResult.CreatedIssueRefs,
+            WorktreePaths = confirmedFixResult.WorktreePaths,
+            ImplementRequestArtifactPaths = confirmedFixResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = confirmedFixResult.CreatedPrRefs,
+            ReviewExecutionUnits = confirmedFixResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = confirmedFixResult.ReviewRequestArtifactPaths,
+            PostedCommentArtifactPaths = confirmedFixResult.PostedCommentArtifactPaths,
+            CommentRefs = confirmedFixResult.CommentRefs,
+            FixingExecutionUnits = confirmedFixResult.FixingExecutionUnits,
+            FixRequestArtifactPaths = confirmedFixResult.FixRequestArtifactPaths,
+            ResubmittedExecutionUnits = resubmittedExecutionUnits,
+            ResubmittedPrRefs = resubmittedPrRefs,
+            ConfirmedItems = confirmedFixResult.ConfirmedItems,
+            BlockedItems = confirmedFixResult.BlockedItems,
+            DownstreamReadiness = confirmedFixResult.DownstreamReadiness
+        };
+    }
+
+    private static string ParseDomain(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current confirmed-resubmit requires a domain.");
+        }
+
+        return args[0].Trim();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedResubmitRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedResubmitRenderer.cs
@@ -1,0 +1,74 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedResubmitRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentConfirmedResubmitResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current confirmed-resubmit processed for domain '{result.Domain}'.");
+
+        if (string.Equals(result.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+        }
+        else if (string.Equals(result.Route, "reconciliation-required", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Confirmed reconstruction artifact path: {result.ConfirmedReconstructionArtifactPath}");
+            writer.WriteLine("Confirmed resubmit did not run because reconciliation is not ready.");
+        }
+
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Generated implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Posted comment artifact paths:");
+        WriteList(writer, result.PostedCommentArtifactPaths);
+        writer.WriteLine("Comment refs:");
+        WriteList(writer, result.CommentRefs);
+        writer.WriteLine("Fixing execution units:");
+        WriteList(writer, result.FixingExecutionUnits);
+        writer.WriteLine("Fix request artifact paths:");
+        WriteList(writer, result.FixRequestArtifactPaths);
+        writer.WriteLine("Resubmitted execution units:");
+        WriteList(writer, result.ResubmittedExecutionUnits);
+        writer.WriteLine("Resubmitted PR refs:");
+        WriteList(writer, result.ResubmittedPrRefs);
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedResubmitResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedResubmitResult.cs
@@ -1,0 +1,50 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentConfirmedResubmitResult
+{
+    public required string Domain { get; init; }
+
+    public required string Route { get; init; }
+
+    public string? ClarificationReturnArtifactPath { get; init; }
+
+    public string? ConfirmedReconstructionArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> PostedCommentArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CommentRefs { get; init; }
+
+    public required IReadOnlyList<string> FixingExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> FixRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1012,6 +1012,55 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentConfirmedResubmitCommand_DispatchesToConfirmedResubmitRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalFixExecutor = GenerateFromCurrentConfirmedResubmitCommand.ConfirmedFixExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedResubmitCommand.ConfirmedFixExecutor = (_, _, _) => new GenerateFromCurrentConfirmedFixResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirmed-resubmit", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current confirmed-resubmit processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedResubmitCommand.ConfirmedFixExecutor = originalFixExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedResubmitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedResubmitCommandTests.cs
@@ -1,0 +1,200 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentConfirmedResubmitCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyConfirmedFix_ComposesToResubmitSummary()
+    {
+        using var writer = new StringWriter();
+        var originalFixExecutor = GenerateFromCurrentConfirmedResubmitCommand.ConfirmedFixExecutor;
+        var originalRunResubmitExecutor = GenerateFromCurrentConfirmedResubmitCommand.RunResubmitExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedResubmitCommand.ConfirmedFixExecutor = (_, _, _) => new GenerateFromCurrentConfirmedFixResult
+            {
+                Domain = "auth",
+                Route = "confirmed-fix",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/501"],
+                WorktreePaths = ["/tmp/worktrees/AUTH-01"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/AUTH-01.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501"],
+                ReviewExecutionUnits = ["AUTH-01"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/AUTH-01.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/AUTH-01.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501#issuecomment-1"],
+                FixingExecutionUnits = ["AUTH-01"],
+                FixRequestArtifactPaths = [".intent-cli/fix/AUTH-01.request.md"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            };
+            GenerateFromCurrentConfirmedResubmitCommand.RunResubmitExecutor = (_, executionUnit) => new RunResubmitResult
+            {
+                ExecutionUnit = executionUnit,
+                Branch = $"issue-501-{executionUnit.ToLowerInvariant()}",
+                WorktreePath = $"/tmp/worktrees/{executionUnit}",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/501"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedResubmitCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current confirmed-resubmit processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Resubmitted execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("Resubmitted PR refs:", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/501", output, StringComparison.Ordinal);
+            Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedResubmitCommand.ConfirmedFixExecutor = originalFixExecutor;
+            GenerateFromCurrentConfirmedResubmitCommand.RunResubmitExecutor = originalRunResubmitExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationReturnRoute_StopsWithoutResubmitTrace()
+    {
+        using var writer = new StringWriter();
+        var originalFixExecutor = GenerateFromCurrentConfirmedResubmitCommand.ConfirmedFixExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedResubmitCommand.ConfirmedFixExecutor = (_, _, _) => new GenerateFromCurrentConfirmedFixResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                ConfirmedReconstructionArtifactPath = null,
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before same linked PR resubmit."],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedResubmitCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(".intent-cli/intake/auth.clarification-return.yaml", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedResubmitCommand.ConfirmedFixExecutor = originalFixExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyConfirmedFix_StopsAtReconciliationPath()
+    {
+        using var writer = new StringWriter();
+        var originalFixExecutor = GenerateFromCurrentConfirmedResubmitCommand.ConfirmedFixExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedResubmitCommand.ConfirmedFixExecutor = (_, _, _) => new GenerateFromCurrentConfirmedFixResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedResubmitCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains(".intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("reconciliation is not ready", output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedResubmitCommand.ConfirmedFixExecutor = originalFixExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentConfirmedResubmitCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What changed
- add `generate-from-current confirmed-resubmit <domain> --from-path <path>` as a thin compose command from confirmed fix to same linked PR resubmit trace
- carry confirmed downstream summary fields through the new result/renderer and append `resubmitted execution units` / `resubmitted PR refs`
- add command router coverage and focused command tests for ready, clarification-return, and reconciliation-required paths

## Why
- issue 170 requires a deterministic `G72` path that reconnects the confirmed downstream handoff to `run resubmit` without expanding into rereview, accept, or closeout

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentConfirmedResubmit|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`

Closes #170
