### PR TITLE
Rename bug execution command to bug plan

### DIFF
--- a/src/IntentSystem.Cli/Commands/BugExecutionArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/BugExecutionArtifactPathResolver.cs
@@ -6,6 +6,6 @@ internal static class BugExecutionArtifactPathResolver
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(bugId);
 
-        return $".intent-cli/bugs/{bugId}.execution.yaml";
+        return $".intent-cli/bugs/{bugId}.plan.yaml";
     }
 }

--- a/src/IntentSystem.Cli/Commands/BugExecutionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugExecutionCommand.cs
@@ -28,7 +28,7 @@ internal static class BugExecutionCommand
 
         if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
         {
-            throw new InvalidOperationException("Bug execution command requires '<bug-id>'.");
+            throw new InvalidOperationException("Bug plan command requires '<bug-id>'.");
         }
 
         var bugId = args[0].Trim();
@@ -100,7 +100,7 @@ internal static class BugExecutionCommand
         var relativePath = BugExecutionArtifactPathResolver.Resolve(artifact.BugId);
         var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
         var directoryPath = Path.GetDirectoryName(absolutePath)
-            ?? throw new InvalidOperationException("Bug execution artifact path did not contain a directory.");
+            ?? throw new InvalidOperationException("Bug plan artifact path did not contain a directory.");
 
         Directory.CreateDirectory(directoryPath);
         File.WriteAllText(absolutePath, BugExecutionArtifactYaml.Serialize(artifact));

--- a/src/IntentSystem.Cli/Commands/BugExecutionRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugExecutionRenderer.cs
@@ -8,7 +8,7 @@ internal static class BugExecutionRenderer
         ArgumentNullException.ThrowIfNull(artifact);
         ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
 
-        writer.WriteLine($"Bug execution artifact generated for '{artifact.BugId}'.");
+        writer.WriteLine($"Bug plan artifact generated for '{artifact.BugId}'.");
         writer.WriteLine($"Downstream action: {artifact.DownstreamAction}");
         writer.WriteLine($"Clarification required: {artifact.ClarificationRequired.ToString().ToLowerInvariant()}");
         writer.WriteLine($"Ready to launch: {artifact.ReadyToLaunch.ToString().ToLowerInvariant()}");

--- a/src/IntentSystem.Cli/Commands/BugImplementationRepairCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugImplementationRepairCommand.cs
@@ -34,11 +34,11 @@ internal static class BugImplementationRepairCommand
         var bugId = args[0].Trim();
         var reportRef = $".intent-cli/bugs/{bugId}.report.yaml";
         var triageRef = $".intent-cli/bugs/{bugId}.triage.yaml";
-        var executionRef = $".intent-cli/bugs/{bugId}.execution.yaml";
+        var executionRef = $".intent-cli/bugs/{bugId}.plan.yaml";
 
         var reportPath = ResolveExistingArtifactPath(context.RepoRoot, reportRef, "Bug report artifact");
         var triagePath = ResolveExistingArtifactPath(context.RepoRoot, triageRef, "Bug triage artifact");
-        var executionPath = ResolveExistingArtifactPath(context.RepoRoot, executionRef, "Bug execution artifact");
+        var executionPath = ResolveExistingArtifactPath(context.RepoRoot, executionRef, "Bug plan artifact");
 
         var report = BugReportArtifactYaml.Deserialize(File.ReadAllText(reportPath));
         var triage = BugTriageArtifactYaml.Deserialize(File.ReadAllText(triagePath));

--- a/src/IntentSystem.Cli/Commands/BugIntentRepairCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentRepairCommand.cs
@@ -34,11 +34,11 @@ internal static class BugIntentRepairCommand
         var bugId = args[0].Trim();
         var reportRef = $".intent-cli/bugs/{bugId}.report.yaml";
         var triageRef = $".intent-cli/bugs/{bugId}.triage.yaml";
-        var executionRef = $".intent-cli/bugs/{bugId}.execution.yaml";
+        var executionRef = $".intent-cli/bugs/{bugId}.plan.yaml";
 
         var reportPath = ResolveExistingArtifactPath(context.RepoRoot, reportRef, "Bug report artifact");
         var triagePath = ResolveExistingArtifactPath(context.RepoRoot, triageRef, "Bug triage artifact");
