### PR TITLE
[codex] Add confirmed-closeout generate-from-current command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -184,6 +184,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "confirmed-closeout", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentConfirmedCloseoutCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "clarify", StringComparison.Ordinal))
         {
             return GenerateFromCurrentClarifyCommand.Execute(context, args[1..], writer);

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedCloseoutCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedCloseoutCommand.cs
@@ -1,0 +1,141 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedCloseoutCommand
+{
+    private const string AcceptedCloseoutPath = "accepted-closeout";
+    private const string RepairAcceptedCloseoutPath = "repair-in-place-accepted-closeout";
+
+    public static Func<CliContext, string[], TextWriter, GenerateFromCurrentConfirmedAcceptResult> ConfirmedAcceptExecutor { get; set; } =
+        (context, args, writer) => GenerateFromCurrentConfirmedAcceptCommand.ExecuteCore(context, args, writer);
+
+    public static Func<CliContext, string[], TextWriter, GenerateFromCurrentConfirmedReacceptResult> ConfirmedReacceptExecutor { get; set; } =
+        (context, args, writer) => GenerateFromCurrentConfirmedReacceptCommand.ExecuteCore(context, args, writer);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args, writer);
+            GenerateFromCurrentConfirmedCloseoutRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentConfirmedCloseoutResult ExecuteCore(
+        CliContext context,
+        string[] args,
+        TextWriter writer)
+    {
+        var (pipelineArgs, hasPreparedRepairComment) = ParseArgs(args);
+        if (hasPreparedRepairComment)
+        {
+            var confirmedReacceptResult = ConfirmedReacceptExecutor(context, args, writer);
+            return new GenerateFromCurrentConfirmedCloseoutResult
+            {
+                Domain = confirmedReacceptResult.Domain,
+                ClarificationReturnArtifactPath = confirmedReacceptResult.ClarificationReturnArtifactPath,
+                ConfirmedReconstructionArtifactPath = confirmedReacceptResult.ConfirmedReconstructionArtifactPath,
+                UpdatedSourceFilePaths = confirmedReacceptResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = confirmedReacceptResult.UpdatedExecutionFilePaths,
+                RegeneratedArtifactPaths = confirmedReacceptResult.RegeneratedArtifactPaths,
+                StartedExecutionUnits = confirmedReacceptResult.StartedExecutionUnits,
+                CreatedIssueRefs = confirmedReacceptResult.CreatedIssueRefs,
+                WorktreePaths = confirmedReacceptResult.WorktreePaths,
+                ImplementRequestArtifactPaths = confirmedReacceptResult.ImplementRequestArtifactPaths,
+                CreatedPrRefs = confirmedReacceptResult.CreatedPrRefs,
+                ReviewExecutionUnits = confirmedReacceptResult.ReviewExecutionUnits,
+                ReviewRequestArtifactPaths = confirmedReacceptResult.ReviewRequestArtifactPaths,
+                PostedCommentArtifactPaths = confirmedReacceptResult.PostedCommentArtifactPaths,
+                CommentRefs = confirmedReacceptResult.CommentRefs,
+                FixingExecutionUnits = confirmedReacceptResult.FixingExecutionUnits,
+                FixRequestArtifactPaths = confirmedReacceptResult.FixRequestArtifactPaths,
+                ResubmittedExecutionUnits = confirmedReacceptResult.ResubmittedExecutionUnits,
+                ResubmittedPrRefs = confirmedReacceptResult.ResubmittedPrRefs,
+                RereviewedExecutionUnits = confirmedReacceptResult.RereviewedExecutionUnits,
+                RereviewedPrRefs = confirmedReacceptResult.RereviewedPrRefs,
+                CompletedExecutionUnits = confirmedReacceptResult.CompletedExecutionUnits,
+                ClosedIssueRefs = confirmedReacceptResult.ClosedIssueRefs,
+                MergedPrRefs = confirmedReacceptResult.MergedPrRefs,
+                ConfirmedItems = confirmedReacceptResult.ConfirmedItems,
+                BlockedItems = confirmedReacceptResult.BlockedItems,
+                DownstreamReadiness = confirmedReacceptResult.DownstreamReadiness,
+                SelectedCloseoutPath = RepairAcceptedCloseoutPath,
+                SkippedStages = [AcceptedCloseoutPath]
+            };
+        }
+
+        var confirmedAcceptResult = ConfirmedAcceptExecutor(context, pipelineArgs, writer);
+        return new GenerateFromCurrentConfirmedCloseoutResult
+        {
+            Domain = confirmedAcceptResult.Domain,
+            ClarificationReturnArtifactPath = confirmedAcceptResult.ClarificationReturnArtifactPath,
+            ConfirmedReconstructionArtifactPath = confirmedAcceptResult.ConfirmedReconstructionArtifactPath,
+            UpdatedSourceFilePaths = confirmedAcceptResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = confirmedAcceptResult.UpdatedExecutionFilePaths,
+            RegeneratedArtifactPaths = confirmedAcceptResult.RegeneratedArtifactPaths,
+            StartedExecutionUnits = confirmedAcceptResult.StartedExecutionUnits,
+            CreatedIssueRefs = confirmedAcceptResult.CreatedIssueRefs,
+            WorktreePaths = confirmedAcceptResult.WorktreePaths,
+            ImplementRequestArtifactPaths = confirmedAcceptResult.ImplementRequestArtifactPaths,
+            CreatedPrRefs = confirmedAcceptResult.CreatedPrRefs,
+            ReviewExecutionUnits = confirmedAcceptResult.ReviewExecutionUnits,
+            ReviewRequestArtifactPaths = confirmedAcceptResult.ReviewRequestArtifactPaths,
+            PostedCommentArtifactPaths = [],
+            CommentRefs = [],
+            FixingExecutionUnits = [],
+            FixRequestArtifactPaths = [],
+            ResubmittedExecutionUnits = [],
+            ResubmittedPrRefs = [],
+            RereviewedExecutionUnits = [],
+            RereviewedPrRefs = [],
+            CompletedExecutionUnits = confirmedAcceptResult.CompletedExecutionUnits,
+            ClosedIssueRefs = confirmedAcceptResult.ClosedIssueRefs,
+            MergedPrRefs = confirmedAcceptResult.MergedPrRefs,
+            ConfirmedItems = confirmedAcceptResult.ConfirmedItems,
+            BlockedItems = confirmedAcceptResult.BlockedItems,
+            DownstreamReadiness = confirmedAcceptResult.DownstreamReadiness,
+            SelectedCloseoutPath = AcceptedCloseoutPath,
+            SkippedStages = [RepairAcceptedCloseoutPath]
+        };
+    }
+
+    private static (string[] PipelineArgs, bool HasPreparedRepairComment) ParseArgs(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current confirmed-closeout requires a domain.");
+        }
+
+        var pipelineArgs = new List<string>();
+        var hasPreparedRepairComment = false;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            if (string.Equals(argument, "--from-file", StringComparison.Ordinal))
+            {
+                if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                {
+                    throw new InvalidOperationException("--from-file requires a value.");
+                }
+
+                hasPreparedRepairComment = true;
+                index++;
+                continue;
+            }
+
+            pipelineArgs.Add(argument);
+        }
+
+        return (pipelineArgs.ToArray(), hasPreparedRepairComment);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedCloseoutRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedCloseoutRenderer.cs
@@ -1,0 +1,87 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentConfirmedCloseoutRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentConfirmedCloseoutResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current confirmed-closeout processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Selected closeout path: {result.SelectedCloseoutPath}");
+
+        if (!string.IsNullOrWhiteSpace(result.ClarificationReturnArtifactPath))
+        {
+            writer.WriteLine($"Clarification-return artifact path: {result.ClarificationReturnArtifactPath}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(result.ConfirmedReconstructionArtifactPath))
+        {
+            writer.WriteLine($"Confirmed reconstruction artifact path: {result.ConfirmedReconstructionArtifactPath}");
+        }
+
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Regenerated artifact paths:");
+        WriteList(writer, result.RegeneratedArtifactPaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Generated implement request artifact paths:");
+        WriteList(writer, result.ImplementRequestArtifactPaths);
+        writer.WriteLine("Created PR refs:");
+        WriteList(writer, result.CreatedPrRefs);
+        writer.WriteLine("Review execution units:");
+        WriteList(writer, result.ReviewExecutionUnits);
+        writer.WriteLine("Review request artifact paths:");
+        WriteList(writer, result.ReviewRequestArtifactPaths);
+        writer.WriteLine("Posted comment artifact paths:");
+        WriteList(writer, result.PostedCommentArtifactPaths);
+        writer.WriteLine("Comment refs:");
+        WriteList(writer, result.CommentRefs);
+        writer.WriteLine("Fixing execution units:");
+        WriteList(writer, result.FixingExecutionUnits);
+        writer.WriteLine("Fix request artifact paths:");
+        WriteList(writer, result.FixRequestArtifactPaths);
+        writer.WriteLine("Resubmitted execution units:");
+        WriteList(writer, result.ResubmittedExecutionUnits);
+        writer.WriteLine("Resubmitted PR refs:");
+        WriteList(writer, result.ResubmittedPrRefs);
+        writer.WriteLine("Rereviewed execution units:");
+        WriteList(writer, result.RereviewedExecutionUnits);
+        writer.WriteLine("Rereviewed PR refs:");
+        WriteList(writer, result.RereviewedPrRefs);
+        writer.WriteLine("Completed execution units:");
+        WriteList(writer, result.CompletedExecutionUnits);
+        writer.WriteLine("Closed issue refs:");
+        WriteList(writer, result.ClosedIssueRefs);
+        writer.WriteLine("Merged PR refs:");
+        WriteList(writer, result.MergedPrRefs);
+        writer.WriteLine("Confirmed items:");
+        WriteList(writer, result.ConfirmedItems);
+        writer.WriteLine("Blocked items:");
+        WriteList(writer, result.BlockedItems);
+        writer.WriteLine($"Downstream readiness: {result.DownstreamReadiness}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedCloseoutResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentConfirmedCloseoutResult.cs
@@ -1,0 +1,62 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentConfirmedCloseoutResult
+{
+    public required string Domain { get; init; }
+
+    public string? ClarificationReturnArtifactPath { get; init; }
+
+    public string? ConfirmedReconstructionArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> RegeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> ImplementRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ReviewExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReviewRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> PostedCommentArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CommentRefs { get; init; }
+
+    public required IReadOnlyList<string> FixingExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> FixRequestArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ResubmittedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> RereviewedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> RereviewedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> CompletedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ClosedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> MergedPrRefs { get; init; }
+
+    public required IReadOnlyList<string> ConfirmedItems { get; init; }
+
+    public required IReadOnlyList<string> BlockedItems { get; init; }
+
+    public required string DownstreamReadiness { get; init; }
+
+    public required string SelectedCloseoutPath { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -975,6 +975,54 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentConfirmedCloseoutCommand_DispatchesToConfirmedCloseoutRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+        var originalAcceptExecutor = GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedAcceptExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedAcceptExecutor = (_, _, _) => new GenerateFromCurrentConfirmedAcceptResult
+            {
+                Domain = "auth",
+                Route = "reconciliation-required",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.confirmed-reconstruction.yaml"],
+                StartedExecutionUnits = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                ImplementRequestArtifactPaths = [],
+                CreatedPrRefs = [],
+                ReviewExecutionUnits = [],
+                ReviewRequestArtifactPaths = [],
+                MergedPrRefs = [],
+                ClosedIssueRefs = [],
+                CompletedExecutionUnits = [],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = ["defer: return interface cleanup after clarification"],
+                DownstreamReadiness = "not-ready"
+            };
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "confirmed-closeout", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "purpose,execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current confirmed-closeout processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedAcceptExecutor = originalAcceptExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentConfirmedCommentCommand_DispatchesToConfirmedCommentRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedCloseoutCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentConfirmedCloseoutCommandTests.cs
@@ -1,0 +1,152 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentConfirmedCloseoutCommandTests
+{
+    [Fact]
+    public void Execute_GivenNoRepairComment_UsesAcceptedCloseoutPath()
+    {
+        using var writer = new StringWriter();
+        var originalAcceptExecutor = GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedAcceptExecutor;
+        var originalReacceptExecutor = GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedReacceptExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedAcceptExecutor = (_, _, _) => new GenerateFromCurrentConfirmedAcceptResult
+            {
+                Domain = "auth",
+                Route = "confirmed-accept",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.concept.yaml"],
+                StartedExecutionUnits = ["AUTH-01"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/501"],
+                WorktreePaths = ["/tmp/worktrees/AUTH-01"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/AUTH-01.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501"],
+                ReviewExecutionUnits = ["AUTH-01"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/AUTH-01.request.json"],
+                MergedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501"],
+                ClosedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/501"],
+                CompletedExecutionUnits = ["AUTH-01"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            };
+            GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedReacceptExecutor = (_, _, _) =>
+                throw new InvalidOperationException("confirmed reaccept path should not run");
+
+            var exitCode = GenerateFromCurrentConfirmedCloseoutCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Selected closeout path: accepted-closeout", output, StringComparison.Ordinal);
+            Assert.Contains("Downstream readiness: ready", output, StringComparison.Ordinal);
+            Assert.Contains("Skipped stages:", output, StringComparison.Ordinal);
+            Assert.Contains("- repair-in-place-accepted-closeout", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedAcceptExecutor = originalAcceptExecutor;
+            GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedReacceptExecutor = originalReacceptExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenRepairComment_UsesRepairAcceptedCloseoutPath()
+    {
+        using var writer = new StringWriter();
+        var originalAcceptExecutor = GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedAcceptExecutor;
+        var originalReacceptExecutor = GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedReacceptExecutor;
+
+        try
+        {
+            GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedAcceptExecutor = (_, _, _) =>
+                throw new InvalidOperationException("confirmed accept path should not run");
+            GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedReacceptExecutor = (_, _, _) => new GenerateFromCurrentConfirmedReacceptResult
+            {
+                Domain = "auth",
+                Route = "confirmed-reaccept",
+                ClarificationReturnArtifactPath = null,
+                ConfirmedReconstructionArtifactPath = ".intent-cli/intake/auth.confirmed-reconstruction.yaml",
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                RegeneratedArtifactPaths = [".intent-cli/intake/auth.concept.yaml"],
+                StartedExecutionUnits = ["AUTH-01"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/501"],
+                WorktreePaths = ["/tmp/worktrees/AUTH-01"],
+                ImplementRequestArtifactPaths = [".intent-cli/implement/AUTH-01.request.md"],
+                CreatedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501"],
+                ReviewExecutionUnits = ["AUTH-01"],
+                ReviewRequestArtifactPaths = [".intent-cli/reviews/AUTH-01.request.json"],
+                PostedCommentArtifactPaths = [".intent-cli/reviews/AUTH-01.comment.json"],
+                CommentRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501#issuecomment-1"],
+                FixingExecutionUnits = ["AUTH-01"],
+                FixRequestArtifactPaths = [".intent-cli/fix/AUTH-01.request.md"],
+                ResubmittedExecutionUnits = ["AUTH-01"],
+                ResubmittedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501"],
+                RereviewedExecutionUnits = ["AUTH-01"],
+                RereviewedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501"],
+                CompletedExecutionUnits = ["AUTH-01"],
+                ClosedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/501"],
+                MergedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/501"],
+                ConfirmedItems = ["confirm: validate current auth boundary"],
+                BlockedItems = [],
+                DownstreamReadiness = "ready"
+            };
+
+            var exitCode = GenerateFromCurrentConfirmedCloseoutCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature", "--from-file", "repair-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Selected closeout path: repair-in-place-accepted-closeout", output, StringComparison.Ordinal);
+            Assert.Contains("Comment refs:", output, StringComparison.Ordinal);
+            Assert.Contains("- accepted-closeout", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedAcceptExecutor = originalAcceptExecutor;
+            GenerateFromCurrentConfirmedCloseoutCommand.ConfirmedReacceptExecutor = originalReacceptExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentConfirmedCloseoutCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What changed
- add `generate-from-current confirmed-closeout <domain> --from-path <path> [--from-file <path>]` to select accepted closeout or repair-in-place accepted closeout
- carry confirmed downstream summary fields through the new result/renderer, including selected closeout path and skipped stages
- add command router coverage and focused command tests for accepted path, repair path, and argument validation

## Why
- issue 176 requires a deterministic `G75` path that closes out confirmed review outcomes while keeping the accepted and repair-in-place accepted paths explicit

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GenerateFromCurrentConfirmedCloseout|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`

Closes #176
