### PR TITLE
[codex] Add bug intent review command

### DIFF
--- a/src/IntentSystem.Cli/Commands/BugIntentReviewArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentReviewArtifactPathResolver.cs
@@ -1,0 +1,11 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentReviewArtifactPathResolver
+{
+    public static string Resolve(string bugId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bugId);
+
+        return $".intent-cli/bugs/{bugId}.intent-review.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentReviewArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentReviewArtifactYaml.cs
@@ -10,6 +10,8 @@ internal sealed record BugIntentReviewArtifact
 
     public required string? ReviewRequestRef { get; init; }
 
+    public required string? LinkedPrUrl { get; init; }
+
     public required bool ReadyToReview { get; init; }
 }
 
@@ -21,6 +23,7 @@ internal static class BugIntentReviewArtifactYaml
         "intent_submit_ref",
         "reviewed_execution_unit",
         "review_request_ref",
+        "linked_pr_url",
         "ready_to_review"
     ];
 
@@ -34,6 +37,7 @@ internal static class BugIntentReviewArtifactYaml
             $"intent_submit_ref: {Quote(artifact.IntentSubmitRef)}",
             $"reviewed_execution_unit: {FormatNullableScalar(artifact.ReviewedExecutionUnit)}",
             $"review_request_ref: {FormatNullableScalar(artifact.ReviewRequestRef)}",
+            $"linked_pr_url: {FormatNullableScalar(artifact.LinkedPrUrl)}",
             $"ready_to_review: {artifact.ReadyToReview.ToString().ToLowerInvariant()}"
         };
 
@@ -53,6 +57,7 @@ internal static class BugIntentReviewArtifactYaml
             IntentSubmitRef = GetRequiredScalar(values, "intent_submit_ref"),
             ReviewedExecutionUnit = GetNullableScalar(values, "reviewed_execution_unit"),
             ReviewRequestRef = GetNullableScalar(values, "review_request_ref"),
+            LinkedPrUrl = GetNullableScalar(values, "linked_pr_url"),
             ReadyToReview = GetRequiredBoolean(values, "ready_to_review")
         };
     }