-        var executionPath = ResolveExistingArtifactPath(context.RepoRoot, executionRef, "Bug execution artifact");
+        var executionPath = ResolveExistingArtifactPath(context.RepoRoot, executionRef, "Bug plan artifact");
 
         var report = BugReportArtifactYaml.Deserialize(File.ReadAllText(reportPath));
         var triage = BugTriageArtifactYaml.Deserialize(File.ReadAllText(triagePath));

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -80,7 +80,7 @@ internal static class CommandRouter
             {
                 ["report"] = BugReportCommand.Execute,
                 ["triage"] = BugTriageCommand.Execute,
-                ["execution"] = BugExecutionCommand.Execute,
+                ["plan"] = BugExecutionCommand.Execute,
                 ["intent-repair"] = BugIntentRepairCommand.Execute,
                 ["implementation-repair"] = BugImplementationRepairCommand.Execute,
                 ["implementation-issue"] = BugImplementationIssueCommand.Execute

--- a/tests/IntentSystem.Cli.Tests/BugExecutionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugExecutionCommandTests.cs
@@ -24,11 +24,11 @@ public sealed class BugExecutionCommandTests
         var exitCode = BugExecutionCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
 
         Assert.Equal(0, exitCode);
-        Assert.Contains("Bug execution artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Bug plan artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
         Assert.Contains("Ready to launch: true", writer.ToString(), StringComparison.Ordinal);
 
         var artifact = BugExecutionArtifactYaml.Deserialize(
-            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.execution.yaml")));
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.plan.yaml")));
         Assert.Equal("BUG-123", artifact.BugId);
         Assert.Equal(".intent-cli/bugs/BUG-123.report.yaml", artifact.ReportRef);
         Assert.Equal(".intent-cli/bugs/BUG-123.triage.yaml", artifact.TriageRef);
@@ -64,7 +64,7 @@ public sealed class BugExecutionCommandTests
         Assert.Equal(0, exitCode);
 
         var artifact = BugExecutionArtifactYaml.Deserialize(
-            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.execution.yaml")));
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.plan.yaml")));
         Assert.Equal("clarification-first", artifact.DownstreamAction);
         Assert.True(artifact.ClarificationRequired);
         Assert.False(artifact.ReadyToLaunch);

--- a/tests/IntentSystem.Cli.Tests/BugExecutionRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugExecutionRendererTests.cs
@@ -25,14 +25,14 @@ public sealed class BugExecutionRendererTests
                 ClarificationRequired = false,
                 ReadyToLaunch = true
             },
-            ".intent-cli/bugs/BUG-123.execution.yaml");
+            ".intent-cli/bugs/BUG-123.plan.yaml");
 
         var output = writer.ToString();
-        Assert.Contains("Bug execution artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
+        Assert.Contains("Bug plan artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
         Assert.Contains("Downstream action: dual-track", output, StringComparison.Ordinal);
         Assert.Contains("Clarification required: false", output, StringComparison.Ordinal);
         Assert.Contains("Ready to launch: true", output, StringComparison.Ordinal);
-        Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.execution.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.plan.yaml", output, StringComparison.Ordinal);
         Assert.Contains("Implementation task candidates: 1", output, StringComparison.Ordinal);
         Assert.Contains("Intent task candidates: 1", output, StringComparison.Ordinal);
     }

--- a/tests/IntentSystem.Cli.Tests/BugImplementationIssueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugImplementationIssueCommandTests.cs
@@ -97,13 +97,13 @@ public sealed class BugImplementationIssueCommandTests
         return new BugImplementationRepairArtifact
         {
             BugId = bugId,
-            ExecutionRef = $".intent-cli/bugs/{bugId}.execution.yaml",
+            ExecutionRef = $".intent-cli/bugs/{bugId}.plan.yaml",
             ImplementationTaskCandidates = readyToIssueCut ? ["G25"] : ["G25"],
             ImplementationRepairTargets = readyToIssueCut ? [".intent-cli/issues/G25/packet.yaml"] : [],
             SuggestedIssueTitle = $"Implementation repair: OAuth callback loop ({bugId})",
             SuggestedGoal = readyToIssueCut
-                ? $"Repair child implementation targets for 'OAuth callback loop' ({bugId}) using .intent-cli/bugs/{bugId}.execution.yaml: .intent-cli/issues/G25/packet.yaml"
-                : $"Prepare child implementation repair for 'OAuth callback loop' ({bugId}) once issue-cut blockers are cleared from .intent-cli/bugs/{bugId}.execution.yaml.",
+                ? $"Repair child implementation targets for 'OAuth callback loop' ({bugId}) using .intent-cli/bugs/{bugId}.plan.yaml: .intent-cli/issues/G25/packet.yaml"
+                : $"Prepare child implementation repair for 'OAuth callback loop' ({bugId}) once issue-cut blockers are cleared from .intent-cli/bugs/{bugId}.plan.yaml.",
             ReadyToIssueCut = readyToIssueCut
         };
     }

--- a/tests/IntentSystem.Cli.Tests/BugImplementationRepairArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugImplementationRepairArtifactYamlTests.cs
@@ -10,11 +10,11 @@ public sealed class BugImplementationRepairArtifactYamlTests
         var artifact = new BugImplementationRepairArtifact
         {
             BugId = "BUG-123",
-            ExecutionRef = ".intent-cli/bugs/BUG-123.execution.yaml",
+            ExecutionRef = ".intent-cli/bugs/BUG-123.plan.yaml",
             ImplementationTaskCandidates = ["G25"],
             ImplementationRepairTargets = [".intent-cli/issues/G25/packet.yaml"],
             SuggestedIssueTitle = "Implementation repair: OAuth callback loop (BUG-123)",
-            SuggestedGoal = "Repair child implementation targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.execution.yaml: .intent-cli/issues/G25/packet.yaml",
+            SuggestedGoal = "Repair child implementation targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.plan.yaml: .intent-cli/issues/G25/packet.yaml",
             ReadyToIssueCut = true
         };
 
@@ -35,7 +35,7 @@ public sealed class BugImplementationRepairArtifactYamlTests
     {
         var yaml = """
         bug_id: BUG-123
-        execution_ref: ".intent-cli/bugs/BUG-123.execution.yaml"
+        execution_ref: ".intent-cli/bugs/BUG-123.plan.yaml"
         implementation_task_candidates: []
         implementation_repair_targets: []
         suggested_issue_title: "Implementation repair: OAuth callback loop (BUG-123)"

--- a/tests/IntentSystem.Cli.Tests/BugImplementationRepairCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugImplementationRepairCommandTests.cs
@@ -18,7 +18,7 @@ public sealed class BugImplementationRepairCommandTests
             Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.triage.yaml"),
             BugTriageArtifactYaml.Serialize(CreateBugTriageArtifact("dual-track", clarificationRequired: false)));
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.execution.yaml"),
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.plan.yaml"),
             BugExecutionArtifactYaml.Serialize(CreateBugExecutionArtifact("dual-track")));
         using var writer = new StringWriter();
 
@@ -31,12 +31,12 @@ public sealed class BugImplementationRepairCommandTests
         var artifact = BugImplementationRepairArtifactYaml.Deserialize(
             File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.implementation-repair.yaml")));
         Assert.Equal("BUG-123", artifact.BugId);
-        Assert.Equal(".intent-cli/bugs/BUG-123.execution.yaml", artifact.ExecutionRef);
+        Assert.Equal(".intent-cli/bugs/BUG-123.plan.yaml", artifact.ExecutionRef);
         Assert.Equal(["G25"], artifact.ImplementationTaskCandidates);
         Assert.Equal([".intent-cli/issues/G25/packet.yaml"], artifact.ImplementationRepairTargets);
         Assert.Equal("Implementation repair: OAuth callback loop (BUG-123)", artifact.SuggestedIssueTitle);
         Assert.Equal(
-            "Repair child implementation targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.execution.yaml: .intent-cli/issues/G25/packet.yaml",
+            "Repair child implementation targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.plan.yaml: .intent-cli/issues/G25/packet.yaml",
             artifact.SuggestedGoal);
         Assert.True(artifact.ReadyToIssueCut);
     }
@@ -53,7 +53,7 @@ public sealed class BugImplementationRepairCommandTests
             Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.triage.yaml"),
             BugTriageArtifactYaml.Serialize(CreateBugTriageArtifact("intent-only", clarificationRequired: false, bugId: "BUG-124")));
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.execution.yaml"),
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.plan.yaml"),
             BugExecutionArtifactYaml.Serialize(CreateBugExecutionArtifact("intent-only", bugId: "BUG-124")));
         using var writer = new StringWriter();
 
@@ -84,7 +84,7 @@ public sealed class BugImplementationRepairCommandTests
         var exitCode = BugImplementationRepairCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("Bug execution artifact was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Bug plan artifact was not found", writer.ToString(), StringComparison.Ordinal);
     }
 
     private static BugReportArtifact CreateBugReportArtifact(string bugId = "BUG-123")

--- a/tests/IntentSystem.Cli.Tests/BugImplementationRepairRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugImplementationRepairRendererTests.cs
@@ -14,11 +14,11 @@ public sealed class BugImplementationRepairRendererTests
             new BugImplementationRepairArtifact
             {
                 BugId = "BUG-123",
-                ExecutionRef = ".intent-cli/bugs/BUG-123.execution.yaml",
+                ExecutionRef = ".intent-cli/bugs/BUG-123.plan.yaml",
                 ImplementationTaskCandidates = ["G25"],
                 ImplementationRepairTargets = [".intent-cli/issues/G25/packet.yaml"],
                 SuggestedIssueTitle = "Implementation repair: OAuth callback loop (BUG-123)",
-                SuggestedGoal = "Repair child implementation targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.execution.yaml: .intent-cli/issues/G25/packet.yaml",
+                SuggestedGoal = "Repair child implementation targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.plan.yaml: .intent-cli/issues/G25/packet.yaml",
                 ReadyToIssueCut = true
             },
             ".intent-cli/bugs/BUG-123.implementation-repair.yaml");

--- a/tests/IntentSystem.Cli.Tests/BugIntentRepairArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentRepairArtifactYamlTests.cs
@@ -10,7 +10,7 @@ public sealed class BugIntentRepairArtifactYamlTests
         var artifact = new BugIntentRepairArtifact
         {
             BugId = "BUG-123",
-            ExecutionRef = ".intent-cli/bugs/BUG-123.execution.yaml",
+            ExecutionRef = ".intent-cli/bugs/BUG-123.plan.yaml",
             IntentTaskCandidates =
             [
                 "intents/intent-cli/means/auth.md",
@@ -22,7 +22,7 @@ public sealed class BugIntentRepairArtifactYamlTests
                 "rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
             ],
             SuggestedIssueTitle = "Intent repair: OAuth callback loop (BUG-123)",
-            SuggestedGoal = "Repair parent intent targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.execution.yaml: intent:intents/intent-cli/means/auth.md, rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md",
+            SuggestedGoal = "Repair parent intent targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.plan.yaml: intent:intents/intent-cli/means/auth.md, rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md",
             ReadyToIssueCut = true
         };
 
@@ -43,7 +43,7 @@ public sealed class BugIntentRepairArtifactYamlTests
     {
         var yaml = """
         bug_id: BUG-123
-        execution_ref: ".intent-cli/bugs/BUG-123.execution.yaml"
+        execution_ref: ".intent-cli/bugs/BUG-123.plan.yaml"
         intent_task_candidates: []
         parent_repair_targets: []
         suggested_issue_title: "Intent repair: OAuth callback loop (BUG-123)"

--- a/tests/IntentSystem.Cli.Tests/BugIntentRepairCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentRepairCommandTests.cs
@@ -18,7 +18,7 @@ public sealed class BugIntentRepairCommandTests
             Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.triage.yaml"),
             BugTriageArtifactYaml.Serialize(CreateBugTriageArtifact("dual-track", clarificationRequired: false)));
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.execution.yaml"),
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.plan.yaml"),
             BugExecutionArtifactYaml.Serialize(CreateBugExecutionArtifact("dual-track")));
         using var writer = new StringWriter();
 
