### PR TITLE
[G79] Implement bug execution command

### DIFF
--- a/src/IntentSystem.Cli/Commands/BugExecutionArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/BugExecutionArtifactPathResolver.cs
@@ -1,0 +1,11 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugExecutionArtifactPathResolver
+{
+    public static string Resolve(string bugId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bugId);
+
+        return $".intent-cli/bugs/{bugId}.execution.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugExecutionArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugExecutionArtifactYaml.cs
@@ -1,0 +1,215 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugExecutionArtifact
+{
+    public required string BugId { get; init; }
+
+    public required string ReportRef { get; init; }
+
+    public required string TriageRef { get; init; }
+
+    public required string DownstreamAction { get; init; }
+
+    public required IReadOnlyList<string> ImplementationTaskCandidates { get; init; }
+
+    public required IReadOnlyList<string> IntentTaskCandidates { get; init; }
+
+    public required bool ClarificationRequired { get; init; }
+
+    public required bool ReadyToLaunch { get; init; }
+}
+
+internal static class BugExecutionArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "bug_id",
+        "report_ref",
+        "triage_ref",
+        "downstream_action",
+        "implementation_task_candidates",
+        "intent_task_candidates",
+        "clarification_required",
+        "ready_to_launch"
+    ];
+
+    public static string Serialize(BugExecutionArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"bug_id: {artifact.BugId}",
+            $"report_ref: {Quote(artifact.ReportRef)}",
+            $"triage_ref: {Quote(artifact.TriageRef)}",
+            $"downstream_action: {artifact.DownstreamAction}",
+            $"clarification_required: {artifact.ClarificationRequired.ToString().ToLowerInvariant()}",
+            $"ready_to_launch: {artifact.ReadyToLaunch.ToString().ToLowerInvariant()}"
+        };
+
+        AppendList(lines, "implementation_task_candidates", artifact.ImplementationTaskCandidates);
+        AppendList(lines, "intent_task_candidates", artifact.IntentTaskCandidates);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static BugExecutionArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new BugExecutionArtifact
+        {
+            BugId = GetRequiredScalar(values, "bug_id"),
+            ReportRef = GetRequiredScalar(values, "report_ref"),
+            TriageRef = GetRequiredScalar(values, "triage_ref"),
+            DownstreamAction = GetRequiredScalar(values, "downstream_action"),
+            ImplementationTaskCandidates = GetRequiredList(values, "implementation_task_candidates"),
+            IntentTaskCandidates = GetRequiredList(values, "intent_task_candidates"),
+            ClarificationRequired = GetRequiredBoolean(values, "clarification_required"),
+            ReadyToLaunch = GetRequiredBoolean(values, "ready_to_launch")
+        };
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add($"{label}: []");
+            return;
+        }
+
+        lines.Add($"{label}:");
+        lines.AddRange(values.Select(value => $"  - {Quote(value)}"));
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("  - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !values.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException(
+                        $"Bug execution YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[4..].TrimStart()));
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Bug execution YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+
+            if (value.Length == 0)
+            {
+                values[key] = new List<string>();
+                currentListKey = key;
+                continue;
+            }
+
+            currentListKey = null;
+            values[key] = value switch
+            {
+                "[]" => Array.Empty<string>(),
+                "true" => true,
+                "false" => false,
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Bug execution YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException($"Bug execution YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static bool GetRequiredBoolean(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not bool booleanValue)
+        {
+            throw new InvalidOperationException($"Bug execution YAML field '{key}' must be a boolean.");
+        }
+
+        return booleanValue;
+    }
+
+    private static IReadOnlyList<string> GetRequiredList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug execution YAML field '{key}' must be a list.");
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException($"Bug execution YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugExecutionArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugExecutionArtifactYaml.cs
@@ -10,6 +10,12 @@ internal sealed record BugExecutionArtifact
 
     public required string DownstreamAction { get; init; }
 
+    public required IReadOnlyList<string> ResolvedImplementationRefs { get; init; }
+
+    public required IReadOnlyList<string> ResolvedReviewContextRefs { get; init; }
+
+    public required IReadOnlyList<string> ResolvedPacketRefs { get; init; }
+
     public required IReadOnlyList<string> ImplementationTaskCandidates { get; init; }
 
     public required IReadOnlyList<string> IntentTaskCandidates { get; init; }
@@ -27,6 +33,9 @@ internal static class BugExecutionArtifactYaml
         "report_ref",
         "triage_ref",
         "downstream_action",
+        "resolved_implementation_refs",
+        "resolved_review_context_refs",
+        "resolved_packet_refs",
         "implementation_task_candidates",
         "intent_task_candidates",
         "clarification_required",
@@ -47,6 +56,9 @@ internal static class BugExecutionArtifactYaml
             $"ready_to_launch: {artifact.ReadyToLaunch.ToString().ToLowerInvariant()}"
         };
 
+        AppendList(lines, "resolved_implementation_refs", artifact.ResolvedImplementationRefs);
+        AppendList(lines, "resolved_review_context_refs", artifact.ResolvedReviewContextRefs);
+        AppendList(lines, "resolved_packet_refs", artifact.ResolvedPacketRefs);
         AppendList(lines, "implementation_task_candidates", artifact.ImplementationTaskCandidates);
         AppendList(lines, "intent_task_candidates", artifact.IntentTaskCandidates);
 
@@ -66,6 +78,9 @@ internal static class BugExecutionArtifactYaml
             ReportRef = GetRequiredScalar(values, "report_ref"),
             TriageRef = GetRequiredScalar(values, "triage_ref"),
             DownstreamAction = GetRequiredScalar(values, "downstream_action"),
+            ResolvedImplementationRefs = GetRequiredList(values, "resolved_implementation_refs"),
+            ResolvedReviewContextRefs = GetRequiredList(values, "resolved_review_context_refs"),
+            ResolvedPacketRefs = GetRequiredList(values, "resolved_packet_refs"),
             ImplementationTaskCandidates = GetRequiredList(values, "implementation_task_candidates"),
             IntentTaskCandidates = GetRequiredList(values, "intent_task_candidates"),
             ClarificationRequired = GetRequiredBoolean(values, "clarification_required"),

--- a/src/IntentSystem.Cli/Commands/BugExecutionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugExecutionCommand.cs
@@ -47,9 +47,12 @@ internal static class BugExecutionCommand
             throw new InvalidOperationException($"Bug triage artifact was not found at {triagePath}");
         }
 
-        var report = BugReportArtifactYaml.Deserialize(File.ReadAllText(reportPath));
+        BugReportArtifactYaml.Deserialize(File.ReadAllText(reportPath));
         var triage = BugTriageArtifactYaml.Deserialize(File.ReadAllText(triagePath));
 
+        var resolvedImplementationRefs = DistinctOrdered(triage.ResolvedImplementationRefs);
+        var resolvedReviewContextRefs = DistinctOrdered(triage.ResolvedReviewContextRefs);
+        var resolvedPacketRefs = DistinctOrdered(triage.ResolvedPacketRefs);
         string[] implementationTaskCandidates;
         string[] intentTaskCandidates;
         var clarificationRequired = triage.ClarificationRequired;
@@ -61,8 +64,8 @@ internal static class BugExecutionCommand
         }
         else
         {
-            implementationTaskCandidates = NormalizeImplementationCandidates(triage);
-            intentTaskCandidates = NormalizeIntentCandidates(report, triage);
+            implementationTaskCandidates = DistinctOrdered(triage.ImplementationRepairCandidates);
+            intentTaskCandidates = DistinctOrdered(triage.IntentRepairCandidates);
         }
 
         var readyToLaunch = !clarificationRequired
