### PR TITLE
Add bug intent enqueue command

### DIFF
--- a/src/IntentSystem.Cli/Commands/BugIntentEnqueueArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentEnqueueArtifactPathResolver.cs
@@ -1,0 +1,11 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentEnqueueArtifactPathResolver
+{
+    public static string Resolve(string bugId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bugId);
+
+        return $".intent-cli/bugs/{bugId}.intent-enqueue.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentEnqueueArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentEnqueueArtifactYaml.cs
@@ -1,0 +1,236 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentEnqueueArtifact
+{
+    public required string BugId { get; init; }
+
+    public required string IntentIssueRef { get; init; }
+
+    public required string IntentRepairRef { get; init; }
+
+    public required string? AllocatedExecutionUnit { get; init; }
+
+    public required string? LinkedIssueUrl { get; init; }
+
+    public required IReadOnlyList<string> ParentRepairTargets { get; init; }
+
+    public required IReadOnlyList<string> GeneratedPacketPaths { get; init; }
+
+    public required bool WasEnqueued { get; init; }
+}
+
+internal static class BugIntentEnqueueArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "bug_id",
+        "intent_issue_ref",
+        "intent_repair_ref",
+        "allocated_execution_unit",
+        "linked_issue_url",
+        "parent_repair_targets",
+        "generated_packet_paths",
+        "was_enqueued"
+    ];
+
+    public static string Serialize(BugIntentEnqueueArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"bug_id: {artifact.BugId}",
+            $"intent_issue_ref: {Quote(artifact.IntentIssueRef)}",
+            $"intent_repair_ref: {Quote(artifact.IntentRepairRef)}",
+            $"allocated_execution_unit: {FormatNullableScalar(artifact.AllocatedExecutionUnit)}",
+            $"linked_issue_url: {FormatNullableScalar(artifact.LinkedIssueUrl)}",
+            $"was_enqueued: {artifact.WasEnqueued.ToString().ToLowerInvariant()}"
+        };
+
+        AppendList(lines, "parent_repair_targets", artifact.ParentRepairTargets);
+        AppendList(lines, "generated_packet_paths", artifact.GeneratedPacketPaths);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static BugIntentEnqueueArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new BugIntentEnqueueArtifact
+        {
+            BugId = GetRequiredScalar(values, "bug_id"),
+            IntentIssueRef = GetRequiredScalar(values, "intent_issue_ref"),
+            IntentRepairRef = GetRequiredScalar(values, "intent_repair_ref"),
+            AllocatedExecutionUnit = GetNullableScalar(values, "allocated_execution_unit"),
+            LinkedIssueUrl = GetNullableScalar(values, "linked_issue_url"),
+            ParentRepairTargets = GetRequiredList(values, "parent_repair_targets"),
+            GeneratedPacketPaths = GetRequiredList(values, "generated_packet_paths"),
+            WasEnqueued = GetRequiredBoolean(values, "was_enqueued")
+        };
+    }
+
+    private static void AppendList(List<string> lines, string label, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add($"{label}: []");
+            return;
+        }
+
+        lines.Add($"{label}:");
+        lines.AddRange(values.Select(value => $"  - {Quote(value)}"));
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("  - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !values.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException(
+                        $"Bug intent-enqueue YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseScalar(line[4..].TrimStart()));
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Bug intent-enqueue YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+
+            if (value.Length == 0)
+            {
+                values[key] = new List<string>();
+                currentListKey = key;
+                continue;
+            }
+
+            currentListKey = null;
+            values[key] = value switch
+            {
+                "[]" => Array.Empty<string>(),
+                "null" => null,
+                "true" => true,
+                "false" => false,
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Bug intent-enqueue YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException($"Bug intent-enqueue YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static string? GetNullableScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug intent-enqueue YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            string text => text,
+            _ => throw new InvalidOperationException($"Bug intent-enqueue YAML field '{key}' must be a scalar string or null.")
+        };
+    }
+
+    private static bool GetRequiredBoolean(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not bool booleanValue)
+        {
+            throw new InvalidOperationException($"Bug intent-enqueue YAML field '{key}' must be a boolean.");
+        }
+
+        return booleanValue;
+    }
+
+    private static IReadOnlyList<string> GetRequiredList(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug intent-enqueue YAML field '{key}' must be a list.");
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException($"Bug intent-enqueue YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static string FormatNullableScalar(string? value)
+    {
+        return value is null ? "null" : Quote(value);
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentEnqueueArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentEnqueueArtifactYaml.cs
@@ -6,17 +6,15 @@ internal sealed record BugIntentEnqueueArtifact
 
     public required string IntentIssueRef { get; init; }
 
-    public required string IntentRepairRef { get; init; }
-
     public required string? AllocatedExecutionUnit { get; init; }
 
     public required string? LinkedIssueUrl { get; init; }
 
-    public required IReadOnlyList<string> ParentRepairTargets { get; init; }
+    public required int? LinkedIssueNumber { get; init; }
 
-    public required IReadOnlyList<string> GeneratedPacketPaths { get; init; }
+    public required IReadOnlyList<string> PacketPaths { get; init; }
 
-    public required bool WasEnqueued { get; init; }
+    public required bool ReadyToEnqueue { get; init; }
 }
 
 internal static class BugIntentEnqueueArtifactYaml
@@ -25,12 +23,11 @@ internal static class BugIntentEnqueueArtifactYaml
     [
         "bug_id",
         "intent_issue_ref",
-        "intent_repair_ref",
         "allocated_execution_unit",
         "linked_issue_url",
-        "parent_repair_targets",
-        "generated_packet_paths",
-        "was_enqueued"
+        "linked_issue_number",
+        "packet_paths",
+        "ready_to_enqueue"
     ];
 
     public static string Serialize(BugIntentEnqueueArtifact artifact)
@@ -41,14 +38,13 @@ internal static class BugIntentEnqueueArtifactYaml
         {
             $"bug_id: {artifact.BugId}",
             $"intent_issue_ref: {Quote(artifact.IntentIssueRef)}",
-            $"intent_repair_ref: {Quote(artifact.IntentRepairRef)}",
             $"allocated_execution_unit: {FormatNullableScalar(artifact.AllocatedExecutionUnit)}",
             $"linked_issue_url: {FormatNullableScalar(artifact.LinkedIssueUrl)}",
-            $"was_enqueued: {artifact.WasEnqueued.ToString().ToLowerInvariant()}"
+            $"linked_issue_number: {FormatNullableInteger(artifact.LinkedIssueNumber)}",
+            $"ready_to_enqueue: {artifact.ReadyToEnqueue.ToString().ToLowerInvariant()}"
         };
 
-        AppendList(lines, "parent_repair_targets", artifact.ParentRepairTargets);
-        AppendList(lines, "generated_packet_paths", artifact.GeneratedPacketPaths);
+        AppendList(lines, "packet_paths", artifact.PacketPaths);
 
         return string.Join(Environment.NewLine, lines) + Environment.NewLine;
     }
@@ -64,12 +60,11 @@ internal static class BugIntentEnqueueArtifactYaml
         {
             BugId = GetRequiredScalar(values, "bug_id"),
             IntentIssueRef = GetRequiredScalar(values, "intent_issue_ref"),
-            IntentRepairRef = GetRequiredScalar(values, "intent_repair_ref"),
             AllocatedExecutionUnit = GetNullableScalar(values, "allocated_execution_unit"),
             LinkedIssueUrl = GetNullableScalar(values, "linked_issue_url"),
-            ParentRepairTargets = GetRequiredList(values, "parent_repair_targets"),
-            GeneratedPacketPaths = GetRequiredList(values, "generated_packet_paths"),
-            WasEnqueued = GetRequiredBoolean(values, "was_enqueued")
+            LinkedIssueNumber = GetNullableInteger(values, "linked_issue_number"),
+            PacketPaths = GetRequiredList(values, "packet_paths"),
+            ReadyToEnqueue = GetRequiredBoolean(values, "ready_to_enqueue")
         };
     }
 
