### PR TITLE
Add auto-id and text input to bug report

### DIFF
--- a/src/IntentSystem.Cli/Commands/BugReportCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugReportCommand.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text;
+
 namespace IntentSystem.Cli.Commands;
 
 internal static class BugReportCommand
@@ -27,17 +30,10 @@ internal static class BugReportCommand
         ArgumentNullException.ThrowIfNull(args);
 
         var parsed = ParseArgs(args);
-        var problemStatementPath = ResolveInputPath(context.RepoRoot, parsed.ProblemStatementPath);
-        if (!File.Exists(problemStatementPath))
-        {
-            throw new InvalidOperationException($"Prepared problem statement file was not found at {problemStatementPath}");
-        }
-
-        var problemStatement = File.ReadAllText(problemStatementPath).TrimEnd();
-        if (string.IsNullOrWhiteSpace(problemStatement))
-        {
-            throw new InvalidOperationException("Prepared problem statement file must not be empty.");
-        }
+        var (problemStatement, reportSource) = ResolveProblemStatement(context.RepoRoot, parsed);
+        var bugId = string.IsNullOrWhiteSpace(parsed.BugId)
+            ? GenerateBugId(parsed.Domain, parsed.Title, problemStatement)
+            : parsed.BugId;
 
         var suspectedFailureLocus = string.IsNullOrWhiteSpace(parsed.SuspectedFailureLocus)
             ? DeriveSuspectedFailureLocus(parsed.Title, problemStatement)
@@ -46,9 +42,9 @@ internal static class BugReportCommand
         var artifact = new BugReportArtifact
         {
             DomainSlug = parsed.Domain,
-            BugId = parsed.BugId,
+            BugId = bugId,
             Title = parsed.Title,
-            ReportSource = "from-file",
+            ReportSource = reportSource,
             ProblemStatement = problemStatement,
             SuspectedFailureLocus = suspectedFailureLocus,
             OriginalInstructionRefs = parsed.OriginalInstructionRefs,
@@ -71,16 +67,30 @@ internal static class BugReportCommand
 
     private static ParsedArgs ParseArgs(string[] args)
     {
-        if (args.Length < 6 || string.IsNullOrWhiteSpace(args[0]) || string.IsNullOrWhiteSpace(args[1]))
+        if (args.Length < 3 || string.IsNullOrWhiteSpace(args[0]))
         {
             throw new InvalidOperationException(
-                "Bug report command requires '<domain> <bug-id> --title <text> --from-file <path>'.");
+                "Bug report command requires '<domain> [<bug-id>] --title <text> [--text <text> | --from-file <path>]'.");
         }
 
         var domain = args[0].Trim();
-        var bugId = args[1].Trim();
+        string? bugId = null;
+        var flagStartIndex = 1;
+        if (args.Length > 1 && !args[1].StartsWith("--", StringComparison.Ordinal))
+        {
+            if (string.IsNullOrWhiteSpace(args[1]))
+            {
+                throw new InvalidOperationException(
+                    "Bug report command requires '<domain> [<bug-id>] --title <text> [--text <text> | --from-file <path>]'.");
+            }
+
+            bugId = args[1].Trim();
+            flagStartIndex = 2;
+        }
+
         string? title = null;
         string? problemStatementPath = null;
+        string? problemStatementText = null;
         string? suspectedFailureLocus = null;
         var originalInstructionRefs = Array.Empty<string>();
         var affectedIntentRefs = Array.Empty<string>();
@@ -91,7 +101,7 @@ internal static class BugReportCommand
         var linkedPrRefs = Array.Empty<string>();
         var linkedReviewRefs = Array.Empty<string>();
 
-        for (var index = 2; index < args.Length; index += 2)
+        for (var index = flagStartIndex; index < args.Length; index += 2)
         {
             if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
             {
@@ -108,6 +118,9 @@ internal static class BugReportCommand
                     break;
                 case "--from-file":
                     problemStatementPath = value.Trim();
+                    break;
+                case "--text":
+                    problemStatementText = value;
                     break;
                 case "--suspected-failure-locus":
                     suspectedFailureLocus = value.Trim();
@@ -138,7 +151,7 @@ internal static class BugReportCommand
                     break;
                 default:
                     throw new InvalidOperationException(
-                        "Bug report command supports '--title <text>', '--from-file <path>', '--suspected-failure-locus <text>', '--instruction-refs <csv>', '--affected-intent-refs <csv>', '--affected-rule-spec-refs <csv>', '--clarification-candidates <csv>', '--execution-units <csv>', '--issues <csv>', '--prs <csv>', and '--reviews <csv>'.");
+                        "Bug report command supports '--title <text>', '--text <text>', '--from-file <path>', '--suspected-failure-locus <text>', '--instruction-refs <csv>', '--affected-intent-refs <csv>', '--affected-rule-spec-refs <csv>', '--clarification-candidates <csv>', '--execution-units <csv>', '--issues <csv>', '--prs <csv>', and '--reviews <csv>'.");
             }
         }
 
