### PR TITLE
[codex] Add confirmed-rereview generate-from-current command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -172,6 +172,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "confirmed-rereview", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentConfirmedRereviewCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "clarify", StringComparison.Ordinal))
         {
             return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedRereviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedRereviewCommand.cs
@@ -1,0 +1,112 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedRereviewCommand
+{
+    public static Func<CliContext, string[], TextWriter, GenerateFromCurrentConfirmedResubmitResult> ConfirmedResubmitExecutor { get; set; } =
+        (context, args, writer) => GenerateFromCurrentConfirmedResubmitCommand.ExecuteCore(context, args, writer);
+
+    public static Func<CliContext, string, RunRereviewResult> RunRereviewExecutor { get; set; } =
+        (context, executionUnit) => RunRereviewCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args, writer);
+            GenerateFromCurrentConfirmedRereviewRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentConfirmedRereviewResult ExecuteCore(
+        CliContext context,
+        string[] args,
+        TextWriter writer)
+    {
+        var domain = ParseDomain(args);
+        var confirmedResubmitResult = ConfirmedResubmitExecutor(context, args, writer);
+
+        if (!string.Equals(confirmedResubmitResult.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed resubmit result domain '{confirmedResubmitResult.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        if (string.Equals(confirmedResubmitResult.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "clarification-return", confirmedResubmitResult, [], []);
+        }
+
+        if (!string.Equals(confirmedResubmitResult.DownstreamReadiness, "ready", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "reconciliation-required", confirmedResubmitResult, [], []);
+        }
+
+        var rereviewResults = confirmedResubmitResult.ResubmittedExecutionUnits
+            .Select(executionUnit => RunRereviewExecutor(context, executionUnit))
+            .ToArray();
+
+        return CreateResult(
+            domain,
+            "confirmed-rereview",
+            confirmedResubmitResult,
+            rereviewResults.Select(result => result.ExecutionUnit).ToArray(),
+            rereviewResults.Select(result => result.LinkedPr).ToArray());
+    }
+
+    private static GenerateFromCurrentConfirmedRereviewResult CreateResult(
+        string domain,
+        string route,
+        GenerateFromCurrentConfirmedResubmitResult confirmedResubmitResult,
+        IReadOnlyList<string> rereviewedExecutionUnits,
+        IReadOnlyList<string> rereviewedPrRefs)
+    {
+        return new GenerateFromCurrentConfirmedRereviewResult
+        {
+            Domain = domain,
+            Route = route,
+            ClarificationReturnArtifactPath = confirmedResubmitResult.ClarificationReturnArtifactPath,
+            ConfirmedReconstructionArtifactPath = confirmedResubmitResult.ConfirmedReconstructionArtifactPath,
+            UpdatedSourceFilePaths = confirmedResubmitResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = confirmedResubmitResult.UpdatedExecutionFilePaths,
+            RegeneratedArtifactPaths = confirmedResubmitResult.RegeneratedArtifactPaths,
+            StartedExecutionUnits = confirmedResubmitResult.StartedExecutionUnits,
+            CreatedIssueRefs = confirmedResubmitResult.CreatedIssueRefs,
+            WorktreePaths = confirmedResubmitResult.WorktreePaths,
+            ImplementRequestArtifactPaths = confirmedResubmitResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = confirmedResubmitResult.CreatedPrRefs,
+            ReviewExecutionUnits = confirmedResubmitResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = confirmedResubmitResult.ReviewRequestArtifactPaths,
+            PostedCommentArtifactPaths = confirmedResubmitResult.PostedCommentArtifactPaths,
+            CommentRefs = confirmedResubmitResult.CommentRefs,
+            FixingExecutionUnits = confirmedResubmitResult.FixingExecutionUnits,
+            FixRequestArtifactPaths = confirmedResubmitResult.FixRequestArtifactPaths,
+            ResubmittedExecutionUnits = confirmedResubmitResult.ResubmittedExecutionUnits,
+            ResubmittedPrRefs = confirmedResubmitResult.ResubmittedPrRefs,
+            RereviewedExecutionUnits = rereviewedExecutionUnits,
+            RereviewedPrRefs = rereviewedPrRefs,
+            ConfirmedItems = confirmedResubmitResult.ConfirmedItems,
+            BlockedItems = confirmedResubmitResult.BlockedItems,
+            DownstreamReadiness = confirmedResubmitResult.DownstreamReadiness
+        };
+    }
+
+    private static string ParseDomain(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current confirmed-rereview requires a domain.");
+        }
+
+        return args[0].Trim();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedRereviewRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedRereviewRenderer.cs
@@ -1,0 +1,78 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedRereviewRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentConfirmedRereviewResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current confirmed-rereview processed for domain '{result.Domain}'.");
+
+        if (string.Equals(result.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+        }
+        else if (string.Equals(result.Route, "reconciliation-required", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Confirmed reconstruction artifact path: {result.ConfirmedReconstructionArtifactPath}");
+            writer.WriteLine("Confirmed rereview did not run because reconciliation is not ready.");
+        }
+
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Generated implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Posted comment artifact paths:");
+        WriteList(writer, result.PostedCommentArtifactPaths);
+        writer.WriteLine("Comment refs:");
+        WriteList(writer, result.CommentRefs);
+        writer.WriteLine("Fixing execution units:");
+        WriteList(writer, result.FixingExecutionUnits);
+        writer.WriteLine("Fix request artifact paths:");
+        WriteList(writer, result.FixRequestArtifactPaths);
+        writer.WriteLine("Resubmitted execution units:");
+        WriteList(writer, result.ResubmittedExecutionUnits);
+        writer.WriteLine("Resubmitted PR refs:");
+        WriteList(writer, result.ResubmittedPrRefs);
+        writer.WriteLine("Rereviewed execution units:");
+        WriteList(writer, result.RereviewedExecutionUnits);
+        writer.WriteLine("Rereviewed PR refs:");
+        WriteList(writer, result.RereviewedPrRefs);
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedRereviewResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedRereviewResult.cs
@@ -1,0 +1,54 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentConfirmedRereviewResult
+{
+    public required string Domain { get; init; }
+
+    public required string Route { get; init; }
+
+    public string? ClarificationReturnArtifactPath { get; init; }
+
+    public string? ConfirmedReconstructionArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> PostedCommentArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CommentRefs { get; init; }
+
+    public required IReadOnlyList<string> FixingExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> FixRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> RereviewedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> RereviewedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1061,6 +1061,57 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentConfirmedRereviewCommand_DispatchesToConfirmedRereviewRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalResubmitExecutor = GenerateFromCurrentConfirmedRereviewCommand.ConfirmedResubmitExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedRereviewCommand.ConfirmedResubmitExecutor = (_, _, _) => new GenerateFromCurrentConfirmedResubmitResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ResubmittedExecutionUnits = [],
+                ResubmittedPrRefs = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirmed-rereview", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current confirmed-rereview processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedRereviewCommand.ConfirmedResubmitExecutor = originalResubmitExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentImplementCommand_DispatchesToImplementRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedRereviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedRereviewCommandTests.cs
@@ -1,0 +1,204 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentConfirmedRereviewCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyConfirmedResubmit_ComposesToRereviewSummary()
+    {
+        using var writer = new StringWriter();
+        var originalResubmitExecutor = GenerateFromCurrentConfirmedRereviewCommand.ConfirmedResubmitExecutor;
+        var originalRunRereviewExecutor = GenerateFromCurrentConfirmedRereviewCommand.RunRereviewExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedRereviewCommand.ConfirmedResubmitExecutor = (_, _, _) => new GenerateFromCurrentConfirmedResubmitResult
+            {
+                Domain = "auth",
+                Route = "confirmed-resubmit",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/501"],
+                WorktreePaths = ["/tmp/worktrees/AUTH-01"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/AUTH-01.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501"],
+                ReviewExecutionUnits = ["AUTH-01"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/AUTH-01.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/AUTH-01.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501#issuecomment-1"],
+                FixingExecutionUnits = ["AUTH-01"],
+                FixRequestArtifactPaths = [".intent-cli/fix/AUTH-01.request.md"],
+                ResubmittedExecutionUnits = ["AUTH-01"],
+                ResubmittedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            };
+            GenerateFromCurrentConfirmedRereviewCommand.RunRereviewExecutor = (_, executionUnit) => new RunRereviewResult
+            {
+                ExecutionUnit = executionUnit,
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/501"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedRereviewCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current confirmed-rereview processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Rereviewed execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("Rereviewed PR refs:", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/501", output, StringComparison.Ordinal);
+            Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedRereviewCommand.ConfirmedResubmitExecutor = originalResubmitExecutor;
+            GenerateFromCurrentConfirmedRereviewCommand.RunRereviewExecutor = originalRunRereviewExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationReturnRoute_StopsWithoutRereviewEntry()
+    {
+        using var writer = new StringWriter();
+        var originalResubmitExecutor = GenerateFromCurrentConfirmedRereviewCommand.ConfirmedResubmitExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedRereviewCommand.ConfirmedResubmitExecutor = (_, _, _) => new GenerateFromCurrentConfirmedResubmitResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                ConfirmedReconstructionArtifactPath = null,
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ResubmittedExecutionUnits = [],
+                ResubmittedPrRefs = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before same linked PR rereview."],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedRereviewCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(".intent-cli/intake/auth.clarification-return.yaml", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedRereviewCommand.ConfirmedResubmitExecutor = originalResubmitExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyConfirmedResubmit_StopsAtReconciliationPath()
+    {
+        using var writer = new StringWriter();
+        var originalResubmitExecutor = GenerateFromCurrentConfirmedRereviewCommand.ConfirmedResubmitExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedRereviewCommand.ConfirmedResubmitExecutor = (_, _, _) => new GenerateFromCurrentConfirmedResubmitResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ResubmittedExecutionUnits = [],
+                ResubmittedPrRefs = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedRereviewCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains(".intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("reconciliation is not ready", output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedRereviewCommand.ConfirmedResubmitExecutor = originalResubmitExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentConfirmedRereviewCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What changed
- add `generate-from-current confirmed-rereview <domain> --from-path <path>` as a thin compose command from confirmed resubmit to same linked PR review return
- carry confirmed downstream summary fields through the new result/renderer and append `rereviewed execution units` / `rereviewed PR refs`
- add command router coverage and focused command tests for ready, clarification-return, and reconciliation-required paths

## Why
- issue 172 requires a deterministic `G73` path that reconnects the confirmed downstream handoff to `run rereview` without expanding into accept or closeout

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentConfirmedRereview|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`

Closes #172
