### PR TITLE
[codex] Add bug intent submit command

### DIFF
--- a/src/IntentSystem.Cli/Commands/BugIntentSubmitArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentSubmitArtifactPathResolver.cs
@@ -1,0 +1,11 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentSubmitArtifactPathResolver
+{
+    public static string Resolve(string bugId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bugId);
+
+        return $".intent-cli/bugs/{bugId}.intent-submit.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentSubmitArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentSubmitArtifactYaml.cs
@@ -1,0 +1,168 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentSubmitArtifact
+{
+    public required string BugId { get; init; }
+
+    public required string IntentStartRef { get; init; }
+
+    public required string? SubmittedExecutionUnit { get; init; }
+
+    public required string? LinkedPr { get; init; }
+
+    public required bool ReadyToSubmit { get; init; }
+}
+
+internal static class BugIntentSubmitArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "bug_id",
+        "intent_start_ref",
+        "submitted_execution_unit",
+        "linked_pr",
+        "ready_to_submit"
+    ];
+
+    public static string Serialize(BugIntentSubmitArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"bug_id: {artifact.BugId}",
+            $"intent_start_ref: {Quote(artifact.IntentStartRef)}",
+            $"submitted_execution_unit: {FormatNullableScalar(artifact.SubmittedExecutionUnit)}",
+            $"linked_pr: {FormatNullableScalar(artifact.LinkedPr)}",
+            $"ready_to_submit: {artifact.ReadyToSubmit.ToString().ToLowerInvariant()}"
+        };
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static BugIntentSubmitArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new BugIntentSubmitArtifact
+        {
+            BugId = GetRequiredScalar(values, "bug_id"),
+            IntentStartRef = GetRequiredScalar(values, "intent_start_ref"),
+            SubmittedExecutionUnit = GetNullableScalar(values, "submitted_execution_unit"),
+            LinkedPr = GetNullableScalar(values, "linked_pr"),
+            ReadyToSubmit = GetRequiredBoolean(values, "ready_to_submit")
+        };
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Bug intent-submit YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+            values[key] = value switch
+            {
+                "null" => null,
+                "true" => true,
+                "false" => false,
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Bug intent-submit YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException($"Bug intent-submit YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static string? GetNullableScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug intent-submit YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            string text => text,
+            _ => throw new InvalidOperationException($"Bug intent-submit YAML field '{key}' must be a scalar string or null.")
+        };
+    }
+
+    private static bool GetRequiredBoolean(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not bool booleanValue)
+        {
+            throw new InvalidOperationException($"Bug intent-submit YAML field '{key}' must be a boolean.");
+        }
+
+        return booleanValue;
+    }
+
+    private static string FormatNullableScalar(string? value)
+    {
+        return value is null ? "null" : Quote(value);
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentSubmitArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentSubmitArtifactYaml.cs
@@ -8,7 +8,9 @@ internal sealed record BugIntentSubmitArtifact
 
     public required string? SubmittedExecutionUnit { get; init; }
 
-    public required string? LinkedPr { get; init; }
+    public required string? LinkedPrUrl { get; init; }
+
+    public required int? LinkedPrNumber { get; init; }
 
     public required bool ReadyToSubmit { get; init; }
 }
@@ -20,7 +22,8 @@ internal static class BugIntentSubmitArtifactYaml
         "bug_id",
         "intent_start_ref",
         "submitted_execution_unit",
-        "linked_pr",
+        "linked_pr_url",
+        "linked_pr_number",
         "ready_to_submit"
     ];
 
@@ -33,7 +36,8 @@ internal static class BugIntentSubmitArtifactYaml
             $"bug_id: {artifact.BugId}",
             $"intent_start_ref: {Quote(artifact.IntentStartRef)}",
             $"submitted_execution_unit: {FormatNullableScalar(artifact.SubmittedExecutionUnit)}",