@@ -75,6 +78,9 @@ internal static class BugExecutionCommand
             ReportRef = reportRef,
             TriageRef = triageRef,
             DownstreamAction = triage.DownstreamAction,
+            ResolvedImplementationRefs = resolvedImplementationRefs,
+            ResolvedReviewContextRefs = resolvedReviewContextRefs,
+            ResolvedPacketRefs = resolvedPacketRefs,
             ImplementationTaskCandidates = implementationTaskCandidates,
             IntentTaskCandidates = intentTaskCandidates,
             ClarificationRequired = clarificationRequired,
@@ -89,44 +95,6 @@ internal static class BugExecutionCommand
         };
     }
 
-    private static string[] NormalizeImplementationCandidates(BugTriageArtifact triage)
-    {
-        if (!string.Equals(triage.DownstreamAction, "implementation-only", StringComparison.Ordinal)
-            && !string.Equals(triage.DownstreamAction, "dual-track", StringComparison.Ordinal))
-        {
-            return [];
-        }
-
-        return triage.ResolvedExecutionUnits
-            .Zip(
-                triage.ResolvedPacketRefs,
-                (executionUnit, packetRef) => (executionUnit, packetRef))
-            .Zip(
-                triage.ResolvedReviewContextRefs,
-                (pair, reviewContextRef) => $"execution_unit={pair.executionUnit};packet_ref={pair.packetRef};review_context_ref={reviewContextRef}")
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
-    }
-
-    private static string[] NormalizeIntentCandidates(BugReportArtifact report, BugTriageArtifact triage)
-    {
-        if (!string.Equals(triage.DownstreamAction, "intent-only", StringComparison.Ordinal)
-            && !string.Equals(triage.DownstreamAction, "dual-track", StringComparison.Ordinal))
-        {
-            return [];
-        }
-
-        var affectedIntentCandidates = report.AffectedIntentRefs
-            .Select(reference => $"intent_ref={reference};source=intent");
-        var affectedRuleSpecCandidates = report.AffectedRuleSpecRefs
-            .Select(reference => $"intent_ref={reference};source=rule-spec");
-
-        return affectedIntentCandidates
-            .Concat(affectedRuleSpecCandidates)
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
-    }
-
     private static string WriteArtifact(string repoRoot, BugExecutionArtifact artifact)
     {
         var relativePath = BugExecutionArtifactPathResolver.Resolve(artifact.BugId);
@@ -138,5 +106,16 @@ internal static class BugExecutionCommand
         File.WriteAllText(absolutePath, BugExecutionArtifactYaml.Serialize(artifact));
 
         return relativePath;
+    }
+
+    private static string[] DistinctOrdered(IEnumerable<string> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        return values
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
     }
 }

