### PR TITLE
Restore generate-from-current activate command

### DIFF
--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentActivateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentActivateCommand.cs
@@ -1,0 +1,83 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentActivateCommand
+{
+    private static readonly string[] DeferredActivationStages =
+    [
+        "issue-generation",
+        "launch"
+    ];
+
+    public static Func<CliContext, string[], GenerateFromCurrentAdvanceResult> AdvanceExecutor { get; set; } =
+        (context, args) => GenerateFromCurrentAdvanceCommand.ExecuteCore(context, args);
+
+    public static Func<CliContext, string, TextWriter, IntakeStartResult> IntakeStartExecutor { get; set; } =
+        (context, domain, writer) => IntakeStartCommand.ExecuteCore(context, domain, writer);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args, writer);
+            GenerateFromCurrentActivateRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static GenerateFromCurrentActivateResult ExecuteCore(CliContext context, string[] args, TextWriter writer)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Generate-from-current activate requires a domain.");
+        }
+
+        var domain = args[0].Trim();
+        var advanceResult = AdvanceExecutor(context, args);
+
+        if (!string.Equals(advanceResult.ReadinessStatus, "ready", StringComparison.Ordinal))
+        {
+            return new GenerateFromCurrentActivateResult
+            {
+                Domain = domain,
+                SourceBundleArtifactPath = advanceResult.SourceBundleArtifactPath,
+                ReconstructedArtifactPaths = advanceResult.ReconstructedArtifactPaths,
+                StandardIntakeArtifactPaths = advanceResult.StandardIntakeArtifactPaths,
+                UpdatedSourceFilePaths = advanceResult.UpdatedSourceFilePaths,
+                UpdatedExecutionFilePaths = advanceResult.UpdatedExecutionFilePaths,
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                StartedExecutionUnits = [],
+                ReadinessStatus = advanceResult.ReadinessStatus,
+                SkippedStages = advanceResult.SkippedStages.Concat(DeferredActivationStages).ToArray()
+            };
+        }
+
+        var startResult = IntakeStartExecutor(context, domain, writer);
+
+        return new GenerateFromCurrentActivateResult
+        {
+            Domain = domain,
+            SourceBundleArtifactPath = advanceResult.SourceBundleArtifactPath,
+            ReconstructedArtifactPaths = advanceResult.ReconstructedArtifactPaths,
+            StandardIntakeArtifactPaths = advanceResult.StandardIntakeArtifactPaths,
+            UpdatedSourceFilePaths = advanceResult.UpdatedSourceFilePaths,
+            UpdatedExecutionFilePaths = advanceResult.UpdatedExecutionFilePaths,
+            GeneratedIssueArtifactPaths = startResult.GeneratedArtifactPaths,
+            CreatedIssueRefs = startResult.CreatedIssueRefs,
+            WorktreePaths = startResult.WorktreePaths,
+            StartedExecutionUnits = startResult.StartedExecutionUnits,
+            ReadinessStatus = advanceResult.ReadinessStatus,
+            SkippedStages = advanceResult.SkippedStages
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentActivateRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentActivateRenderer.cs
@@ -1,0 +1,46 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class GenerateFromCurrentActivateRenderer
+{
+    public static void WriteSummary(TextWriter writer, GenerateFromCurrentActivateResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Generate-from-current activate processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Source bundle artifact path: {result.SourceBundleArtifactPath}");
+        writer.WriteLine("Reconstructed artifact paths:");
+        WriteList(writer, result.ReconstructedArtifactPaths);
+        writer.WriteLine("Regenerated standard intake artifact paths:");
+        WriteList(writer, result.StandardIntakeArtifactPaths);
+        writer.WriteLine("Updated source file paths:");
+        WriteList(writer, result.UpdatedSourceFilePaths);
+        writer.WriteLine("Updated execution file paths:");
+        WriteList(writer, result.UpdatedExecutionFilePaths);
+        writer.WriteLine("Generated issue artifact paths:");
+        WriteList(writer, result.GeneratedIssueArtifactPaths);
+        writer.WriteLine("Created issue refs:");
+        WriteList(writer, result.CreatedIssueRefs);
+        writer.WriteLine("Worktree paths:");
+        WriteList(writer, result.WorktreePaths);
+        writer.WriteLine("Started execution units:");
+        WriteList(writer, result.StartedExecutionUnits);
+        writer.WriteLine($"Readiness status: {result.ReadinessStatus}");
+        writer.WriteLine("Skipped stages:");
+        WriteList(writer, result.SkippedStages);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentActivateResult.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentActivateResult.cs
@@ -1,0 +1,28 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record GenerateFromCurrentActivateResult
+{
+    public required string Domain { get; init; }
+
+    public required string SourceBundleArtifactPath { get; init; }
+
+    public required IReadOnlyList<string> ReconstructedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> StandardIntakeArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedSourceFilePaths { get; init; }
+
+    public required IReadOnlyList<string> UpdatedExecutionFilePaths { get; init; }
+
+    public required IReadOnlyList<string> GeneratedIssueArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedIssueRefs { get; init; }
+
+    public required IReadOnlyList<string> WorktreePaths { get; init; }
+
+    public required IReadOnlyList<string> StartedExecutionUnits { get; init; }
+
+    public required string ReadinessStatus { get; init; }
+
+    public required IReadOnlyList<string> SkippedStages { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentCommand.cs
@@ -46,6 +46,12 @@ internal static class GenerateFromCurrentCommand
         }
 
         if (args.Length > 0
+            && string.Equals(args[0], "activate", StringComparison.Ordinal))
+        {
+            return GenerateFromCurrentActivateCommand.Execute(context, args[1..], writer);
+        }
+
+        if (args.Length > 0
             && string.Equals(args[0], "submit", StringComparison.Ordinal))
         {
             return GenerateFromCurrentSubmitCommand.Execute(context, args[1..], writer);

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -196,6 +196,35 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenGenerateFromCurrentActivateCommand_DispatchesToActivateRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGenerateFromCurrentGitHubRunner();
+
+            var exitCode = CommandRouter.Execute(
+                ["generate-from-current", "activate", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Generate-from-current activate processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentSubmitCommand_DispatchesToSubmitRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentActivateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentActivateCommandTests.cs
@@ -1,0 +1,218 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class GenerateFromCurrentActivateCommandTests
+{
+    [Fact]
+    public void Execute_GivenRealPipeline_NotReadyAfterBridge_RendersDeterministicSummary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "README.md"), "# Intent System");
+        tempDirectory.CreateFile(Path.Combine("repo", "AGENTS.md"), "# Agent Guide");
+        tempDirectory.CreateFile(Path.Combine("repo", "src", "feature", "FeatureA.cs"), "namespace FeatureA;");
+        using var writer = new StringWriter();
+        var originalFactory = GenerateFromCurrentCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = () => new FakeGitHubRunner();
+
+            var exitCode = GenerateFromCurrentCommand.Execute(
+                CreateContext(repoRoot),
+                ["activate", "auth", "--from-path", "src/feature", "--issues", "114", "--prs", "113", "--altitudes", "execution"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current activate processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("Source bundle artifact path: .intent-cli/intake/auth.current-sources.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.reconstructed-concept.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.reconstructed-interview.md", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.concept.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/interviews/auth/iq-1.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: not-ready", output, StringComparison.Ordinal);
+            Assert.Contains("Generated issue artifact paths:", output, StringComparison.Ordinal);
+            Assert.Contains("Started execution units:", output, StringComparison.Ordinal);
+            Assert.Contains("Skipped stages:", output, StringComparison.Ordinal);
+            Assert.Contains("- issue-generation", output, StringComparison.Ordinal);
+            Assert.Contains("- launch", output, StringComparison.Ordinal);
+
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.current-sources.yaml")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.reconstructed-concept.yaml")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.reconstructed-interview.md")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.concept.yaml")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-1.yaml")));
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.compile.md")));
+        }
+        finally
+        {
+            GenerateFromCurrentCommand.GitHubCommandRunnerFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenReadyStageResults_ComposesToActiveSummary()
+    {
+        using var writer = new StringWriter();
+        var originalAdvanceExecutor = GenerateFromCurrentActivateCommand.AdvanceExecutor;
+        var originalStartExecutor = GenerateFromCurrentActivateCommand.IntakeStartExecutor;
+
+        try
+        {
+            GenerateFromCurrentActivateCommand.AdvanceExecutor = (_, _) => new GenerateFromCurrentAdvanceResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            };
+            GenerateFromCurrentActivateCommand.IntakeStartExecutor = (_, _, _) => new IntakeStartResult
+            {
+                Domain = "auth",
+                StartedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                GeneratedArtifactPaths =
+                [
+                    ".intent-cli/issues/AUTH-01/packet.yaml",
+                    ".intent-cli/issues/AUTH-02/github-body.md"
+                ],
+                CreatedIssueRefs =
+                [
+                    "https://github.com/J-Tech-Japan/intent-system/issues/501",
+                    "https://github.com/J-Tech-Japan/intent-system/issues/502"
+                ],
+                WorktreePaths =
+                [
+                    "/tmp/worktrees/AUTH-01",
+                    "/tmp/worktrees/AUTH-02"
+                ],
+                SkippedUnits = []
+            };
+
+            var exitCode = GenerateFromCurrentActivateCommand.Execute(
+                CreateContext("/tmp/intent-system"),
+                ["auth", "--from-path", "src/feature"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Generate-from-current activate processed for domain 'auth'.", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("- https://github.com/J-Tech-Japan/intent-system/issues/501", output, StringComparison.Ordinal);
+            Assert.Contains("- /tmp/worktrees/AUTH-01", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/intake/auth.concept.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("- .intent-cli/issues/AUTH-01/packet.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            GenerateFromCurrentActivateCommand.AdvanceExecutor = originalAdvanceExecutor;
+            GenerateFromCurrentActivateCommand.IntakeStartExecutor = originalStartExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GenerateFromCurrentActivateCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class FakeGitHubRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["issue", "view", "114", "--comments", "--json", "number,title,body,url,state,comments"]))
+            {
+                return Success("""{"number":114,"title":"[G44] Generate From Current","body":"Reconstruct from selected current signals.","url":"https://github.com/J-Tech-Japan/intent-system/issues/114","state":"OPEN","comments":[{"body":"Need deterministic output."}]}""");
+            }
+
+            if (arguments.SequenceEqual(["pr", "view", "113", "--comments", "--json", "number,title,body,url,state,isDraft,mergeStateStatus,comments,reviews"]))
+            {
+                return Success("""{"number":113,"title":"[codex] Add intake activate command","body":"Adds intake activate.","url":"https://github.com/J-Tech-Japan/intent-system/pull/113","state":"OPEN","isDraft":true,"mergeStateStatus":"CLEAN","comments":[{"body":"Looks good."}],"reviews":[{"state":"COMMENTED","body":"Scope stayed thin."}]}""");
+            }
+
+            throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+
+        private static GitHubCommandResult Success(string stdOut)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = stdOut,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-generate-from-current-activate-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GenerateFromCurrentActivateRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GenerateFromCurrentActivateRendererTests.cs
@@ -1,0 +1,76 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GenerateFromCurrentActivateRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenActivateResult_RendersDeterministicSections()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentActivateRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentActivateResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.reconstructed-concept.yaml",
+                    ".intent-cli/intake/auth.reconstructed-interview.md"
+                ],
+                StandardIntakeArtifactPaths =
+                [
+                    ".intent-cli/intake/auth.concept.yaml",
+                    ".intent-cli/interviews/auth/iq-1.yaml"
+                ],
+                UpdatedSourceFilePaths = ["intents/intent-cli/concepts/auth-oauth2.md"],
+                UpdatedExecutionFilePaths = ["intents/intent-cli/execution/05-post-mvp-sub-slices.md"],
+                GeneratedIssueArtifactPaths = [".intent-cli/issues/G124/packet.yaml"],
+                CreatedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/124"],
+                WorktreePaths = [".intent-cli/worktrees/G124"],
+                StartedExecutionUnits = ["G124"],
+                ReadinessStatus = "ready",
+                SkippedStages = []
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("Generate-from-current activate processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Source bundle artifact path: .intent-cli/intake/auth.current-sources.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Generated issue artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Created issue refs:", output, StringComparison.Ordinal);
+        Assert.Contains("Worktree paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Started execution units:", output, StringComparison.Ordinal);
+        Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenEmptyLists_RendersNoneEntries()
+    {
+        using var writer = new StringWriter();
+
+        GenerateFromCurrentActivateRenderer.WriteSummary(
+            writer,
+            new GenerateFromCurrentActivateResult
+            {
+                Domain = "auth",
+                SourceBundleArtifactPath = ".intent-cli/intake/auth.current-sources.yaml",
+                ReconstructedArtifactPaths = [],
+                StandardIntakeArtifactPaths = [],
+                UpdatedSourceFilePaths = [],
+                UpdatedExecutionFilePaths = [],
+                GeneratedIssueArtifactPaths = [],
+                CreatedIssueRefs = [],
+                WorktreePaths = [],
+                StartedExecutionUnits = [],
+                ReadinessStatus = "not-ready",
+                SkippedStages = ["issue-generation", "launch"]
+            });
+
+        var output = writer.ToString();
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+        Assert.Contains("- issue-generation", output, StringComparison.Ordinal);
+        Assert.Contains("- launch", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- restore `generate-from-current activate <domain> --from-path <path>` on the current baseline
- compose current source bundle, reconstruction, bridge, advance, and intake start into an `active` path
- add renderer, runtime, and router coverage for ready and not-ready paths

Closes #201