-            $"linked_pr: {FormatNullableScalar(artifact.LinkedPr)}",
+            $"linked_pr_url: {FormatNullableScalar(artifact.LinkedPrUrl)}",
+            $"linked_pr_number: {FormatNullableInteger(artifact.LinkedPrNumber)}",
             $"ready_to_submit: {artifact.ReadyToSubmit.ToString().ToLowerInvariant()}"
         };
 
@@ -52,7 +56,8 @@ internal static class BugIntentSubmitArtifactYaml
             BugId = GetRequiredScalar(values, "bug_id"),
             IntentStartRef = GetRequiredScalar(values, "intent_start_ref"),
             SubmittedExecutionUnit = GetNullableScalar(values, "submitted_execution_unit"),
-            LinkedPr = GetNullableScalar(values, "linked_pr"),
+            LinkedPrUrl = GetNullableScalar(values, "linked_pr_url"),
+            LinkedPrNumber = GetNullableInteger(values, "linked_pr_number"),
             ReadyToSubmit = GetRequiredBoolean(values, "ready_to_submit")
         };
     }
@@ -83,6 +88,7 @@ internal static class BugIntentSubmitArtifactYaml
                 "null" => null,
                 "true" => true,
                 "false" => false,
+                _ when int.TryParse(value, out var integerValue) => integerValue,
                 _ => ParseScalar(value)
             };
         }
@@ -136,9 +142,29 @@ internal static class BugIntentSubmitArtifactYaml
         return booleanValue;
     }
 
+    private static int? GetNullableInteger(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug intent-submit YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            int integerValue => integerValue,
+            _ => throw new InvalidOperationException($"Bug intent-submit YAML field '{key}' must be an integer or null.")
+        };
+    }
+
     private static string FormatNullableScalar(string? value)
     {
         return value is null ? "null" : Quote(value);
+    }
+
+    private static string FormatNullableInteger(int? value)
+    {
+        return value?.ToString() ?? "null";
     }
 
     private static string ParseScalar(string value)

--- a/src/IntentSystem.Cli/Commands/BugIntentSubmitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentSubmitCommand.cs
@@ -65,7 +65,8 @@ internal static class BugIntentSubmitCommand
                 BugId = bugId,
                 IntentStartRef = intentStartRef,
                 SubmittedExecutionUnit = null,
-                LinkedPr = null,
+                LinkedPrUrl = null,
+                LinkedPrNumber = null,
                 ReadyToSubmit = false
             };
 
@@ -82,7 +83,8 @@ internal static class BugIntentSubmitCommand
             BugId = bugId,
             IntentStartRef = intentStartRef,
             SubmittedExecutionUnit = submitResult.ExecutionUnit,
-            LinkedPr = submitResult.LinkedPr,
+            LinkedPrUrl = submitResult.LinkedPr,
+            LinkedPrNumber = ResolvePullRequestNumber(submitResult.LinkedPr),
             ReadyToSubmit = true
         };
 
@@ -100,5 +102,20 @@ internal static class BugIntentSubmitCommand
         Directory.CreateDirectory(directoryPath);
         File.WriteAllText(absolutePath, BugIntentSubmitArtifactYaml.Serialize(artifact));
         return relativePath;
+    }
+
+    private static int ResolvePullRequestNumber(string linkedPrUrl)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(linkedPrUrl);
+
+        var normalized = linkedPrUrl.TrimEnd('/');
+        var segment = normalized[(normalized.LastIndexOf('/') + 1)..];
+        if (int.TryParse(segment, out var number))
+        {
+            return number;
+        }
+
+        throw new InvalidOperationException(
+            $"Linked PR URL '{linkedPrUrl}' must end with a numeric pull request number.");
     }
 }

