### PR TITLE
[codex] Add confirmed-reaccept generate-from-current command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -178,6 +178,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "confirmed-reaccept", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentConfirmedReacceptCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "clarify", StringComparison.Ordinal))
         {
             return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedReacceptCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedReacceptCommand.cs
@@ -1,0 +1,117 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedReacceptCommand
+{
+    public static Func<CliContext, string[], TextWriter, GenerateFromCurrentConfirmedRereviewResult> ConfirmedRereviewExecutor { get; set; } =
+        (context, args, writer) => GenerateFromCurrentConfirmedRereviewCommand.ExecuteCore(context, args, writer);
+
+    public static Func<CliContext, string, ReviewAcceptResult> ReviewAcceptExecutor { get; set; } =
+        (context, executionUnit) => ReviewAcceptCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args, writer);
+            GenerateFromCurrentConfirmedReacceptRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentConfirmedReacceptResult ExecuteCore(
+        CliContext context,
+        string[] args,
+        TextWriter writer)
+    {
+        var domain = ParseDomain(args);
+        var confirmedRereviewResult = ConfirmedRereviewExecutor(context, args, writer);
+
+        if (!string.Equals(confirmedRereviewResult.Domain, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Confirmed rereview result domain '{confirmedRereviewResult.Domain}' does not match requested domain '{domain}'.");
+        }
+
+        if (string.Equals(confirmedRereviewResult.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "clarification-return", confirmedRereviewResult, [], [], []);
+        }
+
+        if (!string.Equals(confirmedRereviewResult.DownstreamReadiness, "ready", StringComparison.Ordinal))
+        {
+            return CreateResult(domain, "reconciliation-required", confirmedRereviewResult, [], [], []);
+        }
+
+        var acceptResults = confirmedRereviewResult.RereviewedExecutionUnits
+            .Select(executionUnit => ReviewAcceptExecutor(context, executionUnit))
+            .ToArray();
+
+        return CreateResult(
+            domain,
+            "confirmed-reaccept",
+            confirmedRereviewResult,
+            acceptResults.Select(result => result.MergedPrRef).ToArray(),
+            acceptResults.Select(result => result.ClosedIssueRef).ToArray(),
+            acceptResults.Select(result => result.ExecutionUnit).ToArray());
+    }
+
+    private static GenerateFromCurrentConfirmedReacceptResult CreateResult(
+        string domain,
+        string route,
+        GenerateFromCurrentConfirmedRereviewResult confirmedRereviewResult,
+        IReadOnlyList<string> mergedPrRefs,
+        IReadOnlyList<string> closedIssueRefs,
+        IReadOnlyList<string> completedExecutionUnits)
+    {
+        return new GenerateFromCurrentConfirmedReacceptResult
+        {
+            Domain = domain,
+            Route = route,
+            ClarificationReturnArtifactPath = confirmedRereviewResult.ClarificationReturnArtifactPath,
+            ConfirmedReconstructionArtifactPath = confirmedRereviewResult.ConfirmedReconstructionArtifactPath,
+            UpdatedSourceFilePaths = confirmedRereviewResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = confirmedRereviewResult.UpdatedExecutionFilePaths,
+            RegeneratedArtifactPaths = confirmedRereviewResult.RegeneratedArtifactPaths,
+            StartedExecutionUnits = confirmedRereviewResult.StartedExecutionUnits,
+            CreatedIssueRefs = confirmedRereviewResult.CreatedIssueRefs,
+            WorktreePaths = confirmedRereviewResult.WorktreePaths,
+            ImplementRequestArtifactPaths = confirmedRereviewResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = confirmedRereviewResult.CreatedPrRefs,
+            ReviewExecutionUnits = confirmedRereviewResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = confirmedRereviewResult.ReviewRequestArtifactPaths,
+            PostedCommentArtifactPaths = confirmedRereviewResult.PostedCommentArtifactPaths,
+            CommentRefs = confirmedRereviewResult.CommentRefs,
+            FixingExecutionUnits = confirmedRereviewResult.FixingExecutionUnits,
+            FixRequestArtifactPaths = confirmedRereviewResult.FixRequestArtifactPaths,
+            ResubmittedExecutionUnits = confirmedRereviewResult.ResubmittedExecutionUnits,
+            ResubmittedPrRefs = confirmedRereviewResult.ResubmittedPrRefs,
+            RereviewedExecutionUnits = confirmedRereviewResult.RereviewedExecutionUnits,
+            RereviewedPrRefs = confirmedRereviewResult.RereviewedPrRefs,
+            CompletedExecutionUnits = completedExecutionUnits,
+            ClosedIssueRefs = closedIssueRefs,
+            MergedPrRefs = mergedPrRefs,
+            ConfirmedItems = confirmedRereviewResult.ConfirmedItems,
+            BlockedItems = confirmedRereviewResult.BlockedItems,
+            DownstreamReadiness = confirmedRereviewResult.DownstreamReadiness
+        };
+    }
+
+    private static string ParseDomain(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current confirmed-reaccept requires a domain.");
+        }
+
+        return args[0].Trim();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedReacceptRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedReacceptRenderer.cs
@@ -1,0 +1,84 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedReacceptRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentConfirmedReacceptResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current confirmed-reaccept processed for domain '{result.Domain}'.");
+
+        if (string.Equals(result.Route, "clarification-return", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+        }
+        else if (string.Equals(result.Route, "reconciliation-required", StringComparison.Ordinal))
+        {
+            writer.WriteLine($"Confirmed reconstruction artifact path: {result.ConfirmedReconstructionArtifactPath}");
+            writer.WriteLine("Confirmed reaccept did not run because reconciliation is not ready.");
+        }
+
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Generated implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Posted comment artifact paths:");
+        WriteList(writer, result.PostedCommentArtifactPaths);
+        writer.WriteLine("Comment refs:");
+        WriteList(writer, result.CommentRefs);
+        writer.WriteLine("Fixing execution units:");
+        WriteList(writer, result.FixingExecutionUnits);
+        writer.WriteLine("Fix request artifact paths:");
+        WriteList(writer, result.FixRequestArtifactPaths);
+        writer.WriteLine("Resubmitted execution units:");
+        WriteList(writer, result.ResubmittedExecutionUnits);
+        writer.WriteLine("Resubmitted PR refs:");
+        WriteList(writer, result.ResubmittedPrRefs);
+        writer.WriteLine("Rereviewed execution units:");
+        WriteList(writer, result.RereviewedExecutionUnits);
+        writer.WriteLine("Rereviewed PR refs:");
+        WriteList(writer, result.RereviewedPrRefs);
+        writer.WriteLine("Completed execution units:");
+        WriteList(writer, result.CompletedExecutionUnits);
+        writer.WriteLine("Closed issue refs:");
+        WriteList(writer, result.ClosedIssueRefs);
+        writer.WriteLine("Merged PR refs:");
+        WriteList(writer, result.MergedPrRefs);
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedReacceptResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedReacceptResult.cs
@@ -1,0 +1,60 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentConfirmedReacceptResult
+{
+    public required string Domain { get; init; }
+
+    public required string Route { get; init; }
+
+    public string? ClarificationReturnArtifactPath { get; init; }
+
+    public string? ConfirmedReconstructionArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> PostedCommentArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CommentRefs { get; init; }
+
+    public required IReadOnlyList<string> FixingExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> FixRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> RereviewedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> RereviewedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> CompletedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ClosedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> MergedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -922,6 +922,59 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentConfirmedReacceptCommand_DispatchesToConfirmedReacceptRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalRereviewExecutor = GenerateFromCurrentConfirmedReacceptCommand.ConfirmedRereviewExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedReacceptCommand.ConfirmedRereviewExecutor = (_, _, _) => new GenerateFromCurrentConfirmedRereviewResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ResubmittedExecutionUnits = [],
+                ResubmittedPrRefs = [],
+                RereviewedExecutionUnits = [],
+                RereviewedPrRefs = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirmed-reaccept", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current confirmed-reaccept processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedReacceptCommand.ConfirmedRereviewExecutor = originalRereviewExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentConfirmedCommentCommand_DispatchesToConfirmedCommentRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedReacceptCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedReacceptCommandTests.cs
@@ -1,0 +1,276 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentConfirmedReacceptCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyConfirmedRereview_CompletesExecutionUnits()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalRereviewExecutor = GenerateFromCurrentConfirmedReacceptCommand.ConfirmedRereviewExecutor;
+        var originalAcceptExecutor = GenerateFromCurrentConfirmedReacceptCommand.ReviewAcceptExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedReacceptCommand.ConfirmedRereviewExecutor = (_, _, _) => new GenerateFromCurrentConfirmedRereviewResult
+            {
+                Domain = "auth",
+                Route = "confirmed-rereview",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/intake/auth.execution.md",
+                    ".intent-cli/issues/AUTH-01/packet.yaml"
+                ],
+                StartedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                CreatedIssueRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/issues/501",
+                    "https://github.com/J-Tech-Japan/intent-system/issues/502"
+                ],
+                WorktreePaths =
+                [
+                    "/tmp/worktrees/AUTH-01",
+                    "/tmp/worktrees/AUTH-02"
+                ],
+                ImplementRequestArtifactPaths =
+                [
+                    ".intent-cli/implement/AUTH-01.request.md",
+                    ".intent-cli/implement/AUTH-02.request.md"
+                ],
+                CreatedPrRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/pull/501",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/502"
+                ],
+                ReviewExecutionUnits = ["AUTH-01", "AUTH-02"],
+                ReviewRequestArtifactPaths =
+                [
+                    ".intent-cli/reviews/AUTH-01.request.json",
+                    ".intent-cli/reviews/AUTH-02.request.json"
+                ],
+                PostedCommentArtifactPaths =
+                [
+                    ".intent-cli/reviews/AUTH-01.comment.json",
+                    ".intent-cli/reviews/AUTH-02.comment.json"
+                ],
+                CommentRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/pull/501#issuecomment-1",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/502#issuecomment-2"
+                ],
+                FixingExecutionUnits = ["AUTH-01", "AUTH-02"],
+                FixRequestArtifactPaths =
+                [
+                    ".intent-cli/fix/AUTH-01.request.md",
+                    ".intent-cli/fix/AUTH-02.request.md"
+                ],
+                ResubmittedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                ResubmittedPrRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/pull/501",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/502"
+                ],
+                RereviewedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                RereviewedPrRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/pull/501",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/502"
+                ],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            };
+            GenerateFromCurrentConfirmedReacceptCommand.ReviewAcceptExecutor = (_, executionUnit) => new ReviewAcceptResult
+            {
+                ExecutionUnit = executionUnit,
+                MergedPrRef = executionUnit switch
+                {
+                    "AUTH-01" => "https://github.com/J-Tech-Japan/intent-system/pull/501",
+                    "AUTH-02" => "https://github.com/J-Tech-Japan/intent-system/pull/502",
+                    _ => throw new InvalidOperationException($"Unexpected execution unit '{executionUnit}'.")
+                },
+                ClosedIssueRef = executionUnit switch
+                {
+                    "AUTH-01" => "https://github.com/J-Tech-Japan/intent-system/issues/501",
+                    "AUTH-02" => "https://github.com/J-Tech-Japan/intent-system/issues/502",
+                    _ => throw new InvalidOperationException($"Unexpected execution unit '{executionUnit}'.")
+                }
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedReacceptCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current confirmed-reaccept processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/reviews/AUTH-01.request.json", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/pull/501", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/issues/501", output, StringComparison.Ordinal);
+            Assert.Contains("Completed execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedReacceptCommand.ConfirmedRereviewExecutor = originalRereviewExecutor;
+            GenerateFromCurrentConfirmedReacceptCommand.ReviewAcceptExecutor = originalAcceptExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationReturnRoute_StopsWithoutAcceptedCloseout()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalRereviewExecutor = GenerateFromCurrentConfirmedReacceptCommand.ConfirmedRereviewExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedReacceptCommand.ConfirmedRereviewExecutor = (_, _, _) => new GenerateFromCurrentConfirmedRereviewResult
+            {
+                Domain = "auth",
+                Route = "clarification-return",
+                ClarificationReturnArtifactPath = ".intent-cli/intake/auth.clarification-return.yaml",
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                RegeneratedArtifactPaths = [],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ResubmittedExecutionUnits = [],
+                ResubmittedPrRefs = [],
+                RereviewedExecutionUnits = [],
+                RereviewedPrRefs = [],
+                ConfirmedItems = [],
+                BlockedItems = ["clarify: resolve auth boundary before accepted closeout treatment."],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedReacceptCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(".intent-cli/intake/auth.clarification-return.yaml", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedReacceptCommand.ConfirmedRereviewExecutor = originalRereviewExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyConfirmedRereview_StopsAtReconciliationPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalRereviewExecutor = GenerateFromCurrentConfirmedReacceptCommand.ConfirmedRereviewExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedReacceptCommand.ConfirmedRereviewExecutor = (_, _, _) => new GenerateFromCurrentConfirmedRereviewResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                PostedCommentArtifactPaths = [],
+                CommentRefs = [],
+                FixingExecutionUnits = [],
+                FixRequestArtifactPaths = [],
+                ResubmittedExecutionUnits = [],
+                ResubmittedPrRefs = [],
+                RereviewedExecutionUnits = [],
+                RereviewedPrRefs = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedReacceptCommand.Execute(
+                CreateContext(repoRoot),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains(".intent-cli/intake/auth.confirmed-reconstruction.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("reconciliation is not ready", output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedReacceptCommand.ConfirmedRereviewExecutor = originalRereviewExecutor;
+        }
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-confirmed-reaccept-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What changed
- add `generate-from-current confirmed-reaccept <domain> --from-path <path>` as a thin compose command from confirmed rereview to repair-in-place accepted closeout
- carry confirmed downstream summary fields through the new result/renderer and append `completed execution units`, `closed issue refs`, and `merged PR refs`
- add command router coverage and focused command tests for ready, clarification-return, and reconciliation-required paths

## Why
- issue 174 requires a deterministic `G74` path that reconnects the confirmed downstream handoff to accepted closeout without expanding into next issue creation or workflow execution

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentConfirmedReaccept|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`

Closes #174