@@ -31,7 +31,7 @@ public sealed class BugIntentRepairCommandTests
         var artifact = BugIntentRepairArtifactYaml.Deserialize(
             File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.intent-repair.yaml")));
         Assert.Equal("BUG-123", artifact.BugId);
-        Assert.Equal(".intent-cli/bugs/BUG-123.execution.yaml", artifact.ExecutionRef);
+        Assert.Equal(".intent-cli/bugs/BUG-123.plan.yaml", artifact.ExecutionRef);
         Assert.Equal(
             ["intents/intent-cli/means/auth.md", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
             artifact.IntentTaskCandidates);
@@ -40,7 +40,7 @@ public sealed class BugIntentRepairCommandTests
             artifact.ParentRepairTargets);
         Assert.Equal("Intent repair: OAuth callback loop (BUG-123)", artifact.SuggestedIssueTitle);
         Assert.Equal(
-            "Repair parent intent targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.execution.yaml: intent:intents/intent-cli/means/auth.md, rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md",
+            "Repair parent intent targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.plan.yaml: intent:intents/intent-cli/means/auth.md, rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md",
             artifact.SuggestedGoal);
         Assert.True(artifact.ReadyToIssueCut);
     }
@@ -57,7 +57,7 @@ public sealed class BugIntentRepairCommandTests
             Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.triage.yaml"),
             BugTriageArtifactYaml.Serialize(CreateBugTriageArtifact("implementation-only", clarificationRequired: false, bugId: "BUG-124")));
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.execution.yaml"),
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.plan.yaml"),
             BugExecutionArtifactYaml.Serialize(CreateBugExecutionArtifact("implementation-only", bugId: "BUG-124")));
         using var writer = new StringWriter();
 