--- a/src/IntentSystem.Cli/Commands/BugExecutionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugExecutionCommand.cs
@@ -1,0 +1,142 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugExecutionCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            BugExecutionRenderer.WriteSummary(writer, result.Artifact, result.ArtifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static BugExecutionCommandResult ExecuteCore(CliContext context, string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Bug execution command requires '<bug-id>'.");
+        }
+
+        var bugId = args[0].Trim();
+        var reportRef = $".intent-cli/bugs/{bugId}.report.yaml";
+        var triageRef = $".intent-cli/bugs/{bugId}.triage.yaml";
+
+        var reportPath = Path.GetFullPath(Path.Combine(context.RepoRoot, reportRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(reportPath))
+        {
+            throw new InvalidOperationException($"Bug report artifact was not found at {reportPath}");
+        }
+
+        var triagePath = Path.GetFullPath(Path.Combine(context.RepoRoot, triageRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(triagePath))
+        {
+            throw new InvalidOperationException($"Bug triage artifact was not found at {triagePath}");
+        }
+
+        var report = BugReportArtifactYaml.Deserialize(File.ReadAllText(reportPath));
+        var triage = BugTriageArtifactYaml.Deserialize(File.ReadAllText(triagePath));
+
+        string[] implementationTaskCandidates;
+        string[] intentTaskCandidates;
+        var clarificationRequired = triage.ClarificationRequired;
+
+        if (clarificationRequired || string.Equals(triage.DownstreamAction, "clarification-first", StringComparison.Ordinal))
+        {
+            implementationTaskCandidates = [];
+            intentTaskCandidates = [];
+        }
+        else
+        {
+            implementationTaskCandidates = NormalizeImplementationCandidates(triage);
+            intentTaskCandidates = NormalizeIntentCandidates(report, triage);
+        }
+
+        var readyToLaunch = !clarificationRequired
+            && !string.Equals(triage.DownstreamAction, "clarification-first", StringComparison.Ordinal)
+            && (implementationTaskCandidates.Length > 0 || intentTaskCandidates.Length > 0);
+
+        var artifact = new BugExecutionArtifact
+        {
+            BugId = bugId,
+            ReportRef = reportRef,
+            TriageRef = triageRef,
+            DownstreamAction = triage.DownstreamAction,
+            ImplementationTaskCandidates = implementationTaskCandidates,
+            IntentTaskCandidates = intentTaskCandidates,
+            ClarificationRequired = clarificationRequired,
+            ReadyToLaunch = readyToLaunch
+        };
+
+        var artifactPath = WriteArtifact(context.RepoRoot, artifact);
+        return new BugExecutionCommandResult
+        {
+            Artifact = artifact,
+            ArtifactPath = artifactPath
+        };
+    }
+
+    private static string[] NormalizeImplementationCandidates(BugTriageArtifact triage)
+    {
+        if (!string.Equals(triage.DownstreamAction, "implementation-only", StringComparison.Ordinal)
+            && !string.Equals(triage.DownstreamAction, "dual-track", StringComparison.Ordinal))
+        {
+            return [];
+        }
+
+        return triage.ResolvedExecutionUnits
+            .Zip(
+                triage.ResolvedPacketRefs,
+                (executionUnit, packetRef) => (executionUnit, packetRef))
+            .Zip(
+                triage.ResolvedReviewContextRefs,
+                (pair, reviewContextRef) => $"execution_unit={pair.executionUnit};packet_ref={pair.packetRef};review_context_ref={reviewContextRef}")
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string[] NormalizeIntentCandidates(BugReportArtifact report, BugTriageArtifact triage)
+    {
+        if (!string.Equals(triage.DownstreamAction, "intent-only", StringComparison.Ordinal)
+            && !string.Equals(triage.DownstreamAction, "dual-track", StringComparison.Ordinal))
+        {
+            return [];
+        }
+
+        var affectedIntentCandidates = report.AffectedIntentRefs
+            .Select(reference => $"intent_ref={reference};source=intent");
+        var affectedRuleSpecCandidates = report.AffectedRuleSpecRefs
+            .Select(reference => $"intent_ref={reference};source=rule-spec");
+
+        return affectedIntentCandidates
+            .Concat(affectedRuleSpecCandidates)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string WriteArtifact(string repoRoot, BugExecutionArtifact artifact)
+    {
+        var relativePath = BugExecutionArtifactPathResolver.Resolve(artifact.BugId);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Bug execution artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, BugExecutionArtifactYaml.Serialize(artifact));
+
+        return relativePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugExecutionCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/BugExecutionCommandResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugExecutionCommandResult
+{
+    public required BugExecutionArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/BugExecutionRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugExecutionRenderer.cs
@@ -1,0 +1,19 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugExecutionRenderer
+{
+    public static void WriteSummary(TextWriter writer, BugExecutionArtifact artifact, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Bug execution artifact generated for '{artifact.BugId}'.");
+        writer.WriteLine($"Downstream action: {artifact.DownstreamAction}");
+        writer.WriteLine($"Clarification required: {artifact.ClarificationRequired.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"Ready to launch: {artifact.ReadyToLaunch.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Implementation task candidates: {artifact.ImplementationTaskCandidates.Count}");
+        writer.WriteLine($"Intent task candidates: {artifact.IntentTaskCandidates.Count}");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -79,7 +79,8 @@ internal static class CommandRouter
             ["bug"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["report"] = BugReportCommand.Execute,
-                ["triage"] = BugTriageCommand.Execute
+                ["triage"] = BugTriageCommand.Execute,
+                ["execution"] = BugExecutionCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/tests/IntentSystem.Cli.Tests/BugExecutionArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugExecutionArtifactYamlTests.cs
@@ -13,14 +13,14 @@ public sealed class BugExecutionArtifactYamlTests
             ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
             TriageRef = ".intent-cli/bugs/BUG-123.triage.yaml",
             DownstreamAction = "dual-track",
-            ImplementationTaskCandidates =
-            [
-                "execution_unit=G25;packet_ref=.intent-cli/issues/G25/packet.yaml;review_context_ref=.intent-cli/issues/G25/review-context.md"
-            ],
+            ResolvedImplementationRefs = [".intent-cli/issues/G25/implementation.md"],
+            ResolvedReviewContextRefs = [".intent-cli/issues/G25/review-context.md"],
+            ResolvedPacketRefs = [".intent-cli/issues/G25/packet.yaml"],
+            ImplementationTaskCandidates = ["G25"],
             IntentTaskCandidates =
             [
-                "intent_ref=intents/intent-cli/means/auth.md;source=intent",
-                "intent_ref=intents/intent-cli/specs/12-bug-fix-and-intent-repair.md;source=rule-spec"
+                "intents/intent-cli/means/auth.md",
+                "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
             ],
             ClarificationRequired = false,
             ReadyToLaunch = true
@@ -33,6 +33,9 @@ public sealed class BugExecutionArtifactYamlTests
         Assert.Equal(artifact.ReportRef, roundTripped.ReportRef);
         Assert.Equal(artifact.TriageRef, roundTripped.TriageRef);
         Assert.Equal(artifact.DownstreamAction, roundTripped.DownstreamAction);
+        Assert.Equal(artifact.ResolvedImplementationRefs, roundTripped.ResolvedImplementationRefs);
+        Assert.Equal(artifact.ResolvedReviewContextRefs, roundTripped.ResolvedReviewContextRefs);
+        Assert.Equal(artifact.ResolvedPacketRefs, roundTripped.ResolvedPacketRefs);
         Assert.Equal(artifact.ImplementationTaskCandidates, roundTripped.ImplementationTaskCandidates);
         Assert.Equal(artifact.IntentTaskCandidates, roundTripped.IntentTaskCandidates);
         Assert.Equal(artifact.ClarificationRequired, roundTripped.ClarificationRequired);
@@ -46,6 +49,9 @@ public sealed class BugExecutionArtifactYamlTests
         bug_id: BUG-123
         report_ref: ".intent-cli/bugs/BUG-123.report.yaml"
         downstream_action: dual-track
+        resolved_implementation_refs: []
+        resolved_review_context_refs: []
+        resolved_packet_refs: []
         implementation_task_candidates: []
         intent_task_candidates: []
         clarification_required: false

--- a/tests/IntentSystem.Cli.Tests/BugExecutionArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugExecutionArtifactYamlTests.cs
@@ -1,0 +1,59 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugExecutionArtifactYamlTests
+{
+    [Fact]
+    public void SerializeDeserialize_RoundTripsBugExecutionArtifact()
+    {
+        var artifact = new BugExecutionArtifact
+        {
+            BugId = "BUG-123",
+            ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
+            TriageRef = ".intent-cli/bugs/BUG-123.triage.yaml",
+            DownstreamAction = "dual-track",
+            ImplementationTaskCandidates =
+            [
+                "execution_unit=G25;packet_ref=.intent-cli/issues/G25/packet.yaml;review_context_ref=.intent-cli/issues/G25/review-context.md"
+            ],
+            IntentTaskCandidates =
+            [
+                "intent_ref=intents/intent-cli/means/auth.md;source=intent",
+                "intent_ref=intents/intent-cli/specs/12-bug-fix-and-intent-repair.md;source=rule-spec"
+            ],
+            ClarificationRequired = false,
+            ReadyToLaunch = true
+        };
+
+        var yaml = BugExecutionArtifactYaml.Serialize(artifact);
+        var roundTripped = BugExecutionArtifactYaml.Deserialize(yaml);
+
+        Assert.Equal(artifact.BugId, roundTripped.BugId);
+        Assert.Equal(artifact.ReportRef, roundTripped.ReportRef);
+        Assert.Equal(artifact.TriageRef, roundTripped.TriageRef);
+        Assert.Equal(artifact.DownstreamAction, roundTripped.DownstreamAction);
+        Assert.Equal(artifact.ImplementationTaskCandidates, roundTripped.ImplementationTaskCandidates);
+        Assert.Equal(artifact.IntentTaskCandidates, roundTripped.IntentTaskCandidates);
+        Assert.Equal(artifact.ClarificationRequired, roundTripped.ClarificationRequired);
+        Assert.Equal(artifact.ReadyToLaunch, roundTripped.ReadyToLaunch);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_ThrowsInvalidOperationException()
+    {
+        var yaml = """
+        bug_id: BUG-123
+        report_ref: ".intent-cli/bugs/BUG-123.report.yaml"
+        downstream_action: dual-track
+        implementation_task_candidates: []
+        intent_task_candidates: []
+        clarification_required: false
+        ready_to_launch: true
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BugExecutionArtifactYaml.Deserialize(yaml));
+
+        Assert.Contains("triage_ref", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugExecutionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugExecutionCommandTests.cs
@@ -35,14 +35,12 @@ public sealed class BugExecutionCommandTests
         Assert.Equal("dual-track", artifact.DownstreamAction);
         Assert.False(artifact.ClarificationRequired);
         Assert.True(artifact.ReadyToLaunch);
+        Assert.Equal([".intent-cli/issues/G25/implementation.md"], artifact.ResolvedImplementationRefs);
+        Assert.Equal([".intent-cli/issues/G25/review-context.md"], artifact.ResolvedReviewContextRefs);
+        Assert.Equal([".intent-cli/issues/G25/packet.yaml"], artifact.ResolvedPacketRefs);
+        Assert.Equal(["G25"], artifact.ImplementationTaskCandidates);
         Assert.Equal(
-            ["execution_unit=G25;packet_ref=.intent-cli/issues/G25/packet.yaml;review_context_ref=.intent-cli/issues/G25/review-context.md"],
-            artifact.ImplementationTaskCandidates);
-        Assert.Equal(
-            [
-                "intent_ref=intents/intent-cli/means/auth.md;source=intent",
-                "intent_ref=intents/intent-cli/specs/12-bug-fix-and-intent-repair.md;source=rule-spec"
-            ],
+            ["intents/intent-cli/means/auth.md", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
             artifact.IntentTaskCandidates);
     }
 
@@ -101,8 +99,8 @@ public sealed class BugExecutionCommandTests
             ProblemStatement = "Observed callback loop after login.",
             SuspectedFailureLocus = "Observed callback loop after login.",
             OriginalInstructionRefs = ["ICL.P.PRODUCT_GOAL"],
-            AffectedIntentRefs = ["intents/intent-cli/means/auth.md"],
-            AffectedRuleSpecRefs = ["intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
+            AffectedIntentRefs = ["intents/intent-cli/means/auth.md", "intents/intent-cli/means/session.md"],
+            AffectedRuleSpecRefs = ["intents/intent-cli/specs/12-bug-fix-and-intent-repair.md", "intents/intent-cli/specs/99-extra.md"],
             ClarificationCandidates = ["Should provider retry reuse callback state token?"],
             LinkedExecutionUnits = ["G25"],
             LinkedIssueRefs = [],

--- a/tests/IntentSystem.Cli.Tests/BugExecutionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugExecutionCommandTests.cs
@@ -1,0 +1,185 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class BugExecutionCommandTests
+{
+    [Fact]
+    public void Execute_GivenDualTrackTriage_WritesExecutionArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.report.yaml"),
+            BugReportArtifactYaml.Serialize(CreateBugReportArtifact()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.triage.yaml"),
+            BugTriageArtifactYaml.Serialize(CreateBugTriageArtifact(
+                downstreamAction: "dual-track",
+                clarificationRequired: false)));
+        using var writer = new StringWriter();
+
+        var exitCode = BugExecutionCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Bug execution artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Ready to launch: true", writer.ToString(), StringComparison.Ordinal);
+
+        var artifact = BugExecutionArtifactYaml.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.execution.yaml")));
+        Assert.Equal("BUG-123", artifact.BugId);
+        Assert.Equal(".intent-cli/bugs/BUG-123.report.yaml", artifact.ReportRef);
+        Assert.Equal(".intent-cli/bugs/BUG-123.triage.yaml", artifact.TriageRef);
+        Assert.Equal("dual-track", artifact.DownstreamAction);
+        Assert.False(artifact.ClarificationRequired);
+        Assert.True(artifact.ReadyToLaunch);
+        Assert.Equal(
+            ["execution_unit=G25;packet_ref=.intent-cli/issues/G25/packet.yaml;review_context_ref=.intent-cli/issues/G25/review-context.md"],
+            artifact.ImplementationTaskCandidates);
+        Assert.Equal(
+            [
+                "intent_ref=intents/intent-cli/means/auth.md;source=intent",
+                "intent_ref=intents/intent-cli/specs/12-bug-fix-and-intent-repair.md;source=rule-spec"
+            ],
+            artifact.IntentTaskCandidates);
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationRequired_DoesNotInventTaskCandidates()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.report.yaml"),
+            BugReportArtifactYaml.Serialize(CreateBugReportArtifact()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.triage.yaml"),
+            BugTriageArtifactYaml.Serialize(CreateBugTriageArtifact(
+                downstreamAction: "clarification-first",
+                clarificationRequired: true)));
+        using var writer = new StringWriter();
+
+        var exitCode = BugExecutionCommand.Execute(CreateContext(repoRoot), ["BUG-124"], writer);
+
+        Assert.Equal(0, exitCode);
+
+        var artifact = BugExecutionArtifactYaml.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.execution.yaml")));
+        Assert.Equal("clarification-first", artifact.DownstreamAction);
+        Assert.True(artifact.ClarificationRequired);
+        Assert.False(artifact.ReadyToLaunch);
+        Assert.Empty(artifact.ImplementationTaskCandidates);
+        Assert.Empty(artifact.IntentTaskCandidates);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingBugTriageArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.report.yaml"),
+            BugReportArtifactYaml.Serialize(CreateBugReportArtifact()));
+        using var writer = new StringWriter();
+
+        var exitCode = BugExecutionCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Bug triage artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static BugReportArtifact CreateBugReportArtifact()
+    {
+        return new BugReportArtifact
+        {
+            DomainSlug = "auth",
+            BugId = "BUG-123",
+            Title = "OAuth callback loop",
+            ReportSource = "from-file",
+            ProblemStatement = "Observed callback loop after login.",
+            SuspectedFailureLocus = "Observed callback loop after login.",
+            OriginalInstructionRefs = ["ICL.P.PRODUCT_GOAL"],
+            AffectedIntentRefs = ["intents/intent-cli/means/auth.md"],
+            AffectedRuleSpecRefs = ["intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
+            ClarificationCandidates = ["Should provider retry reuse callback state token?"],
+            LinkedExecutionUnits = ["G25"],
+            LinkedIssueRefs = [],
+            LinkedPrRefs = [],
+            LinkedReviewRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"]
+        };
+    }
+
+    private static BugTriageArtifact CreateBugTriageArtifact(string downstreamAction, bool clarificationRequired)
+    {
+        return new BugTriageArtifact
+        {
+            BugId = "BUG-123",
+            ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
+            TriageClassification = downstreamAction == "clarification-first" ? "unknown" : "implementation-mismatch",
+            DownstreamAction = downstreamAction,
+            ClarificationRequired = clarificationRequired,
+            ClarificationReasons = clarificationRequired
+                ? ["original instruction root could not be reconstructed from current bug report artifact and linked packet/review refs."]
+                : [],
+            OriginalInstructionRootRefs = ["ICL.P.PRODUCT_GOAL"],
+            LinkedReviewRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"],
+            ResolvedExecutionUnits = ["G25"],
+            ResolvedImplementationRefs = [".intent-cli/issues/G25/implementation.md"],
+            ResolvedReviewContextRefs = [".intent-cli/issues/G25/review-context.md"],
+            ResolvedPacketRefs = [".intent-cli/issues/G25/packet.yaml"],
+            UnresolvedExecutionUnits = [],
+            ImplementationRepairCandidates = ["G25"],
+            IntentRepairCandidates = ["intents/intent-cli/means/auth.md", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"]
+        };
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-bug-execution-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugExecutionRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugExecutionRendererTests.cs
@@ -1,0 +1,42 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugExecutionRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenArtifact_RendersDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        BugExecutionRenderer.WriteSummary(
+            writer,
+            new BugExecutionArtifact
+            {
+                BugId = "BUG-123",
+                ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
+                TriageRef = ".intent-cli/bugs/BUG-123.triage.yaml",
+                DownstreamAction = "dual-track",
+                ImplementationTaskCandidates =
+                [
+                    "execution_unit=G25;packet_ref=.intent-cli/issues/G25/packet.yaml;review_context_ref=.intent-cli/issues/G25/review-context.md"
+                ],
+                IntentTaskCandidates =
+                [
+                    "intent_ref=intents/intent-cli/means/auth.md;source=intent"
+                ],
+                ClarificationRequired = false,
+                ReadyToLaunch = true
+            },
+            ".intent-cli/bugs/BUG-123.execution.yaml");
+
+        var output = writer.ToString();
+        Assert.Contains("Bug execution artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
+        Assert.Contains("Downstream action: dual-track", output, StringComparison.Ordinal);
+        Assert.Contains("Clarification required: false", output, StringComparison.Ordinal);
+        Assert.Contains("Ready to launch: true", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.execution.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Implementation task candidates: 1", output, StringComparison.Ordinal);
+        Assert.Contains("Intent task candidates: 1", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugExecutionRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugExecutionRendererTests.cs
@@ -17,14 +17,11 @@ public sealed class BugExecutionRendererTests
                 ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
                 TriageRef = ".intent-cli/bugs/BUG-123.triage.yaml",
                 DownstreamAction = "dual-track",
-                ImplementationTaskCandidates =
-                [
-                    "execution_unit=G25;packet_ref=.intent-cli/issues/G25/packet.yaml;review_context_ref=.intent-cli/issues/G25/review-context.md"
-                ],
-                IntentTaskCandidates =
-                [
-                    "intent_ref=intents/intent-cli/means/auth.md;source=intent"
-                ],
+                ResolvedImplementationRefs = [".intent-cli/issues/G25/implementation.md"],
+                ResolvedReviewContextRefs = [".intent-cli/issues/G25/review-context.md"],
+                ResolvedPacketRefs = [".intent-cli/issues/G25/packet.yaml"],
+                ImplementationTaskCandidates = ["G25"],
+                IntentTaskCandidates = ["intents/intent-cli/means/auth.md"],
                 ClarificationRequired = false,
                 ReadyToLaunch = true
             },

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1464,6 +1464,61 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenBugExecutionCommand_DispatchesToBugExecutionRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.report.yaml"),
+            BugReportArtifactYaml.Serialize(
+                new BugReportArtifact
+                {
+                    DomainSlug = "auth",
+                    BugId = "BUG-123",
+                    Title = "OAuth callback loop",
+                    ReportSource = "from-file",
+                    ProblemStatement = "Observed callback loop after login.",
+                    SuspectedFailureLocus = "Observed callback loop after login.",
+                    OriginalInstructionRefs = ["ICL.P.PRODUCT_GOAL"],
+                    AffectedIntentRefs = ["intents/intent-cli/means/auth.md"],
+                    AffectedRuleSpecRefs = ["intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
+                    ClarificationCandidates = ["Should provider retry reuse callback state token?"],
+                    LinkedExecutionUnits = ["G25"],
+                    LinkedIssueRefs = [],
+                    LinkedPrRefs = [],
+                    LinkedReviewRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"]
+                }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.triage.yaml"),
+            BugTriageArtifactYaml.Serialize(
+                new BugTriageArtifact
+                {
+                    BugId = "BUG-123",
+                    ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
+                    TriageClassification = "implementation-mismatch",
+                    DownstreamAction = "dual-track",
+                    ClarificationRequired = false,
+                    ClarificationReasons = [],
+                    OriginalInstructionRootRefs = ["ICL.P.PRODUCT_GOAL"],
+                    LinkedReviewRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"],
+                    ResolvedExecutionUnits = ["G25"],
+                    ResolvedImplementationRefs = [".intent-cli/issues/G25/implementation.md"],
+                    ResolvedReviewContextRefs = [".intent-cli/issues/G25/review-context.md"],
+                    ResolvedPacketRefs = [".intent-cli/issues/G25/packet.yaml"],
+                    UnresolvedExecutionUnits = [],
+                    ImplementationRepairCandidates = ["G25"],
+                    IntentRepairCandidates = ["intents/intent-cli/means/auth.md", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"]
+                }));
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["bug", "execution", "BUG-123"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Bug execution artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Ready to launch: true", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenInterviewStartCommand_DispatchesToInterviewStartRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- add `intent-cli bug execution <bug-id>` to normalize implementation and intent repair candidates from current bug report and triage artifacts
- generate deterministic `.intent-cli/bugs/<bug-id>.execution.yaml` with downstream action, task candidates, clarification gating, and ready-to-launch state
- add artifact, renderer, command, router, and runtime coverage for normal and clarification-first flows

## Testing
- dotnet test IntentSystem.sln

Closes #187