@@ -136,6 +131,7 @@ internal static class BugIntentEnqueueArtifactYaml
                 "null" => null,
                 "true" => true,
                 "false" => false,
+                _ when int.TryParse(value, out var integerValue) => integerValue,
                 _ => ParseScalar(value)
             };
         }
@@ -204,9 +200,29 @@ internal static class BugIntentEnqueueArtifactYaml
         };
     }
 
+    private static int? GetNullableInteger(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug intent-enqueue YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            int integerValue => integerValue,
+            _ => throw new InvalidOperationException($"Bug intent-enqueue YAML field '{key}' must be an integer or null.")
+        };
+    }
+
     private static string FormatNullableScalar(string? value)
     {
         return value is null ? "null" : Quote(value);
+    }
+
+    private static string FormatNullableInteger(int? value)
+    {
+        return value?.ToString() ?? "null";
     }
 
     private static string ParseScalar(string value)

--- a/src/IntentSystem.Cli/Commands/BugIntentEnqueueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentEnqueueCommand.cs
@@ -1,0 +1,372 @@
+using IntentSystem.Cli.Models;
+using IntentSystem.Projection;
+using IntentSystem.Projection.Models;
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentEnqueueCommand
+{
+    private const string TransitionActor = "intent-cli";
+    private const string ParentIntentRoot = "intents/intent-cli/intent-tree/00-map.md";
+    private const string ClarificationReturnPath = "intents/intent-cli/clarifications/open.md";
+    private const string DefaultPriority = "high";
+
+    private static readonly string[] TechnicalBaseline =
+    [
+        "C# / .NET",
+        ".NET 10.0.100+ baseline",
+        "dnx / dotnet tool exec",
+        "do not switch to Node or TypeScript toolchain"
+    ];
+
+    private static readonly string[] ProjectLocalGuide =
+    [
+        "AGENTS.md",
+        "CLAUDE.md"
+    ];
+
+    private static readonly string[] VerificationEvidence =
+    [
+        "contract-reviewed",
+        "tests-passing",
+        "acceptance-criteria-checked"
+    ];
+
+    private static readonly string[] IntentBaseline =
+    [
+        "bug intent enqueue stays deterministic",
+        "execution unit allocation follows queue snapshot monotonic G<number>"
+    ];
+
+    private static readonly string[] OutOfScope =
+    [
+        "parent repair issue recreation",
+        "parent repair launch",
+        "review / merge / closeout",
+        "workflow execution",
+        "parent source-of-truth canonical markdown mutation"
+    ];
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            BugIntentEnqueueRenderer.WriteSummary(writer, result.Artifact, result.ArtifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static BugIntentEnqueueCommandResult ExecuteCore(CliContext context, string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Bug intent-enqueue command requires '<bug-id>'.");
+        }
+
+        var bugId = args[0].Trim();
+        var artifactPath = ResolveArtifactPath(context.RepoRoot, bugId);
+        if (File.Exists(artifactPath))
+        {
+            throw new InvalidOperationException($"Bug intent-enqueue artifact already exists at {artifactPath}");
+        }
+
+        var intentIssueRef = $".intent-cli/bugs/{bugId}.intent-issue.yaml";
+        var intentIssuePath = ResolveExistingArtifactPath(context.RepoRoot, intentIssueRef, "Bug intent-issue artifact");
+        var intentIssue = BugIntentIssueArtifactYaml.Deserialize(File.ReadAllText(intentIssuePath));
+        if (!string.Equals(intentIssue.BugId, bugId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Bug intent-issue artifact bug id '{intentIssue.BugId}' does not match requested bug id '{bugId}'.");
+        }
+
+        var intentRepairPath = ResolveExistingArtifactPath(context.RepoRoot, intentIssue.IntentRepairRef, "Bug intent-repair artifact");
+        var intentRepair = BugIntentRepairArtifactYaml.Deserialize(File.ReadAllText(intentRepairPath));
+        if (!string.Equals(intentRepair.BugId, bugId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Bug intent-repair artifact bug id '{intentRepair.BugId}' does not match requested bug id '{bugId}'.");
+        }
+
+        ValidateIssueLinkConsistency(intentIssue);
+
+        if (intentIssue.CreatedIssueUrl is null)
+        {
+            var notReadyArtifact = new BugIntentEnqueueArtifact
+            {
+                BugId = bugId,
+                IntentIssueRef = intentIssueRef,
+                IntentRepairRef = intentIssue.IntentRepairRef,
+                AllocatedExecutionUnit = null,
+                LinkedIssueUrl = null,
+                ParentRepairTargets = intentIssue.ParentRepairTargets,
+                GeneratedPacketPaths = [],
+                WasEnqueued = false
+            };
+
+            return new BugIntentEnqueueCommandResult
+            {
+                Artifact = notReadyArtifact,
+                ArtifactPath = WriteArtifact(context.RepoRoot, notReadyArtifact)
+            };
+        }
+
+        var queueStatePath = context.GetQueueStatePath();
+        if (!File.Exists(queueStatePath))
+        {
+            throw new InvalidOperationException($"Queue state artifact was not found at {queueStatePath}");
+        }
+
+        var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        var executionUnit = AllocateNextExecutionUnit(queueState);
+        var parentRepoRoot = ParentRepairTargetRepoResolver.Resolve(context, intentIssue.ParentRepairTargets);
+        var packet = CreatePacket(context, executionUnit, intentIssue, intentRepair, parentRepoRoot);
+        ProjectionArtifactWriter.Write(packet, context.RepoRoot, overwrite: false);
+
+        var packetPaths = QueueEnqueueCommand.ResolvePacketPaths(context.RepoRoot, executionUnit);
+        var queueItem = QueueEnqueueCommand.CreateQueueItem(
+            context,
+            new QueueEnqueueCommand.ResolvedQueuePacket
+            {
+                ExecutionUnit = executionUnit,
+                IssueTitle = $"[{executionUnit}] {intentIssue.CreatedIssueTitle}",
+                Dependencies = [],
+                ClarificationReturnPath = ClarificationReturnPath
+            },
+            packetPaths) with
+        {
+            LinkedIssue = ParseLinkedIssue(intentIssue.CreatedIssueUrl, intentIssue.CreatedIssueNumber!.Value)
+        };
+
+        var enqueueResult = QueueManager.Enqueue(
+            queueState,
+            queueItem,
+            TransitionActor,
+            QueueEnqueueCommand.TimestampFactory());
+
+        if (!enqueueResult.WasEnqueued)
+        {
+            throw new InvalidOperationException(
+                $"Execution unit '{executionUnit}' is already present in queue-state.json after allocation.");
+        }
+
+        QueueEnqueueCommand.PersistEnqueue(context, enqueueResult);
+
+        var artifact = new BugIntentEnqueueArtifact
+        {
+            BugId = bugId,
+            IntentIssueRef = intentIssueRef,
+            IntentRepairRef = intentIssue.IntentRepairRef,
+            AllocatedExecutionUnit = executionUnit,
+            LinkedIssueUrl = intentIssue.CreatedIssueUrl,
+            ParentRepairTargets = intentIssue.ParentRepairTargets,
+            GeneratedPacketPaths =
+            [
+                packet.Paths.Implementation,
+                packet.Paths.ReviewContext,
+                packet.Paths.Yaml
+            ],
+            WasEnqueued = true
+        };
+
+        return new BugIntentEnqueueCommandResult
+        {
+            Artifact = artifact,
+            ArtifactPath = WriteArtifact(context.RepoRoot, artifact)
+        };
+    }
+
+    internal static string AllocateNextExecutionUnit(QueueState queueState)
+    {
+        ArgumentNullException.ThrowIfNull(queueState);
+
+        var maxExecutionUnit = 0;
+        foreach (var item in queueState.Items)
+        {
+            if (!TryParseExecutionUnitNumber(item.ExecutionUnit, out var number))
+            {
+                continue;
+            }
+
+            maxExecutionUnit = Math.Max(maxExecutionUnit, number);
+        }
+
+        return $"G{maxExecutionUnit + 1}";
+    }
+
+    private static GeneratedPacket CreatePacket(
+        CliContext context,
+        string executionUnit,
+        BugIntentIssueArtifact intentIssue,
+        BugIntentRepairArtifact intentRepair,
+        string parentRepoRoot)
+    {
+        var relativeTargetRepo = Path.GetRelativePath(context.RepoRoot, parentRepoRoot)
+            .Replace(Path.DirectorySeparatorChar, '/');
+        var normalizedTargets = intentIssue.ParentRepairTargets
+            .Select(NormalizeTarget)
+            .ToArray();
+        var issueTitle = $"[{executionUnit}] {intentIssue.CreatedIssueTitle}";
+
+        return PacketGenerator.Generate(
+            new SubSliceRow
+            {
+                SourceExecutionUnit = executionUnit,
+                Goal = intentRepair.SuggestedGoal,
+                TargetRepo = relativeTargetRepo,
+                TargetPath = ".",
+                TargetPart = "parent intent repair targets",
+                DependsOnSubslices = [],
+                RelatedIntents = normalizedTargets,
+                SourceConcepts = normalizedTargets,
+                SuccessSignal = $"Parent repair targets for `{intentIssue.CreatedIssueTitle}` are updated deterministically.",
+                ReviewMode = "deterministic-review",
+                CompletionAction = "wait-for-deterministic-review",
+                LandingPolicy = "merge-after-review"
+            },
+            new ProjectionContext
+            {
+                IssueTitle = issueTitle,
+                IssueKind = IssueKind.Bugfix,
+                ParentIntentRoot = ParentIntentRoot,
+                ClarificationReturnPath = ClarificationReturnPath,
+                AcceptanceCriteria =
+                [
+                    $"Selected bug repair is allocated to execution unit `{executionUnit}`.",
+                    $"Changes stay limited to declared parent repair targets.",
+                    $"Linked issue `{intentIssue.CreatedIssueUrl}` remains the current parent repair issue."
+                ],
+                DeterministicReviewChecks =
+                [
+                    "queue insertion stays deterministic",
+                    "changes stay limited to declared parent repair targets",
+                    "linked issue ref remains unchanged"
+                ],
+                VerificationEvidence = VerificationEvidence,
+                TechnicalBaseline = TechnicalBaseline,
+                ProjectLocalGuide = ProjectLocalGuide,
+                IntentBaseline = IntentBaseline,
+                AdditionalInScope =
+                [
+                    $"bug id `{intentIssue.BugId}`",
+                    $"linked parent issue `{intentIssue.CreatedIssueUrl}`",
+                    ..intentIssue.ParentRepairTargets.Select(target => $"parent repair target `{target}`")
+                ],
+                OutOfScope = OutOfScope
+            });
+    }
+
+    private static LinkedIssue ParseLinkedIssue(string createdIssueUrl, int createdIssueNumber)
+    {
+        if (!Uri.TryCreate(createdIssueUrl, UriKind.Absolute, out var uri))
+        {
+            throw new InvalidOperationException($"Created issue URL '{createdIssueUrl}' must be an absolute URL.");
+        }
+
+        var segments = uri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (segments.Length != 4
+            || !string.Equals(segments[2], "issues", StringComparison.Ordinal)
+            || !int.TryParse(segments[3], out var parsedIssueNumber))
+        {
+            throw new InvalidOperationException(
+                $"Created issue URL '{createdIssueUrl}' must use the GitHub issue URL shape.");
+        }
+
+        if (parsedIssueNumber != createdIssueNumber)
+        {
+            throw new InvalidOperationException(
+                $"Created issue URL number '{parsedIssueNumber}' does not match artifact issue number '{createdIssueNumber}'.");
+        }
+
+        return new LinkedIssue
+        {
+            Repo = $"{segments[0]}/{segments[1]}",
+            Number = createdIssueNumber,
+            Url = createdIssueUrl
+        };
+    }
+
+    private static void ValidateIssueLinkConsistency(BugIntentIssueArtifact artifact)
+    {
+        if (artifact.CreatedIssueUrl is null && artifact.CreatedIssueNumber is null)
+        {
+            return;
+        }
+
+        if (artifact.CreatedIssueUrl is null || artifact.CreatedIssueNumber is null)
+        {
+            throw new InvalidOperationException(
+                "Bug intent-issue artifact must contain both created_issue_url and created_issue_number when issue creation succeeded.");
+        }
+    }
+
+    private static string NormalizeTarget(string target)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(target);
+
+        var separatorIndex = target.IndexOf(':');
+        if (separatorIndex < 0 || separatorIndex == target.Length - 1)
+        {
+            throw new InvalidOperationException($"Parent repair target '{target}' must use the kind:path shape.");
+        }
+
+        return target[(separatorIndex + 1)..].Trim();
+    }
+
+    private static bool TryParseExecutionUnitNumber(string executionUnit, out int number)
+    {
+        number = 0;
+        if (executionUnit.Length < 2 || executionUnit[0] != 'G')
+        {
+            return false;
+        }
+
+        return int.TryParse(executionUnit[1..], out number);
+    }
+
+    private static string ResolveExistingArtifactPath(string repoRoot, string relativePath, string artifactLabel)
+    {
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(absolutePath))
+        {
+            throw new InvalidOperationException($"{artifactLabel} was not found at {absolutePath}");
+        }
+
+        return absolutePath;
+    }
+
+    private static string ResolveArtifactPath(string repoRoot, string bugId)
+    {
+        return Path.GetFullPath(
+            Path.Combine(
+                repoRoot,
+                BugIntentEnqueueArtifactPathResolver.Resolve(bugId).Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static string WriteArtifact(string repoRoot, BugIntentEnqueueArtifact artifact)
+    {
+        var relativePath = BugIntentEnqueueArtifactPathResolver.Resolve(artifact.BugId);
+        var absolutePath = ResolveArtifactPath(repoRoot, artifact.BugId);
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Bug intent-enqueue artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, BugIntentEnqueueArtifactYaml.Serialize(artifact));
+        return relativePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentEnqueueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentEnqueueCommand.cs
@@ -111,12 +111,11 @@ internal static class BugIntentEnqueueCommand
             {
                 BugId = bugId,
                 IntentIssueRef = intentIssueRef,
-                IntentRepairRef = intentIssue.IntentRepairRef,
                 AllocatedExecutionUnit = null,
                 LinkedIssueUrl = null,
-                ParentRepairTargets = intentIssue.ParentRepairTargets,
-                GeneratedPacketPaths = [],
-                WasEnqueued = false
+                LinkedIssueNumber = null,
+                PacketPaths = [],
+                ReadyToEnqueue = false
             };
 
             return new BugIntentEnqueueCommandResult
@@ -171,17 +170,16 @@ internal static class BugIntentEnqueueCommand
         {
             BugId = bugId,
             IntentIssueRef = intentIssueRef,
-            IntentRepairRef = intentIssue.IntentRepairRef,
             AllocatedExecutionUnit = executionUnit,
             LinkedIssueUrl = intentIssue.CreatedIssueUrl,
-            ParentRepairTargets = intentIssue.ParentRepairTargets,
-            GeneratedPacketPaths =
+            LinkedIssueNumber = intentIssue.CreatedIssueNumber,
+            PacketPaths =
             [
                 packet.Paths.Implementation,
                 packet.Paths.ReviewContext,
                 packet.Paths.Yaml
             ],
-            WasEnqueued = true
+            ReadyToEnqueue = true
         };
 
         return new BugIntentEnqueueCommandResult

--- a/src/IntentSystem.Cli/Commands/BugIntentEnqueueCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentEnqueueCommandResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentEnqueueCommandResult
+{
+    public required BugIntentEnqueueArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentEnqueueRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentEnqueueRenderer.cs
@@ -12,7 +12,8 @@ internal static class BugIntentEnqueueRenderer
         writer.WriteLine($"Artifact path: {artifactPath}");
         writer.WriteLine($"Allocated execution unit: {artifact.AllocatedExecutionUnit ?? "not-allocated"}");
         writer.WriteLine($"Linked issue URL: {artifact.LinkedIssueUrl ?? "not-linked"}");
-        writer.WriteLine($"Generated packet paths: {artifact.GeneratedPacketPaths.Count}");
-        writer.WriteLine($"Was enqueued: {artifact.WasEnqueued.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"Linked issue number: {artifact.LinkedIssueNumber?.ToString() ?? "not-linked"}");
+        writer.WriteLine($"Packet paths: {artifact.PacketPaths.Count}");
+        writer.WriteLine($"Ready to enqueue: {artifact.ReadyToEnqueue.ToString().ToLowerInvariant()}");
     }
 }

--- a/src/IntentSystem.Cli/Commands/BugIntentEnqueueRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentEnqueueRenderer.cs
@@ -1,0 +1,18 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentEnqueueRenderer
+{
+    public static void WriteSummary(TextWriter writer, BugIntentEnqueueArtifact artifact, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Bug intent-enqueue artifact generated for '{artifact.BugId}'.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Allocated execution unit: {artifact.AllocatedExecutionUnit ?? "not-allocated"}");
+        writer.WriteLine($"Linked issue URL: {artifact.LinkedIssueUrl ?? "not-linked"}");
+        writer.WriteLine($"Generated packet paths: {artifact.GeneratedPacketPaths.Count}");
+        writer.WriteLine($"Was enqueued: {artifact.WasEnqueued.ToString().ToLowerInvariant()}");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentIssueCommand.cs
@@ -92,7 +92,7 @@ internal static class BugIntentIssueCommand
 
     private static string ResolveParentGitHubTargetRepo(CliContext context, BugIntentRepairArtifact repair)
     {
-        var parentRepoRoot = ResolveParentRepoRoot(context, repair.ParentRepairTargets);
+        var parentRepoRoot = ParentRepairTargetRepoResolver.Resolve(context, repair.ParentRepairTargets);
         var result = GitCommandRunnerFactory().Run(parentRepoRoot, ["remote", "get-url", "origin"]);
         if (result.ExitCode != 0)
         {
@@ -103,63 +103,6 @@ internal static class BugIntentIssueCommand
         }
 
         return GitHubRepositoryTargetResolver.ParseRemoteUrl(result.StdOut.Trim());
-    }
-
-    private static string ResolveParentRepoRoot(CliContext context, IReadOnlyList<string> parentRepairTargets)
-    {
-        if (parentRepairTargets.Count == 0)
-        {
-            throw new InvalidOperationException("Parent repair targets must contain at least one target.");
-        }
-
-        var normalizedTargetPaths = parentRepairTargets
-            .Select(NormalizeParentRepairTargetPath)
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
-
-        var candidates = new List<string>();
-        var configuredParentRepoRoot = context.ResolveParentIntentRepoRootPath();
-        if (!string.IsNullOrWhiteSpace(configuredParentRepoRoot))
-        {
-            candidates.Add(configuredParentRepoRoot);
-        }
-
-        var repoParentDirectory = Directory.GetParent(context.RepoRoot);
-        if (repoParentDirectory is not null)
-        {
-            candidates.AddRange(
-                repoParentDirectory.EnumerateDirectories()
-                    .Select(directory => directory.FullName)
-                    .Where(path => !string.Equals(path, context.RepoRoot, StringComparison.Ordinal)));
-        }
-
-        var matchingRoots = candidates
-            .Distinct(StringComparer.Ordinal)
-            .Where(Directory.Exists)
-            .Where(candidate => normalizedTargetPaths.All(
-                target => File.Exists(Path.Combine(candidate, target.Replace('/', Path.DirectorySeparatorChar)))))
-            .ToArray();
-
-        return matchingRoots.Length switch
-        {
-            1 => matchingRoots[0],
-            0 => throw new InvalidOperationException("Current parent repo root could not be resolved from parent repair targets."),
-            _ => throw new InvalidOperationException(
-                $"Parent repair targets resolved to multiple candidate parent repo roots: {string.Join(", ", matchingRoots)}")
-        };
-    }
-
-    private static string NormalizeParentRepairTargetPath(string target)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(target);
-
-        var separatorIndex = target.IndexOf(':');
-        if (separatorIndex < 0 || separatorIndex == target.Length - 1)
-        {
-            throw new InvalidOperationException($"Parent repair target '{target}' must use the kind:path shape.");
-        }
-
-        return target[(separatorIndex + 1)..].Trim();
     }
 
     private static string BuildIssueBody(BugIntentRepairArtifact repair)

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -83,6 +83,7 @@ internal static class CommandRouter
                 ["plan"] = BugExecutionCommand.Execute,
                 ["intent-repair"] = BugIntentRepairCommand.Execute,
                 ["intent-issue"] = BugIntentIssueCommand.Execute,
+                ["intent-enqueue"] = BugIntentEnqueueCommand.Execute,
                 ["implementation-repair"] = BugImplementationRepairCommand.Execute,
                 ["implementation-issue"] = BugImplementationIssueCommand.Execute
             },

--- a/src/IntentSystem.Cli/Commands/ParentRepairTargetRepoResolver.cs
+++ b/src/IntentSystem.Cli/Commands/ParentRepairTargetRepoResolver.cs
@@ -1,0 +1,64 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class ParentRepairTargetRepoResolver
+{
+    public static string Resolve(CliContext context, IReadOnlyList<string> parentRepairTargets)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(parentRepairTargets);
+
+        if (parentRepairTargets.Count == 0)
+        {
+            throw new InvalidOperationException("Parent repair targets must contain at least one target.");
+        }
+
+        var normalizedTargetPaths = parentRepairTargets
+            .Select(NormalizeParentRepairTargetPath)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        var candidates = new List<string>();
+        var configuredParentRepoRoot = context.ResolveParentIntentRepoRootPath();
+        if (!string.IsNullOrWhiteSpace(configuredParentRepoRoot))
+        {
+            candidates.Add(configuredParentRepoRoot);
+        }
+
+        var repoParentDirectory = Directory.GetParent(context.RepoRoot);
+        if (repoParentDirectory is not null)
+        {
+            candidates.AddRange(
+                repoParentDirectory.EnumerateDirectories()
+                    .Select(directory => directory.FullName)
+                    .Where(path => !string.Equals(path, context.RepoRoot, StringComparison.Ordinal)));
+        }
+
+        var matchingRoots = candidates
+            .Distinct(StringComparer.Ordinal)
+            .Where(Directory.Exists)
+            .Where(candidate => normalizedTargetPaths.All(
+                target => File.Exists(Path.Combine(candidate, target.Replace('/', Path.DirectorySeparatorChar)))))
+            .ToArray();
+
+        return matchingRoots.Length switch
+        {
+            1 => matchingRoots[0],
+            0 => throw new InvalidOperationException("Current parent repo root could not be resolved from parent repair targets."),
+            _ => throw new InvalidOperationException(
+                $"Parent repair targets resolved to multiple candidate parent repo roots: {string.Join(", ", matchingRoots)}")
+        };
+    }
+
+    private static string NormalizeParentRepairTargetPath(string target)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(target);
+
+        var separatorIndex = target.IndexOf(':');
+        if (separatorIndex < 0 || separatorIndex == target.Length - 1)
+        {
+            throw new InvalidOperationException($"Parent repair target '{target}' must use the kind:path shape.");
+        }
+
+        return target[(separatorIndex + 1)..].Trim();
+    }
+}

--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -65,7 +65,8 @@ public static class QueueManager
                 Ts = ts,
                 ExecutionUnit = normalizedItem.ExecutionUnit,
                 Event = "queued",
-                By = by
+                By = by,
+                LinkedIssue = normalizedItem.LinkedIssue?.Url
             }
         };
     }

