### PR TITLE
Add bug intent issue command

### DIFF
--- a/src/IntentSystem.Cli/Commands/BugIntentIssueArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentIssueArtifactPathResolver.cs
@@ -1,0 +1,11 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentIssueArtifactPathResolver
+{
+    public static string Resolve(string bugId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bugId);
+
+        return $".intent-cli/bugs/{bugId}.intent-issue.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentIssueArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentIssueArtifactYaml.cs
@@ -1,0 +1,237 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentIssueArtifact
+{
+    public required string BugId { get; init; }
+
+    public required string IntentRepairRef { get; init; }
+
+    public required string CreatedIssueTitle { get; init; }
+
+    public required string? CreatedIssueUrl { get; init; }
+
+    public required int? CreatedIssueNumber { get; init; }
+
+    public required IReadOnlyList<string> ParentRepairTargets { get; init; }
+}
+
+internal static class BugIntentIssueArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "bug_id",
+        "intent_repair_ref",
+        "created_issue_title",
+        "created_issue_url",
+        "created_issue_number",
+        "parent_repair_targets"
+    ];
+
+    public static string Serialize(BugIntentIssueArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"bug_id: {artifact.BugId}",
+            $"intent_repair_ref: {Quote(artifact.IntentRepairRef)}",
+            $"created_issue_title: {Quote(artifact.CreatedIssueTitle)}",
+            $"created_issue_url: {FormatNullableScalar(artifact.CreatedIssueUrl)}",
+            $"created_issue_number: {FormatNullableInteger(artifact.CreatedIssueNumber)}"
+        };
+
+        AppendList(lines, "parent_repair_targets", artifact.ParentRepairTargets);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static BugIntentIssueArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new BugIntentIssueArtifact
+        {
+            BugId = GetRequiredScalar(values, "bug_id"),
+            IntentRepairRef = GetRequiredScalar(values, "intent_repair_ref"),
+            CreatedIssueTitle = GetRequiredScalar(values, "created_issue_title"),
+            CreatedIssueUrl = GetNullableScalar(values, "created_issue_url"),
+            CreatedIssueNumber = GetNullableInteger(values, "created_issue_number"),
+            ParentRepairTargets = GetRequiredList(values, "parent_repair_targets")
+        };
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add($"{label}: []");
+            return;
+        }
+
+        lines.Add($"{label}:");
+        lines.AddRange(values.Select(value => $"  - {Quote(value)}"));
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("  - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !values.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException(
+                        $"Bug intent-issue YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[4..].TrimStart()));
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Bug intent-issue YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+
+            if (value.Length == 0)
+            {
+                values[key] = new List<string>();
+                currentListKey = key;
+                continue;
+            }
+
+            currentListKey = null;
+            values[key] = value switch
+            {
+                "[]" => Array.Empty<string>(),
+                "null" => null,
+                _ when int.TryParse(value, out var integerValue) => integerValue,
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Bug intent-issue YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException($"Bug intent-issue YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static string? GetNullableScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug intent-issue YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            string text => text,
+            _ => throw new InvalidOperationException($"Bug intent-issue YAML field '{key}' must be a scalar string or null.")
+        };
+    }
+
+    private static int? GetNullableInteger(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug intent-issue YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            int integerValue => integerValue,
+            _ => throw new InvalidOperationException($"Bug intent-issue YAML field '{key}' must be an integer or null.")
+        };
+    }
+
+    private static IReadOnlyList<string> GetRequiredList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug intent-issue YAML field '{key}' must be a list.");
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException($"Bug intent-issue YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+
+    private static string FormatNullableScalar(string? value)
+    {
+        return value is null
+            ? "null"
+            : Quote(value);
+    }
+
+    private static string FormatNullableInteger(int? value)
+    {
+        return value?.ToString() ?? "null";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentIssueCommand.cs
@@ -54,7 +54,7 @@ internal static class BugIntentIssueCommand
 
         if (repair.ReadyToIssueCut)
         {
-            var targetRepo = ResolveParentGitHubTargetRepo(context);
+            var targetRepo = ResolveParentGitHubTargetRepo(context, repair);
             var body = BuildIssueBody(repair);
             var linkedIssue = PublisherFactory().CreateIssue(targetRepo, repair.SuggestedIssueTitle, body);
             createdIssueUrl = linkedIssue.Url;
@@ -90,19 +90,9 @@ internal static class BugIntentIssueCommand
         return absolutePath;
     }
 
-    private static string ResolveParentGitHubTargetRepo(CliContext context)
+    private static string ResolveParentGitHubTargetRepo(CliContext context, BugIntentRepairArtifact repair)
     {
-        var parentRepoRoot = context.ResolveParentIntentRepoRootPath();
-        if (string.IsNullOrWhiteSpace(parentRepoRoot))
-        {
-            throw new InvalidOperationException("Parent intent repo root is not configured.");
-        }
-
-        if (!Directory.Exists(parentRepoRoot))
-        {
-            throw new InvalidOperationException($"Parent intent repo root was not found at {parentRepoRoot}");
-        }
-
+        var parentRepoRoot = ResolveParentRepoRoot(context, repair.ParentRepairTargets);
         var result = GitCommandRunnerFactory().Run(parentRepoRoot, ["remote", "get-url", "origin"]);
         if (result.ExitCode != 0)
         {
@@ -113,6 +103,63 @@ internal static class BugIntentIssueCommand
         }
 
         return GitHubRepositoryTargetResolver.ParseRemoteUrl(result.StdOut.Trim());
+    }
+
+    private static string ResolveParentRepoRoot(CliContext context, IReadOnlyList<string> parentRepairTargets)
+    {
+        if (parentRepairTargets.Count == 0)
+        {
+            throw new InvalidOperationException("Parent repair targets must contain at least one target.");
+        }
+
+        var normalizedTargetPaths = parentRepairTargets
+            .Select(NormalizeParentRepairTargetPath)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        var candidates = new List<string>();
+        var configuredParentRepoRoot = context.ResolveParentIntentRepoRootPath();
+        if (!string.IsNullOrWhiteSpace(configuredParentRepoRoot))
+        {
+            candidates.Add(configuredParentRepoRoot);
+        }
+
+        var repoParentDirectory = Directory.GetParent(context.RepoRoot);
+        if (repoParentDirectory is not null)
+        {
+            candidates.AddRange(
+                repoParentDirectory.EnumerateDirectories()
+                    .Select(directory => directory.FullName)
+                    .Where(path => !string.Equals(path, context.RepoRoot, StringComparison.Ordinal)));
+        }
+
+        var matchingRoots = candidates
+            .Distinct(StringComparer.Ordinal)
+            .Where(Directory.Exists)
+            .Where(candidate => normalizedTargetPaths.All(
+                target => File.Exists(Path.Combine(candidate, target.Replace('/', Path.DirectorySeparatorChar)))))
+            .ToArray();
+
+        return matchingRoots.Length switch
+        {
+            1 => matchingRoots[0],
+            0 => throw new InvalidOperationException("Current parent repo root could not be resolved from parent repair targets."),
+            _ => throw new InvalidOperationException(
+                $"Parent repair targets resolved to multiple candidate parent repo roots: {string.Join(", ", matchingRoots)}")
+        };
+    }
+
+    private static string NormalizeParentRepairTargetPath(string target)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(target);
+
+        var separatorIndex = target.IndexOf(':');
+        if (separatorIndex < 0 || separatorIndex == target.Length - 1)
+        {
+            throw new InvalidOperationException($"Parent repair target '{target}' must use the kind:path shape.");
+        }
+
+        return target[(separatorIndex + 1)..].Trim();
     }
 
     private static string BuildIssueBody(BugIntentRepairArtifact repair)

--- a/src/IntentSystem.Cli/Commands/BugIntentIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentIssueCommand.cs
@@ -1,0 +1,144 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentIssueCommand
+{
+    public static Func<IQueueDispatchPublisher> PublisherFactory { get; set; } = () => new GhQueueDispatchPublisher();
+
+    public static Func<IGitRemoteCommandRunner> GitCommandRunnerFactory { get; set; } = () => new GitRemoteCommandRunner();
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            BugIntentIssueRenderer.WriteSummary(writer, result.Artifact, result.ArtifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static BugIntentIssueCommandResult ExecuteCore(CliContext context, string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Bug intent-issue command requires '<bug-id>'.");
+        }
+
+        var bugId = args[0].Trim();
+        var intentRepairRef = $".intent-cli/bugs/{bugId}.intent-repair.yaml";
+        var intentRepairPath = ResolveExistingArtifactPath(
+            context.RepoRoot,
+            intentRepairRef,
+            "Bug intent-repair artifact");
+
+        var repair = BugIntentRepairArtifactYaml.Deserialize(File.ReadAllText(intentRepairPath));
+        if (!string.Equals(repair.BugId, bugId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Bug intent-repair artifact bug id '{repair.BugId}' does not match requested bug id '{bugId}'.");
+        }
+
+        string? createdIssueUrl = null;
+        int? createdIssueNumber = null;
+
+        if (repair.ReadyToIssueCut)
+        {
+            var targetRepo = ResolveParentGitHubTargetRepo(context);
+            var body = BuildIssueBody(repair);
+            var linkedIssue = PublisherFactory().CreateIssue(targetRepo, repair.SuggestedIssueTitle, body);
+            createdIssueUrl = linkedIssue.Url;
+            createdIssueNumber = linkedIssue.Number;
+        }
+
+        var artifact = new BugIntentIssueArtifact
+        {
+            BugId = bugId,
+            IntentRepairRef = intentRepairRef,
+            CreatedIssueTitle = repair.SuggestedIssueTitle,
+            CreatedIssueUrl = createdIssueUrl,
+            CreatedIssueNumber = createdIssueNumber,
+            ParentRepairTargets = repair.ParentRepairTargets
+        };
+
+        var artifactPath = WriteArtifact(context.RepoRoot, artifact);
+        return new BugIntentIssueCommandResult
+        {
+            Artifact = artifact,
+            ArtifactPath = artifactPath
+        };
+    }
+
+    private static string ResolveExistingArtifactPath(string repoRoot, string relativePath, string artifactLabel)
+    {
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(absolutePath))
+        {
+            throw new InvalidOperationException($"{artifactLabel} was not found at {absolutePath}");
+        }
+
+        return absolutePath;
+    }
+
+    private static string ResolveParentGitHubTargetRepo(CliContext context)
+    {
+        var parentRepoRoot = context.ResolveParentIntentRepoRootPath();
+        if (string.IsNullOrWhiteSpace(parentRepoRoot))
+        {
+            throw new InvalidOperationException("Parent intent repo root is not configured.");
+        }
+
+        if (!Directory.Exists(parentRepoRoot))
+        {
+            throw new InvalidOperationException($"Parent intent repo root was not found at {parentRepoRoot}");
+        }
+
+        var result = GitCommandRunnerFactory().Run(parentRepoRoot, ["remote", "get-url", "origin"]);
+        if (result.ExitCode != 0)
+        {
+            var error = string.IsNullOrWhiteSpace(result.StdErr)
+                ? "git remote get-url origin failed."
+                : result.StdErr.Trim();
+            throw new InvalidOperationException(error);
+        }
+
+        return GitHubRepositoryTargetResolver.ParseRemoteUrl(result.StdOut.Trim());
+    }
+
+    private static string BuildIssueBody(BugIntentRepairArtifact repair)
+    {
+        return string.Join(
+            Environment.NewLine,
+            [
+                $"# {repair.SuggestedIssueTitle}",
+                string.Empty,
+                repair.SuggestedGoal,
+                string.Empty,
+                "## Parent Repair Targets",
+                ..repair.ParentRepairTargets.Select(target => $"- {target}")
+            ]);
+    }
+
+    private static string WriteArtifact(string repoRoot, BugIntentIssueArtifact artifact)
+    {
+        var relativePath = BugIntentIssueArtifactPathResolver.Resolve(artifact.BugId);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Bug intent-issue artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, BugIntentIssueArtifactYaml.Serialize(artifact));
+
+        return relativePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentIssueCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentIssueCommandResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentIssueCommandResult
+{
+    public required BugIntentIssueArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentIssueRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentIssueRenderer.cs
@@ -1,0 +1,17 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentIssueRenderer
+{
+    public static void WriteSummary(TextWriter writer, BugIntentIssueArtifact artifact, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Bug intent-issue artifact generated for '{artifact.BugId}'.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Created issue title: {artifact.CreatedIssueTitle}");
+        writer.WriteLine($"Created issue URL: {artifact.CreatedIssueUrl ?? "not-created"}");
+        writer.WriteLine($"Parent repair targets: {artifact.ParentRepairTargets.Count}");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -82,6 +82,7 @@ internal static class CommandRouter
                 ["triage"] = BugTriageCommand.Execute,
                 ["plan"] = BugExecutionCommand.Execute,
                 ["intent-repair"] = BugIntentRepairCommand.Execute,
+                ["intent-issue"] = BugIntentIssueCommand.Execute,
                 ["implementation-repair"] = BugImplementationRepairCommand.Execute,
                 ["implementation-issue"] = BugImplementationIssueCommand.Execute
             },

--- a/tests/IntentSystem.Cli.Tests/BugIntentIssueArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentIssueArtifactYamlTests.cs
@@ -1,0 +1,50 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentIssueArtifactYamlTests
+{
+    [Fact]
+    public void SerializeDeserialize_RoundTripsBugIntentIssueArtifact()
+    {
+        var artifact = new BugIntentIssueArtifact
+        {
+            BugId = "BUG-123",
+            IntentRepairRef = ".intent-cli/bugs/BUG-123.intent-repair.yaml",
+            CreatedIssueTitle = "Intent repair: OAuth callback loop (BUG-123)",
+            CreatedIssueUrl = "https://github.com/J-Tech-Japan/MyIntentHost/issues/53",
+            CreatedIssueNumber = 53,
+            ParentRepairTargets =
+            [
+                "intent:intents/intent-cli/means/auth.md",
+                "rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
+            ]
+        };
+
+        var yaml = BugIntentIssueArtifactYaml.Serialize(artifact);
+        var roundTripped = BugIntentIssueArtifactYaml.Deserialize(yaml);
+
+        Assert.Equal(artifact.BugId, roundTripped.BugId);
+        Assert.Equal(artifact.IntentRepairRef, roundTripped.IntentRepairRef);
+        Assert.Equal(artifact.CreatedIssueTitle, roundTripped.CreatedIssueTitle);
+        Assert.Equal(artifact.CreatedIssueUrl, roundTripped.CreatedIssueUrl);
+        Assert.Equal(artifact.CreatedIssueNumber, roundTripped.CreatedIssueNumber);
+        Assert.Equal(artifact.ParentRepairTargets, roundTripped.ParentRepairTargets);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_ThrowsInvalidOperationException()
+    {
+        var yaml = """
+        bug_id: BUG-123
+        intent_repair_ref: ".intent-cli/bugs/BUG-123.intent-repair.yaml"
+        created_issue_title: "Intent repair: OAuth callback loop (BUG-123)"
+        created_issue_url: null
+        parent_repair_targets: []
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BugIntentIssueArtifactYaml.Deserialize(yaml));
+
+        Assert.Contains("created_issue_number", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentIssueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentIssueCommandTests.cs
@@ -11,7 +11,10 @@ public sealed class BugIntentIssueCommandTests
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
-        tempDirectory.CreateDirectory("parent-intent");
+        tempDirectory.CreateFile(Path.Combine("parent-intent", "intents", "intent-cli", "means", "auth.md"), "# auth");
+        tempDirectory.CreateFile(
+            Path.Combine("parent-intent", "intents", "intent-cli", "specs", "12-bug-fix-and-intent-repair.md"),
+            "# spec");
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-repair.yaml"),
             BugIntentRepairArtifactYaml.Serialize(CreateRepairArtifact(readyToIssueCut: true)));
@@ -124,8 +127,7 @@ public sealed class BugIntentIssueCommandTests
                 {
                     Domain = "intent-system",
                     WorkflowEngine = "intent-cli",
-                    ArtifactRoot = ".intent-cli",
-                    ParentIntentRepoRoot = "../parent-intent"
+                    ArtifactRoot = ".intent-cli"
                 }
             }
         };

--- a/tests/IntentSystem.Cli.Tests/BugIntentIssueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentIssueCommandTests.cs
@@ -1,0 +1,198 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentIssueCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyIntentRepair_CreatesSingleParentIssueAndWritesArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory("parent-intent");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-repair.yaml"),
+            BugIntentRepairArtifactYaml.Serialize(CreateRepairArtifact(readyToIssueCut: true)));
+        using var writer = new StringWriter();
+        var originalPublisherFactory = BugIntentIssueCommand.PublisherFactory;
+        var originalGitRunnerFactory = BugIntentIssueCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            BugIntentIssueCommand.PublisherFactory = () => new FakePublisher();
+            BugIntentIssueCommand.GitCommandRunnerFactory = () => new FakeGitCommandRunner();
+
+            var exitCode = BugIntentIssueCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-issue artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = BugIntentIssueArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.intent-issue.yaml")));
+            Assert.Equal(".intent-cli/bugs/BUG-123.intent-repair.yaml", artifact.IntentRepairRef);
+            Assert.Equal("Intent repair: OAuth callback loop (BUG-123)", artifact.CreatedIssueTitle);
+            Assert.Equal("https://github.com/J-Tech-Japan/MyIntentHost/issues/53", artifact.CreatedIssueUrl);
+            Assert.Equal(53, artifact.CreatedIssueNumber);
+            Assert.Equal(
+                ["intent:intents/intent-cli/means/auth.md", "rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
+                artifact.ParentRepairTargets);
+        }
+        finally
+        {
+            BugIntentIssueCommand.PublisherFactory = originalPublisherFactory;
+            BugIntentIssueCommand.GitCommandRunnerFactory = originalGitRunnerFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyIntentRepair_DoesNotCreateIssue()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.intent-repair.yaml"),
+            BugIntentRepairArtifactYaml.Serialize(CreateRepairArtifact(bugId: "BUG-124", readyToIssueCut: false)));
+        using var writer = new StringWriter();
+        var originalPublisherFactory = BugIntentIssueCommand.PublisherFactory;
+
+        try
+        {
+            BugIntentIssueCommand.PublisherFactory = () => new ThrowingPublisher();
+
+            var exitCode = BugIntentIssueCommand.Execute(CreateContext(repoRoot), ["BUG-124"], writer);
+
+            Assert.Equal(0, exitCode);
+
+            var artifact = BugIntentIssueArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.intent-issue.yaml")));
+            Assert.Equal("Intent repair: OAuth callback loop (BUG-124)", artifact.CreatedIssueTitle);
+            Assert.Null(artifact.CreatedIssueUrl);
+            Assert.Null(artifact.CreatedIssueNumber);
+            Assert.Empty(artifact.ParentRepairTargets);
+        }
+        finally
+        {
+            BugIntentIssueCommand.PublisherFactory = originalPublisherFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingIntentRepairArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = BugIntentIssueCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Bug intent-repair artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static BugIntentRepairArtifact CreateRepairArtifact(string bugId = "BUG-123", bool readyToIssueCut = true)
+    {
+        return new BugIntentRepairArtifact
+        {
+            BugId = bugId,
+            ExecutionRef = $".intent-cli/bugs/{bugId}.plan.yaml",
+            IntentTaskCandidates =
+            [
+                "intents/intent-cli/means/auth.md",
+                "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
+            ],
+            ParentRepairTargets = readyToIssueCut
+                ? ["intent:intents/intent-cli/means/auth.md", "rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"]
+                : [],
+            SuggestedIssueTitle = $"Intent repair: OAuth callback loop ({bugId})",
+            SuggestedGoal = readyToIssueCut
+                ? $"Repair parent intent targets for 'OAuth callback loop' ({bugId}) using .intent-cli/bugs/{bugId}.plan.yaml: intent:intents/intent-cli/means/auth.md, rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
+                : $"Prepare parent intent repair for 'OAuth callback loop' ({bugId}) once issue-cut blockers are cleared from .intent-cli/bugs/{bugId}.plan.yaml.",
+            ReadyToIssueCut = readyToIssueCut
+        };
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    ParentIntentRepoRoot = "../parent-intent"
+                }
+            }
+        };
+    }
+
+    private sealed class FakePublisher : IQueueDispatchPublisher
+    {
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            return new LinkedIssue
+            {
+                Repo = targetRepo,
+                Number = 53,
+                Url = "https://github.com/J-Tech-Japan/MyIntentHost/issues/53"
+            };
+        }
+    }
+
+    private sealed class ThrowingPublisher : IQueueDispatchPublisher
+    {
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            throw new InvalidOperationException("CreateIssue should not be called when ready_to_issue_cut is false.");
+        }
+    }
+
+    private sealed class FakeGitCommandRunner : IGitRemoteCommandRunner
+    {
+        public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            return new GitRemoteCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "git@github.com:J-Tech-Japan/MyIntentHost.git" + Environment.NewLine,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-bug-intent-issue-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentIssueRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentIssueRendererTests.cs
@@ -1,0 +1,36 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentIssueRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenArtifact_RendersDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        BugIntentIssueRenderer.WriteSummary(
+            writer,
+            new BugIntentIssueArtifact
+            {
+                BugId = "BUG-123",
+                IntentRepairRef = ".intent-cli/bugs/BUG-123.intent-repair.yaml",
+                CreatedIssueTitle = "Intent repair: OAuth callback loop (BUG-123)",
+                CreatedIssueUrl = "https://github.com/J-Tech-Japan/MyIntentHost/issues/53",
+                CreatedIssueNumber = 53,
+                ParentRepairTargets =
+                [
+                    "intent:intents/intent-cli/means/auth.md",
+                    "rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
+                ]
+            },
+            ".intent-cli/bugs/BUG-123.intent-issue.yaml");
+
+        var output = writer.ToString();
+        Assert.Contains("Bug intent-issue artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.intent-issue.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Created issue title: Intent repair: OAuth callback loop (BUG-123)", output, StringComparison.Ordinal);
+        Assert.Contains("Created issue URL: https://github.com/J-Tech-Japan/MyIntentHost/issues/53", output, StringComparison.Ordinal);
+        Assert.Contains("Parent repair targets: 2", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1776,6 +1776,10 @@ public sealed class CommandRouterTests
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("parent-intent", "intents", "intent-cli", "means", "auth.md"), "# auth");
+        tempDirectory.CreateFile(
+            Path.Combine("parent-intent", "intents", "intent-cli", "specs", "12-bug-fix-and-intent-repair.md"),
+            "# spec");
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-repair.yaml"),
             BugIntentRepairArtifactYaml.Serialize(
@@ -1807,7 +1811,7 @@ public sealed class CommandRouterTests
             BugIntentIssueCommand.PublisherFactory = () => new FakeQueueDispatchPublisher();
             BugIntentIssueCommand.GitCommandRunnerFactory = () => new FakeParentIntentGitRunner();
 
-            var exitCode = CommandRouter.Execute(["bug", "intent-issue", "BUG-123"], CreateContext(repoRoot, "../parent-intent"), writer);
+            var exitCode = CommandRouter.Execute(["bug", "intent-issue", "BUG-123"], CreateContext(repoRoot), writer);
 
             Assert.Equal(0, exitCode);
             Assert.Contains("Bug intent-issue artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1772,6 +1772,55 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenBugIntentIssueCommand_DispatchesToBugIntentIssueRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-repair.yaml"),
+            BugIntentRepairArtifactYaml.Serialize(
+                new BugIntentRepairArtifact
+                {
+                    BugId = "BUG-123",
+                    ExecutionRef = ".intent-cli/bugs/BUG-123.plan.yaml",
+                    IntentTaskCandidates =
+                    [
+                        "intents/intent-cli/means/auth.md",
+                        "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
+                    ],
+                    ParentRepairTargets =
+                    [
+                        "intent:intents/intent-cli/means/auth.md",
+                        "rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
+                    ],
+                    SuggestedIssueTitle = "Intent repair: OAuth callback loop (BUG-123)",
+                    SuggestedGoal = "Repair parent intent targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.plan.yaml: intent:intents/intent-cli/means/auth.md, rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md",
+                    ReadyToIssueCut = true
+                }));
+        tempDirectory.CreateDirectory(Path.Combine("parent-intent"));
+        using var writer = new StringWriter();
+        var originalPublisherFactory = BugIntentIssueCommand.PublisherFactory;
+        var originalGitRunnerFactory = BugIntentIssueCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            BugIntentIssueCommand.PublisherFactory = () => new FakeQueueDispatchPublisher();
+            BugIntentIssueCommand.GitCommandRunnerFactory = () => new FakeParentIntentGitRunner();
+
+            var exitCode = CommandRouter.Execute(["bug", "intent-issue", "BUG-123"], CreateContext(repoRoot, "../parent-intent"), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-issue artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Created issue URL: https://github.com/J-Tech-Japan/intent-system/issues/53", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            BugIntentIssueCommand.PublisherFactory = originalPublisherFactory;
+            BugIntentIssueCommand.GitCommandRunnerFactory = originalGitRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenInterviewStartCommand_DispatchesToInterviewStartRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -4686,6 +4735,19 @@ recommended_updates:
             {
                 ExitCode = 0,
                 StdOut = "git@github.com:J-Tech-Japan/intent-system.git" + Environment.NewLine,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class FakeParentIntentGitRunner : IGitRemoteCommandRunner
+    {
+        public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            return new GitRemoteCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "git@github.com:J-Tech-Japan/MyIntentHost.git" + Environment.NewLine,
                 StdErr = string.Empty
             };
         }


### PR DESCRIPTION
## Summary
- add `intent-cli bug intent-issue <bug-id>` to cut parent-side repair issues from current bug intent-repair artifacts
- resolve the current parent repo target from configured `parent_intent_repo_root` and its `origin` remote
- persist deterministic `.intent-cli/bugs/<bug-id>.intent-issue.yaml` artifacts and cover renderer/runtime/router paths

Closes #195