--- a/src/IntentSystem.Cli/Commands/BugIntentReviewArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentReviewArtifactYaml.cs
@@ -1,0 +1,168 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentReviewArtifact
+{
+    public required string BugId { get; init; }
+
+    public required string IntentSubmitRef { get; init; }
+
+    public required string? ReviewedExecutionUnit { get; init; }
+
+    public required string? ReviewRequestRef { get; init; }
+
+    public required bool ReadyToReview { get; init; }
+}
+
+internal static class BugIntentReviewArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "bug_id",
+        "intent_submit_ref",
+        "reviewed_execution_unit",
+        "review_request_ref",
+        "ready_to_review"
+    ];
+
+    public static string Serialize(BugIntentReviewArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"bug_id: {artifact.BugId}",
+            $"intent_submit_ref: {Quote(artifact.IntentSubmitRef)}",
+            $"reviewed_execution_unit: {FormatNullableScalar(artifact.ReviewedExecutionUnit)}",
+            $"review_request_ref: {FormatNullableScalar(artifact.ReviewRequestRef)}",
+            $"ready_to_review: {artifact.ReadyToReview.ToString().ToLowerInvariant()}"
+        };
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static BugIntentReviewArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new BugIntentReviewArtifact
+        {
+            BugId = GetRequiredScalar(values, "bug_id"),
+            IntentSubmitRef = GetRequiredScalar(values, "intent_submit_ref"),
+            ReviewedExecutionUnit = GetNullableScalar(values, "reviewed_execution_unit"),
+            ReviewRequestRef = GetNullableScalar(values, "review_request_ref"),
+            ReadyToReview = GetRequiredBoolean(values, "ready_to_review")
+        };
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Bug intent-review YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+            values[key] = value switch
+            {
+                "null" => null,
+                "true" => true,
+                "false" => false,
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Bug intent-review YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException($"Bug intent-review YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static string? GetNullableScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug intent-review YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            string text => text,
+            _ => throw new InvalidOperationException($"Bug intent-review YAML field '{key}' must be a scalar string or null.")
+        };
+    }
+
+    private static bool GetRequiredBoolean(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not bool booleanValue)
+        {
+            throw new InvalidOperationException($"Bug intent-review YAML field '{key}' must be a boolean.");
+        }
+
+        return booleanValue;
+    }
+
+    private static string FormatNullableScalar(string? value)
+    {
+        return value is null ? "null" : Quote(value);
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentReviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentReviewCommand.cs
@@ -1,0 +1,104 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentReviewCommand
+{
+    public static Func<CliContext, string, ReviewRunResult> ReviewRunExecutor { get; set; } =
+        (context, executionUnit) => ReviewRunCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            BugIntentReviewRenderer.WriteSummary(writer, result.Artifact, result.ArtifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static BugIntentReviewCommandResult ExecuteCore(CliContext context, string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Bug intent-review command requires '<bug-id>'.");
+        }
+
+        var bugId = args[0].Trim();
+        var relativeArtifactPath = BugIntentReviewArtifactPathResolver.Resolve(bugId);
+        var artifactPath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, relativeArtifactPath.Replace('/', Path.DirectorySeparatorChar)));
+        if (File.Exists(artifactPath))
+        {
+            throw new InvalidOperationException($"Bug intent-review artifact already exists at {artifactPath}");
+        }
+
+        var intentSubmitRef = $".intent-cli/bugs/{bugId}.intent-submit.yaml";
+        var intentSubmitPath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, intentSubmitRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(intentSubmitPath))
+        {
+            throw new InvalidOperationException($"Bug intent-submit artifact was not found at {intentSubmitPath}");
+        }
+
+        var intentSubmit = BugIntentSubmitArtifactYaml.Deserialize(File.ReadAllText(intentSubmitPath));
+        if (!string.Equals(intentSubmit.BugId, bugId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Bug intent-submit artifact bug id '{intentSubmit.BugId}' does not match requested bug id '{bugId}'.");
+        }
+
+        if (!intentSubmit.ReadyToSubmit || string.IsNullOrWhiteSpace(intentSubmit.SubmittedExecutionUnit))
+        {
+            var notReadyArtifact = new BugIntentReviewArtifact
+            {
+                BugId = bugId,
+                IntentSubmitRef = intentSubmitRef,
+                ReviewedExecutionUnit = null,
+                ReviewRequestRef = null,
+                ReadyToReview = false
+            };
+
+            return new BugIntentReviewCommandResult
+            {
+                Artifact = notReadyArtifact,
+                ArtifactPath = WriteArtifact(artifactPath, relativeArtifactPath, notReadyArtifact)
+            };
+        }
+
+        var reviewRunResult = ReviewRunExecutor(context, intentSubmit.SubmittedExecutionUnit);
+        var artifact = new BugIntentReviewArtifact
+        {
+            BugId = bugId,
+            IntentSubmitRef = intentSubmitRef,
+            ReviewedExecutionUnit = reviewRunResult.ExecutionUnit,
+            ReviewRequestRef = reviewRunResult.ArtifactPath,
+            ReadyToReview = true
+        };
+
+        return new BugIntentReviewCommandResult
+        {
+            Artifact = artifact,
+            ArtifactPath = WriteArtifact(artifactPath, relativeArtifactPath, artifact)
+        };
+    }
+
+    private static string WriteArtifact(string absolutePath, string relativePath, BugIntentReviewArtifact artifact)
+    {
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Bug intent-review artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, BugIntentReviewArtifactYaml.Serialize(artifact));
+        return relativePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentReviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentReviewCommand.cs
@@ -66,6 +66,7 @@ internal static class BugIntentReviewCommand
                 IntentSubmitRef = intentSubmitRef,
                 ReviewedExecutionUnit = null,
                 ReviewRequestRef = null,
+                LinkedPrUrl = intentSubmit.LinkedPrUrl,
                 ReadyToReview = false
             };
 