--- a/src/IntentSystem.Cli/Commands/BugIntentSubmitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentSubmitCommand.cs
@@ -1,0 +1,104 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentSubmitCommand
+{
+    public static Func<CliContext, string, RunSubmitResult> RunSubmitExecutor { get; set; } =
+        (context, executionUnit) => RunSubmitCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            BugIntentSubmitRenderer.WriteSummary(writer, result.Artifact, result.ArtifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static BugIntentSubmitCommandResult ExecuteCore(CliContext context, string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Bug intent-submit command requires '<bug-id>'.");
+        }
+
+        var bugId = args[0].Trim();
+        var relativeArtifactPath = BugIntentSubmitArtifactPathResolver.Resolve(bugId);
+        var artifactPath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, relativeArtifactPath.Replace('/', Path.DirectorySeparatorChar)));
+        if (File.Exists(artifactPath))
+        {
+            throw new InvalidOperationException($"Bug intent-submit artifact already exists at {artifactPath}");
+        }
+
+        var intentStartRef = $".intent-cli/bugs/{bugId}.intent-start.yaml";
+        var intentStartPath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, intentStartRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(intentStartPath))
+        {
+            throw new InvalidOperationException($"Bug intent-start artifact was not found at {intentStartPath}");
+        }
+
+        var intentStart = BugIntentStartArtifactYaml.Deserialize(File.ReadAllText(intentStartPath));
+        if (!string.Equals(intentStart.BugId, bugId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Bug intent-start artifact bug id '{intentStart.BugId}' does not match requested bug id '{bugId}'.");
+        }
+
+        if (!intentStart.ReadyToStart || string.IsNullOrWhiteSpace(intentStart.StartedExecutionUnit))
+        {
+            var notReadyArtifact = new BugIntentSubmitArtifact
+            {
+                BugId = bugId,
+                IntentStartRef = intentStartRef,
+                SubmittedExecutionUnit = null,
+                LinkedPr = null,
+                ReadyToSubmit = false
+            };
+
+            return new BugIntentSubmitCommandResult
+            {
+                Artifact = notReadyArtifact,
+                ArtifactPath = WriteArtifact(artifactPath, relativeArtifactPath, notReadyArtifact)
+            };
+        }
+
+        var submitResult = RunSubmitExecutor(context, intentStart.StartedExecutionUnit);
+        var artifact = new BugIntentSubmitArtifact
+        {
+            BugId = bugId,
+            IntentStartRef = intentStartRef,
+            SubmittedExecutionUnit = submitResult.ExecutionUnit,
+            LinkedPr = submitResult.LinkedPr,
+            ReadyToSubmit = true
+        };
+
+        return new BugIntentSubmitCommandResult
+        {
+            Artifact = artifact,
+            ArtifactPath = WriteArtifact(artifactPath, relativeArtifactPath, artifact)
+        };
+    }
+
+    private static string WriteArtifact(string absolutePath, string relativePath, BugIntentSubmitArtifact artifact)
+    {
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Bug intent-submit artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, BugIntentSubmitArtifactYaml.Serialize(artifact));
+        return relativePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentSubmitCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentSubmitCommandResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentSubmitCommandResult
+{
+    public required BugIntentSubmitArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentSubmitRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentSubmitRenderer.cs
@@ -11,7 +11,8 @@ internal static class BugIntentSubmitRenderer
         writer.WriteLine($"Bug intent-submit artifact generated for '{artifact.BugId}'.");
         writer.WriteLine($"Artifact path: {artifactPath}");
         writer.WriteLine($"Submitted execution unit: {artifact.SubmittedExecutionUnit ?? "not-submitted"}");
-        writer.WriteLine($"Linked PR: {artifact.LinkedPr ?? "not-submitted"}");
+        writer.WriteLine($"Linked PR URL: {artifact.LinkedPrUrl ?? "not-submitted"}");
+        writer.WriteLine($"Linked PR number: {artifact.LinkedPrNumber?.ToString() ?? "not-submitted"}");
         writer.WriteLine($"Ready to submit: {artifact.ReadyToSubmit.ToString().ToLowerInvariant()}");
     }
 }