@@ -147,9 +160,12 @@ internal static class BugReportCommand
             throw new InvalidOperationException("Bug report command requires '--title <text>'.");
         }
 
-        if (string.IsNullOrWhiteSpace(problemStatementPath))
+        var hasProblemStatementPath = !string.IsNullOrWhiteSpace(problemStatementPath);
+        var hasProblemStatementText = !string.IsNullOrWhiteSpace(problemStatementText);
+        if (hasProblemStatementPath == hasProblemStatementText)
         {
-            throw new InvalidOperationException("Bug report command requires '--from-file <path>'.");
+            throw new InvalidOperationException(
+                "Bug report command requires exactly one of '--text <text>' or '--from-file <path>'.");
         }
 
         return new ParsedArgs
@@ -158,6 +174,7 @@ internal static class BugReportCommand
             BugId = bugId,
             Title = title,
             ProblemStatementPath = problemStatementPath,
+            ProblemStatementText = problemStatementText,
             SuspectedFailureLocus = suspectedFailureLocus,
             OriginalInstructionRefs = originalInstructionRefs,
             AffectedIntentRefs = affectedIntentRefs,
@@ -168,6 +185,37 @@ internal static class BugReportCommand
             LinkedPrRefs = linkedPrRefs,
             LinkedReviewRefs = linkedReviewRefs
         };
+    }
+
+    private static (string ProblemStatement, string ReportSource) ResolveProblemStatement(string repoRoot, ParsedArgs parsed)
+    {
+        if (!string.IsNullOrWhiteSpace(parsed.ProblemStatementText))
+        {
+            var problemStatementText = parsed.ProblemStatementText.TrimEnd();
+            if (string.IsNullOrWhiteSpace(problemStatementText))
+            {
+                throw new InvalidOperationException("Inline bug report text must not be empty.");
+            }
+
+            return (problemStatementText, "inline-text");
+        }
+
+        var problemStatementPath = ResolveInputPath(
+            repoRoot,
+            parsed.ProblemStatementPath
+            ?? throw new InvalidOperationException("Bug report command requires '--from-file <path>'."));
+        if (!File.Exists(problemStatementPath))
+        {
+            throw new InvalidOperationException($"Prepared problem statement file was not found at {problemStatementPath}");
+        }
+
+        var problemStatement = File.ReadAllText(problemStatementPath).TrimEnd();
+        if (string.IsNullOrWhiteSpace(problemStatement))
+        {
+            throw new InvalidOperationException("Prepared problem statement file must not be empty.");
+        }
+
+        return (problemStatement, "from-file");
     }
 
     private static string[] ParseCsvList(string value)
@@ -188,6 +236,17 @@ internal static class BugReportCommand
         }
 
         return title;
+    }
+
+    private static string GenerateBugId(string domain, string title, string problemStatement)
+    {
+        var normalizedInput = string.Join(
+            "\n",
+            domain.Trim().ToLowerInvariant(),
+            title.Trim(),
+            problemStatement.Trim());
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalizedInput));
+        return $"BUG-{Convert.ToHexString(hash)[..12]}";
     }
 
     private static string ResolveInputPath(string repoRoot, string path)