@@ -83,6 +84,7 @@ internal static class BugIntentReviewCommand
             IntentSubmitRef = intentSubmitRef,
             ReviewedExecutionUnit = reviewRunResult.ExecutionUnit,
             ReviewRequestRef = reviewRunResult.ArtifactPath,
+            LinkedPrUrl = intentSubmit.LinkedPrUrl,
             ReadyToReview = true
         };
 

--- a/src/IntentSystem.Cli/Commands/BugIntentReviewCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentReviewCommandResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentReviewCommandResult
+{
+    public required BugIntentReviewArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentReviewRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentReviewRenderer.cs
@@ -12,6 +12,7 @@ internal static class BugIntentReviewRenderer
         writer.WriteLine($"Artifact path: {artifactPath}");
         writer.WriteLine($"Reviewed execution unit: {artifact.ReviewedExecutionUnit ?? "not-reviewed"}");
         writer.WriteLine($"Review request ref: {artifact.ReviewRequestRef ?? "not-reviewed"}");
+        writer.WriteLine($"Linked PR URL: {artifact.LinkedPrUrl ?? "not-reviewed"}");
         writer.WriteLine($"Ready to review: {artifact.ReadyToReview.ToString().ToLowerInvariant()}");
     }
 }

--- a/src/IntentSystem.Cli/Commands/BugIntentReviewRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentReviewRenderer.cs
@@ -1,0 +1,17 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentReviewRenderer
+{
+    public static void WriteSummary(TextWriter writer, BugIntentReviewArtifact artifact, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Bug intent-review artifact generated for '{artifact.BugId}'.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Reviewed execution unit: {artifact.ReviewedExecutionUnit ?? "not-reviewed"}");
+        writer.WriteLine($"Review request ref: {artifact.ReviewRequestRef ?? "not-reviewed"}");
+        writer.WriteLine($"Ready to review: {artifact.ReadyToReview.ToString().ToLowerInvariant()}");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -86,6 +86,7 @@ internal static class CommandRouter
                 ["intent-enqueue"] = BugIntentEnqueueCommand.Execute,
                 ["intent-start"] = BugIntentStartCommand.Execute,
                 ["intent-submit"] = BugIntentSubmitCommand.Execute,
+                ["intent-review"] = BugIntentReviewCommand.Execute,
                 ["implementation-repair"] = BugImplementationRepairCommand.Execute,
                 ["implementation-issue"] = BugImplementationIssueCommand.Execute
             },

--- a/tests/IntentSystem.Cli.Tests/BugIntentReviewArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentReviewArtifactYamlTests.cs
@@ -13,6 +13,7 @@ public sealed class BugIntentReviewArtifactYamlTests
             IntentSubmitRef = ".intent-cli/bugs/BUG-123.intent-submit.yaml",
             ReviewedExecutionUnit = "G41",
             ReviewRequestRef = ".intent-cli/reviews/G41.request.json",
+            LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
             ReadyToReview = true
         };
 
@@ -28,11 +29,12 @@ public sealed class BugIntentReviewArtifactYamlTests
         bug_id: BUG-123
         intent_submit_ref: ".intent-cli/bugs/BUG-123.intent-submit.yaml"
         reviewed_execution_unit: null
