### PR TITLE
Implement G82 bug implementation-issue command

### DIFF
--- a/src/IntentSystem.Cli/Commands/BugImplementationIssueArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/BugImplementationIssueArtifactPathResolver.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugImplementationIssueArtifactPathResolver
+{
+    public static string Resolve(string bugId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bugId);
+        return $".intent-cli/bugs/{bugId}.implementation-issue.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugImplementationIssueArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugImplementationIssueArtifactYaml.cs
@@ -1,0 +1,235 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugImplementationIssueArtifact
+{
+    public required string BugId { get; init; }
+
+    public required string ImplementationRepairRef { get; init; }
+
+    public required string CreatedIssueTitle { get; init; }
+
+    public required string? CreatedIssueUrl { get; init; }
+
+    public required int? CreatedIssueNumber { get; init; }
+
+    public required IReadOnlyList<string> ImplementationRepairTargets { get; init; }
+}
+
+internal static class BugImplementationIssueArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "bug_id",
+        "implementation_repair_ref",
+        "created_issue_title",
+        "created_issue_url",
+        "created_issue_number",
+        "implementation_repair_targets"
+    ];
+
+    public static string Serialize(BugImplementationIssueArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"bug_id: {artifact.BugId}",
+            $"implementation_repair_ref: {Quote(artifact.ImplementationRepairRef)}",
+            $"created_issue_title: {Quote(artifact.CreatedIssueTitle)}",
+            $"created_issue_url: {FormatNullableScalar(artifact.CreatedIssueUrl)}",
+            $"created_issue_number: {FormatNullableInteger(artifact.CreatedIssueNumber)}"
+        };
+
+        AppendList(lines, "implementation_repair_targets", artifact.ImplementationRepairTargets);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static BugImplementationIssueArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new BugImplementationIssueArtifact
+        {
+            BugId = GetRequiredScalar(values, "bug_id"),
+            ImplementationRepairRef = GetRequiredScalar(values, "implementation_repair_ref"),
+            CreatedIssueTitle = GetRequiredScalar(values, "created_issue_title"),
+            CreatedIssueUrl = GetNullableScalar(values, "created_issue_url"),
+            CreatedIssueNumber = GetNullableInteger(values, "created_issue_number"),
+            ImplementationRepairTargets = GetRequiredList(values, "implementation_repair_targets")
+        };
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add($"{label}: []");
+            return;
+        }
+
+        lines.Add($"{label}:");
+        lines.AddRange(values.Select(value => $"  - {Quote(value)}"));
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("  - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !values.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException(
+                        $"Bug implementation-issue YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[4..].TrimStart()));
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Bug implementation-issue YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+
+            if (value.Length == 0)
+            {
+                values[key] = new List<string>();
+                currentListKey = key;
+                continue;
+            }
+
+            currentListKey = null;
+            values[key] = value switch
+            {
+                "[]" => Array.Empty<string>(),
+                "null" => null,
+                _ when int.TryParse(value, out var integerValue) => integerValue,
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Bug implementation-issue YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException($"Bug implementation-issue YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static string? GetNullableScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug implementation-issue YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            string text => text,
+            _ => throw new InvalidOperationException($"Bug implementation-issue YAML field '{key}' must be a scalar string or null.")
+        };
+    }
+
+    private static int? GetNullableInteger(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug implementation-issue YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            int integerValue => integerValue,
+            _ => throw new InvalidOperationException($"Bug implementation-issue YAML field '{key}' must be an integer or null.")
+        };
+    }
+
+    private static IReadOnlyList<string> GetRequiredList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug implementation-issue YAML field '{key}' must be a list.");
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException($"Bug implementation-issue YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+
+    private static string FormatNullableScalar(string? value)
+    {
+        return value is null ? "null" : Quote(value);
+    }
+
+    private static string FormatNullableInteger(int? value)
+    {
+        return value?.ToString() ?? "null";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugImplementationIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugImplementationIssueCommand.cs
@@ -1,0 +1,158 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugImplementationIssueCommand
+{
+    public static Func<IQueueDispatchPublisher> PublisherFactory { get; set; } = () => new GhQueueDispatchPublisher();
+
+    public static Func<IGitRemoteCommandRunner> GitCommandRunnerFactory { get; set; } = () => new GitRemoteCommandRunner();
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            BugImplementationIssueRenderer.WriteSummary(writer, result.Artifact, result.ArtifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static BugImplementationIssueCommandResult ExecuteCore(CliContext context, string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Bug implementation-issue command requires '<bug-id>'.");
+        }
+
+        var bugId = args[0].Trim();
+        var implementationRepairRef = $".intent-cli/bugs/{bugId}.implementation-repair.yaml";
+        var implementationRepairPath = ResolveExistingArtifactPath(
+            context.RepoRoot,
+            implementationRepairRef,
+            "Bug implementation-repair artifact");
+
+        var repair = BugImplementationRepairArtifactYaml.Deserialize(File.ReadAllText(implementationRepairPath));
+        if (!string.Equals(repair.BugId, bugId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Bug implementation-repair artifact bug id '{repair.BugId}' does not match requested bug id '{bugId}'.");
+        }
+
+        string? createdIssueUrl = null;
+        int? createdIssueNumber = null;
+
+        if (repair.ReadyToIssueCut)
+        {
+            var targetRepo = ResolveSingleGitHubTargetRepo(context.RepoRoot, repair.ImplementationRepairTargets);
+            var body = BuildIssueBody(repair);
+            var linkedIssue = PublisherFactory().CreateIssue(targetRepo, repair.SuggestedIssueTitle, body);
+            createdIssueUrl = linkedIssue.Url;
+            createdIssueNumber = linkedIssue.Number;
+        }
+
+        var artifact = new BugImplementationIssueArtifact
+        {
+            BugId = bugId,
+            ImplementationRepairRef = implementationRepairRef,
+            CreatedIssueTitle = repair.SuggestedIssueTitle,
+            CreatedIssueUrl = createdIssueUrl,
+            CreatedIssueNumber = createdIssueNumber,
+            ImplementationRepairTargets = repair.ImplementationRepairTargets
+        };
+
+        var artifactPath = WriteArtifact(context.RepoRoot, artifact);
+        return new BugImplementationIssueCommandResult
+        {
+            Artifact = artifact,
+            ArtifactPath = artifactPath
+        };
+    }
+
+    private static string ResolveExistingArtifactPath(string repoRoot, string relativePath, string artifactLabel)
+    {
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(absolutePath))
+        {
+            throw new InvalidOperationException($"{artifactLabel} was not found at {absolutePath}");
+        }
+
+        return absolutePath;
+    }
+
+    private static string ResolveSingleGitHubTargetRepo(string repoRoot, IReadOnlyList<string> implementationRepairTargets)
+    {
+        if (implementationRepairTargets.Count == 0)
+        {
+            throw new InvalidOperationException("Implementation repair targets must contain at least one packet ref.");
+        }
+
+        var targetRepos = new List<string>();
+        foreach (var target in implementationRepairTargets)
+        {
+            var packetPath = Path.GetFullPath(Path.Combine(repoRoot, target.Replace('/', Path.DirectorySeparatorChar)));
+            if (!File.Exists(packetPath))
+            {
+                throw new InvalidOperationException($"Implementation repair target packet was not found at {packetPath}");
+            }
+
+            var packet = ProjectionPacketRuntimeReader.Read(File.ReadAllText(packetPath));
+            if (string.IsNullOrWhiteSpace(packet.TargetRepo))
+            {
+                throw new InvalidOperationException("Projection packet must contain a target repo.");
+            }
+
+            targetRepos.Add(
+                GitHubRepositoryTargetResolver.Resolve(
+                    repoRoot,
+                    packet.TargetRepo,
+                    GitCommandRunnerFactory()));
+        }
+
+        var distinctRepos = targetRepos.Distinct(StringComparer.Ordinal).ToArray();
+        if (distinctRepos.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"Implementation repair targets must resolve to exactly one child repo, but resolved: {string.Join(", ", distinctRepos)}");
+        }
+
+        return distinctRepos[0];
+    }
+
+    private static string BuildIssueBody(BugImplementationRepairArtifact repair)
+    {
+        return string.Join(
+            Environment.NewLine,
+            [
+                $"# {repair.SuggestedIssueTitle}",
+                string.Empty,
+                repair.SuggestedGoal,
+                string.Empty,
+                "## Implementation Repair Targets",
+                ..repair.ImplementationRepairTargets.Select(target => $"- {target}")
+            ]);
+    }
+
+    private static string WriteArtifact(string repoRoot, BugImplementationIssueArtifact artifact)
+    {
+        var relativePath = BugImplementationIssueArtifactPathResolver.Resolve(artifact.BugId);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Bug implementation-issue artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, BugImplementationIssueArtifactYaml.Serialize(artifact));
+
+        return relativePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugImplementationIssueCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/BugImplementationIssueCommandResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugImplementationIssueCommandResult
+{
+    public required BugImplementationIssueArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/BugImplementationIssueRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugImplementationIssueRenderer.cs
@@ -1,0 +1,17 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugImplementationIssueRenderer
+{
+    public static void WriteSummary(TextWriter writer, BugImplementationIssueArtifact artifact, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Bug implementation-issue artifact generated for '{artifact.BugId}'.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Created issue title: {artifact.CreatedIssueTitle}");
+        writer.WriteLine($"Created issue URL: {artifact.CreatedIssueUrl ?? "not-created"}");
+        writer.WriteLine($"Implementation repair targets: {artifact.ImplementationRepairTargets.Count}");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -82,7 +82,8 @@ internal static class CommandRouter
                 ["triage"] = BugTriageCommand.Execute,
                 ["execution"] = BugExecutionCommand.Execute,
                 ["intent-repair"] = BugIntentRepairCommand.Execute,
-                ["implementation-repair"] = BugImplementationRepairCommand.Execute
+                ["implementation-repair"] = BugImplementationRepairCommand.Execute,
+                ["implementation-issue"] = BugImplementationIssueCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/tests/IntentSystem.Cli.Tests/BugImplementationIssueArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugImplementationIssueArtifactYamlTests.cs
@@ -1,0 +1,46 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugImplementationIssueArtifactYamlTests
+{
+    [Fact]
+    public void SerializeDeserialize_RoundTripsBugImplementationIssueArtifact()
+    {
+        var artifact = new BugImplementationIssueArtifact
+        {
+            BugId = "BUG-123",
+            ImplementationRepairRef = ".intent-cli/bugs/BUG-123.implementation-repair.yaml",
+            CreatedIssueTitle = "Implementation repair: OAuth callback loop (BUG-123)",
+            CreatedIssueUrl = "https://github.com/J-Tech-Japan/intent-system/issues/53",
+            CreatedIssueNumber = 53,
+            ImplementationRepairTargets = [".intent-cli/issues/G25/packet.yaml"]
+        };
+
+        var yaml = BugImplementationIssueArtifactYaml.Serialize(artifact);
+        var roundTripped = BugImplementationIssueArtifactYaml.Deserialize(yaml);
+
+        Assert.Equal(artifact.BugId, roundTripped.BugId);
+        Assert.Equal(artifact.ImplementationRepairRef, roundTripped.ImplementationRepairRef);
+        Assert.Equal(artifact.CreatedIssueTitle, roundTripped.CreatedIssueTitle);
+        Assert.Equal(artifact.CreatedIssueUrl, roundTripped.CreatedIssueUrl);
+        Assert.Equal(artifact.CreatedIssueNumber, roundTripped.CreatedIssueNumber);
+        Assert.Equal(artifact.ImplementationRepairTargets, roundTripped.ImplementationRepairTargets);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_ThrowsInvalidOperationException()
+    {
+        var yaml = """
+        bug_id: BUG-123
+        implementation_repair_ref: ".intent-cli/bugs/BUG-123.implementation-repair.yaml"
+        created_issue_title: "Implementation repair: OAuth callback loop (BUG-123)"
+        created_issue_url: null
+        implementation_repair_targets: []
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BugImplementationIssueArtifactYaml.Deserialize(yaml));
+
+        Assert.Contains("created_issue_number", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugImplementationIssueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugImplementationIssueCommandTests.cs
@@ -1,0 +1,241 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugImplementationIssueCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyImplementationRepair_CreatesSingleChildIssueAndWritesArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.implementation-repair.yaml"),
+            BugImplementationRepairArtifactYaml.Serialize(CreateRepairArtifact(readyToIssueCut: true)));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        using var writer = new StringWriter();
+        var originalPublisherFactory = BugImplementationIssueCommand.PublisherFactory;
+        var originalGitRunnerFactory = BugImplementationIssueCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            BugImplementationIssueCommand.PublisherFactory = () => new FakePublisher();
+            BugImplementationIssueCommand.GitCommandRunnerFactory = () => new FakeGitCommandRunner();
+
+            var exitCode = BugImplementationIssueCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug implementation-issue artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = BugImplementationIssueArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.implementation-issue.yaml")));
+            Assert.Equal(".intent-cli/bugs/BUG-123.implementation-repair.yaml", artifact.ImplementationRepairRef);
+            Assert.Equal("Implementation repair: OAuth callback loop (BUG-123)", artifact.CreatedIssueTitle);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/53", artifact.CreatedIssueUrl);
+            Assert.Equal(53, artifact.CreatedIssueNumber);
+            Assert.Equal([".intent-cli/issues/G25/packet.yaml"], artifact.ImplementationRepairTargets);
+        }
+        finally
+        {
+            BugImplementationIssueCommand.PublisherFactory = originalPublisherFactory;
+            BugImplementationIssueCommand.GitCommandRunnerFactory = originalGitRunnerFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyImplementationRepair_DoesNotCreateIssue()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.implementation-repair.yaml"),
+            BugImplementationRepairArtifactYaml.Serialize(CreateRepairArtifact(bugId: "BUG-124", readyToIssueCut: false)));
+        using var writer = new StringWriter();
+        var originalPublisherFactory = BugImplementationIssueCommand.PublisherFactory;
+
+        try
+        {
+            BugImplementationIssueCommand.PublisherFactory = () => new ThrowingPublisher();
+
+            var exitCode = BugImplementationIssueCommand.Execute(CreateContext(repoRoot), ["BUG-124"], writer);
+
+            Assert.Equal(0, exitCode);
+
+            var artifact = BugImplementationIssueArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.implementation-issue.yaml")));
+            Assert.Equal("Implementation repair: OAuth callback loop (BUG-124)", artifact.CreatedIssueTitle);
+            Assert.Null(artifact.CreatedIssueUrl);
+            Assert.Null(artifact.CreatedIssueNumber);
+            Assert.Empty(artifact.ImplementationRepairTargets);
+        }
+        finally
+        {
+            BugImplementationIssueCommand.PublisherFactory = originalPublisherFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingImplementationRepairArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = BugImplementationIssueCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Bug implementation-repair artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static BugImplementationRepairArtifact CreateRepairArtifact(string bugId = "BUG-123", bool readyToIssueCut = true)
+    {
+        return new BugImplementationRepairArtifact
+        {
+            BugId = bugId,
+            ExecutionRef = $".intent-cli/bugs/{bugId}.execution.yaml",
+            ImplementationTaskCandidates = readyToIssueCut ? ["G25"] : ["G25"],
+            ImplementationRepairTargets = readyToIssueCut ? [".intent-cli/issues/G25/packet.yaml"] : [],
+            SuggestedIssueTitle = $"Implementation repair: OAuth callback loop ({bugId})",
+            SuggestedGoal = readyToIssueCut
+                ? $"Repair child implementation targets for 'OAuth callback loop' ({bugId}) using .intent-cli/bugs/{bugId}.execution.yaml: .intent-cli/issues/G25/packet.yaml"
+                : $"Prepare child implementation repair for 'OAuth callback loop' ({bugId}) once issue-cut blockers are cleared from .intent-cli/bugs/{bugId}.execution.yaml.",
+            ReadyToIssueCut = readyToIssueCut
+        };
+    }
+
+    private static string CreatePacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "[G25] Repair callback flow"
+          issue_kind: "bugfix"
+          source_execution_unit: "G25"
+          goal: "Repair callback flow."
+          in_scope:
+            - "callback flow"
+          out_of_scope:
+            - "review flow"
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "auth callback"
+          dependencies: []
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "keep repair deterministic"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/issue-lifecycle-and-landing.md"
+          acceptance_criteria:
+            - "repair issue created"
+          verification_evidence:
+            - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G25"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+            - "intents/rules/issue-lifecycle-and-landing.md"
+          acceptance_criteria:
+            - "repair issue created"
+          deterministic_review_checks:
+            - "repair remains thin"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private sealed class FakePublisher : IQueueDispatchPublisher
+    {
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            return new LinkedIssue
+            {
+                Repo = targetRepo,
+                Number = 53,
+                Url = "https://github.com/J-Tech-Japan/intent-system/issues/53"
+            };
+        }
+    }
+
+    private sealed class ThrowingPublisher : IQueueDispatchPublisher
+    {
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            throw new InvalidOperationException("CreateIssue should not be called when ready_to_issue_cut is false.");
+        }
+    }
+
+    private sealed class FakeGitCommandRunner : IGitRemoteCommandRunner
+    {
+        public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            return new GitRemoteCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "git@github.com:J-Tech-Japan/intent-system.git" + Environment.NewLine,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-bug-implementation-issue-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugImplementationIssueRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugImplementationIssueRendererTests.cs
@@ -1,0 +1,32 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugImplementationIssueRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenArtifact_RendersDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        BugImplementationIssueRenderer.WriteSummary(
+            writer,
+            new BugImplementationIssueArtifact
+            {
+                BugId = "BUG-123",
+                ImplementationRepairRef = ".intent-cli/bugs/BUG-123.implementation-repair.yaml",
+                CreatedIssueTitle = "Implementation repair: OAuth callback loop (BUG-123)",
+                CreatedIssueUrl = "https://github.com/J-Tech-Japan/intent-system/issues/53",
+                CreatedIssueNumber = 53,
+                ImplementationRepairTargets = [".intent-cli/issues/G25/packet.yaml"]
+            },
+            ".intent-cli/bugs/BUG-123.implementation-issue.yaml");
+
+        var output = writer.ToString();
+        Assert.Contains("Bug implementation-issue artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.implementation-issue.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Created issue title: Implementation repair: OAuth callback loop (BUG-123)", output, StringComparison.Ordinal);
+        Assert.Contains("Created issue URL: https://github.com/J-Tech-Japan/intent-system/issues/53", output, StringComparison.Ordinal);
+        Assert.Contains("Implementation repair targets: 1", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1663,6 +1663,81 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenBugImplementationIssueCommand_DispatchesToBugImplementationIssueRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.implementation-repair.yaml"),
+            BugImplementationRepairArtifactYaml.Serialize(
+                new BugImplementationRepairArtifact
+                {
+                    BugId = "BUG-123",
+                    ExecutionRef = ".intent-cli/bugs/BUG-123.execution.yaml",
+                    ImplementationTaskCandidates = ["G25"],
+                    ImplementationRepairTargets = [".intent-cli/issues/G25/packet.yaml"],
+                    SuggestedIssueTitle = "Implementation repair: OAuth callback loop (BUG-123)",
+                    SuggestedGoal = "Repair child implementation targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.execution.yaml: .intent-cli/issues/G25/packet.yaml",
+                    ReadyToIssueCut = true
+                }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            """
+            implementation_issue_packet:
+              issue_title: "[G25] Repair callback flow"
+              issue_kind: "bugfix"
+              source_execution_unit: "G25"
+              goal: "Repair callback flow."
+              in_scope: []
+              out_of_scope: []
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "auth callback"
+              dependencies: []
+              technical_baseline: []
+              project_local_guide: []
+              intent_baseline: []
+              intent_references: []
+              rules_and_specs: []
+              acceptance_criteria: []
+              verification_evidence: []
+              review_mode: "deterministic-review"
+              completion_action: "wait-for-deterministic-review"
+              landing_policy: "merge-after-review"
+
+            review_context_packet:
+              source_execution_unit: "G25"
+              parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+              intent_references: []
+              rules_and_specs: []
+              acceptance_criteria: []
+              deterministic_review_checks: []
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        using var writer = new StringWriter();
+        var originalPublisherFactory = BugImplementationIssueCommand.PublisherFactory;
+        var originalGitRunnerFactory = BugImplementationIssueCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            BugImplementationIssueCommand.PublisherFactory = () => new FakeQueueDispatchPublisher();
+            BugImplementationIssueCommand.GitCommandRunnerFactory = () => new FakeQueueDispatchGitRunner();
+
+            var exitCode = CommandRouter.Execute(["bug", "implementation-issue", "BUG-123"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug implementation-issue artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Created issue URL: https://github.com/J-Tech-Japan/intent-system/issues/53", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            BugImplementationIssueCommand.PublisherFactory = originalPublisherFactory;
+            BugImplementationIssueCommand.GitCommandRunnerFactory = originalGitRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenInterviewStartCommand_DispatchesToInterviewStartRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- add `intent-cli bug implementation-issue <bug-id>` to create a child repair issue from `.intent-cli/bugs/<bug-id>.implementation-repair.yaml`
- persist deterministic `.intent-cli/bugs/<bug-id>.implementation-issue.yaml` with created issue metadata and carried repair targets
- add serializer, renderer, command tests, and router coverage

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~BugImplementationIssue|FullyQualifiedName~BugImplementationRepair|FullyQualifiedName~CommandRouter"
- dotnet test IntentSystem.sln

Closes #193