@@ -214,11 +273,13 @@ internal static class BugReportCommand
     {
         public required string Domain { get; init; }
 
-        public required string BugId { get; init; }
+        public string? BugId { get; init; }
 
         public required string Title { get; init; }
 
-        public required string ProblemStatementPath { get; init; }
+        public string? ProblemStatementPath { get; init; }
+
+        public string? ProblemStatementText { get; init; }
 
         public string? SuspectedFailureLocus { get; init; }
 

--- a/src/IntentSystem.Cli/Commands/BugReportCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugReportCommand.cs
@@ -1,10 +1,12 @@
-using System.Security.Cryptography;
+using System.Globalization;
 using System.Text;
 
 namespace IntentSystem.Cli.Commands;
 
 internal static class BugReportCommand
 {
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -32,7 +34,7 @@ internal static class BugReportCommand
         var parsed = ParseArgs(args);
         var (problemStatement, reportSource) = ResolveProblemStatement(context.RepoRoot, parsed);
         var bugId = string.IsNullOrWhiteSpace(parsed.BugId)
-            ? GenerateBugId(parsed.Domain, parsed.Title, problemStatement)
+            ? GenerateBugId(parsed.Title)
             : parsed.BugId;
 
         var suspectedFailureLocus = string.IsNullOrWhiteSpace(parsed.SuspectedFailureLocus)
@@ -238,15 +240,38 @@ internal static class BugReportCommand
         return title;
     }
 
-    private static string GenerateBugId(string domain, string title, string problemStatement)
+    private static string GenerateBugId(string title)
     {
-        var normalizedInput = string.Join(
-            "\n",
-            domain.Trim().ToLowerInvariant(),
-            title.Trim(),
-            problemStatement.Trim());
-        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalizedInput));
-        return $"BUG-{Convert.ToHexString(hash)[..12]}";
+        var currentDate = TimestampFactory().ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+        var normalizedTitle = NormalizeTitle(title);
+        return $"BUG-{currentDate}-{normalizedTitle}";
+    }
+
+    private static string NormalizeTitle(string title)
+    {
+        var builder = new StringBuilder();
+        var previousWasSeparator = false;
+
+        foreach (var character in title.Trim().ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                builder.Append(character);
+                previousWasSeparator = false;
+                continue;
+            }
+
+            if (!previousWasSeparator)
+            {
+                builder.Append('-');
+                previousWasSeparator = true;
+            }
+        }
+
+        var normalizedTitle = builder.ToString().Trim('-');
+        return string.IsNullOrWhiteSpace(normalizedTitle)
+            ? "bug-report"
+            : normalizedTitle;
     }
 
     private static string ResolveInputPath(string repoRoot, string path)