@@ -90,7 +90,7 @@ public sealed class BugIntentRepairCommandTests
         var exitCode = BugIntentRepairCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("Bug execution artifact was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Bug plan artifact was not found", writer.ToString(), StringComparison.Ordinal);
     }
 
     private static BugReportArtifact CreateBugReportArtifact(string bugId = "BUG-123")

--- a/tests/IntentSystem.Cli.Tests/BugIntentRepairRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentRepairRendererTests.cs
@@ -14,11 +14,11 @@ public sealed class BugIntentRepairRendererTests
             new BugIntentRepairArtifact
             {
                 BugId = "BUG-123",
-                ExecutionRef = ".intent-cli/bugs/BUG-123.execution.yaml",
+                ExecutionRef = ".intent-cli/bugs/BUG-123.plan.yaml",
                 IntentTaskCandidates = ["intents/intent-cli/means/auth.md"],
                 ParentRepairTargets = ["intent:intents/intent-cli/means/auth.md"],
                 SuggestedIssueTitle = "Intent repair: OAuth callback loop (BUG-123)",
-                SuggestedGoal = "Repair parent intent targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.execution.yaml: intent:intents/intent-cli/means/auth.md",
+                SuggestedGoal = "Repair parent intent targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.plan.yaml: intent:intents/intent-cli/means/auth.md",
                 ReadyToIssueCut = true
             },
             ".intent-cli/bugs/BUG-123.intent-repair.yaml");

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1464,7 +1464,7 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
-    public void Execute_GivenBugExecutionCommand_DispatchesToBugExecutionRenderer()
+    public void Execute_GivenBugPlanCommand_DispatchesToBugExecutionRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -1511,11 +1511,22 @@ public sealed class CommandRouterTests
                 }));
         using var writer = new StringWriter();
 