+        review_request_ref: null
         ready_to_review: false
         """;
 
         var exception = Assert.Throws<InvalidOperationException>(() => BugIntentReviewArtifactYaml.Deserialize(yaml));
 
-        Assert.Contains("review_request_ref", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("linked_pr_url", exception.Message, StringComparison.Ordinal);
     }
 }

--- a/tests/IntentSystem.Cli.Tests/BugIntentReviewArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentReviewArtifactYamlTests.cs
@@ -1,0 +1,38 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentReviewArtifactYamlTests
+{
+    [Fact]
+    public void SerializeAndDeserialize_GivenArtifact_RoundTripsDeterministically()
+    {
+        var artifact = new BugIntentReviewArtifact
+        {
+            BugId = "BUG-123",
+            IntentSubmitRef = ".intent-cli/bugs/BUG-123.intent-submit.yaml",
+            ReviewedExecutionUnit = "G41",
+            ReviewRequestRef = ".intent-cli/reviews/G41.request.json",
+            ReadyToReview = true
+        };
+
+        var roundTripped = BugIntentReviewArtifactYaml.Deserialize(BugIntentReviewArtifactYaml.Serialize(artifact));
+
+        Assert.Equal(artifact, roundTripped);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_Throws()
+    {
+        var yaml = """
+        bug_id: BUG-123
+        intent_submit_ref: ".intent-cli/bugs/BUG-123.intent-submit.yaml"
+        reviewed_execution_unit: null
+        ready_to_review: false
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BugIntentReviewArtifactYaml.Deserialize(yaml));
+
+        Assert.Contains("review_request_ref", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentReviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentReviewCommandTests.cs
@@ -44,6 +44,7 @@ public sealed class BugIntentReviewCommandTests
             Assert.Equal(".intent-cli/bugs/BUG-123.intent-submit.yaml", artifact.IntentSubmitRef);
             Assert.Equal("G41", artifact.ReviewedExecutionUnit);
             Assert.Equal(".intent-cli/reviews/G41.request.json", artifact.ReviewRequestRef);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", artifact.LinkedPrUrl);
             Assert.True(artifact.ReadyToReview);
         }
         finally
@@ -86,6 +87,7 @@ public sealed class BugIntentReviewCommandTests
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.intent-review.yaml")));
             Assert.Null(artifact.ReviewedExecutionUnit);
             Assert.Null(artifact.ReviewRequestRef);
+            Assert.Null(artifact.LinkedPrUrl);
             Assert.False(artifact.ReadyToReview);
         }
         finally