--- a/tests/IntentSystem.Cli.Tests/BugIntentEnqueueArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentEnqueueArtifactYamlTests.cs
@@ -1,0 +1,60 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentEnqueueArtifactYamlTests
+{
+    [Fact]
+    public void SerializeAndDeserialize_GivenArtifact_RoundTripsDeterministically()
+    {
+        var artifact = new BugIntentEnqueueArtifact
+        {
+            BugId = "BUG-123",
+            IntentIssueRef = ".intent-cli/bugs/BUG-123.intent-issue.yaml",
+            IntentRepairRef = ".intent-cli/bugs/BUG-123.intent-repair.yaml",
+            AllocatedExecutionUnit = "G41",
+            LinkedIssueUrl = "https://github.com/J-Tech-Japan/MyIntentHost/issues/53",
+            ParentRepairTargets =
+            [
+                "intent:intents/intent-cli/means/auth.md",
+                "rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
+            ],
+            GeneratedPacketPaths =
+            [
+                ".intent-cli/issues/G41/implementation.md",
+                ".intent-cli/issues/G41/review-context.md",
+                ".intent-cli/issues/G41/packet.yaml"
+            ],
+            WasEnqueued = true
+        };
+
+        var roundTripped = BugIntentEnqueueArtifactYaml.Deserialize(BugIntentEnqueueArtifactYaml.Serialize(artifact));
+
+        Assert.Equal(artifact.BugId, roundTripped.BugId);
+        Assert.Equal(artifact.IntentIssueRef, roundTripped.IntentIssueRef);
+        Assert.Equal(artifact.IntentRepairRef, roundTripped.IntentRepairRef);
+        Assert.Equal(artifact.AllocatedExecutionUnit, roundTripped.AllocatedExecutionUnit);
+        Assert.Equal(artifact.LinkedIssueUrl, roundTripped.LinkedIssueUrl);
+        Assert.Equal(artifact.ParentRepairTargets, roundTripped.ParentRepairTargets);
+        Assert.Equal(artifact.GeneratedPacketPaths, roundTripped.GeneratedPacketPaths);
+        Assert.Equal(artifact.WasEnqueued, roundTripped.WasEnqueued);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_Throws()
+    {
+        var yaml = """
+        bug_id: BUG-123
+        intent_issue_ref: ".intent-cli/bugs/BUG-123.intent-issue.yaml"
+        intent_repair_ref: ".intent-cli/bugs/BUG-123.intent-repair.yaml"
+        allocated_execution_unit: null
+        linked_issue_url: null
+        parent_repair_targets: []
+        was_enqueued: false
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BugIntentEnqueueArtifactYaml.Deserialize(yaml));
+
+        Assert.Contains("generated_packet_paths", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentEnqueueArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentEnqueueArtifactYamlTests.cs
@@ -11,33 +11,27 @@ public sealed class BugIntentEnqueueArtifactYamlTests
         {
             BugId = "BUG-123",
             IntentIssueRef = ".intent-cli/bugs/BUG-123.intent-issue.yaml",
-            IntentRepairRef = ".intent-cli/bugs/BUG-123.intent-repair.yaml",
             AllocatedExecutionUnit = "G41",
             LinkedIssueUrl = "https://github.com/J-Tech-Japan/MyIntentHost/issues/53",
-            ParentRepairTargets =
-            [
-                "intent:intents/intent-cli/means/auth.md",
-                "rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
-            ],
-            GeneratedPacketPaths =
+            LinkedIssueNumber = 53,
+            PacketPaths =
             [
                 ".intent-cli/issues/G41/implementation.md",
                 ".intent-cli/issues/G41/review-context.md",
                 ".intent-cli/issues/G41/packet.yaml"
             ],
-            WasEnqueued = true
+            ReadyToEnqueue = true
         };
 
         var roundTripped = BugIntentEnqueueArtifactYaml.Deserialize(BugIntentEnqueueArtifactYaml.Serialize(artifact));
 
         Assert.Equal(artifact.BugId, roundTripped.BugId);
         Assert.Equal(artifact.IntentIssueRef, roundTripped.IntentIssueRef);
-        Assert.Equal(artifact.IntentRepairRef, roundTripped.IntentRepairRef);
         Assert.Equal(artifact.AllocatedExecutionUnit, roundTripped.AllocatedExecutionUnit);
         Assert.Equal(artifact.LinkedIssueUrl, roundTripped.LinkedIssueUrl);
-        Assert.Equal(artifact.ParentRepairTargets, roundTripped.ParentRepairTargets);
-        Assert.Equal(artifact.GeneratedPacketPaths, roundTripped.GeneratedPacketPaths);
-        Assert.Equal(artifact.WasEnqueued, roundTripped.WasEnqueued);
+        Assert.Equal(artifact.LinkedIssueNumber, roundTripped.LinkedIssueNumber);
+        Assert.Equal(artifact.PacketPaths, roundTripped.PacketPaths);
+        Assert.Equal(artifact.ReadyToEnqueue, roundTripped.ReadyToEnqueue);
     }
 
     [Fact]
@@ -46,15 +40,14 @@ public sealed class BugIntentEnqueueArtifactYamlTests
         var yaml = """
         bug_id: BUG-123
         intent_issue_ref: ".intent-cli/bugs/BUG-123.intent-issue.yaml"
-        intent_repair_ref: ".intent-cli/bugs/BUG-123.intent-repair.yaml"
         allocated_execution_unit: null
         linked_issue_url: null
-        parent_repair_targets: []
-        was_enqueued: false
+        linked_issue_number: null
+        ready_to_enqueue: false
         """;
 
         var exception = Assert.Throws<InvalidOperationException>(() => BugIntentEnqueueArtifactYaml.Deserialize(yaml));
 
-        Assert.Contains("generated_packet_paths", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("packet_paths", exception.Message, StringComparison.Ordinal);
     }
 }

--- a/tests/IntentSystem.Cli.Tests/BugIntentEnqueueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentEnqueueCommandTests.cs
@@ -1,0 +1,262 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentEnqueueCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyIntentIssue_AllocatesNextExecutionUnitAndEnqueuesLinkedIssue()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("parent-intent", "intents", "intent-cli", "means", "auth.md"), "# auth");
+        tempDirectory.CreateFile(
+            Path.Combine("parent-intent", "intents", "intent-cli", "specs", "12-bug-fix-and-intent-repair.md"),
+            "# spec");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-repair.yaml"),
+            BugIntentRepairArtifactYaml.Serialize(CreateRepairArtifact()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-issue.yaml"),
+            BugIntentIssueArtifactYaml.Serialize(CreateIssueArtifact()));
+        var originalTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+        using var writer = new StringWriter();
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T12:30:00Z");
+
+            var exitCode = BugIntentEnqueueCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-enqueue artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Allocated execution unit: G13", writer.ToString(), StringComparison.Ordinal);
+
+            var enqueueArtifact = BugIntentEnqueueArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.intent-enqueue.yaml")));
+            Assert.Equal(".intent-cli/bugs/BUG-123.intent-issue.yaml", enqueueArtifact.IntentIssueRef);
+            Assert.Equal(".intent-cli/bugs/BUG-123.intent-repair.yaml", enqueueArtifact.IntentRepairRef);
+            Assert.Equal("G13", enqueueArtifact.AllocatedExecutionUnit);
+            Assert.Equal("https://github.com/J-Tech-Japan/MyIntentHost/issues/53", enqueueArtifact.LinkedIssueUrl);
+            Assert.True(enqueueArtifact.WasEnqueued);
+
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "G13", "implementation.md")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "G13", "review-context.md")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "G13", "packet.yaml")));
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            var selectedItem = queueState.Items.Single(item => item.ExecutionUnit == "G13");
+            Assert.Equal("[G13] Intent repair: OAuth callback loop (BUG-123)", selectedItem.Title);
+            Assert.NotNull(selectedItem.LinkedIssue);
+            Assert.Equal("J-Tech-Japan/MyIntentHost", selectedItem.LinkedIssue!.Repo);
+            Assert.Equal(53, selectedItem.LinkedIssue.Number);
+            Assert.Equal("https://github.com/J-Tech-Japan/MyIntentHost/issues/53", selectedItem.LinkedIssue.Url);
+            Assert.Equal(".intent-cli/issues/G13/packet.yaml", selectedItem.PacketPaths.Yaml);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            var queued = Assert.Single(runEvents);
+            Assert.Equal("queued", queued.Event);
+            Assert.Equal("G13", queued.ExecutionUnit);
+            Assert.Equal("https://github.com/J-Tech-Japan/MyIntentHost/issues/53", queued.LinkedIssue);
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyIntentIssue_WritesArtifactWithoutQueueMutation()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.intent-repair.yaml"),
+            BugIntentRepairArtifactYaml.Serialize(CreateRepairArtifact(bugId: "BUG-124")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.intent-issue.yaml"),
+            BugIntentIssueArtifactYaml.Serialize(CreateIssueArtifact(bugId: "BUG-124", linkedIssueUrl: null, linkedIssueNumber: null)));
+        using var writer = new StringWriter();
+
+        var originalQueueState = File.ReadAllText(queueStatePath);
+        var exitCode = BugIntentEnqueueCommand.Execute(CreateContext(repoRoot), ["BUG-124"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Allocated execution unit: not-allocated", writer.ToString(), StringComparison.Ordinal);
+
+        var artifact = BugIntentEnqueueArtifactYaml.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.intent-enqueue.yaml")));
+        Assert.Null(artifact.AllocatedExecutionUnit);
+        Assert.Null(artifact.LinkedIssueUrl);
+        Assert.False(artifact.WasEnqueued);
+        Assert.Empty(artifact.GeneratedPacketPaths);
+
+        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingIntentIssueArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = BugIntentEnqueueCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Bug intent-issue artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AllocateNextExecutionUnit_GivenCurrentQueueSnapshot_UsesNextMonotonicGNumber()
+    {
+        var executionUnit = BugIntentEnqueueCommand.AllocateNextExecutionUnit(CreateQueueState());
+
+        Assert.Equal("G13", executionUnit);
+    }
+
+    private static BugIntentRepairArtifact CreateRepairArtifact(string bugId = "BUG-123")
+    {
+        return new BugIntentRepairArtifact
+        {
+            BugId = bugId,
+            ExecutionRef = $".intent-cli/bugs/{bugId}.plan.yaml",
+            IntentTaskCandidates =
+            [
+                "intents/intent-cli/means/auth.md",
+                "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
+            ],
+            ParentRepairTargets =
+            [
+                "intent:intents/intent-cli/means/auth.md",
+                "rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
+            ],
+            SuggestedIssueTitle = $"Intent repair: OAuth callback loop ({bugId})",
+            SuggestedGoal = $"Repair parent intent targets for 'OAuth callback loop' ({bugId}) using .intent-cli/bugs/{bugId}.plan.yaml: intent:intents/intent-cli/means/auth.md, rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md",
+            ReadyToIssueCut = true
+        };
+    }
+
+    private static BugIntentIssueArtifact CreateIssueArtifact(
+        string bugId = "BUG-123",
+        string? linkedIssueUrl = "https://github.com/J-Tech-Japan/MyIntentHost/issues/53",
+        int? linkedIssueNumber = 53)
+    {
+        return new BugIntentIssueArtifact
+        {
+            BugId = bugId,
+            IntentRepairRef = $".intent-cli/bugs/{bugId}.intent-repair.yaml",
+            CreatedIssueTitle = $"Intent repair: OAuth callback loop ({bugId})",
+            CreatedIssueUrl = linkedIssueUrl,
+            CreatedIssueNumber = linkedIssueNumber,
+            ParentRepairTargets =
+            [
+                "intent:intents/intent-cli/means/auth.md",
+                "rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
+            ]
+        };
+    }
+
+    private static QueueState CreateQueueState()
+    {
+        return new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-08T12:00:00Z"),
+            Items =
+            [
+                CreateItem("G9", QueueItemState.Completed),
+                CreateItem("G12", QueueItemState.Queued),
+                CreateItem("AUTH-01", QueueItemState.Queued)
+            ]
+        };
+    }
+
+    private static QueueItem CreateItem(string executionUnit, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = $"[{executionUnit}] Existing Item",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            LinkedIssue = null,
+            WorkerRole = "Claude",
+            ReviewRole = "Codex",
+            Priority = "high"
+        };
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli"
+                },
+                Roles = new RoleMappings
+                {
+                    Implement = "Claude",
+                    Review = "Codex"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-bug-intent-enqueue-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentEnqueueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentEnqueueCommandTests.cs
@@ -41,10 +41,17 @@ public sealed class BugIntentEnqueueCommandTests
             var enqueueArtifact = BugIntentEnqueueArtifactYaml.Deserialize(
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.intent-enqueue.yaml")));
             Assert.Equal(".intent-cli/bugs/BUG-123.intent-issue.yaml", enqueueArtifact.IntentIssueRef);
-            Assert.Equal(".intent-cli/bugs/BUG-123.intent-repair.yaml", enqueueArtifact.IntentRepairRef);
             Assert.Equal("G13", enqueueArtifact.AllocatedExecutionUnit);
             Assert.Equal("https://github.com/J-Tech-Japan/MyIntentHost/issues/53", enqueueArtifact.LinkedIssueUrl);
-            Assert.True(enqueueArtifact.WasEnqueued);
+            Assert.Equal(53, enqueueArtifact.LinkedIssueNumber);
+            Assert.True(enqueueArtifact.ReadyToEnqueue);
+            Assert.Equal(
+                [
+                    ".intent-cli/issues/G13/implementation.md",
+                    ".intent-cli/issues/G13/review-context.md",
+                    ".intent-cli/issues/G13/packet.yaml"
+                ],
+                enqueueArtifact.PacketPaths);
 
             Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "G13", "implementation.md")));
             Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "G13", "review-context.md")));
@@ -99,8 +106,9 @@ public sealed class BugIntentEnqueueCommandTests
             File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.intent-enqueue.yaml")));
         Assert.Null(artifact.AllocatedExecutionUnit);
         Assert.Null(artifact.LinkedIssueUrl);
-        Assert.False(artifact.WasEnqueued);
-        Assert.Empty(artifact.GeneratedPacketPaths);
+        Assert.Null(artifact.LinkedIssueNumber);
+        Assert.False(artifact.ReadyToEnqueue);
+        Assert.Empty(artifact.PacketPaths);
 
         Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
         Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));

--- a/tests/IntentSystem.Cli.Tests/BugIntentEnqueueRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentEnqueueRendererTests.cs
@@ -15,17 +15,16 @@ public sealed class BugIntentEnqueueRendererTests
             {
                 BugId = "BUG-123",
                 IntentIssueRef = ".intent-cli/bugs/BUG-123.intent-issue.yaml",
-                IntentRepairRef = ".intent-cli/bugs/BUG-123.intent-repair.yaml",
                 AllocatedExecutionUnit = "G41",
                 LinkedIssueUrl = "https://github.com/J-Tech-Japan/MyIntentHost/issues/53",
-                ParentRepairTargets = ["intent:intents/intent-cli/means/auth.md"],
-                GeneratedPacketPaths =
+                LinkedIssueNumber = 53,
+                PacketPaths =
                 [
                     ".intent-cli/issues/G41/implementation.md",
                     ".intent-cli/issues/G41/review-context.md",
                     ".intent-cli/issues/G41/packet.yaml"
                 ],
-                WasEnqueued = true
+                ReadyToEnqueue = true
             },
             ".intent-cli/bugs/BUG-123.intent-enqueue.yaml");
 
@@ -34,7 +33,8 @@ public sealed class BugIntentEnqueueRendererTests
         Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.intent-enqueue.yaml", output, StringComparison.Ordinal);
         Assert.Contains("Allocated execution unit: G41", output, StringComparison.Ordinal);
         Assert.Contains("Linked issue URL: https://github.com/J-Tech-Japan/MyIntentHost/issues/53", output, StringComparison.Ordinal);
-        Assert.Contains("Generated packet paths: 3", output, StringComparison.Ordinal);
-        Assert.Contains("Was enqueued: true", output, StringComparison.Ordinal);
+        Assert.Contains("Linked issue number: 53", output, StringComparison.Ordinal);
+        Assert.Contains("Packet paths: 3", output, StringComparison.Ordinal);
+        Assert.Contains("Ready to enqueue: true", output, StringComparison.Ordinal);
     }
 }

--- a/tests/IntentSystem.Cli.Tests/BugIntentEnqueueRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentEnqueueRendererTests.cs
@@ -1,0 +1,40 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentEnqueueRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenArtifact_RendersDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        BugIntentEnqueueRenderer.WriteSummary(
+            writer,
+            new BugIntentEnqueueArtifact
+            {
+                BugId = "BUG-123",
+                IntentIssueRef = ".intent-cli/bugs/BUG-123.intent-issue.yaml",
+                IntentRepairRef = ".intent-cli/bugs/BUG-123.intent-repair.yaml",
+                AllocatedExecutionUnit = "G41",
+                LinkedIssueUrl = "https://github.com/J-Tech-Japan/MyIntentHost/issues/53",
+                ParentRepairTargets = ["intent:intents/intent-cli/means/auth.md"],
+                GeneratedPacketPaths =
+                [
+                    ".intent-cli/issues/G41/implementation.md",
+                    ".intent-cli/issues/G41/review-context.md",
+                    ".intent-cli/issues/G41/packet.yaml"
+                ],
+                WasEnqueued = true
+            },
+            ".intent-cli/bugs/BUG-123.intent-enqueue.yaml");
+
+        var output = writer.ToString();
+        Assert.Contains("Bug intent-enqueue artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.intent-enqueue.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Allocated execution unit: G41", output, StringComparison.Ordinal);
+        Assert.Contains("Linked issue URL: https://github.com/J-Tech-Japan/MyIntentHost/issues/53", output, StringComparison.Ordinal);
+        Assert.Contains("Generated packet paths: 3", output, StringComparison.Ordinal);
+        Assert.Contains("Was enqueued: true", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -1854,6 +1854,101 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenBugIntentEnqueueCommand_DispatchesToBugIntentEnqueueRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("parent-intent", "intents", "intent-cli", "means", "auth.md"), "# auth");
+        tempDirectory.CreateFile(
+            Path.Combine("parent-intent", "intents", "intent-cli", "specs", "12-bug-fix-and-intent-repair.md"),
+            "# spec");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(
+                new QueueState
+                {
+                    SchemaVersion = "1",
+                    UpdatedAt = DateTimeOffset.Parse("2026-04-08T12:00:00Z"),
+                    Items =
+                    [
+                        new QueueItem
+                        {
+                            ExecutionUnit = "G12",
+                            Title = "[G12] Existing Item",
+                            State = QueueItemState.Queued,
+                            Dependencies = [],
+                            BlockedBy = [],
+                            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                            PacketPaths = new PacketPaths
+                            {
+                                Implementation = ".intent-cli/issues/G12/implementation.md",
+                                ReviewContext = ".intent-cli/issues/G12/review-context.md",
+                                Yaml = ".intent-cli/issues/G12/packet.yaml"
+                            },
+                            LinkedIssue = null,
+                            WorkerRole = "Claude",
+                            ReviewRole = "Codex",
+                            Priority = "high"
+                        }
+                    ]
+                }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-repair.yaml"),
+            BugIntentRepairArtifactYaml.Serialize(
+                new BugIntentRepairArtifact
+                {
+                    BugId = "BUG-123",
+                    ExecutionRef = ".intent-cli/bugs/BUG-123.plan.yaml",
+                    IntentTaskCandidates =
+                    [
+                        "intents/intent-cli/means/auth.md",
+                        "intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
+                    ],
+                    ParentRepairTargets =
+                    [
+                        "intent:intents/intent-cli/means/auth.md",
+                        "rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
+                    ],
+                    SuggestedIssueTitle = "Intent repair: OAuth callback loop (BUG-123)",
+                    SuggestedGoal = "Repair parent intent targets for 'OAuth callback loop' (BUG-123) using .intent-cli/bugs/BUG-123.plan.yaml: intent:intents/intent-cli/means/auth.md, rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md",
+                    ReadyToIssueCut = true
+                }));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-issue.yaml"),
+            BugIntentIssueArtifactYaml.Serialize(
+                new BugIntentIssueArtifact
+                {
+                    BugId = "BUG-123",
+                    IntentRepairRef = ".intent-cli/bugs/BUG-123.intent-repair.yaml",
+                    CreatedIssueTitle = "Intent repair: OAuth callback loop (BUG-123)",
+                    CreatedIssueUrl = "https://github.com/J-Tech-Japan/MyIntentHost/issues/53",
+                    CreatedIssueNumber = 53,
+                    ParentRepairTargets =
+                    [
+                        "intent:intents/intent-cli/means/auth.md",
+                        "rule-spec:intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"
+                    ]
+                }));
+        using var writer = new StringWriter();
+        var originalTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T12:30:00Z");
+
+            var exitCode = CommandRouter.Execute(["bug", "intent-enqueue", "BUG-123"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-enqueue artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Allocated execution unit: G13", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenInterviewStartCommand_DispatchesToInterviewStartRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
@@ -214,6 +214,26 @@ public sealed class QueueManagerTests
     }
 
     [Fact]
+    public void Enqueue_GivenLinkedIssue_PropagatesLinkedIssueToQueuedEvent()
+    {
+        var state = CreateState([]);
+        var candidate = CreateItem("B1", QueueItemState.Active) with
+        {
+            LinkedIssue = new LinkedIssue
+            {
+                Repo = "J-Tech-Japan/MyIntentHost",
+                Number = 53,
+                Url = "https://github.com/J-Tech-Japan/MyIntentHost/issues/53"
+            }
+        };
+
+        var result = QueueManager.Enqueue(state, candidate, "intent-cli", BaseTime);
+
+        Assert.NotNull(result.Event);
+        Assert.Equal("https://github.com/J-Tech-Japan/MyIntentHost/issues/53", result.Event!.LinkedIssue);
+    }
+
+    [Fact]
     public void Enqueue_GivenExistingExecutionUnit_SkipsWithoutMutation()
     {
         var existingItem = CreateItem("A1", QueueItemState.Queued);


### PR DESCRIPTION
## Summary
- add `bug intent-enqueue <bug-id>` as a deterministic bridge from bug intent-issue artifacts into the current queue pipeline
- allocate the next monotonic `G<number>` from the current queue snapshot and generate packet stubs for the parent repair issue
- enqueue the linked issue into queue-state and runs.jsonl, with renderer and runtime coverage for ready and not-ready paths

Closes #203