### PR TITLE
Implement G81 bug implementation-repair command

### DIFF
--- a/src/IntentSystem.Cli/Commands/BugImplementationRepairArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/BugImplementationRepairArtifactPathResolver.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugImplementationRepairArtifactPathResolver
+{
+    public static string Resolve(string bugId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bugId);
+        return $".intent-cli/bugs/{bugId}.implementation-repair.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugImplementationRepairArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugImplementationRepairArtifactYaml.cs
@@ -1,0 +1,210 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugImplementationRepairArtifact
+{
+    public required string BugId { get; init; }
+
+    public required string ExecutionRef { get; init; }
+
+    public required IReadOnlyList<string> ImplementationTaskCandidates { get; init; }
+
+    public required IReadOnlyList<string> ImplementationRepairTargets { get; init; }
+
+    public required string SuggestedIssueTitle { get; init; }
+
+    public required string SuggestedGoal { get; init; }
+
+    public required bool ReadyToIssueCut { get; init; }
+}
+
+internal static class BugImplementationRepairArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "bug_id",
+        "execution_ref",
+        "implementation_task_candidates",
+        "implementation_repair_targets",
+        "suggested_issue_title",
+        "suggested_goal",
+        "ready_to_issue_cut"
+    ];
+
+    public static string Serialize(BugImplementationRepairArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"bug_id: {artifact.BugId}",
+            $"execution_ref: {Quote(artifact.ExecutionRef)}",
+            $"suggested_issue_title: {Quote(artifact.SuggestedIssueTitle)}",
+            $"suggested_goal: {Quote(artifact.SuggestedGoal)}",
+            $"ready_to_issue_cut: {artifact.ReadyToIssueCut.ToString().ToLowerInvariant()}"
+        };
+
+        AppendList(lines, "implementation_task_candidates", artifact.ImplementationTaskCandidates);
+        AppendList(lines, "implementation_repair_targets", artifact.ImplementationRepairTargets);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static BugImplementationRepairArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new BugImplementationRepairArtifact
+        {
+            BugId = GetRequiredScalar(values, "bug_id"),
+            ExecutionRef = GetRequiredScalar(values, "execution_ref"),
+            ImplementationTaskCandidates = GetRequiredList(values, "implementation_task_candidates"),
+            ImplementationRepairTargets = GetRequiredList(values, "implementation_repair_targets"),
+            SuggestedIssueTitle = GetRequiredScalar(values, "suggested_issue_title"),
+            SuggestedGoal = GetRequiredScalar(values, "suggested_goal"),
+            ReadyToIssueCut = GetRequiredBoolean(values, "ready_to_issue_cut")
+        };
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add($"{label}: []");
+            return;
+        }
+
+        lines.Add($"{label}:");
+        lines.AddRange(values.Select(value => $"  - {Quote(value)}"));
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("  - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !values.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException(
+                        $"Bug implementation-repair YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[4..].TrimStart()));
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Bug implementation-repair YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+
+            if (value.Length == 0)
+            {
+                values[key] = new List<string>();
+                currentListKey = key;
+                continue;
+            }
+
+            currentListKey = null;
+            values[key] = value switch
+            {
+                "[]" => Array.Empty<string>(),
+                "true" => true,
+                "false" => false,
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Bug implementation-repair YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException($"Bug implementation-repair YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static bool GetRequiredBoolean(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not bool booleanValue)
+        {
+            throw new InvalidOperationException($"Bug implementation-repair YAML field '{key}' must be a boolean.");
+        }
+
+        return booleanValue;
+    }
+
+    private static IReadOnlyList<string> GetRequiredList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug implementation-repair YAML field '{key}' must be a list.");
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException($"Bug implementation-repair YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugImplementationRepairCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugImplementationRepairCommand.cs
@@ -1,0 +1,145 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugImplementationRepairCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            BugImplementationRepairRenderer.WriteSummary(writer, result.Artifact, result.ArtifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static BugImplementationRepairCommandResult ExecuteCore(CliContext context, string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Bug implementation-repair command requires '<bug-id>'.");
+        }
+
+        var bugId = args[0].Trim();
+        var reportRef = $".intent-cli/bugs/{bugId}.report.yaml";
+        var triageRef = $".intent-cli/bugs/{bugId}.triage.yaml";
+        var executionRef = $".intent-cli/bugs/{bugId}.execution.yaml";
+
+        var reportPath = ResolveExistingArtifactPath(context.RepoRoot, reportRef, "Bug report artifact");
+        var triagePath = ResolveExistingArtifactPath(context.RepoRoot, triageRef, "Bug triage artifact");
+        var executionPath = ResolveExistingArtifactPath(context.RepoRoot, executionRef, "Bug execution artifact");
+
+        var report = BugReportArtifactYaml.Deserialize(File.ReadAllText(reportPath));
+        var triage = BugTriageArtifactYaml.Deserialize(File.ReadAllText(triagePath));
+        var execution = BugExecutionArtifactYaml.Deserialize(File.ReadAllText(executionPath));
+
+        ValidateBugId("report", bugId, report.BugId);
+        ValidateBugId("triage", bugId, triage.BugId);
+        ValidateBugId("execution", bugId, execution.BugId);
+
+        var implementationTaskCandidates = DistinctOrdered(execution.ImplementationTaskCandidates);
+        var readyToIssueCut = !triage.ClarificationRequired
+            && !string.Equals(triage.DownstreamAction, "intent-only", StringComparison.Ordinal)
+            && implementationTaskCandidates.Length > 0;
+
+        var implementationRepairTargets = readyToIssueCut
+            ? NormalizeImplementationRepairTargets(implementationTaskCandidates)
+            : [];
+
+        var artifact = new BugImplementationRepairArtifact
+        {
+            BugId = bugId,
+            ExecutionRef = executionRef,
+            ImplementationTaskCandidates = implementationTaskCandidates,
+            ImplementationRepairTargets = implementationRepairTargets,
+            SuggestedIssueTitle = $"Implementation repair: {report.Title} ({bugId})",
+            SuggestedGoal = BuildSuggestedGoal(report, bugId, implementationRepairTargets, executionRef, readyToIssueCut),
+            ReadyToIssueCut = readyToIssueCut
+        };
+
+        var artifactPath = WriteArtifact(context.RepoRoot, artifact);
+        return new BugImplementationRepairCommandResult
+        {
+            Artifact = artifact,
+            ArtifactPath = artifactPath
+        };
+    }
+
+    private static string ResolveExistingArtifactPath(string repoRoot, string relativePath, string artifactLabel)
+    {
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(absolutePath))
+        {
+            throw new InvalidOperationException($"{artifactLabel} was not found at {absolutePath}");
+        }
+
+        return absolutePath;
+    }
+
+    private static void ValidateBugId(string source, string requestedBugId, string artifactBugId)
+    {
+        if (!string.Equals(requestedBugId, artifactBugId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Bug {source} artifact bug id '{artifactBugId}' does not match requested bug id '{requestedBugId}'.");
+        }
+    }
+
+    private static string[] NormalizeImplementationRepairTargets(IEnumerable<string> implementationTaskCandidates)
+    {
+        return implementationTaskCandidates
+            .Select(candidate => $".intent-cli/issues/{candidate}/packet.yaml")
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string BuildSuggestedGoal(
+        BugReportArtifact report,
+        string bugId,
+        IReadOnlyList<string> implementationRepairTargets,
+        string executionRef,
+        bool readyToIssueCut)
+    {
+        if (!readyToIssueCut)
+        {
+            return $"Prepare child implementation repair for '{report.Title}' ({bugId}) once issue-cut blockers are cleared from {executionRef}.";
+        }
+
+        return $"Repair child implementation targets for '{report.Title}' ({bugId}) using {executionRef}: {string.Join(", ", implementationRepairTargets)}";
+    }
+
+    private static string WriteArtifact(string repoRoot, BugImplementationRepairArtifact artifact)
+    {
+        var relativePath = BugImplementationRepairArtifactPathResolver.Resolve(artifact.BugId);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Bug implementation-repair artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, BugImplementationRepairArtifactYaml.Serialize(artifact));
+
+        return relativePath;
+    }
+
+    private static string[] DistinctOrdered(IEnumerable<string> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        return values
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugImplementationRepairCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/BugImplementationRepairCommandResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugImplementationRepairCommandResult
+{
+    public required BugImplementationRepairArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/BugImplementationRepairRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugImplementationRepairRenderer.cs
@@ -1,0 +1,18 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugImplementationRepairRenderer
+{
+    public static void WriteSummary(TextWriter writer, BugImplementationRepairArtifact artifact, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Bug implementation-repair artifact generated for '{artifact.BugId}'.");
+        writer.WriteLine($"Ready to issue cut: {artifact.ReadyToIssueCut.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Implementation task candidates: {artifact.ImplementationTaskCandidates.Count}");
+        writer.WriteLine($"Implementation repair targets: {artifact.ImplementationRepairTargets.Count}");
+        writer.WriteLine($"Suggested issue title: {artifact.SuggestedIssueTitle}");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -81,7 +81,8 @@ internal static class CommandRouter
                 ["report"] = BugReportCommand.Execute,
                 ["triage"] = BugTriageCommand.Execute,
                 ["execution"] = BugExecutionCommand.Execute,
-                ["intent-repair"] = BugIntentRepairCommand.Execute
+                ["intent-repair"] = BugIntentRepairCommand.Execute,
+                ["implementation-repair"] = BugImplementationRepairCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/tests/IntentSystem.Cli.Tests/BugImplementationRepairArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugImplementationRepairArtifactYamlTests.cs
@@ -1,0 +1,49 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugImplementationRepairArtifactYamlTests
+{
+    [Fact]
+    public void SerializeDeserialize_RoundTripsBugImplementationRepairArtifact()
+    {
+        var artifact = new BugImplementationRepairArtifact
+        {
+            BugId = "BUG-123",
+            ExecutionRef = ".intent-cli/bugs/BUG-123.execution.yaml",
+            ImplementationTaskCandidates = ["G25"],
+            ImplementationRepairTargets = [".intent-cli/issues/G25/packet.yaml"],
+            SuggestedIssueTitle = "Implementation repair: OAuth callback loop (BUG-123)",
+            SuggestedGoal = "Repair child implementation targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.execution.yaml: .intent-cli/issues/G25/packet.yaml",
+            ReadyToIssueCut = true
+        };
+
+        var yaml = BugImplementationRepairArtifactYaml.Serialize(artifact);
+        var roundTripped = BugImplementationRepairArtifactYaml.Deserialize(yaml);
+
+        Assert.Equal(artifact.BugId, roundTripped.BugId);
+        Assert.Equal(artifact.ExecutionRef, roundTripped.ExecutionRef);
+        Assert.Equal(artifact.ImplementationTaskCandidates, roundTripped.ImplementationTaskCandidates);
+        Assert.Equal(artifact.ImplementationRepairTargets, roundTripped.ImplementationRepairTargets);
+        Assert.Equal(artifact.SuggestedIssueTitle, roundTripped.SuggestedIssueTitle);
+        Assert.Equal(artifact.SuggestedGoal, roundTripped.SuggestedGoal);
+        Assert.Equal(artifact.ReadyToIssueCut, roundTripped.ReadyToIssueCut);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_ThrowsInvalidOperationException()
+    {
+        var yaml = """
+        bug_id: BUG-123
+        execution_ref: ".intent-cli/bugs/BUG-123.execution.yaml"
+        implementation_task_candidates: []
+        implementation_repair_targets: []
+        suggested_issue_title: "Implementation repair: OAuth callback loop (BUG-123)"
+        ready_to_issue_cut: false
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BugImplementationRepairArtifactYaml.Deserialize(yaml));
+
+        Assert.Contains("suggested_goal", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugImplementationRepairCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugImplementationRepairCommandTests.cs
@@ -1,0 +1,198 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class BugImplementationRepairCommandTests
+{
+    [Fact]
+    public void Execute_GivenDualTrackExecution_WritesImplementationRepairArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.report.yaml"),
+            BugReportArtifactYaml.Serialize(CreateBugReportArtifact()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.triage.yaml"),
+            BugTriageArtifactYaml.Serialize(CreateBugTriageArtifact("dual-track", clarificationRequired: false)));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.execution.yaml"),
+            BugExecutionArtifactYaml.Serialize(CreateBugExecutionArtifact("dual-track")));
+        using var writer = new StringWriter();
+
+        var exitCode = BugImplementationRepairCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Bug implementation-repair artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Ready to issue cut: true", writer.ToString(), StringComparison.Ordinal);
+
+        var artifact = BugImplementationRepairArtifactYaml.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.implementation-repair.yaml")));
+        Assert.Equal("BUG-123", artifact.BugId);
+        Assert.Equal(".intent-cli/bugs/BUG-123.execution.yaml", artifact.ExecutionRef);
+        Assert.Equal(["G25"], artifact.ImplementationTaskCandidates);
+        Assert.Equal([".intent-cli/issues/G25/packet.yaml"], artifact.ImplementationRepairTargets);
+        Assert.Equal("Implementation repair: OAuth callback loop (BUG-123)", artifact.SuggestedIssueTitle);
+        Assert.Equal(
+            "Repair child implementation targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.execution.yaml: .intent-cli/issues/G25/packet.yaml",
+            artifact.SuggestedGoal);
+        Assert.True(artifact.ReadyToIssueCut);
+    }
+
+    [Fact]
+    public void Execute_GivenIntentOnlyTriage_ReturnsNotReadyWithoutImplementationTargets()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.report.yaml"),
+            BugReportArtifactYaml.Serialize(CreateBugReportArtifact(bugId: "BUG-124")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.triage.yaml"),
+            BugTriageArtifactYaml.Serialize(CreateBugTriageArtifact("intent-only", clarificationRequired: false, bugId: "BUG-124")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.execution.yaml"),
+            BugExecutionArtifactYaml.Serialize(CreateBugExecutionArtifact("intent-only", bugId: "BUG-124")));
+        using var writer = new StringWriter();
+
+        var exitCode = BugImplementationRepairCommand.Execute(CreateContext(repoRoot), ["BUG-124"], writer);
+
+        Assert.Equal(0, exitCode);
+
+        var artifact = BugImplementationRepairArtifactYaml.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.implementation-repair.yaml")));
+        Assert.False(artifact.ReadyToIssueCut);
+        Assert.Empty(artifact.ImplementationRepairTargets);
+        Assert.Equal(["G25"], artifact.ImplementationTaskCandidates);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingBugExecutionArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.report.yaml"),
+            BugReportArtifactYaml.Serialize(CreateBugReportArtifact()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.triage.yaml"),
+            BugTriageArtifactYaml.Serialize(CreateBugTriageArtifact("dual-track", clarificationRequired: false)));
+        using var writer = new StringWriter();
+
+        var exitCode = BugImplementationRepairCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Bug execution artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static BugReportArtifact CreateBugReportArtifact(string bugId = "BUG-123")
+    {
+        return new BugReportArtifact
+        {
+            DomainSlug = "auth",
+            BugId = bugId,
+            Title = "OAuth callback loop",
+            ReportSource = "from-file",
+            ProblemStatement = "Observed callback loop after login.",
+            SuspectedFailureLocus = "Observed callback loop after login.",
+            OriginalInstructionRefs = ["ICL.P.PRODUCT_GOAL"],
+            AffectedIntentRefs = ["intents/intent-cli/means/auth.md"],
+            AffectedRuleSpecRefs = ["intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
+            ClarificationCandidates = ["Should provider retry reuse callback state token?"],
+            LinkedExecutionUnits = ["G25"],
+            LinkedIssueRefs = [],
+            LinkedPrRefs = [],
+            LinkedReviewRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"]
+        };
+    }
+
+    private static BugTriageArtifact CreateBugTriageArtifact(string downstreamAction, bool clarificationRequired, string bugId = "BUG-123")
+    {
+        return new BugTriageArtifact
+        {
+            BugId = bugId,
+            ReportRef = $".intent-cli/bugs/{bugId}.report.yaml",
+            TriageClassification = downstreamAction == "intent-only" ? "intent-gap" : "implementation-mismatch",
+            DownstreamAction = downstreamAction,
+            ClarificationRequired = clarificationRequired,
+            ClarificationReasons = clarificationRequired ? ["Need clarification."] : [],
+            OriginalInstructionRootRefs = ["ICL.P.PRODUCT_GOAL"],
+            LinkedReviewRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"],
+            ResolvedExecutionUnits = ["G25"],
+            ResolvedImplementationRefs = [".intent-cli/issues/G25/implementation.md"],
+            ResolvedReviewContextRefs = [".intent-cli/issues/G25/review-context.md"],
+            ResolvedPacketRefs = [".intent-cli/issues/G25/packet.yaml"],
+            UnresolvedExecutionUnits = [],
+            ImplementationRepairCandidates = ["G25"],
+            IntentRepairCandidates = ["intents/intent-cli/means/auth.md", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"]
+        };
+    }
+
+    private static BugExecutionArtifact CreateBugExecutionArtifact(string downstreamAction, string bugId = "BUG-123")
+    {
+        return new BugExecutionArtifact
+        {
+            BugId = bugId,
+            ReportRef = $".intent-cli/bugs/{bugId}.report.yaml",
+            TriageRef = $".intent-cli/bugs/{bugId}.triage.yaml",
+            DownstreamAction = downstreamAction,
+            ResolvedImplementationRefs = [".intent-cli/issues/G25/implementation.md"],
+            ResolvedReviewContextRefs = [".intent-cli/issues/G25/review-context.md"],
+            ResolvedPacketRefs = [".intent-cli/issues/G25/packet.yaml"],
+            ImplementationTaskCandidates = ["G25"],
+            IntentTaskCandidates = ["intents/intent-cli/means/auth.md", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
+            ClarificationRequired = false,
+            ReadyToLaunch = true
+        };
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-bug-implementation-repair-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugImplementationRepairRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugImplementationRepairRendererTests.cs
@@ -1,0 +1,34 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugImplementationRepairRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenArtifact_RendersDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        BugImplementationRepairRenderer.WriteSummary(
+            writer,
+            new BugImplementationRepairArtifact
+            {
+                BugId = "BUG-123",
+                ExecutionRef = ".intent-cli/bugs/BUG-123.execution.yaml",
+                ImplementationTaskCandidates = ["G25"],
+                ImplementationRepairTargets = [".intent-cli/issues/G25/packet.yaml"],
+                SuggestedIssueTitle = "Implementation repair: OAuth callback loop (BUG-123)",
+                SuggestedGoal = "Repair child implementation targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.execution.yaml: .intent-cli/issues/G25/packet.yaml",
+                ReadyToIssueCut = true
+            },
+            ".intent-cli/bugs/BUG-123.implementation-repair.yaml");
+
+        var output = writer.ToString();
+        Assert.Contains("Bug implementation-repair artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
+        Assert.Contains("Ready to issue cut: true", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.implementation-repair.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Implementation task candidates: 1", output, StringComparison.Ordinal);
+        Assert.Contains("Implementation repair targets: 1", output, StringComparison.Ordinal);
+        Assert.Contains("Suggested issue title: Implementation repair: OAuth callback loop (BUG-123)", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1591,6 +1591,78 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenBugImplementationRepairCommand_DispatchesToBugImplementationRepairRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.report.yaml"),
+            BugReportArtifactYaml.Serialize(
+                new BugReportArtifact
+                {
+                    DomainSlug = "auth",
+                    BugId = "BUG-123",
+                    Title = "OAuth callback loop",
+                    ReportSource = "from-file",
+                    ProblemStatement = "Observed callback loop after login.",
+                    SuspectedFailureLocus = "Observed callback loop after login.",
+                    OriginalInstructionRefs = ["ICL.P.PRODUCT_GOAL"],
+                    AffectedIntentRefs = ["intents/intent-cli/means/auth.md"],
+                    AffectedRuleSpecRefs = ["intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
+                    ClarificationCandidates = ["Should provider retry reuse callback state token?"],
+                    LinkedExecutionUnits = ["G25"],
+                    LinkedIssueRefs = [],
+                    LinkedPrRefs = [],
+                    LinkedReviewRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"]
+                }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.triage.yaml"),
+            BugTriageArtifactYaml.Serialize(
+                new BugTriageArtifact
+                {
+                    BugId = "BUG-123",
+                    ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
+                    TriageClassification = "implementation-mismatch",
+                    DownstreamAction = "dual-track",
+                    ClarificationRequired = false,
+                    ClarificationReasons = [],
+                    OriginalInstructionRootRefs = ["ICL.P.PRODUCT_GOAL"],
+                    LinkedReviewRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"],
+                    ResolvedExecutionUnits = ["G25"],
+                    ResolvedImplementationRefs = [".intent-cli/issues/G25/implementation.md"],
+                    ResolvedReviewContextRefs = [".intent-cli/issues/G25/review-context.md"],
+                    ResolvedPacketRefs = [".intent-cli/issues/G25/packet.yaml"],
+                    UnresolvedExecutionUnits = [],
+                    ImplementationRepairCandidates = ["G25"],
+                    IntentRepairCandidates = ["intents/intent-cli/means/auth.md", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"]
+                }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.execution.yaml"),
+            BugExecutionArtifactYaml.Serialize(
+                new BugExecutionArtifact
+                {
+                    BugId = "BUG-123",
+                    ReportRef = ".intent-cli/bugs/BUG-123.report.yaml",
+                    TriageRef = ".intent-cli/bugs/BUG-123.triage.yaml",
+                    DownstreamAction = "dual-track",
+                    ResolvedImplementationRefs = [".intent-cli/issues/G25/implementation.md"],
+                    ResolvedReviewContextRefs = [".intent-cli/issues/G25/review-context.md"],
+                    ResolvedPacketRefs = [".intent-cli/issues/G25/packet.yaml"],
+                    ImplementationTaskCandidates = ["G25"],
+                    IntentTaskCandidates = ["intents/intent-cli/means/auth.md", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
+                    ClarificationRequired = false,
+                    ReadyToLaunch = true
+                }));
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["bug", "implementation-repair", "BUG-123"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Bug implementation-repair artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Ready to issue cut: true", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenInterviewStartCommand_DispatchesToInterviewStartRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- add `intent-cli bug implementation-repair <bug-id>` to generate `.intent-cli/bugs/<bug-id>.implementation-repair.yaml`
- normalize execution implementation task candidates into deterministic child repair targets and suggested issue metadata
- add serializer, renderer, command tests, and router coverage

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~BugImplementationRepair|FullyQualifiedName~BugExecution|FullyQualifiedName~CommandRouter"
- dotnet test IntentSystem.sln

Closes #191