### PR TITLE
[G76] Guard queue dispatch existing-link reuse

### DIFF
--- a/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
@@ -41,6 +41,23 @@ internal static class QueueDispatchCommand
             return 1;
         }
 
+        if (queueItem.LinkedIssue is not null)
+        {
+            PersistRunEvent(
+                context,
+                new IntentSystem.Supervisor.Models.RunEvent
+                {
+                    Ts = TimestampFactory(),
+                    ExecutionUnit = executionUnit,
+                    Event = "issue-reused",
+                    By = TransitionActor,
+                    LinkedIssue = queueItem.LinkedIssue.Url
+                });
+
+            writer.WriteLine($"Queue item {executionUnit} reused existing linked issue {queueItem.LinkedIssue.Url}.");
+            return 0;
+        }
+
         var packetPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.Yaml);
         if (!File.Exists(packetPath))
         {
@@ -116,12 +133,17 @@ internal static class QueueDispatchCommand
         var queueStatePath = context.GetQueueStatePath();
         File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
 
+        PersistRunEvent(context, result.Event);
+    }
+
+    private static void PersistRunEvent(CliContext context, IntentSystem.Supervisor.Models.RunEvent runEvent)
+    {
         var runLogPath = context.GetRunLogPath();
         var runLogDirectory = Path.GetDirectoryName(runLogPath)
             ?? throw new InvalidOperationException("Run log path did not contain a directory.");
         Directory.CreateDirectory(runLogDirectory);
         File.AppendAllText(
             runLogPath,
-            RunLogSerializer.SerializeLine(result.Event) + Environment.NewLine);
+            RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
     }
 }

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1331,6 +1331,38 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenQueueDispatchCommandWithExistingLinkedIssue_DispatchesToReuseRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueDispatchQueueState(withExistingLinkedIssue: true)));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalTimestampFactory = QueueDispatchCommand.TimestampFactory;
+
+        try
+        {
+            QueueDispatchCommand.PublisherFactory = () => new ThrowingQueueDispatchPublisher();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T06:00:00Z");
+
+            var exitCode = CommandRouter.Execute(["queue", "dispatch", "G13"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("reused existing linked issue", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenQueueEnqueueCommand_DispatchesToQueueEnqueueRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -2780,7 +2812,7 @@ public sealed class CommandRouterTests
         };
     }
 
-    private static QueueState CreateQueueDispatchQueueState()
+    private static QueueState CreateQueueDispatchQueueState(bool withExistingLinkedIssue = false)
     {
         return new QueueState
         {
@@ -2802,6 +2834,14 @@ public sealed class CommandRouterTests
                         ReviewContext = ".intent-cli/issues/G13/review-context.md",
                         Yaml = ".intent-cli/issues/G13/packet.yaml"
                     },
+                    LinkedIssue = withExistingLinkedIssue
+                        ? new LinkedIssue
+                        {
+                            Repo = "J-Tech-Japan/intent-system",
+                            Number = 41,
+                            Url = "https://github.com/J-Tech-Japan/intent-system/issues/41"
+                        }
+                        : null,
                     WorkerRole = "coder",
                     ReviewRole = "reviewer",
                     Priority = "high"
@@ -4247,6 +4287,14 @@ recommended_updates:
                 Number = 53,
                 Url = "https://github.com/J-Tech-Japan/intent-system/issues/53"
             };
+        }
+    }
+
+    private sealed class ThrowingQueueDispatchPublisher : IQueueDispatchPublisher
+    {
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            throw new InvalidOperationException("CreateIssue should not be called when linked issue already exists.");
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/QueueDispatchCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueDispatchCommandTests.cs
@@ -67,6 +67,45 @@ public sealed class QueueDispatchCommandTests
     }
 
     [Fact]
+    public void Execute_GivenExistingLinkedIssue_ReusesItWithoutCreatingDuplicateIssueOrMutatingQueue()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(withExistingLinkedIssue: true)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalTimestampFactory = QueueDispatchCommand.TimestampFactory;
+
+        try
+        {
+            QueueDispatchCommand.PublisherFactory = () => new ThrowingPublisher();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T06:00:00Z");
+
+            var originalQueueState = File.ReadAllText(queueStatePath);
+            var exitCode = QueueDispatchCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("reused existing linked issue", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            var reuseEvent = Assert.Single(runEvents);
+            Assert.Equal("issue-reused", reuseEvent.Event);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/41", reuseEvent.LinkedIssue);
+        }
+        finally
+        {
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenMissingPacketArtifact_ReturnsExitCodeOne()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -244,7 +283,7 @@ public sealed class QueueDispatchCommandTests
         };
     }
 
-    private static QueueState CreateQueueState()
+    private static QueueState CreateQueueState(bool withExistingLinkedIssue = false)
     {
         return new QueueState
         {
@@ -252,13 +291,16 @@ public sealed class QueueDispatchCommandTests
             UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
             Items =
             [
-                CreateItem("G13", QueueItemState.Queued),
+                CreateItem("G13", QueueItemState.Queued, withExistingLinkedIssue),
                 CreateItem("G14", QueueItemState.Queued)
             ]
         };
     }
 
-    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    private static QueueItem CreateItem(
+        string executionUnit,
+        QueueItemState state,
+        bool withExistingLinkedIssue = false)
     {
         return new QueueItem
         {
@@ -274,6 +316,14 @@ public sealed class QueueDispatchCommandTests
                 ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
                 Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
             },
+            LinkedIssue = withExistingLinkedIssue
+                ? new LinkedIssue
+                {
+                    Repo = "J-Tech-Japan/intent-system",
+                    Number = 41,
+                    Url = "https://github.com/J-Tech-Japan/intent-system/issues/41"
+                }
+                : null,
             WorkerRole = "coder",
             ReviewRole = "reviewer",
             Priority = "high"
@@ -359,6 +409,14 @@ public sealed class QueueDispatchCommandTests
                 Number = 53,
                 Url = "https://github.com/J-Tech-Japan/intent-system/issues/53"
             };
+        }
+    }
+
+    private sealed class ThrowingPublisher : IQueueDispatchPublisher
+    {
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            throw new InvalidOperationException("CreateIssue should not be called when linked issue already exists.");
         }
     }
 


### PR DESCRIPTION
## Summary
- short-circuit `queue dispatch` when the selected queued item already has a linked issue
- append an `issue-reused` run-log event instead of creating a duplicate child issue
- add runtime and router tests for both reuse and normal create paths

## Testing
- dotnet test IntentSystem.sln

Closes #181