--- a/src/IntentSystem.Cli/Commands/BugIntentSubmitRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentSubmitRenderer.cs
@@ -1,0 +1,17 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentSubmitRenderer
+{
+    public static void WriteSummary(TextWriter writer, BugIntentSubmitArtifact artifact, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Bug intent-submit artifact generated for '{artifact.BugId}'.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Submitted execution unit: {artifact.SubmittedExecutionUnit ?? "not-submitted"}");
+        writer.WriteLine($"Linked PR: {artifact.LinkedPr ?? "not-submitted"}");
+        writer.WriteLine($"Ready to submit: {artifact.ReadyToSubmit.ToString().ToLowerInvariant()}");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -85,6 +85,7 @@ internal static class CommandRouter
                 ["intent-issue"] = BugIntentIssueCommand.Execute,
                 ["intent-enqueue"] = BugIntentEnqueueCommand.Execute,
                 ["intent-start"] = BugIntentStartCommand.Execute,
+                ["intent-submit"] = BugIntentSubmitCommand.Execute,
                 ["implementation-repair"] = BugImplementationRepairCommand.Execute,
                 ["implementation-issue"] = BugImplementationIssueCommand.Execute
             },

--- a/tests/IntentSystem.Cli.Tests/BugIntentSubmitArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentSubmitArtifactYamlTests.cs
@@ -12,7 +12,8 @@ public sealed class BugIntentSubmitArtifactYamlTests
             BugId = "BUG-123",
             IntentStartRef = ".intent-cli/bugs/BUG-123.intent-start.yaml",
             SubmittedExecutionUnit = "G41",
-            LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+            LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+            LinkedPrNumber = 58,
             ReadyToSubmit = true
         };
 
@@ -28,11 +29,12 @@ public sealed class BugIntentSubmitArtifactYamlTests
         bug_id: BUG-123
         intent_start_ref: ".intent-cli/bugs/BUG-123.intent-start.yaml"
         submitted_execution_unit: null
+        linked_pr_url: null
         ready_to_submit: false
         """;
 
         var exception = Assert.Throws<InvalidOperationException>(() => BugIntentSubmitArtifactYaml.Deserialize(yaml));
 
-        Assert.Contains("linked_pr", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("linked_pr_number", exception.Message, StringComparison.Ordinal);
     }
 }

--- a/tests/IntentSystem.Cli.Tests/BugIntentSubmitArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentSubmitArtifactYamlTests.cs
@@ -1,0 +1,38 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentSubmitArtifactYamlTests
+{
+    [Fact]
+    public void SerializeAndDeserialize_GivenArtifact_RoundTripsDeterministically()
+    {
+        var artifact = new BugIntentSubmitArtifact
+        {
+            BugId = "BUG-123",
+            IntentStartRef = ".intent-cli/bugs/BUG-123.intent-start.yaml",
+            SubmittedExecutionUnit = "G41",
+            LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+            ReadyToSubmit = true
+        };
+
+        var roundTripped = BugIntentSubmitArtifactYaml.Deserialize(BugIntentSubmitArtifactYaml.Serialize(artifact));
+
+        Assert.Equal(artifact, roundTripped);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_Throws()
+    {
+        var yaml = """
+        bug_id: BUG-123
+        intent_start_ref: ".intent-cli/bugs/BUG-123.intent-start.yaml"
+        submitted_execution_unit: null
+        ready_to_submit: false
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BugIntentSubmitArtifactYaml.Deserialize(yaml));
+
+        Assert.Contains("linked_pr", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentSubmitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentSubmitCommandTests.cs
@@ -44,7 +44,8 @@ public sealed class BugIntentSubmitCommandTests
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.intent-submit.yaml")));
             Assert.Equal(".intent-cli/bugs/BUG-123.intent-start.yaml", artifact.IntentStartRef);
             Assert.Equal("G41", artifact.SubmittedExecutionUnit);
-            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", artifact.LinkedPr);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", artifact.LinkedPrUrl);
+            Assert.Equal(58, artifact.LinkedPrNumber);
             Assert.True(artifact.ReadyToSubmit);
         }
         finally