--- a/tests/IntentSystem.Cli.Tests/BugIntentReviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentReviewCommandTests.cs
@@ -1,0 +1,158 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentReviewCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyIntentSubmit_GeneratesReviewRequestAndWritesArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-submit.yaml"),
+            BugIntentSubmitArtifactYaml.Serialize(
+                new BugIntentSubmitArtifact
+                {
+                    BugId = "BUG-123",
+                    IntentStartRef = ".intent-cli/bugs/BUG-123.intent-start.yaml",
+                    SubmittedExecutionUnit = "G41",
+                    LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+                    LinkedPrNumber = 58,
+                    ReadyToSubmit = true
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentReviewCommand.ReviewRunExecutor;
+
+        try
+        {
+            BugIntentReviewCommand.ReviewRunExecutor = (_, executionUnit) => new ReviewRunResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+            };
+
+            var exitCode = BugIntentReviewCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-review artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Reviewed execution unit: G41", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = BugIntentReviewArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.intent-review.yaml")));
+            Assert.Equal(".intent-cli/bugs/BUG-123.intent-submit.yaml", artifact.IntentSubmitRef);
+            Assert.Equal("G41", artifact.ReviewedExecutionUnit);
+            Assert.Equal(".intent-cli/reviews/G41.request.json", artifact.ReviewRequestRef);
+            Assert.True(artifact.ReadyToReview);
+        }
+        finally
+        {
+            BugIntentReviewCommand.ReviewRunExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyIntentSubmit_WritesNotReadyArtifactWithoutReviewRun()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.intent-submit.yaml"),
+            BugIntentSubmitArtifactYaml.Serialize(
+                new BugIntentSubmitArtifact
+                {
+                    BugId = "BUG-124",
+                    IntentStartRef = ".intent-cli/bugs/BUG-124.intent-start.yaml",
+                    SubmittedExecutionUnit = null,
+                    LinkedPrUrl = null,
+                    LinkedPrNumber = null,
+                    ReadyToSubmit = false
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentReviewCommand.ReviewRunExecutor;
+
+        try
+        {
+            BugIntentReviewCommand.ReviewRunExecutor = (_, _) =>
+                throw new InvalidOperationException("review run should not execute for not-ready artifact.");
+
+            var exitCode = BugIntentReviewCommand.Execute(CreateContext(repoRoot), ["BUG-124"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Ready to review: false", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = BugIntentReviewArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.intent-review.yaml")));
+            Assert.Null(artifact.ReviewedExecutionUnit);
+            Assert.Null(artifact.ReviewRequestRef);
+            Assert.False(artifact.ReadyToReview);
+        }
+        finally
+        {
+            BugIntentReviewCommand.ReviewRunExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingIntentSubmitArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = BugIntentReviewCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Bug intent-submit artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-bug-intent-review-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentReviewRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentReviewRendererTests.cs
@@ -1,0 +1,31 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentReviewRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenArtifact_RendersDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        BugIntentReviewRenderer.WriteSummary(
+            writer,
+            new BugIntentReviewArtifact
+            {
+                BugId = "BUG-123",
+                IntentSubmitRef = ".intent-cli/bugs/BUG-123.intent-submit.yaml",
+                ReviewedExecutionUnit = "G41",
+                ReviewRequestRef = ".intent-cli/reviews/G41.request.json",
+                ReadyToReview = true
+            },
+            ".intent-cli/bugs/BUG-123.intent-review.yaml");
+
+        var output = writer.ToString();
+        Assert.Contains("Bug intent-review artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.intent-review.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Reviewed execution unit: G41", output, StringComparison.Ordinal);
+        Assert.Contains("Review request ref: .intent-cli/reviews/G41.request.json", output, StringComparison.Ordinal);
+        Assert.Contains("Ready to review: true", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentReviewRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentReviewRendererTests.cs
@@ -17,6 +17,7 @@ public sealed class BugIntentReviewRendererTests
                 IntentSubmitRef = ".intent-cli/bugs/BUG-123.intent-submit.yaml",
                 ReviewedExecutionUnit = "G41",
                 ReviewRequestRef = ".intent-cli/reviews/G41.request.json",
+                LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
                 ReadyToReview = true
             },
             ".intent-cli/bugs/BUG-123.intent-review.yaml");
@@ -26,6 +27,7 @@ public sealed class BugIntentReviewRendererTests
         Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.intent-review.yaml", output, StringComparison.Ordinal);
         Assert.Contains("Reviewed execution unit: G41", output, StringComparison.Ordinal);
         Assert.Contains("Review request ref: .intent-cli/reviews/G41.request.json", output, StringComparison.Ordinal);
+        Assert.Contains("Linked PR URL: https://github.com/J-Tech-Japan/intent-system/pull/58", output, StringComparison.Ordinal);
         Assert.Contains("Ready to review: true", output, StringComparison.Ordinal);
     }
 }

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -2853,6 +2853,46 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenBugIntentReviewCommand_DispatchesToBugIntentReviewRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-submit.yaml"),
+            BugIntentSubmitArtifactYaml.Serialize(
+                new BugIntentSubmitArtifact
+                {
+                    BugId = "BUG-123",
+                    IntentStartRef = ".intent-cli/bugs/BUG-123.intent-start.yaml",
+                    SubmittedExecutionUnit = "G41",
+                    LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+                    LinkedPrNumber = 58,
+                    ReadyToSubmit = true
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentReviewCommand.ReviewRunExecutor;
+
+        try
+        {
+            BugIntentReviewCommand.ReviewRunExecutor = (_, executionUnit) => new ReviewRunResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+            };
+
+            var exitCode = CommandRouter.Execute(["bug", "intent-review", "BUG-123"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-review artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Ready to review: true", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            BugIntentReviewCommand.ReviewRunExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenRunSubmitCommand_DispatchesToRunSubmitRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary

- add `bug intent-review <bug-id>` as a thin bridge from current bug intent-submit artifacts into `review run <execution-unit>`
- generate `.intent-cli/bugs/<bug-id>.intent-review.yaml` with deterministic ready/non-ready output
- cover command routing, artifact serialization, renderer output, and runtime behavior with CLI tests

## Validation

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~BugIntentReview|FullyQualifiedName~ReviewRun|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`
