### PR TITLE
[G78] Implement bug triage command

### DIFF
--- a/src/IntentSystem.Cli/Commands/BugTriageArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/BugTriageArtifactPathResolver.cs
@@ -1,0 +1,11 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugTriageArtifactPathResolver
+{
+    public static string Resolve(string bugId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bugId);
+
+        return $".intent-cli/bugs/{bugId}.triage.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugTriageArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugTriageArtifactYaml.cs
@@ -1,0 +1,250 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugTriageArtifact
+{
+    public required string BugId { get; init; }
+
+    public required string ReportRef { get; init; }
+
+    public required string Classification { get; init; }
+
+    public required string DownstreamAction { get; init; }
+
+    public required bool ClarificationRequired { get; init; }
+
+    public required IReadOnlyList<string> ClarificationReasons { get; init; }
+
+    public required IReadOnlyList<string> OriginalInstructionRootRefs { get; init; }
+
+    public required IReadOnlyList<string> LinkedReviewRefs { get; init; }
+
+    public required IReadOnlyList<string> ResolvedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ResolvedImplementationRefs { get; init; }
+
+    public required IReadOnlyList<string> ResolvedReviewContextRefs { get; init; }
+
+    public required IReadOnlyList<string> ResolvedPacketRefs { get; init; }
+
+    public required IReadOnlyList<string> UnresolvedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ImplementationRepairCandidates { get; init; }
+
+    public required IReadOnlyList<string> IntentRepairCandidates { get; init; }
+}
+
+internal static class BugTriageArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "bug_id",
+        "report_ref",
+        "classification",
+        "downstream_action",
+        "clarification_required",
+        "clarification_reasons",
+        "original_instruction_root_refs",
+        "linked_review_refs",
+        "resolved_execution_units",
+        "resolved_implementation_refs",
+        "resolved_review_context_refs",
+        "resolved_packet_refs",
+        "unresolved_execution_units",
+        "implementation_repair_candidates",
+        "intent_repair_candidates"
+    ];
+
+    public static string Serialize(BugTriageArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"bug_id: {artifact.BugId}",
+            $"report_ref: {Quote(artifact.ReportRef)}",
+            $"classification: {artifact.Classification}",
+            $"downstream_action: {artifact.DownstreamAction}",
+            $"clarification_required: {artifact.ClarificationRequired.ToString().ToLowerInvariant()}"
+        };
+
+        AppendList(lines, "clarification_reasons", artifact.ClarificationReasons);
+        AppendList(lines, "original_instruction_root_refs", artifact.OriginalInstructionRootRefs);
+        AppendList(lines, "linked_review_refs", artifact.LinkedReviewRefs);
+        AppendList(lines, "resolved_execution_units", artifact.ResolvedExecutionUnits);
+        AppendList(lines, "resolved_implementation_refs", artifact.ResolvedImplementationRefs);
+        AppendList(lines, "resolved_review_context_refs", artifact.ResolvedReviewContextRefs);
+        AppendList(lines, "resolved_packet_refs", artifact.ResolvedPacketRefs);
+        AppendList(lines, "unresolved_execution_units", artifact.UnresolvedExecutionUnits);
+        AppendList(lines, "implementation_repair_candidates", artifact.ImplementationRepairCandidates);
+        AppendList(lines, "intent_repair_candidates", artifact.IntentRepairCandidates);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static BugTriageArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new BugTriageArtifact
+        {
+            BugId = GetRequiredScalar(values, "bug_id"),
+            ReportRef = GetRequiredScalar(values, "report_ref"),
+            Classification = GetRequiredScalar(values, "classification"),
+            DownstreamAction = GetRequiredScalar(values, "downstream_action"),
+            ClarificationRequired = GetRequiredBoolean(values, "clarification_required"),
+            ClarificationReasons = GetRequiredList(values, "clarification_reasons"),
+            OriginalInstructionRootRefs = GetRequiredList(values, "original_instruction_root_refs"),
+            LinkedReviewRefs = GetRequiredList(values, "linked_review_refs"),
+            ResolvedExecutionUnits = GetRequiredList(values, "resolved_execution_units"),
+            ResolvedImplementationRefs = GetRequiredList(values, "resolved_implementation_refs"),
+            ResolvedReviewContextRefs = GetRequiredList(values, "resolved_review_context_refs"),
+            ResolvedPacketRefs = GetRequiredList(values, "resolved_packet_refs"),
+            UnresolvedExecutionUnits = GetRequiredList(values, "unresolved_execution_units"),
+            ImplementationRepairCandidates = GetRequiredList(values, "implementation_repair_candidates"),
+            IntentRepairCandidates = GetRequiredList(values, "intent_repair_candidates")
+        };
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add($"{label}: []");
+            return;
+        }
+
+        lines.Add($"{label}:");
+        lines.AddRange(values.Select(value => $"  - {Quote(value)}"));
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("  - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !values.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException(
+                        $"Bug triage YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[4..].TrimStart()));
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Bug triage YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+
+            if (value.Length == 0)
+            {
+                values[key] = new List<string>();
+                currentListKey = key;
+                continue;
+            }
+
+            currentListKey = null;
+            values[key] = value switch
+            {
+                "[]" => Array.Empty<string>(),
+                "true" => true,
+                "false" => false,
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Bug triage YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException($"Bug triage YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static bool GetRequiredBoolean(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not bool booleanValue)
+        {
+            throw new InvalidOperationException($"Bug triage YAML field '{key}' must be a boolean.");
+        }
+
+        return booleanValue;
+    }
+
+    private static IReadOnlyList<string> GetRequiredList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug triage YAML field '{key}' must be a list.");
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException($"Bug triage YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugTriageArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugTriageArtifactYaml.cs
@@ -6,7 +6,7 @@ internal sealed record BugTriageArtifact
 
     public required string ReportRef { get; init; }
 
-    public required string Classification { get; init; }
+    public required string TriageClassification { get; init; }
 
     public required string DownstreamAction { get; init; }
 
@@ -39,7 +39,7 @@ internal static class BugTriageArtifactYaml
     [
         "bug_id",
         "report_ref",
-        "classification",
+        "triage_classification",
         "downstream_action",
         "clarification_required",
         "clarification_reasons",
@@ -62,7 +62,7 @@ internal static class BugTriageArtifactYaml
         {
             $"bug_id: {artifact.BugId}",
             $"report_ref: {Quote(artifact.ReportRef)}",
-            $"classification: {artifact.Classification}",
+            $"triage_classification: {artifact.TriageClassification}",
             $"downstream_action: {artifact.DownstreamAction}",
             $"clarification_required: {artifact.ClarificationRequired.ToString().ToLowerInvariant()}"
         };
@@ -92,7 +92,7 @@ internal static class BugTriageArtifactYaml
         {
             BugId = GetRequiredScalar(values, "bug_id"),
             ReportRef = GetRequiredScalar(values, "report_ref"),
-            Classification = GetRequiredScalar(values, "classification"),
+            TriageClassification = GetRequiredScalar(values, "triage_classification"),
             DownstreamAction = GetRequiredScalar(values, "downstream_action"),
             ClarificationRequired = GetRequiredBoolean(values, "clarification_required"),
             ClarificationReasons = GetRequiredList(values, "clarification_reasons"),

--- a/src/IntentSystem.Cli/Commands/BugTriageCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugTriageCommand.cs
@@ -95,24 +95,33 @@ internal static class BugTriageCommand
         var implementationRepairCandidates = resolvedExecutionUnits.ToArray();
         var intentRepairCandidates = DistinctOrdered(report.AffectedIntentRefs.Concat(report.AffectedRuleSpecRefs));
 
-        var classification = !canReconstructOriginalInstructionRoot
-            ? "clarification-first"
-            : implementationRepairCandidates.Length > 0 && intentRepairCandidates.Length > 0
-                ? "implementation-and-intent-impact"
-                : implementationRepairCandidates.Length > 0
-                    ? "implementation-impact"
-                    : intentRepairCandidates.Length > 0
-                        ? "intent-impact"
-                        : "review-linked-impact";
+        var hasIntentCandidates = report.AffectedIntentRefs.Count > 0;
+        var hasRuleCandidates = report.AffectedRuleSpecRefs.Count > 0;
+        var hasImplementationCandidates = implementationRepairCandidates.Length > 0;
 
-        var downstreamAction = classification switch
-        {
-            "clarification-first" => "clarification-first",
-            "implementation-and-intent-impact" => "implementation-and-intent-repair",
-            "implementation-impact" => "implementation-repair",
-            "intent-impact" => "intent-repair",
-            _ => "review-linked-investigation"
-        };
+        var classification = !canReconstructOriginalInstructionRoot
+            ? "unknown"
+            : unresolvedExecutionUnits.Count > 0
+                ? "packet-gap"
+                : hasImplementationCandidates
+                    ? "implementation-mismatch"
+                    : hasRuleCandidates
+                        ? "rule-gap"
+                        : hasIntentCandidates
+                            ? "intent-gap"
+                            : linkedReviewRefs.Length > 0
+                                ? "edge-case-gap"
+                                : "unknown";
+
+        var downstreamAction = !canReconstructOriginalInstructionRoot
+            ? "clarification-first"
+            : hasImplementationCandidates && (hasIntentCandidates || hasRuleCandidates)
+                ? "dual-track"
+                : hasImplementationCandidates
+                    ? "implementation-only"
+                    : hasIntentCandidates || hasRuleCandidates
+                        ? "intent-only"
+                        : "clarification-first";
 
         var artifact = new BugTriageArtifact
         {

--- a/src/IntentSystem.Cli/Commands/BugTriageCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugTriageCommand.cs
@@ -127,7 +127,7 @@ internal static class BugTriageCommand
         {
             BugId = bugId,
             ReportRef = reportRef,
-            Classification = classification,
+            TriageClassification = classification,
             DownstreamAction = downstreamAction,
             ClarificationRequired = clarificationReasons.Count > 0,
             ClarificationReasons = clarificationReasons,

--- a/src/IntentSystem.Cli/Commands/BugTriageCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugTriageCommand.cs
@@ -1,0 +1,165 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugTriageCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            BugTriageRenderer.WriteSummary(writer, result.Artifact, result.ArtifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static BugTriageCommandResult ExecuteCore(CliContext context, string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Bug triage command requires '<bug-id>'.");
+        }
+
+        var bugId = args[0].Trim();
+        var reportRef = $".intent-cli/bugs/{bugId}.report.yaml";
+        var reportPath = Path.GetFullPath(Path.Combine(context.RepoRoot, reportRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(reportPath))
+        {
+            throw new InvalidOperationException($"Bug report artifact was not found at {reportPath}");
+        }
+
+        var report = BugReportArtifactYaml.Deserialize(File.ReadAllText(reportPath));
+        var originalInstructionRootRefs = DistinctOrdered(
+            report.OriginalInstructionRefs
+                .Concat(report.AffectedIntentRefs)
+                .Concat(report.AffectedRuleSpecRefs));
+
+        var linkedReviewRefs = DistinctOrdered(report.LinkedReviewRefs);
+        var resolvedExecutionUnits = new List<string>();
+        var resolvedImplementationRefs = new List<string>();
+        var resolvedReviewContextRefs = new List<string>();
+        var resolvedPacketRefs = new List<string>();
+        var unresolvedExecutionUnits = new List<string>();
+
+        foreach (var executionUnit in DistinctOrdered(report.LinkedExecutionUnits))
+        {
+            var implementationRef = $".intent-cli/issues/{executionUnit}/implementation.md";
+            var reviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md";
+            var packetRef = $".intent-cli/issues/{executionUnit}/packet.yaml";
+
+            var implementationPath = Path.GetFullPath(Path.Combine(context.RepoRoot, implementationRef.Replace('/', Path.DirectorySeparatorChar)));
+            var reviewContextPath = Path.GetFullPath(Path.Combine(context.RepoRoot, reviewContextRef.Replace('/', Path.DirectorySeparatorChar)));
+            var packetPath = Path.GetFullPath(Path.Combine(context.RepoRoot, packetRef.Replace('/', Path.DirectorySeparatorChar)));
+
+            if (File.Exists(implementationPath) && File.Exists(reviewContextPath) && File.Exists(packetPath))
+            {
+                resolvedExecutionUnits.Add(executionUnit);
+                resolvedImplementationRefs.Add(implementationRef);
+                resolvedReviewContextRefs.Add(reviewContextRef);
+                resolvedPacketRefs.Add(packetRef);
+                continue;
+            }
+
+            unresolvedExecutionUnits.Add(executionUnit);
+        }
+
+        var clarificationReasons = new List<string>();
+        if (unresolvedExecutionUnits.Count > 0)
+        {
+            clarificationReasons.Add(
+                $"execution unit roots could not be fully resolved for: {string.Join(", ", unresolvedExecutionUnits)}");
+        }
+
+        var reconstructableRootRefs = originalInstructionRootRefs
+            .Concat(resolvedPacketRefs)
+            .Concat(linkedReviewRefs)
+            .ToArray();
+        var canReconstructOriginalInstructionRoot = reconstructableRootRefs.Length > 0;
+        if (!canReconstructOriginalInstructionRoot)
+        {
+            clarificationReasons.Add(
+                "original instruction root could not be reconstructed from current bug report artifact and linked packet/review refs.");
+        }
+
+        var implementationRepairCandidates = resolvedExecutionUnits.ToArray();
+        var intentRepairCandidates = DistinctOrdered(report.AffectedIntentRefs.Concat(report.AffectedRuleSpecRefs));
+
+        var classification = !canReconstructOriginalInstructionRoot
+            ? "clarification-first"
+            : implementationRepairCandidates.Length > 0 && intentRepairCandidates.Length > 0
+                ? "implementation-and-intent-impact"
+                : implementationRepairCandidates.Length > 0
+                    ? "implementation-impact"
+                    : intentRepairCandidates.Length > 0
+                        ? "intent-impact"
+                        : "review-linked-impact";
+
+        var downstreamAction = classification switch
+        {
+            "clarification-first" => "clarification-first",
+            "implementation-and-intent-impact" => "implementation-and-intent-repair",
+            "implementation-impact" => "implementation-repair",
+            "intent-impact" => "intent-repair",
+            _ => "review-linked-investigation"
+        };
+
+        var artifact = new BugTriageArtifact
+        {
+            BugId = bugId,
+            ReportRef = reportRef,
+            Classification = classification,
+            DownstreamAction = downstreamAction,
+            ClarificationRequired = clarificationReasons.Count > 0,
+            ClarificationReasons = clarificationReasons,
+            OriginalInstructionRootRefs = originalInstructionRootRefs,
+            LinkedReviewRefs = linkedReviewRefs,
+            ResolvedExecutionUnits = resolvedExecutionUnits,
+            ResolvedImplementationRefs = resolvedImplementationRefs,
+            ResolvedReviewContextRefs = resolvedReviewContextRefs,
+            ResolvedPacketRefs = resolvedPacketRefs,
+            UnresolvedExecutionUnits = unresolvedExecutionUnits,
+            ImplementationRepairCandidates = implementationRepairCandidates,
+            IntentRepairCandidates = intentRepairCandidates
+        };
+
+        var artifactPath = WriteArtifact(context.RepoRoot, artifact);
+        return new BugTriageCommandResult
+        {
+            Artifact = artifact,
+            ArtifactPath = artifactPath
+        };
+    }
+
+    private static string[] DistinctOrdered(IEnumerable<string> values)
+    {
+        return values
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string WriteArtifact(string repoRoot, BugTriageArtifact artifact)
+    {
+        var relativePath = BugTriageArtifactPathResolver.Resolve(artifact.BugId);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Bug triage artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, BugTriageArtifactYaml.Serialize(artifact));
+
+        return relativePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugTriageCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/BugTriageCommandResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugTriageCommandResult
+{
+    public required BugTriageArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/BugTriageRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugTriageRenderer.cs
@@ -9,7 +9,7 @@ internal static class BugTriageRenderer
         ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
 
         writer.WriteLine($"Bug triage artifact generated for '{artifact.BugId}'.");
-        writer.WriteLine($"Classification: {artifact.Classification}");
+        writer.WriteLine($"Triage classification: {artifact.TriageClassification}");
         writer.WriteLine($"Downstream action: {artifact.DownstreamAction}");
         writer.WriteLine($"Clarification required: {artifact.ClarificationRequired.ToString().ToLowerInvariant()}");
         writer.WriteLine($"Artifact path: {artifactPath}");

--- a/src/IntentSystem.Cli/Commands/BugTriageRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugTriageRenderer.cs
@@ -1,0 +1,22 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugTriageRenderer
+{
+    public static void WriteSummary(TextWriter writer, BugTriageArtifact artifact, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Bug triage artifact generated for '{artifact.BugId}'.");
+        writer.WriteLine($"Classification: {artifact.Classification}");
+        writer.WriteLine($"Downstream action: {artifact.DownstreamAction}");
+        writer.WriteLine($"Clarification required: {artifact.ClarificationRequired.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Implementation repair candidates: {artifact.ImplementationRepairCandidates.Count}");
+        writer.WriteLine($"Intent repair candidates: {artifact.IntentRepairCandidates.Count}");
+        writer.WriteLine($"Resolved execution units: {artifact.ResolvedExecutionUnits.Count}");
+        writer.WriteLine($"Unresolved execution units: {artifact.UnresolvedExecutionUnits.Count}");
+        writer.WriteLine($"Linked review refs: {artifact.LinkedReviewRefs.Count}");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -78,7 +78,8 @@ internal static class CommandRouter
             },
             ["bug"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
-                ["report"] = BugReportCommand.Execute
+                ["report"] = BugReportCommand.Execute,
+                ["triage"] = BugTriageCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/tests/IntentSystem.Cli.Tests/BugTriageArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugTriageArtifactYamlTests.cs
@@ -11,8 +11,8 @@ public sealed class BugTriageArtifactYamlTests
         {
             BugId = "BUG-123",
             ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
-            Classification = "implementation-and-intent-impact",
-            DownstreamAction = "implementation-and-intent-repair",
+            Classification = "implementation-mismatch",
+            DownstreamAction = "dual-track",
             ClarificationRequired = true,
             ClarificationReasons = ["execution unit roots could not be fully resolved for: G77"],
             OriginalInstructionRootRefs = ["ICL.P.PRODUCT_GOAL", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
@@ -52,8 +52,8 @@ public sealed class BugTriageArtifactYamlTests
         var yaml = """
         bug_id: BUG-123
         report_ref: ".intent-cli/bugs/BUG-123.report.yaml"
-        classification: implementation-impact
-        downstream_action: implementation-repair
+        classification: implementation-mismatch
+        downstream_action: implementation-only
         clarification_required: false
         clarification_reasons: []
         original_instruction_root_refs: []

--- a/tests/IntentSystem.Cli.Tests/BugTriageArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugTriageArtifactYamlTests.cs
@@ -1,0 +1,73 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugTriageArtifactYamlTests
+{
+    [Fact]
+    public void SerializeDeserialize_RoundTripsBugTriageArtifact()
+    {
+        var artifact = new BugTriageArtifact
+        {
+            BugId = "BUG-123",
+            ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
+            Classification = "implementation-and-intent-impact",
+            DownstreamAction = "implementation-and-intent-repair",
+            ClarificationRequired = true,
+            ClarificationReasons = ["execution unit roots could not be fully resolved for: G77"],
+            OriginalInstructionRootRefs = ["ICL.P.PRODUCT_GOAL", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
+            LinkedReviewRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"],
+            ResolvedExecutionUnits = ["G25"],
+            ResolvedImplementationRefs = [".intent-cli/issues/G25/implementation.md"],
+            ResolvedReviewContextRefs = [".intent-cli/issues/G25/review-context.md"],
+            ResolvedPacketRefs = [".intent-cli/issues/G25/packet.yaml"],
+            UnresolvedExecutionUnits = ["G77"],
+            ImplementationRepairCandidates = ["G25"],
+            IntentRepairCandidates = ["intents/intent-cli/means/auth.md"]
+        };
+
+        var yaml = BugTriageArtifactYaml.Serialize(artifact);
+        var roundTripped = BugTriageArtifactYaml.Deserialize(yaml);
+
+        Assert.Equal(artifact.BugId, roundTripped.BugId);
+        Assert.Equal(artifact.ReportRef, roundTripped.ReportRef);
+        Assert.Equal(artifact.Classification, roundTripped.Classification);
+        Assert.Equal(artifact.DownstreamAction, roundTripped.DownstreamAction);
+        Assert.Equal(artifact.ClarificationRequired, roundTripped.ClarificationRequired);
+        Assert.Equal(artifact.ClarificationReasons, roundTripped.ClarificationReasons);
+        Assert.Equal(artifact.OriginalInstructionRootRefs, roundTripped.OriginalInstructionRootRefs);
+        Assert.Equal(artifact.LinkedReviewRefs, roundTripped.LinkedReviewRefs);
+        Assert.Equal(artifact.ResolvedExecutionUnits, roundTripped.ResolvedExecutionUnits);
+        Assert.Equal(artifact.ResolvedImplementationRefs, roundTripped.ResolvedImplementationRefs);
+        Assert.Equal(artifact.ResolvedReviewContextRefs, roundTripped.ResolvedReviewContextRefs);
+        Assert.Equal(artifact.ResolvedPacketRefs, roundTripped.ResolvedPacketRefs);
+        Assert.Equal(artifact.UnresolvedExecutionUnits, roundTripped.UnresolvedExecutionUnits);
+        Assert.Equal(artifact.ImplementationRepairCandidates, roundTripped.ImplementationRepairCandidates);
+        Assert.Equal(artifact.IntentRepairCandidates, roundTripped.IntentRepairCandidates);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_ThrowsInvalidOperationException()
+    {
+        var yaml = """
+        bug_id: BUG-123
+        report_ref: ".intent-cli/bugs/BUG-123.report.yaml"
+        classification: implementation-impact
+        downstream_action: implementation-repair
+        clarification_required: false
+        clarification_reasons: []
+        original_instruction_root_refs: []
+        linked_review_refs: []
+        resolved_execution_units: []
+        resolved_implementation_refs: []
+        resolved_review_context_refs: []
+        unresolved_execution_units: []
+        implementation_repair_candidates: []
+        intent_repair_candidates: []
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BugTriageArtifactYaml.Deserialize(yaml));
+
+        Assert.Contains("resolved_packet_refs", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugTriageArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugTriageArtifactYamlTests.cs
@@ -11,7 +11,7 @@ public sealed class BugTriageArtifactYamlTests
         {
             BugId = "BUG-123",
             ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
-            Classification = "implementation-mismatch",
+            TriageClassification = "implementation-mismatch",
             DownstreamAction = "dual-track",
             ClarificationRequired = true,
             ClarificationReasons = ["execution unit roots could not be fully resolved for: G77"],
@@ -31,7 +31,7 @@ public sealed class BugTriageArtifactYamlTests
 
         Assert.Equal(artifact.BugId, roundTripped.BugId);
         Assert.Equal(artifact.ReportRef, roundTripped.ReportRef);
-        Assert.Equal(artifact.Classification, roundTripped.Classification);
+        Assert.Equal(artifact.TriageClassification, roundTripped.TriageClassification);
         Assert.Equal(artifact.DownstreamAction, roundTripped.DownstreamAction);
         Assert.Equal(artifact.ClarificationRequired, roundTripped.ClarificationRequired);
         Assert.Equal(artifact.ClarificationReasons, roundTripped.ClarificationReasons);
@@ -52,7 +52,7 @@ public sealed class BugTriageArtifactYamlTests
         var yaml = """
         bug_id: BUG-123
         report_ref: ".intent-cli/bugs/BUG-123.report.yaml"
-        classification: implementation-mismatch
+        triage_classification: implementation-mismatch
         downstream_action: implementation-only
         clarification_required: false
         clarification_reasons: []

--- a/tests/IntentSystem.Cli.Tests/BugTriageCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugTriageCommandTests.cs
@@ -23,13 +23,13 @@ public sealed class BugTriageCommandTests
 
         Assert.Equal(0, exitCode);
         Assert.Contains("Bug triage artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("Classification: implementation-mismatch", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Triage classification: implementation-mismatch", writer.ToString(), StringComparison.Ordinal);
 
         var artifact = BugTriageArtifactYaml.Deserialize(
             File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.triage.yaml")));
         Assert.Equal("BUG-123", artifact.BugId);
         Assert.Equal(".intent-cli/bugs/BUG-123.report.yaml", artifact.ReportRef);
-        Assert.Equal("implementation-mismatch", artifact.Classification);
+        Assert.Equal("implementation-mismatch", artifact.TriageClassification);
         Assert.Equal("dual-track", artifact.DownstreamAction);
         Assert.False(artifact.ClarificationRequired);
         Assert.Equal(["G25"], artifact.ResolvedExecutionUnits);
@@ -75,7 +75,7 @@ public sealed class BugTriageCommandTests
 
         var artifact = BugTriageArtifactYaml.Deserialize(
             File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.triage.yaml")));
-        Assert.Equal("unknown", artifact.Classification);
+        Assert.Equal("unknown", artifact.TriageClassification);
         Assert.Equal("clarification-first", artifact.DownstreamAction);
         Assert.True(artifact.ClarificationRequired);
         Assert.Equal(["G77"], artifact.UnresolvedExecutionUnits);

--- a/tests/IntentSystem.Cli.Tests/BugTriageCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugTriageCommandTests.cs
@@ -1,0 +1,169 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class BugTriageCommandTests
+{
+    [Fact]
+    public void Execute_GivenResolvedExecutionRoots_WritesBugTriageArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.report.yaml"),
+            BugReportArtifactYaml.Serialize(CreateBugReportArtifact(["G25"], ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"])));
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent-cli", "issues", "G25", "implementation.md"), "# Implementation");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent-cli", "issues", "G25", "review-context.md"), "# Review Context");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"), "execution_unit: G25");
+        using var writer = new StringWriter();
+
+        var exitCode = BugTriageCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Bug triage artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Classification: implementation-and-intent-impact", writer.ToString(), StringComparison.Ordinal);
+
+        var artifact = BugTriageArtifactYaml.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.triage.yaml")));
+        Assert.Equal("BUG-123", artifact.BugId);
+        Assert.Equal(".intent-cli/bugs/BUG-123.report.yaml", artifact.ReportRef);
+        Assert.Equal("implementation-and-intent-impact", artifact.Classification);
+        Assert.Equal("implementation-and-intent-repair", artifact.DownstreamAction);
+        Assert.False(artifact.ClarificationRequired);
+        Assert.Equal(["G25"], artifact.ResolvedExecutionUnits);
+        Assert.Equal([".intent-cli/issues/G25/implementation.md"], artifact.ResolvedImplementationRefs);
+        Assert.Equal([".intent-cli/issues/G25/review-context.md"], artifact.ResolvedReviewContextRefs);
+        Assert.Equal([".intent-cli/issues/G25/packet.yaml"], artifact.ResolvedPacketRefs);
+        Assert.Equal(["G25"], artifact.ImplementationRepairCandidates);
+        Assert.Equal(
+            ["intents/intent-cli/means/auth.md", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
+            artifact.IntentRepairCandidates);
+    }
+
+    [Fact]
+    public void Execute_GivenUnreconstructableRoot_ReturnsClarificationFirstArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.report.yaml"),
+            BugReportArtifactYaml.Serialize(
+                new BugReportArtifact
+                {
+                    DomainSlug = "auth",
+                    BugId = "BUG-124",
+                    Title = "OAuth callback loop",
+                    ReportSource = "from-file",
+                    ProblemStatement = "Observed callback loop after login.",
+                    SuspectedFailureLocus = "Observed callback loop after login.",
+                    OriginalInstructionRefs = [],
+                    AffectedIntentRefs = [],
+                    AffectedRuleSpecRefs = [],
+                    ClarificationCandidates = [],
+                    LinkedExecutionUnits = ["G77"],
+                    LinkedIssueRefs = [],
+                    LinkedPrRefs = [],
+                    LinkedReviewRefs = []
+                }));
+        using var writer = new StringWriter();
+
+        var exitCode = BugTriageCommand.Execute(CreateContext(repoRoot), ["BUG-124"], writer);
+
+        Assert.Equal(0, exitCode);
+
+        var artifact = BugTriageArtifactYaml.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.triage.yaml")));
+        Assert.Equal("clarification-first", artifact.Classification);
+        Assert.Equal("clarification-first", artifact.DownstreamAction);
+        Assert.True(artifact.ClarificationRequired);
+        Assert.Equal(["G77"], artifact.UnresolvedExecutionUnits);
+        Assert.Contains(
+            "original instruction root could not be reconstructed from current bug report artifact and linked packet/review refs.",
+            artifact.ClarificationReasons,
+            StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingBugReportArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = BugTriageCommand.Execute(CreateContext(repoRoot), ["BUG-999"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Bug report artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static BugReportArtifact CreateBugReportArtifact(IReadOnlyList<string> linkedExecutionUnits, IReadOnlyList<string> linkedReviewRefs)
+    {
+        return new BugReportArtifact
+        {
+            DomainSlug = "auth",
+            BugId = "BUG-123",
+            Title = "OAuth callback loop",
+            ReportSource = "from-file",
+            ProblemStatement = "Observed callback loop after login.",
+            SuspectedFailureLocus = "Observed callback loop after login.",
+            OriginalInstructionRefs = ["ICL.P.PRODUCT_GOAL"],
+            AffectedIntentRefs = ["intents/intent-cli/means/auth.md"],
+            AffectedRuleSpecRefs = ["intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
+            ClarificationCandidates = ["Should provider retry reuse callback state token?"],
+            LinkedExecutionUnits = linkedExecutionUnits,
+            LinkedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/178"],
+            LinkedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180"],
+            LinkedReviewRefs = linkedReviewRefs
+        };
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-bug-triage-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugTriageCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugTriageCommandTests.cs
@@ -23,14 +23,14 @@ public sealed class BugTriageCommandTests
 
         Assert.Equal(0, exitCode);
         Assert.Contains("Bug triage artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("Classification: implementation-and-intent-impact", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Classification: implementation-mismatch", writer.ToString(), StringComparison.Ordinal);
 
         var artifact = BugTriageArtifactYaml.Deserialize(
             File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.triage.yaml")));
         Assert.Equal("BUG-123", artifact.BugId);
         Assert.Equal(".intent-cli/bugs/BUG-123.report.yaml", artifact.ReportRef);
-        Assert.Equal("implementation-and-intent-impact", artifact.Classification);
-        Assert.Equal("implementation-and-intent-repair", artifact.DownstreamAction);
+        Assert.Equal("implementation-mismatch", artifact.Classification);
+        Assert.Equal("dual-track", artifact.DownstreamAction);
         Assert.False(artifact.ClarificationRequired);
         Assert.Equal(["G25"], artifact.ResolvedExecutionUnits);
         Assert.Equal([".intent-cli/issues/G25/implementation.md"], artifact.ResolvedImplementationRefs);
@@ -75,7 +75,7 @@ public sealed class BugTriageCommandTests
 
         var artifact = BugTriageArtifactYaml.Deserialize(
             File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.triage.yaml")));
-        Assert.Equal("clarification-first", artifact.Classification);
+        Assert.Equal("unknown", artifact.Classification);
         Assert.Equal("clarification-first", artifact.DownstreamAction);
         Assert.True(artifact.ClarificationRequired);
         Assert.Equal(["G77"], artifact.UnresolvedExecutionUnits);

--- a/tests/IntentSystem.Cli.Tests/BugTriageRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugTriageRendererTests.cs
@@ -15,8 +15,8 @@ public sealed class BugTriageRendererTests
             {
                 BugId = "BUG-123",
                 ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
-                Classification = "implementation-impact",
-                DownstreamAction = "implementation-repair",
+                Classification = "implementation-mismatch",
+                DownstreamAction = "implementation-only",
                 ClarificationRequired = true,
                 ClarificationReasons = ["execution unit roots could not be fully resolved for: G77"],
                 OriginalInstructionRootRefs = ["ICL.P.PRODUCT_GOAL"],
@@ -33,8 +33,8 @@ public sealed class BugTriageRendererTests
 
         var output = writer.ToString();
         Assert.Contains("Bug triage artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
-        Assert.Contains("Classification: implementation-impact", output, StringComparison.Ordinal);
-        Assert.Contains("Downstream action: implementation-repair", output, StringComparison.Ordinal);
+        Assert.Contains("Classification: implementation-mismatch", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream action: implementation-only", output, StringComparison.Ordinal);
         Assert.Contains("Clarification required: true", output, StringComparison.Ordinal);
         Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.triage.yaml", output, StringComparison.Ordinal);
         Assert.Contains("Implementation repair candidates: 1", output, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/BugTriageRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugTriageRendererTests.cs
@@ -15,7 +15,7 @@ public sealed class BugTriageRendererTests
             {
                 BugId = "BUG-123",
                 ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
-                Classification = "implementation-mismatch",
+                TriageClassification = "implementation-mismatch",
                 DownstreamAction = "implementation-only",
                 ClarificationRequired = true,
                 ClarificationReasons = ["execution unit roots could not be fully resolved for: G77"],
@@ -33,7 +33,7 @@ public sealed class BugTriageRendererTests
 
         var output = writer.ToString();
         Assert.Contains("Bug triage artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
-        Assert.Contains("Classification: implementation-mismatch", output, StringComparison.Ordinal);
+        Assert.Contains("Triage classification: implementation-mismatch", output, StringComparison.Ordinal);
         Assert.Contains("Downstream action: implementation-only", output, StringComparison.Ordinal);
         Assert.Contains("Clarification required: true", output, StringComparison.Ordinal);
         Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.triage.yaml", output, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/BugTriageRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugTriageRendererTests.cs
@@ -1,0 +1,46 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugTriageRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenArtifact_RendersDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        BugTriageRenderer.WriteSummary(
+            writer,
+            new BugTriageArtifact
+            {
+                BugId = "BUG-123",
+                ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
+                Classification = "implementation-impact",
+                DownstreamAction = "implementation-repair",
+                ClarificationRequired = true,
+                ClarificationReasons = ["execution unit roots could not be fully resolved for: G77"],
+                OriginalInstructionRootRefs = ["ICL.P.PRODUCT_GOAL"],
+                LinkedReviewRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"],
+                ResolvedExecutionUnits = ["G25"],
+                ResolvedImplementationRefs = [".intent-cli/issues/G25/implementation.md"],
+                ResolvedReviewContextRefs = [".intent-cli/issues/G25/review-context.md"],
+                ResolvedPacketRefs = [".intent-cli/issues/G25/packet.yaml"],
+                UnresolvedExecutionUnits = ["G77"],
+                ImplementationRepairCandidates = ["G25"],
+                IntentRepairCandidates = []
+            },
+            ".intent-cli/bugs/BUG-123.triage.yaml");
+
+        var output = writer.ToString();
+        Assert.Contains("Bug triage artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
+        Assert.Contains("Classification: implementation-impact", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream action: implementation-repair", output, StringComparison.Ordinal);
+        Assert.Contains("Clarification required: true", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.triage.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Implementation repair candidates: 1", output, StringComparison.Ordinal);
+        Assert.Contains("Intent repair candidates: 0", output, StringComparison.Ordinal);
+        Assert.Contains("Resolved execution units: 1", output, StringComparison.Ordinal);
+        Assert.Contains("Unresolved execution units: 1", output, StringComparison.Ordinal);
+        Assert.Contains("Linked review refs: 1", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1460,7 +1460,7 @@ public sealed class CommandRouterTests
 
         Assert.Equal(0, exitCode);
         Assert.Contains("Bug triage artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("Classification: implementation-mismatch", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Triage classification: implementation-mismatch", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1427,6 +1427,43 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenBugTriageCommand_DispatchesToBugTriageRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.report.yaml"),
+            BugReportArtifactYaml.Serialize(
+                new BugReportArtifact
+                {
+                    DomainSlug = "auth",
+                    BugId = "BUG-123",
+                    Title = "OAuth callback loop",
+                    ReportSource = "from-file",
+                    ProblemStatement = "Observed callback loop after login.",
+                    SuspectedFailureLocus = "Observed callback loop after login.",
+                    OriginalInstructionRefs = ["ICL.P.PRODUCT_GOAL"],
+                    AffectedIntentRefs = ["intents/intent-cli/means/auth.md"],
+                    AffectedRuleSpecRefs = ["intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
+                    ClarificationCandidates = ["Should provider retry reuse callback state token?"],
+                    LinkedExecutionUnits = ["G25"],
+                    LinkedIssueRefs = [],
+                    LinkedPrRefs = [],
+                    LinkedReviewRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"]
+                }));
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent-cli", "issues", "G25", "implementation.md"), "# Implementation");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent-cli", "issues", "G25", "review-context.md"), "# Review Context");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"), "execution_unit: G25");
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["bug", "triage", "BUG-123"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Bug triage artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Classification: implementation-and-intent-impact", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenInterviewStartCommand_DispatchesToInterviewStartRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1460,7 +1460,7 @@ public sealed class CommandRouterTests
 
         Assert.Equal(0, exitCode);
         Assert.Contains("Bug triage artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("Classification: implementation-and-intent-impact", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Classification: implementation-mismatch", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add `intent-cli bug triage <bug-id>` to read current bug report artifacts and generate deterministic triage output
- resolve linked execution unit implementation/review-context/packet roots and classify downstream recommendation without mutating queue or parent state
- add artifact, renderer, command, router, and runtime coverage for happy-path and clarification-first triage

## Testing
- dotnet test IntentSystem.sln

Closes #185