--- a/tests/IntentSystem.Cli.Tests/BugReportCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugReportCommandTests.cs
@@ -81,10 +81,13 @@ public sealed class BugReportCommandTests
     {
         using var writer = new StringWriter();
 
-        var exitCode = BugReportCommand.Execute(CreateContext("/tmp/intent-system"), ["auth", "BUG-123"], writer);
+        var exitCode = BugReportCommand.Execute(CreateContext("/tmp/intent-system"), ["auth"], writer);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("requires '<domain> <bug-id> --title <text> --from-file <path>'", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains(
+            "requires '<domain> [<bug-id>] --title <text> [--text <text> | --from-file <path>]'",
+            writer.ToString(),
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -111,6 +114,60 @@ public sealed class BugReportCommandTests
         var artifact = BugReportArtifactYaml.Deserialize(
             File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.report.yaml")));
         Assert.Equal("explicit fallback locus", artifact.SuspectedFailureLocus);
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenInlineTextWithoutBugId_GeneratesDeterministicBugId()
+    {
+        using var firstTempDirectory = new TemporaryDirectory();
+        using var secondTempDirectory = new TemporaryDirectory();
+        var firstRepoRoot = firstTempDirectory.CreateDirectory("repo");
+        var secondRepoRoot = secondTempDirectory.CreateDirectory("repo");
+        string[] args =
+        [
+            "auth",
+            "--title", "OAuth callback loop",
+            "--text", "Observed callback loop after login." + Environment.NewLine + "Affects GitHub provider path."
+        ];
+
+        var firstResult = BugReportCommand.ExecuteCore(CreateContext(firstRepoRoot), args);
+        var secondResult = BugReportCommand.ExecuteCore(CreateContext(secondRepoRoot), args);
+
+        Assert.StartsWith("BUG-", firstResult.Artifact.BugId, StringComparison.Ordinal);
+        Assert.Equal(firstResult.Artifact.BugId, secondResult.Artifact.BugId);
+        Assert.Equal(firstResult.ArtifactPath, secondResult.ArtifactPath);
+        Assert.Equal("inline-text", firstResult.Artifact.ReportSource);
+        Assert.Equal(
+            "Observed callback loop after login." + Environment.NewLine + "Affects GitHub provider path.",
+            firstResult.Artifact.ProblemStatement);
+        Assert.True(
+            File.Exists(
+                Path.Combine(firstRepoRoot, ".intent-cli", "bugs", $"{firstResult.Artifact.BugId}.report.yaml")));
+    }
+
+    [Fact]
+    public void Execute_GivenInlineTextAndPreparedFileTogether_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "prepared", "bug.md"), "Observed callback loop after login.");
+        using var writer = new StringWriter();
+
+        var exitCode = BugReportCommand.Execute(
+            CreateContext(repoRoot),
+            [
+                "auth",
+                "--title", "OAuth callback loop",
+                "--text", "Observed callback loop after login.",
+                "--from-file", "prepared/bug.md"
+            ],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains(
+            "requires exactly one of '--text <text>' or '--from-file <path>'",
+            writer.ToString(),
+            StringComparison.Ordinal);
     }
 
     private static CliContext CreateContext(string repoRoot)

--- a/tests/IntentSystem.Cli.Tests/BugReportCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugReportCommandTests.cs
@@ -7,6 +7,33 @@ namespace IntentSystem.Cli.Tests;
 public sealed class BugReportCommandTests
 {
     [Fact]
+    public void ExecuteCore_GivenInlineTextWithoutBugId_UsesCurrentDatePlusNormalizedTitle()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var originalTimestampFactory = BugReportCommand.TimestampFactory;
+        BugReportCommand.TimestampFactory = () => new DateTimeOffset(2026, 4, 9, 8, 30, 0, TimeSpan.Zero);
+
+        try
+        {
+            var result = BugReportCommand.ExecuteCore(
+                CreateContext(repoRoot),
+                [
+                    "auth",
+                    "--title", "OAuth callback loop!",
+                    "--text", "Observed callback loop after login."
+                ]);
+
+            Assert.Equal("BUG-20260409-oauth-callback-loop", result.Artifact.BugId);
+            Assert.Equal(".intent-cli/bugs/BUG-20260409-oauth-callback-loop.report.yaml", result.ArtifactPath);
+        }
+        finally
+        {
+            BugReportCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenPreparedProblemStatementAndRefs_WritesBugReportArtifact()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -117,32 +144,150 @@ public sealed class BugReportCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenInlineTextWithoutBugId_SameTitleAndDateStayDeterministicAcrossDifferentText()
+    {
+        using var firstTempDirectory = new TemporaryDirectory();
+        using var secondTempDirectory = new TemporaryDirectory();
+        var firstRepoRoot = firstTempDirectory.CreateDirectory("repo");
+        var secondRepoRoot = secondTempDirectory.CreateDirectory("repo");
+        var originalTimestampFactory = BugReportCommand.TimestampFactory;
+        BugReportCommand.TimestampFactory = () => new DateTimeOffset(2026, 4, 9, 8, 30, 0, TimeSpan.Zero);
+
+        try
+        {
+            var firstResult = BugReportCommand.ExecuteCore(
+                CreateContext(firstRepoRoot),
+                [
+                    "auth",
+                    "--title", "OAuth callback loop",
+                    "--text", "Observed callback loop after login." + Environment.NewLine + "Affects GitHub provider path."
+                ]);
+            var secondResult = BugReportCommand.ExecuteCore(
+                CreateContext(secondRepoRoot),
+                [
+                    "auth",
+                    "--title", "OAuth callback loop",
+                    "--text", "Observed callback loop after login." + Environment.NewLine + "Affects second-pass callback path."
+                ]);
+
+            Assert.Equal("BUG-20260409-oauth-callback-loop", firstResult.Artifact.BugId);
+            Assert.Equal(firstResult.Artifact.BugId, secondResult.Artifact.BugId);
+            Assert.Equal(firstResult.ArtifactPath, secondResult.ArtifactPath);
+            Assert.True(
+                File.Exists(
+                    Path.Combine(firstRepoRoot, ".intent-cli", "bugs", $"{firstResult.Artifact.BugId}.report.yaml")));
+        }
+        finally
+        {
+            BugReportCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenTextAndFileInput_ConvergeToSameArtifactShapeApartFromReportSource()
+    {
+        using var fileTempDirectory = new TemporaryDirectory();
+        using var textTempDirectory = new TemporaryDirectory();
+        var fileRepoRoot = fileTempDirectory.CreateDirectory("repo");
+        var textRepoRoot = textTempDirectory.CreateDirectory("repo");
+        fileTempDirectory.CreateFile(
+            Path.Combine("repo", "prepared", "bug.md"),
+            "Observed callback loop after login." + Environment.NewLine + "Affects GitHub provider path.");
+        var originalTimestampFactory = BugReportCommand.TimestampFactory;
+        BugReportCommand.TimestampFactory = () => new DateTimeOffset(2026, 4, 9, 8, 30, 0, TimeSpan.Zero);
+
+        try
+        {
+            var fileResult = BugReportCommand.ExecuteCore(
+                CreateContext(fileRepoRoot),
+                [
+                    "auth",
+                    "--title", "OAuth callback loop",
+                    "--from-file", "prepared/bug.md",
+                    "--instruction-refs", "ICL.P.PRODUCT_GOAL",
+                    "--affected-intent-refs", "intents/intent-cli/means/auth.md",
+                    "--affected-rule-spec-refs", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md",
+                    "--clarification-candidates", "Should provider retry reuse callback state token?",
+                    "--execution-units", "G25",
+                    "--issues", "https://github.com/J-Tech-Japan/intent-system/issues/178",
+                    "--prs", "https://github.com/J-Tech-Japan/intent-system/pull/180",
+                    "--reviews", "https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"
+                ]);
+            var textResult = BugReportCommand.ExecuteCore(
+                CreateContext(textRepoRoot),
+                [
+                    "auth",
+                    "--title", "OAuth callback loop",
+                    "--text", "Observed callback loop after login." + Environment.NewLine + "Affects GitHub provider path.",
+                    "--instruction-refs", "ICL.P.PRODUCT_GOAL",
+                    "--affected-intent-refs", "intents/intent-cli/means/auth.md",
+                    "--affected-rule-spec-refs", "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md",
+                    "--clarification-candidates", "Should provider retry reuse callback state token?",
+                    "--execution-units", "G25",
+                    "--issues", "https://github.com/J-Tech-Japan/intent-system/issues/178",
+                    "--prs", "https://github.com/J-Tech-Japan/intent-system/pull/180",
+                    "--reviews", "https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"
+                ]);
+
+            Assert.Equal(fileResult.Artifact.DomainSlug, textResult.Artifact.DomainSlug);
+            Assert.Equal(fileResult.Artifact.BugId, textResult.Artifact.BugId);
+            Assert.Equal(fileResult.Artifact.Title, textResult.Artifact.Title);
+            Assert.Equal(fileResult.Artifact.ProblemStatement, textResult.Artifact.ProblemStatement);
+            Assert.Equal(fileResult.Artifact.SuspectedFailureLocus, textResult.Artifact.SuspectedFailureLocus);
+            Assert.Equal(fileResult.Artifact.OriginalInstructionRefs, textResult.Artifact.OriginalInstructionRefs);
+            Assert.Equal(fileResult.Artifact.AffectedIntentRefs, textResult.Artifact.AffectedIntentRefs);
+            Assert.Equal(fileResult.Artifact.AffectedRuleSpecRefs, textResult.Artifact.AffectedRuleSpecRefs);
+            Assert.Equal(fileResult.Artifact.ClarificationCandidates, textResult.Artifact.ClarificationCandidates);
+            Assert.Equal(fileResult.Artifact.LinkedExecutionUnits, textResult.Artifact.LinkedExecutionUnits);
+            Assert.Equal(fileResult.Artifact.LinkedIssueRefs, textResult.Artifact.LinkedIssueRefs);
+            Assert.Equal(fileResult.Artifact.LinkedPrRefs, textResult.Artifact.LinkedPrRefs);
+            Assert.Equal(fileResult.Artifact.LinkedReviewRefs, textResult.Artifact.LinkedReviewRefs);
+            Assert.Equal("from-file", fileResult.Artifact.ReportSource);
+            Assert.Equal("inline-text", textResult.Artifact.ReportSource);
+        }
+        finally
+        {
+            BugReportCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenInlineTextWithoutBugId_GeneratesDeterministicBugId()
     {
         using var firstTempDirectory = new TemporaryDirectory();
         using var secondTempDirectory = new TemporaryDirectory();
         var firstRepoRoot = firstTempDirectory.CreateDirectory("repo");
         var secondRepoRoot = secondTempDirectory.CreateDirectory("repo");
-        string[] args =
-        [
-            "auth",
-            "--title", "OAuth callback loop",
-            "--text", "Observed callback loop after login." + Environment.NewLine + "Affects GitHub provider path."
-        ];
+        var originalTimestampFactory = BugReportCommand.TimestampFactory;
+        BugReportCommand.TimestampFactory = () => new DateTimeOffset(2026, 4, 9, 8, 30, 0, TimeSpan.Zero);
 
-        var firstResult = BugReportCommand.ExecuteCore(CreateContext(firstRepoRoot), args);
-        var secondResult = BugReportCommand.ExecuteCore(CreateContext(secondRepoRoot), args);
+        try
+        {
+            string[] args =
+            [
+                "auth",
+                "--title", "OAuth callback loop",
+                "--text", "Observed callback loop after login." + Environment.NewLine + "Affects GitHub provider path."
+            ];
 
-        Assert.StartsWith("BUG-", firstResult.Artifact.BugId, StringComparison.Ordinal);
-        Assert.Equal(firstResult.Artifact.BugId, secondResult.Artifact.BugId);
-        Assert.Equal(firstResult.ArtifactPath, secondResult.ArtifactPath);
-        Assert.Equal("inline-text", firstResult.Artifact.ReportSource);
-        Assert.Equal(
-            "Observed callback loop after login." + Environment.NewLine + "Affects GitHub provider path.",
-            firstResult.Artifact.ProblemStatement);
-        Assert.True(
-            File.Exists(
-                Path.Combine(firstRepoRoot, ".intent-cli", "bugs", $"{firstResult.Artifact.BugId}.report.yaml")));
+            var firstResult = BugReportCommand.ExecuteCore(CreateContext(firstRepoRoot), args);
+            var secondResult = BugReportCommand.ExecuteCore(CreateContext(secondRepoRoot), args);
+
+            Assert.Equal("BUG-20260409-oauth-callback-loop", firstResult.Artifact.BugId);
+            Assert.Equal(firstResult.Artifact.BugId, secondResult.Artifact.BugId);
+            Assert.Equal(firstResult.ArtifactPath, secondResult.ArtifactPath);
+            Assert.Equal("inline-text", firstResult.Artifact.ReportSource);
+            Assert.Equal(
+                "Observed callback loop after login." + Environment.NewLine + "Affects GitHub provider path.",
+                firstResult.Artifact.ProblemStatement);
+            Assert.True(
+                File.Exists(
+                    Path.Combine(firstRepoRoot, ".intent-cli", "bugs", $"{firstResult.Artifact.BugId}.report.yaml")));
+        }
+        finally
+        {
+            BugReportCommand.TimestampFactory = originalTimestampFactory;
+        }
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1464,6 +1464,29 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenBugReportCommandWithoutBugIdAndWithText_DispatchesToBugReportRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(
+            [
+                "bug",
+                "report",
+                "auth",
+                "--title", "OAuth callback loop",
+                "--text", "Observed callback loop after login." + Environment.NewLine + "Affects GitHub provider path."
+            ],
+            CreateContext(repoRoot),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Bug report artifact generated for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Bug ID: BUG-", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenBugPlanCommand_DispatchesToBugExecutionRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- allow `bug report` to omit `bug-id` and deterministically generate one from the input
- add inline `--text <text>` support alongside existing `--from-file <path>` input
- keep the existing explicit bug-id and file-based path intact while tightening router and command coverage

Closes #196