@@ -86,8 +87,49 @@ public sealed class BugIntentSubmitCommandTests
             var artifact = BugIntentSubmitArtifactYaml.Deserialize(
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.intent-submit.yaml")));
             Assert.Null(artifact.SubmittedExecutionUnit);
-            Assert.Null(artifact.LinkedPr);
+            Assert.Null(artifact.LinkedPrUrl);
+            Assert.Null(artifact.LinkedPrNumber);
             Assert.False(artifact.ReadyToSubmit);
+        }
+        finally
+        {
+            BugIntentSubmitCommand.RunSubmitExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenSubmitResultWithoutNumericPullRequestNumber_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-125.intent-start.yaml"),
+            BugIntentStartArtifactYaml.Serialize(
+                new BugIntentStartArtifact
+                {
+                    BugId = "BUG-125",
+                    IntentEnqueueRef = ".intent-cli/bugs/BUG-125.intent-enqueue.yaml",
+                    StartedExecutionUnit = "G42",
+                    WorktreePath = "/tmp/worktrees/G42",
+                    BranchName = "issue-53-g42",
+                    ReadyToStart = true
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentSubmitCommand.RunSubmitExecutor;
+
+        try
+        {
+            BugIntentSubmitCommand.RunSubmitExecutor = (_, executionUnit) => new RunSubmitResult
+            {
+                ExecutionUnit = executionUnit,
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/not-a-number"
+            };
+
+            var exitCode = BugIntentSubmitCommand.Execute(CreateContext(repoRoot), ["BUG-125"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("must end with a numeric pull request number", writer.ToString(), StringComparison.Ordinal);
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-125.intent-submit.yaml")));
         }
         finally
         {

--- a/tests/IntentSystem.Cli.Tests/BugIntentSubmitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentSubmitCommandTests.cs
@@ -1,0 +1,159 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class BugIntentSubmitCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyIntentStart_SubmitsStartedExecutionUnitAndWritesArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-start.yaml"),
+            BugIntentStartArtifactYaml.Serialize(
+                new BugIntentStartArtifact
+                {
+                    BugId = "BUG-123",
+                    IntentEnqueueRef = ".intent-cli/bugs/BUG-123.intent-enqueue.yaml",
+                    StartedExecutionUnit = "G41",
+                    WorktreePath = "/tmp/worktrees/G41",
+                    BranchName = "issue-53-g41",
+                    ReadyToStart = true
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentSubmitCommand.RunSubmitExecutor;
+
+        try
+        {
+            BugIntentSubmitCommand.RunSubmitExecutor = (_, executionUnit) => new RunSubmitResult
+            {
+                ExecutionUnit = executionUnit,
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/58"
+            };
+
+            var exitCode = BugIntentSubmitCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-submit artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Submitted execution unit: G41", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = BugIntentSubmitArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.intent-submit.yaml")));
+            Assert.Equal(".intent-cli/bugs/BUG-123.intent-start.yaml", artifact.IntentStartRef);
+            Assert.Equal("G41", artifact.SubmittedExecutionUnit);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", artifact.LinkedPr);
+            Assert.True(artifact.ReadyToSubmit);
+        }
+        finally
+        {
+            BugIntentSubmitCommand.RunSubmitExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyIntentStart_WritesNotReadyArtifactWithoutSubmitting()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.intent-start.yaml"),
+            BugIntentStartArtifactYaml.Serialize(
+                new BugIntentStartArtifact
+                {
+                    BugId = "BUG-124",
+                    IntentEnqueueRef = ".intent-cli/bugs/BUG-124.intent-enqueue.yaml",
+                    StartedExecutionUnit = null,
+                    WorktreePath = null,
+                    BranchName = null,
+                    ReadyToStart = false
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentSubmitCommand.RunSubmitExecutor;
+
+        try
+        {
+            BugIntentSubmitCommand.RunSubmitExecutor = (_, _) =>
+                throw new InvalidOperationException("run submit should not execute for not-ready artifact.");
+
+            var exitCode = BugIntentSubmitCommand.Execute(CreateContext(repoRoot), ["BUG-124"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Ready to submit: false", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = BugIntentSubmitArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.intent-submit.yaml")));
+            Assert.Null(artifact.SubmittedExecutionUnit);
+            Assert.Null(artifact.LinkedPr);
+            Assert.False(artifact.ReadyToSubmit);
+        }
+        finally
+        {
+            BugIntentSubmitCommand.RunSubmitExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingIntentStartArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = BugIntentSubmitCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Bug intent-start artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-bug-intent-submit-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentSubmitRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentSubmitRendererTests.cs
@@ -16,7 +16,8 @@ public sealed class BugIntentSubmitRendererTests
                 BugId = "BUG-123",
                 IntentStartRef = ".intent-cli/bugs/BUG-123.intent-start.yaml",
                 SubmittedExecutionUnit = "G41",
-                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+                LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+                LinkedPrNumber = 58,
                 ReadyToSubmit = true
             },
             ".intent-cli/bugs/BUG-123.intent-submit.yaml");
@@ -25,7 +26,8 @@ public sealed class BugIntentSubmitRendererTests
         Assert.Contains("Bug intent-submit artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
         Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.intent-submit.yaml", output, StringComparison.Ordinal);
         Assert.Contains("Submitted execution unit: G41", output, StringComparison.Ordinal);
-        Assert.Contains("Linked PR: https://github.com/J-Tech-Japan/intent-system/pull/58", output, StringComparison.Ordinal);
+        Assert.Contains("Linked PR URL: https://github.com/J-Tech-Japan/intent-system/pull/58", output, StringComparison.Ordinal);
+        Assert.Contains("Linked PR number: 58", output, StringComparison.Ordinal);
         Assert.Contains("Ready to submit: true", output, StringComparison.Ordinal);
     }
 }

--- a/tests/IntentSystem.Cli.Tests/BugIntentSubmitRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentSubmitRendererTests.cs
@@ -1,0 +1,31 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentSubmitRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenArtifact_RendersDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        BugIntentSubmitRenderer.WriteSummary(
+            writer,
+            new BugIntentSubmitArtifact
+            {
+                BugId = "BUG-123",
+                IntentStartRef = ".intent-cli/bugs/BUG-123.intent-start.yaml",
+                SubmittedExecutionUnit = "G41",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+                ReadyToSubmit = true
+            },
+            ".intent-cli/bugs/BUG-123.intent-submit.yaml");
+
+        var output = writer.ToString();
+        Assert.Contains("Bug intent-submit artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.intent-submit.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Submitted execution unit: G41", output, StringComparison.Ordinal);
+        Assert.Contains("Linked PR: https://github.com/J-Tech-Japan/intent-system/pull/58", output, StringComparison.Ordinal);
+        Assert.Contains("Ready to submit: true", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -2813,6 +2813,46 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenBugIntentSubmitCommand_DispatchesToBugIntentSubmitRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-start.yaml"),
+            BugIntentStartArtifactYaml.Serialize(
+                new BugIntentStartArtifact
+                {
+                    BugId = "BUG-123",
+                    IntentEnqueueRef = ".intent-cli/bugs/BUG-123.intent-enqueue.yaml",
+                    StartedExecutionUnit = "G41",
+                    WorktreePath = "/tmp/worktrees/G41",
+                    BranchName = "issue-53-g41",
+                    ReadyToStart = true
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentSubmitCommand.RunSubmitExecutor;
+
+        try
+        {
+            BugIntentSubmitCommand.RunSubmitExecutor = (_, executionUnit) => new RunSubmitResult
+            {
+                ExecutionUnit = executionUnit,
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/58"
+            };
+
+            var exitCode = CommandRouter.Execute(["bug", "intent-submit", "BUG-123"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-submit artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Ready to submit: true", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            BugIntentSubmitCommand.RunSubmitExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenRunSubmitCommand_DispatchesToRunSubmitRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary

- add `bug intent-submit <bug-id>` as a thin bridge from current bug intent-start artifacts into `run submit <execution-unit>`
- generate `.intent-cli/bugs/<bug-id>.intent-submit.yaml` with deterministic ready/non-ready output
- cover command routing, artifact serialization, renderer output, and runtime behavior with CLI tests

## Validation

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~BugIntentSubmit|FullyQualifiedName~RunSubmit|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`
