### PR TITLE
Add bug intent start command

### DIFF
--- a/src/IntentSystem.Cli/Commands/BugIntentStartArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentStartArtifactPathResolver.cs
@@ -1,0 +1,11 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentStartArtifactPathResolver
+{
+    public static string Resolve(string bugId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bugId);
+
+        return $".intent-cli/bugs/{bugId}.intent-start.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentStartArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentStartArtifactYaml.cs
@@ -6,7 +6,7 @@ internal sealed record BugIntentStartArtifact
 
     public required string IntentEnqueueRef { get; init; }
 
-    public required string? AllocatedExecutionUnit { get; init; }
+    public required string? StartedExecutionUnit { get; init; }
 
     public required string? WorktreePath { get; init; }
 
@@ -21,7 +21,7 @@ internal static class BugIntentStartArtifactYaml
     [
         "bug_id",
         "intent_enqueue_ref",
-        "allocated_execution_unit",
+        "started_execution_unit",
         "worktree_path",
         "branch_name",
         "ready_to_start"
@@ -35,7 +35,7 @@ internal static class BugIntentStartArtifactYaml
         {
             $"bug_id: {artifact.BugId}",
             $"intent_enqueue_ref: {Quote(artifact.IntentEnqueueRef)}",
-            $"allocated_execution_unit: {FormatNullableScalar(artifact.AllocatedExecutionUnit)}",
+            $"started_execution_unit: {FormatNullableScalar(artifact.StartedExecutionUnit)}",
             $"worktree_path: {FormatNullableScalar(artifact.WorktreePath)}",
             $"branch_name: {FormatNullableScalar(artifact.BranchName)}",
             $"ready_to_start: {artifact.ReadyToStart.ToString().ToLowerInvariant()}"
@@ -55,7 +55,7 @@ internal static class BugIntentStartArtifactYaml
         {
             BugId = GetRequiredScalar(values, "bug_id"),
             IntentEnqueueRef = GetRequiredScalar(values, "intent_enqueue_ref"),
-            AllocatedExecutionUnit = GetNullableScalar(values, "allocated_execution_unit"),
+            StartedExecutionUnit = GetNullableScalar(values, "started_execution_unit"),
             WorktreePath = GetNullableScalar(values, "worktree_path"),
             BranchName = GetNullableScalar(values, "branch_name"),
             ReadyToStart = GetRequiredBoolean(values, "ready_to_start")

--- a/src/IntentSystem.Cli/Commands/BugIntentStartArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentStartArtifactYaml.cs
@@ -1,0 +1,173 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentStartArtifact
+{
+    public required string BugId { get; init; }
+
+    public required string IntentEnqueueRef { get; init; }
+
+    public required string? AllocatedExecutionUnit { get; init; }
+
+    public required string? WorktreePath { get; init; }
+
+    public required string? BranchName { get; init; }
+
+    public required bool ReadyToStart { get; init; }
+}
+
+internal static class BugIntentStartArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "bug_id",
+        "intent_enqueue_ref",
+        "allocated_execution_unit",
+        "worktree_path",
+        "branch_name",
+        "ready_to_start"
+    ];
+
+    public static string Serialize(BugIntentStartArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"bug_id: {artifact.BugId}",
+            $"intent_enqueue_ref: {Quote(artifact.IntentEnqueueRef)}",
+            $"allocated_execution_unit: {FormatNullableScalar(artifact.AllocatedExecutionUnit)}",
+            $"worktree_path: {FormatNullableScalar(artifact.WorktreePath)}",
+            $"branch_name: {FormatNullableScalar(artifact.BranchName)}",
+            $"ready_to_start: {artifact.ReadyToStart.ToString().ToLowerInvariant()}"
+        };
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static BugIntentStartArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new BugIntentStartArtifact
+        {
+            BugId = GetRequiredScalar(values, "bug_id"),
+            IntentEnqueueRef = GetRequiredScalar(values, "intent_enqueue_ref"),
+            AllocatedExecutionUnit = GetNullableScalar(values, "allocated_execution_unit"),
+            WorktreePath = GetNullableScalar(values, "worktree_path"),
+            BranchName = GetNullableScalar(values, "branch_name"),
+            ReadyToStart = GetRequiredBoolean(values, "ready_to_start")
+        };
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Bug intent-start YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+            values[key] = value switch
+            {
+                "null" => null,
+                "true" => true,
+                "false" => false,
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Bug intent-start YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException($"Bug intent-start YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static string? GetNullableScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug intent-start YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            string text => text,
+            _ => throw new InvalidOperationException($"Bug intent-start YAML field '{key}' must be a scalar string or null.")
+        };
+    }
+
+    private static bool GetRequiredBoolean(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not bool booleanValue)
+        {
+            throw new InvalidOperationException($"Bug intent-start YAML field '{key}' must be a boolean.");
+        }
+
+        return booleanValue;
+    }
+
+    private static string FormatNullableScalar(string? value)
+    {
+        return value is null ? "null" : Quote(value);
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentStartCommand.cs
@@ -64,7 +64,7 @@ internal static class BugIntentStartCommand
             {
                 BugId = bugId,
                 IntentEnqueueRef = intentEnqueueRef,
-                AllocatedExecutionUnit = intentEnqueue.AllocatedExecutionUnit,
+                StartedExecutionUnit = null,
                 WorktreePath = null,
                 BranchName = null,
                 ReadyToStart = false
@@ -82,7 +82,7 @@ internal static class BugIntentStartCommand
         {
             BugId = bugId,
             IntentEnqueueRef = intentEnqueueRef,
-            AllocatedExecutionUnit = startResult.ExecutionUnit,
+            StartedExecutionUnit = startResult.ExecutionUnit,
             WorktreePath = startResult.WorktreePath,
             BranchName = startResult.BranchName,
             ReadyToStart = true

--- a/src/IntentSystem.Cli/Commands/BugIntentStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentStartCommand.cs
@@ -1,0 +1,106 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentStartCommand
+{
+    public static Func<CliContext, string, RunStartResult> RunStartExecutor { get; set; } =
+        (context, executionUnit) => RunStartCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            BugIntentStartRenderer.WriteSummary(writer, result.Artifact, result.ArtifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static BugIntentStartCommandResult ExecuteCore(CliContext context, string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Bug intent-start command requires '<bug-id>'.");
+        }
+
+        var bugId = args[0].Trim();
+        var relativeArtifactPath = BugIntentStartArtifactPathResolver.Resolve(bugId);
+        var artifactPath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, relativeArtifactPath.Replace('/', Path.DirectorySeparatorChar)));
+        if (File.Exists(artifactPath))
+        {
+            throw new InvalidOperationException($"Bug intent-start artifact already exists at {artifactPath}");
+        }
+
+        var intentEnqueueRef = $".intent-cli/bugs/{bugId}.intent-enqueue.yaml";
+        var intentEnqueuePath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, intentEnqueueRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(intentEnqueuePath))
+        {
+            throw new InvalidOperationException($"Bug intent-enqueue artifact was not found at {intentEnqueuePath}");
+        }
+
+        var intentEnqueue = BugIntentEnqueueArtifactYaml.Deserialize(File.ReadAllText(intentEnqueuePath));
+        if (!string.Equals(intentEnqueue.BugId, bugId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Bug intent-enqueue artifact bug id '{intentEnqueue.BugId}' does not match requested bug id '{bugId}'.");
+        }
+
+        if (!intentEnqueue.ReadyToEnqueue || string.IsNullOrWhiteSpace(intentEnqueue.AllocatedExecutionUnit))
+        {
+            var notReadyArtifact = new BugIntentStartArtifact
+            {
+                BugId = bugId,
+                IntentEnqueueRef = intentEnqueueRef,
+                AllocatedExecutionUnit = intentEnqueue.AllocatedExecutionUnit,
+                WorktreePath = null,
+                BranchName = null,
+                ReadyToStart = false
+            };
+
+            return new BugIntentStartCommandResult
+            {
+                Artifact = notReadyArtifact,
+                ArtifactPath = WriteArtifact(artifactPath, relativeArtifactPath, notReadyArtifact)
+            };
+        }
+
+        var startResult = RunStartExecutor(context, intentEnqueue.AllocatedExecutionUnit);
+        var artifact = new BugIntentStartArtifact
+        {
+            BugId = bugId,
+            IntentEnqueueRef = intentEnqueueRef,
+            AllocatedExecutionUnit = startResult.ExecutionUnit,
+            WorktreePath = startResult.WorktreePath,
+            BranchName = startResult.BranchName,
+            ReadyToStart = true
+        };
+
+        return new BugIntentStartCommandResult
+        {
+            Artifact = artifact,
+            ArtifactPath = WriteArtifact(artifactPath, relativeArtifactPath, artifact)
+        };
+    }
+
+    private static string WriteArtifact(string absolutePath, string relativePath, BugIntentStartArtifact artifact)
+    {
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Bug intent-start artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, BugIntentStartArtifactYaml.Serialize(artifact));
+        return relativePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentStartCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentStartCommandResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentStartCommandResult
+{
+    public required BugIntentStartArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentStartRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentStartRenderer.cs
@@ -10,7 +10,7 @@ internal static class BugIntentStartRenderer
 
         writer.WriteLine($"Bug intent-start artifact generated for '{artifact.BugId}'.");
         writer.WriteLine($"Artifact path: {artifactPath}");
-        writer.WriteLine($"Allocated execution unit: {artifact.AllocatedExecutionUnit ?? "not-allocated"}");
+        writer.WriteLine($"Started execution unit: {artifact.StartedExecutionUnit ?? "not-started"}");
         writer.WriteLine($"Worktree path: {artifact.WorktreePath ?? "not-started"}");
         writer.WriteLine($"Branch name: {artifact.BranchName ?? "not-started"}");
         writer.WriteLine($"Ready to start: {artifact.ReadyToStart.ToString().ToLowerInvariant()}");

--- a/src/IntentSystem.Cli/Commands/BugIntentStartRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentStartRenderer.cs
@@ -1,0 +1,18 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentStartRenderer
+{
+    public static void WriteSummary(TextWriter writer, BugIntentStartArtifact artifact, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Bug intent-start artifact generated for '{artifact.BugId}'.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Allocated execution unit: {artifact.AllocatedExecutionUnit ?? "not-allocated"}");
+        writer.WriteLine($"Worktree path: {artifact.WorktreePath ?? "not-started"}");
+        writer.WriteLine($"Branch name: {artifact.BranchName ?? "not-started"}");
+        writer.WriteLine($"Ready to start: {artifact.ReadyToStart.ToString().ToLowerInvariant()}");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -84,6 +84,7 @@ internal static class CommandRouter
                 ["intent-repair"] = BugIntentRepairCommand.Execute,
                 ["intent-issue"] = BugIntentIssueCommand.Execute,
                 ["intent-enqueue"] = BugIntentEnqueueCommand.Execute,
+                ["intent-start"] = BugIntentStartCommand.Execute,
                 ["implementation-repair"] = BugImplementationRepairCommand.Execute,
                 ["implementation-issue"] = BugImplementationIssueCommand.Execute
             },

--- a/src/IntentSystem.Cli/Commands/RunStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunStartCommand.cs
@@ -25,67 +25,10 @@ internal static class RunStartCommand
             return 1;
         }
 
-        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
-        if (queueState is null)
-        {
-            return 1;
-        }
-
-        var executionUnit = args[0];
-        var queueItem = queueState.Items.FirstOrDefault(item =>
-            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
-
-        if (queueItem is null)
-        {
-            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
-            return 1;
-        }
-
-        if (queueItem.LinkedIssue is null)
-        {
-            writer.WriteLine($"Execution unit '{executionUnit}' must have a linked issue before run start.");
-            return 1;
-        }
-
-        var packetPath = Path.Combine(
-            context.RepoRoot,
-            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
-        if (!File.Exists(packetPath))
-        {
-            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
-            return 1;
-        }
-
         try
         {
-            var packet = ProjectionPacketRuntimeReader.Read(File.ReadAllText(packetPath));
-            var childRepoRef = packet.TargetRepo;
-            if (string.IsNullOrWhiteSpace(childRepoRef))
-            {
-                throw new InvalidOperationException("Projection packet must contain a target repo.");
-            }
-
-            var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
-            if (!Directory.Exists(childRepoPath))
-            {
-                throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
-            }
-
-            var worktreePath = ResolveWorktreePath(context, executionUnit);
-            if (Directory.Exists(worktreePath))
-            {
-                throw new InvalidOperationException($"Worktree path already exists at {worktreePath}");
-            }
-
-            var branchName = ResolveBranchName(executionUnit, queueItem.LinkedIssue);
-            var gitRunner = GitCommandRunnerFactory();
-            CreateWorktree(childRepoPath, worktreePath, branchName, gitRunner);
-
-            var timestamp = TimestampFactory();
-            var transition = QueueManager.Activate(queueState, executionUnit, TransitionActor, timestamp);
-            PersistStart(context, transition);
-
-            writer.WriteLine($"Run started for {executionUnit}.");
+            var result = ExecuteCore(context, args[0].Trim());
+            writer.WriteLine($"Run started for {result.ExecutionUnit}.");
             return 0;
         }
         catch (InvalidOperationException exception)
@@ -93,6 +36,74 @@ internal static class RunStartCommand
             writer.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    internal static RunStartResult ExecuteCore(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var queueStatePath = context.GetQueueStatePath();
+        if (!File.Exists(queueStatePath))
+        {
+            throw new InvalidOperationException($"No queue state found at {queueStatePath}");
+        }
+
+        var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (queueItem is null)
+        {
+            throw new InvalidOperationException($"Execution unit '{executionUnit}' was not found in queue state.");
+        }
+
+        if (queueItem.LinkedIssue is null)
+        {
+            throw new InvalidOperationException($"Execution unit '{executionUnit}' must have a linked issue before run start.");
+        }
+
+        var packetPath = Path.Combine(
+            context.RepoRoot,
+            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(packetPath))
+        {
+            throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
+        }
+
+        var packet = ProjectionPacketRuntimeReader.Read(File.ReadAllText(packetPath));
+        var childRepoRef = packet.TargetRepo;
+        if (string.IsNullOrWhiteSpace(childRepoRef))
+        {
+            throw new InvalidOperationException("Projection packet must contain a target repo.");
+        }
+
+        var childRepoPath = ResolveChildRepoPath(context.RepoRoot, childRepoRef);
+        if (!Directory.Exists(childRepoPath))
+        {
+            throw new InvalidOperationException($"Child repo path was not found at {childRepoPath}");
+        }
+
+        var worktreePath = ResolveWorktreePath(context, executionUnit);
+        if (Directory.Exists(worktreePath))
+        {
+            throw new InvalidOperationException($"Worktree path already exists at {worktreePath}");
+        }
+
+        var branchName = ResolveBranchName(executionUnit, queueItem.LinkedIssue);
+        var gitRunner = GitCommandRunnerFactory();
+        CreateWorktree(childRepoPath, worktreePath, branchName, gitRunner);
+
+        var timestamp = TimestampFactory();
+        var transition = QueueManager.Activate(queueState, executionUnit, TransitionActor, timestamp);
+        PersistStart(context, transition);
+
+        return new RunStartResult
+        {
+            ExecutionUnit = executionUnit,
+            WorktreePath = worktreePath,
+            BranchName = branchName
+        };
     }
 
     internal static string ResolveBranchName(string executionUnit, LinkedIssue linkedIssue)

--- a/src/IntentSystem.Cli/Commands/RunStartResult.cs
+++ b/src/IntentSystem.Cli/Commands/RunStartResult.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record RunStartResult
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required string WorktreePath { get; init; }
+
+    public required string BranchName { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentStartArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentStartArtifactYamlTests.cs
@@ -1,0 +1,40 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentStartArtifactYamlTests
+{
+    [Fact]
+    public void SerializeAndDeserialize_GivenArtifact_RoundTripsDeterministically()
+    {
+        var artifact = new BugIntentStartArtifact
+        {
+            BugId = "BUG-123",
+            IntentEnqueueRef = ".intent-cli/bugs/BUG-123.intent-enqueue.yaml",
+            AllocatedExecutionUnit = "G41",
+            WorktreePath = "/tmp/repo/.intent-cli/worktrees/G41",
+            BranchName = "issue-53-g41",
+            ReadyToStart = true
+        };
+
+        var roundTripped = BugIntentStartArtifactYaml.Deserialize(BugIntentStartArtifactYaml.Serialize(artifact));
+
+        Assert.Equal(artifact, roundTripped);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_Throws()
+    {
+        var yaml = """
+        bug_id: BUG-123
+        intent_enqueue_ref: ".intent-cli/bugs/BUG-123.intent-enqueue.yaml"
+        allocated_execution_unit: null
+        worktree_path: null
+        ready_to_start: false
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BugIntentStartArtifactYaml.Deserialize(yaml));
+
+        Assert.Contains("branch_name", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentStartArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentStartArtifactYamlTests.cs
@@ -11,7 +11,7 @@ public sealed class BugIntentStartArtifactYamlTests
         {
             BugId = "BUG-123",
             IntentEnqueueRef = ".intent-cli/bugs/BUG-123.intent-enqueue.yaml",
-            AllocatedExecutionUnit = "G41",
+            StartedExecutionUnit = "G41",
             WorktreePath = "/tmp/repo/.intent-cli/worktrees/G41",
             BranchName = "issue-53-g41",
             ReadyToStart = true
@@ -28,7 +28,7 @@ public sealed class BugIntentStartArtifactYamlTests
         var yaml = """
         bug_id: BUG-123
         intent_enqueue_ref: ".intent-cli/bugs/BUG-123.intent-enqueue.yaml"
-        allocated_execution_unit: null
+        started_execution_unit: null
         worktree_path: null
         ready_to_start: false
         """;

--- a/tests/IntentSystem.Cli.Tests/BugIntentStartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentStartCommandTests.cs
@@ -44,12 +44,12 @@ public sealed class BugIntentStartCommandTests
 
             Assert.Equal(0, exitCode);
             Assert.Contains("Bug intent-start artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
-            Assert.Contains("Allocated execution unit: G41", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Started execution unit: G41", writer.ToString(), StringComparison.Ordinal);
 
             var artifact = BugIntentStartArtifactYaml.Deserialize(
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.intent-start.yaml")));
             Assert.Equal(".intent-cli/bugs/BUG-123.intent-enqueue.yaml", artifact.IntentEnqueueRef);
-            Assert.Equal("G41", artifact.AllocatedExecutionUnit);
+            Assert.Equal("G41", artifact.StartedExecutionUnit);
             Assert.Equal("/tmp/worktrees/G41", artifact.WorktreePath);
             Assert.Equal("issue-53-g41", artifact.BranchName);
             Assert.True(artifact.ReadyToStart);
@@ -93,7 +93,7 @@ public sealed class BugIntentStartCommandTests
 
             var artifact = BugIntentStartArtifactYaml.Deserialize(
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.intent-start.yaml")));
-            Assert.Null(artifact.AllocatedExecutionUnit);
+            Assert.Null(artifact.StartedExecutionUnit);
             Assert.Null(artifact.WorktreePath);
             Assert.Null(artifact.BranchName);
             Assert.False(artifact.ReadyToStart);

--- a/tests/IntentSystem.Cli.Tests/BugIntentStartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentStartCommandTests.cs
@@ -1,0 +1,168 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentStartCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyIntentEnqueue_StartsAllocatedExecutionUnitAndWritesArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-enqueue.yaml"),
+            BugIntentEnqueueArtifactYaml.Serialize(
+                new BugIntentEnqueueArtifact
+                {
+                    BugId = "BUG-123",
+                    IntentIssueRef = ".intent-cli/bugs/BUG-123.intent-issue.yaml",
+                    AllocatedExecutionUnit = "G41",
+                    LinkedIssueUrl = "https://github.com/J-Tech-Japan/MyIntentHost/issues/53",
+                    LinkedIssueNumber = 53,
+                    PacketPaths =
+                    [
+                        ".intent-cli/issues/G41/implementation.md",
+                        ".intent-cli/issues/G41/review-context.md",
+                        ".intent-cli/issues/G41/packet.yaml"
+                    ],
+                    ReadyToEnqueue = true
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentStartCommand.RunStartExecutor;
+
+        try
+        {
+            BugIntentStartCommand.RunStartExecutor = (_, executionUnit) => new RunStartResult
+            {
+                ExecutionUnit = executionUnit,
+                WorktreePath = $"/tmp/worktrees/{executionUnit}",
+                BranchName = $"issue-53-{executionUnit.ToLowerInvariant()}"
+            };
+
+            var exitCode = BugIntentStartCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-start artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Allocated execution unit: G41", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = BugIntentStartArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.intent-start.yaml")));
+            Assert.Equal(".intent-cli/bugs/BUG-123.intent-enqueue.yaml", artifact.IntentEnqueueRef);
+            Assert.Equal("G41", artifact.AllocatedExecutionUnit);
+            Assert.Equal("/tmp/worktrees/G41", artifact.WorktreePath);
+            Assert.Equal("issue-53-g41", artifact.BranchName);
+            Assert.True(artifact.ReadyToStart);
+        }
+        finally
+        {
+            BugIntentStartCommand.RunStartExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyIntentEnqueue_WritesNotReadyArtifactWithoutStarting()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.intent-enqueue.yaml"),
+            BugIntentEnqueueArtifactYaml.Serialize(
+                new BugIntentEnqueueArtifact
+                {
+                    BugId = "BUG-124",
+                    IntentIssueRef = ".intent-cli/bugs/BUG-124.intent-issue.yaml",
+                    AllocatedExecutionUnit = null,
+                    LinkedIssueUrl = null,
+                    LinkedIssueNumber = null,
+                    PacketPaths = [],
+                    ReadyToEnqueue = false
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentStartCommand.RunStartExecutor;
+
+        try
+        {
+            BugIntentStartCommand.RunStartExecutor = (_, _) =>
+                throw new InvalidOperationException("run start should not execute for not-ready artifact.");
+
+            var exitCode = BugIntentStartCommand.Execute(CreateContext(repoRoot), ["BUG-124"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Ready to start: false", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = BugIntentStartArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.intent-start.yaml")));
+            Assert.Null(artifact.AllocatedExecutionUnit);
+            Assert.Null(artifact.WorktreePath);
+            Assert.Null(artifact.BranchName);
+            Assert.False(artifact.ReadyToStart);
+        }
+        finally
+        {
+            BugIntentStartCommand.RunStartExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingIntentEnqueueArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = BugIntentStartCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Bug intent-enqueue artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-bug-intent-start-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentStartRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentStartRendererTests.cs
@@ -15,7 +15,7 @@ public sealed class BugIntentStartRendererTests
             {
                 BugId = "BUG-123",
                 IntentEnqueueRef = ".intent-cli/bugs/BUG-123.intent-enqueue.yaml",
-                AllocatedExecutionUnit = "G41",
+                StartedExecutionUnit = "G41",
                 WorktreePath = "/tmp/repo/.intent-cli/worktrees/G41",
                 BranchName = "issue-53-g41",
                 ReadyToStart = true
@@ -25,7 +25,7 @@ public sealed class BugIntentStartRendererTests
         var output = writer.ToString();
         Assert.Contains("Bug intent-start artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
         Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.intent-start.yaml", output, StringComparison.Ordinal);
-        Assert.Contains("Allocated execution unit: G41", output, StringComparison.Ordinal);
+        Assert.Contains("Started execution unit: G41", output, StringComparison.Ordinal);
         Assert.Contains("Worktree path: /tmp/repo/.intent-cli/worktrees/G41", output, StringComparison.Ordinal);
         Assert.Contains("Branch name: issue-53-g41", output, StringComparison.Ordinal);
         Assert.Contains("Ready to start: true", output, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/BugIntentStartRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentStartRendererTests.cs
@@ -1,0 +1,33 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentStartRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenArtifact_RendersDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        BugIntentStartRenderer.WriteSummary(
+            writer,
+            new BugIntentStartArtifact
+            {
+                BugId = "BUG-123",
+                IntentEnqueueRef = ".intent-cli/bugs/BUG-123.intent-enqueue.yaml",
+                AllocatedExecutionUnit = "G41",
+                WorktreePath = "/tmp/repo/.intent-cli/worktrees/G41",
+                BranchName = "issue-53-g41",
+                ReadyToStart = true
+            },
+            ".intent-cli/bugs/BUG-123.intent-start.yaml");
+
+        var output = writer.ToString();
+        Assert.Contains("Bug intent-start artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.intent-start.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Allocated execution unit: G41", output, StringComparison.Ordinal);
+        Assert.Contains("Worktree path: /tmp/repo/.intent-cli/worktrees/G41", output, StringComparison.Ordinal);
+        Assert.Contains("Branch name: issue-53-g41", output, StringComparison.Ordinal);
+        Assert.Contains("Ready to start: true", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -2766,6 +2766,53 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenBugIntentStartCommand_DispatchesToBugIntentStartRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-enqueue.yaml"),
+            BugIntentEnqueueArtifactYaml.Serialize(
+                new BugIntentEnqueueArtifact
+                {
+                    BugId = "BUG-123",
+                    IntentIssueRef = ".intent-cli/bugs/BUG-123.intent-issue.yaml",
+                    AllocatedExecutionUnit = "G41",
+                    LinkedIssueUrl = "https://github.com/J-Tech-Japan/MyIntentHost/issues/53",
+                    LinkedIssueNumber = 53,
+                    PacketPaths =
+                    [
+                        ".intent-cli/issues/G41/implementation.md",
+                        ".intent-cli/issues/G41/review-context.md",
+                        ".intent-cli/issues/G41/packet.yaml"
+                    ],
+                    ReadyToEnqueue = true
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentStartCommand.RunStartExecutor;
+
+        try
+        {
+            BugIntentStartCommand.RunStartExecutor = (_, executionUnit) => new RunStartResult
+            {
+                ExecutionUnit = executionUnit,
+                WorktreePath = $"/tmp/worktrees/{executionUnit}",
+                BranchName = $"issue-53-{executionUnit.ToLowerInvariant()}"
+            };
+
+            var exitCode = CommandRouter.Execute(["bug", "intent-start", "BUG-123"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-start artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Ready to start: true", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            BugIntentStartCommand.RunStartExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenRunSubmitCommand_DispatchesToRunSubmitRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunStartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunStartCommandTests.cs
@@ -221,6 +221,45 @@ public sealed class RunStartCommandTests
             worktreePath);
     }
 
+    [Fact]
+    public void ExecuteCore_GivenQueuedItemWithLinkedIssue_ReturnsDeterministicResult()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        var gitRunner = new FakeGitRunner();
+        var originalGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = RunStartCommand.TimestampFactory;
+
+        try
+        {
+            RunStartCommand.GitCommandRunnerFactory = () => gitRunner;
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T09:30:00Z");
+
+            var result = RunStartCommand.ExecuteCore(CreateContext(repoRoot), "G14");
+
+            Assert.Equal("G14", result.ExecutionUnit);
+            Assert.Equal(
+                Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "worktrees", "G14")),
+                result.WorktreePath);
+            Assert.Equal("issue-56-g14", result.BranchName);
+        }
+        finally
+        {
+            RunStartCommand.GitCommandRunnerFactory = originalGitFactory;
+            RunStartCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext


### PR DESCRIPTION
## Summary
- add `bug intent-start <bug-id>` as a deterministic bridge from bug intent-enqueue artifacts into the current `run start` flow
- factor `run start` into a reusable core result so bug-scoped start can reuse the existing worktree, branch, and active-transition baseline
- add artifact, renderer, runtime, and router coverage for ready and not-ready paths

Closes #205