-        var exitCode = CommandRouter.Execute(["bug", "execution", "BUG-123"], CreateContext(repoRoot), writer);
+        var exitCode = CommandRouter.Execute(["bug", "plan", "BUG-123"], CreateContext(repoRoot), writer);
 
         Assert.Equal(0, exitCode);
-        Assert.Contains("Bug execution artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Bug plan artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
         Assert.Contains("Ready to launch: true", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenRemovedBugExecutionSurface_ReturnsNotImplemented()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["bug", "execution", "BUG-123"], CreateContext("/tmp/repo"), writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Command 'bug execution' is not yet implemented.", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1565,7 +1576,7 @@ public sealed class CommandRouterTests
                     IntentRepairCandidates = ["intents/intent-cli/means/auth.md", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"]
                 }));
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.execution.yaml"),
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.plan.yaml"),
             BugExecutionArtifactYaml.Serialize(
                 new BugExecutionArtifact
                 {
@@ -1637,7 +1648,7 @@ public sealed class CommandRouterTests
                     IntentRepairCandidates = ["intents/intent-cli/means/auth.md", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"]
                 }));
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.execution.yaml"),
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.plan.yaml"),
             BugExecutionArtifactYaml.Serialize(
                 new BugExecutionArtifact
                 {
@@ -1673,11 +1684,11 @@ public sealed class CommandRouterTests
                 new BugImplementationRepairArtifact
                 {
                     BugId = "BUG-123",
-                    ExecutionRef = ".intent-cli/bugs/BUG-123.execution.yaml",
+                    ExecutionRef = ".intent-cli/bugs/BUG-123.plan.yaml",
                     ImplementationTaskCandidates = ["G25"],
                     ImplementationRepairTargets = [".intent-cli/issues/G25/packet.yaml"],
                     SuggestedIssueTitle = "Implementation repair: OAuth callback loop (BUG-123)",
-                    SuggestedGoal = "Repair child implementation targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.execution.yaml: .intent-cli/issues/G25/packet.yaml",
+                    SuggestedGoal = "Repair child implementation targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.plan.yaml: .intent-cli/issues/G25/packet.yaml",
                     ReadyToIssueCut = true
                 }));
         tempDirectory.CreateFile(


### PR DESCRIPTION
## Summary
- rename the user-facing `bug execution` command to `bug plan`
- switch the canonical bug planning artifact from `.execution.yaml` to `.plan.yaml`
- remove the old `bug execution` command surface and update downstream tests/consumers

Closes #197