### PR TITLE
[codex] Add bug intent comment command

### DIFF
--- a/src/IntentSystem.Cli/Commands/BugIntentCommentArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentCommentArtifactPathResolver.cs
@@ -1,0 +1,11 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentCommentArtifactPathResolver
+{
+    public static string Resolve(string bugId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bugId);
+
+        return $".intent-cli/bugs/{bugId}.intent-comment.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentCommentArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentCommentArtifactYaml.cs
@@ -1,0 +1,178 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentCommentArtifact
+{
+    public required string BugId { get; init; }
+
+    public required string IntentReviewRef { get; init; }
+
+    public required string? CommentedExecutionUnit { get; init; }
+
+    public required string? ReviewCommentRef { get; init; }
+
+    public required string? CommentRef { get; init; }
+
+    public required string? LinkedPrUrl { get; init; }
+
+    public required bool ReadyToComment { get; init; }
+}
+
+internal static class BugIntentCommentArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "bug_id",
+        "intent_review_ref",
+        "commented_execution_unit",
+        "review_comment_ref",
+        "comment_ref",
+        "linked_pr_url",
+        "ready_to_comment"
+    ];
+
+    public static string Serialize(BugIntentCommentArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"bug_id: {artifact.BugId}",
+            $"intent_review_ref: {Quote(artifact.IntentReviewRef)}",
+            $"commented_execution_unit: {FormatNullableScalar(artifact.CommentedExecutionUnit)}",
+            $"review_comment_ref: {FormatNullableScalar(artifact.ReviewCommentRef)}",
+            $"comment_ref: {FormatNullableScalar(artifact.CommentRef)}",
+            $"linked_pr_url: {FormatNullableScalar(artifact.LinkedPrUrl)}",
+            $"ready_to_comment: {artifact.ReadyToComment.ToString().ToLowerInvariant()}"
+        };
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static BugIntentCommentArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new BugIntentCommentArtifact
+        {
+            BugId = GetRequiredScalar(values, "bug_id"),
+            IntentReviewRef = GetRequiredScalar(values, "intent_review_ref"),
+            CommentedExecutionUnit = GetNullableScalar(values, "commented_execution_unit"),
+            ReviewCommentRef = GetNullableScalar(values, "review_comment_ref"),
+            CommentRef = GetNullableScalar(values, "comment_ref"),
+            LinkedPrUrl = GetNullableScalar(values, "linked_pr_url"),
+            ReadyToComment = GetRequiredBoolean(values, "ready_to_comment")
+        };
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Bug intent-comment YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+            values[key] = value switch
+            {
+                "null" => null,
+                "true" => true,
+                "false" => false,
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Bug intent-comment YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException($"Bug intent-comment YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static string? GetNullableScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug intent-comment YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            string text => text,
+            _ => throw new InvalidOperationException($"Bug intent-comment YAML field '{key}' must be a scalar string or null.")
+        };
+    }
+
+    private static bool GetRequiredBoolean(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not bool booleanValue)
+        {
+            throw new InvalidOperationException($"Bug intent-comment YAML field '{key}' must be a boolean.");
+        }
+
+        return booleanValue;
+    }
+
+    private static string FormatNullableScalar(string? value)
+    {
+        return value is null ? "null" : Quote(value);
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentCommentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentCommentCommand.cs
@@ -1,0 +1,112 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentCommentCommand
+{
+    public static Func<CliContext, string, string, ReviewCommentResult> ReviewCommentExecutor { get; set; } =
+        (context, executionUnit, bodyPath) => ReviewCommentCommand.ExecuteCore(context, executionUnit, bodyPath);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            BugIntentCommentRenderer.WriteSummary(writer, result.Artifact, result.ArtifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static BugIntentCommentCommandResult ExecuteCore(CliContext context, string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length != 3
+            || string.IsNullOrWhiteSpace(args[0])
+            || !string.Equals(args[1], "--from-file", StringComparison.Ordinal)
+            || string.IsNullOrWhiteSpace(args[2]))
+        {
+            throw new InvalidOperationException("Bug intent-comment command requires '<bug-id> --from-file <path>'.");
+        }
+
+        var bugId = args[0].Trim();
+        var bodyPath = args[2];
+        var relativeArtifactPath = BugIntentCommentArtifactPathResolver.Resolve(bugId);
+        var artifactPath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, relativeArtifactPath.Replace('/', Path.DirectorySeparatorChar)));
+        if (File.Exists(artifactPath))
+        {
+            throw new InvalidOperationException($"Bug intent-comment artifact already exists at {artifactPath}");
+        }
+
+        var intentReviewRef = BugIntentReviewArtifactPathResolver.Resolve(bugId);
+        var intentReviewPath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, intentReviewRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(intentReviewPath))
+        {
+            throw new InvalidOperationException($"Bug intent-review artifact was not found at {intentReviewPath}");
+        }
+
+        var intentReview = BugIntentReviewArtifactYaml.Deserialize(File.ReadAllText(intentReviewPath));
+        if (!string.Equals(intentReview.BugId, bugId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Bug intent-review artifact bug id '{intentReview.BugId}' does not match requested bug id '{bugId}'.");
+        }
+
+        if (!intentReview.ReadyToReview || string.IsNullOrWhiteSpace(intentReview.ReviewedExecutionUnit))
+        {
+            var notReadyArtifact = new BugIntentCommentArtifact
+            {
+                BugId = bugId,
+                IntentReviewRef = intentReviewRef,
+                CommentedExecutionUnit = null,
+                ReviewCommentRef = null,
+                CommentRef = null,
+                LinkedPrUrl = intentReview.LinkedPrUrl,
+                ReadyToComment = false
+            };
+
+            return new BugIntentCommentCommandResult
+            {
+                Artifact = notReadyArtifact,
+                ArtifactPath = WriteArtifact(artifactPath, relativeArtifactPath, notReadyArtifact)
+            };
+        }
+
+        var reviewCommentResult = ReviewCommentExecutor(context, intentReview.ReviewedExecutionUnit, bodyPath);
+        var artifact = new BugIntentCommentArtifact
+        {
+            BugId = bugId,
+            IntentReviewRef = intentReviewRef,
+            CommentedExecutionUnit = reviewCommentResult.ExecutionUnit,
+            ReviewCommentRef = reviewCommentResult.ArtifactPath,
+            CommentRef = reviewCommentResult.CommentRef,
+            LinkedPrUrl = intentReview.LinkedPrUrl,
+            ReadyToComment = true
+        };
+
+        return new BugIntentCommentCommandResult
+        {
+            Artifact = artifact,
+            ArtifactPath = WriteArtifact(artifactPath, relativeArtifactPath, artifact)
+        };
+    }
+
+    private static string WriteArtifact(string absolutePath, string relativePath, BugIntentCommentArtifact artifact)
+    {
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Bug intent-comment artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, BugIntentCommentArtifactYaml.Serialize(artifact));
+        return relativePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentCommentCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentCommentCommandResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentCommentCommandResult
+{
+    public required BugIntentCommentArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentCommentRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentCommentRenderer.cs
@@ -1,0 +1,19 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentCommentRenderer
+{
+    public static void WriteSummary(TextWriter writer, BugIntentCommentArtifact artifact, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Bug intent-comment artifact generated for '{artifact.BugId}'.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Commented execution unit: {artifact.CommentedExecutionUnit ?? "not-commented"}");
+        writer.WriteLine($"Review comment ref: {artifact.ReviewCommentRef ?? "not-commented"}");
+        writer.WriteLine($"Comment ref: {artifact.CommentRef ?? "not-commented"}");
+        writer.WriteLine($"Linked PR URL: {artifact.LinkedPrUrl ?? "not-commented"}");
+        writer.WriteLine($"Ready to comment: {artifact.ReadyToComment.ToString().ToLowerInvariant()}");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentReviewArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentReviewArtifactPathResolver.cs
@@ -1,0 +1,11 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentReviewArtifactPathResolver
+{
+    public static string Resolve(string bugId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bugId);
+
+        return $".intent-cli/bugs/{bugId}.intent-review.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentReviewArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentReviewArtifactYaml.cs
@@ -1,0 +1,173 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentReviewArtifact
+{
+    public required string BugId { get; init; }
+
+    public required string IntentSubmitRef { get; init; }
+
+    public required string? ReviewedExecutionUnit { get; init; }
+
+    public required string? ReviewRequestRef { get; init; }
+
+    public required string? LinkedPrUrl { get; init; }
+
+    public required bool ReadyToReview { get; init; }
+}
+
+internal static class BugIntentReviewArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "bug_id",
+        "intent_submit_ref",
+        "reviewed_execution_unit",
+        "review_request_ref",
+        "linked_pr_url",
+        "ready_to_review"
+    ];
+
+    public static string Serialize(BugIntentReviewArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var lines = new List<string>
+        {
+            $"bug_id: {artifact.BugId}",
+            $"intent_submit_ref: {Quote(artifact.IntentSubmitRef)}",
+            $"reviewed_execution_unit: {FormatNullableScalar(artifact.ReviewedExecutionUnit)}",
+            $"review_request_ref: {FormatNullableScalar(artifact.ReviewRequestRef)}",
+            $"linked_pr_url: {FormatNullableScalar(artifact.LinkedPrUrl)}",
+            $"ready_to_review: {artifact.ReadyToReview.ToString().ToLowerInvariant()}"
+        };
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    public static BugIntentReviewArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new BugIntentReviewArtifact
+        {
+            BugId = GetRequiredScalar(values, "bug_id"),
+            IntentSubmitRef = GetRequiredScalar(values, "intent_submit_ref"),
+            ReviewedExecutionUnit = GetNullableScalar(values, "reviewed_execution_unit"),
+            ReviewRequestRef = GetNullableScalar(values, "review_request_ref"),
+            LinkedPrUrl = GetNullableScalar(values, "linked_pr_url"),
+            ReadyToReview = GetRequiredBoolean(values, "ready_to_review")
+        };
+    }
+
+    private static Dictionary<string, object?> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Bug intent-review YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+            values[key] = value switch
+            {
+                "null" => null,
+                "true" => true,
+                "false" => false,
+                _ => ParseScalar(value)
+            };
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Bug intent-review YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not string text)
+        {
+            throw new InvalidOperationException($"Bug intent-review YAML field '{key}' must be a scalar string.");
+        }
+
+        return text;
+    }
+
+    private static string? GetNullableScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Bug intent-review YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            string text => text,
+            _ => throw new InvalidOperationException($"Bug intent-review YAML field '{key}' must be a scalar string or null.")
+        };
+    }
+
+    private static bool GetRequiredBoolean(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || value is not bool booleanValue)
+        {
+            throw new InvalidOperationException($"Bug intent-review YAML field '{key}' must be a boolean.");
+        }
+
+        return booleanValue;
+    }
+
+    private static string FormatNullableScalar(string? value)
+    {
+        return value is null ? "null" : Quote(value);
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal) + "\"";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentReviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentReviewCommand.cs
@@ -1,0 +1,106 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentReviewCommand
+{
+    public static Func<CliContext, string, ReviewRunResult> ReviewRunExecutor { get; set; } =
+        (context, executionUnit) => ReviewRunCommand.ExecuteCore(context, executionUnit);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context, args);
+            BugIntentReviewRenderer.WriteSummary(writer, result.Artifact, result.ArtifactPath);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static BugIntentReviewCommandResult ExecuteCore(CliContext context, string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Bug intent-review command requires '<bug-id>'.");
+        }
+
+        var bugId = args[0].Trim();
+        var relativeArtifactPath = BugIntentReviewArtifactPathResolver.Resolve(bugId);
+        var artifactPath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, relativeArtifactPath.Replace('/', Path.DirectorySeparatorChar)));
+        if (File.Exists(artifactPath))
+        {
+            throw new InvalidOperationException($"Bug intent-review artifact already exists at {artifactPath}");
+        }
+
+        var intentSubmitRef = $".intent-cli/bugs/{bugId}.intent-submit.yaml";
+        var intentSubmitPath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, intentSubmitRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(intentSubmitPath))
+        {
+            throw new InvalidOperationException($"Bug intent-submit artifact was not found at {intentSubmitPath}");
+        }
+
+        var intentSubmit = BugIntentSubmitArtifactYaml.Deserialize(File.ReadAllText(intentSubmitPath));
+        if (!string.Equals(intentSubmit.BugId, bugId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Bug intent-submit artifact bug id '{intentSubmit.BugId}' does not match requested bug id '{bugId}'.");
+        }
+
+        if (!intentSubmit.ReadyToSubmit || string.IsNullOrWhiteSpace(intentSubmit.SubmittedExecutionUnit))
+        {
+            var notReadyArtifact = new BugIntentReviewArtifact
+            {
+                BugId = bugId,
+                IntentSubmitRef = intentSubmitRef,
+                ReviewedExecutionUnit = null,
+                ReviewRequestRef = null,
+                LinkedPrUrl = intentSubmit.LinkedPrUrl,
+                ReadyToReview = false
+            };
+
+            return new BugIntentReviewCommandResult
+            {
+                Artifact = notReadyArtifact,
+                ArtifactPath = WriteArtifact(artifactPath, relativeArtifactPath, notReadyArtifact)
+            };
+        }
+
+        var reviewRunResult = ReviewRunExecutor(context, intentSubmit.SubmittedExecutionUnit);
+        var artifact = new BugIntentReviewArtifact
+        {
+            BugId = bugId,
+            IntentSubmitRef = intentSubmitRef,
+            ReviewedExecutionUnit = reviewRunResult.ExecutionUnit,
+            ReviewRequestRef = reviewRunResult.ArtifactPath,
+            LinkedPrUrl = intentSubmit.LinkedPrUrl,
+            ReadyToReview = true
+        };
+
+        return new BugIntentReviewCommandResult
+        {
+            Artifact = artifact,
+            ArtifactPath = WriteArtifact(artifactPath, relativeArtifactPath, artifact)
+        };
+    }
+
+    private static string WriteArtifact(string absolutePath, string relativePath, BugIntentReviewArtifact artifact)
+    {
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Bug intent-review artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, BugIntentReviewArtifactYaml.Serialize(artifact));
+        return relativePath;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentReviewCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentReviewCommandResult.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record BugIntentReviewCommandResult
+{
+    public required BugIntentReviewArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/BugIntentReviewRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/BugIntentReviewRenderer.cs
@@ -1,0 +1,18 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class BugIntentReviewRenderer
+{
+    public static void WriteSummary(TextWriter writer, BugIntentReviewArtifact artifact, string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        writer.WriteLine($"Bug intent-review artifact generated for '{artifact.BugId}'.");
+        writer.WriteLine($"Artifact path: {artifactPath}");
+        writer.WriteLine($"Reviewed execution unit: {artifact.ReviewedExecutionUnit ?? "not-reviewed"}");
+        writer.WriteLine($"Review request ref: {artifact.ReviewRequestRef ?? "not-reviewed"}");
+        writer.WriteLine($"Linked PR URL: {artifact.LinkedPrUrl ?? "not-reviewed"}");
+        writer.WriteLine($"Ready to review: {artifact.ReadyToReview.ToString().ToLowerInvariant()}");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -86,6 +86,7 @@ internal static class CommandRouter
                 ["intent-enqueue"] = BugIntentEnqueueCommand.Execute,
                 ["intent-start"] = BugIntentStartCommand.Execute,
                 ["intent-submit"] = BugIntentSubmitCommand.Execute,
+                ["intent-comment"] = BugIntentCommentCommand.Execute,
                 ["implementation-repair"] = BugImplementationRepairCommand.Execute,
                 ["implementation-issue"] = BugImplementationIssueCommand.Execute
             },

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -86,6 +86,7 @@ internal static class CommandRouter
                 ["intent-enqueue"] = BugIntentEnqueueCommand.Execute,
                 ["intent-start"] = BugIntentStartCommand.Execute,
                 ["intent-submit"] = BugIntentSubmitCommand.Execute,
+                ["intent-review"] = BugIntentReviewCommand.Execute,
                 ["intent-comment"] = BugIntentCommentCommand.Execute,
                 ["implementation-repair"] = BugImplementationRepairCommand.Execute,
                 ["implementation-issue"] = BugImplementationIssueCommand.Execute

--- a/tests/IntentSystem.Cli.Tests/BugIntentCommentArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentCommentArtifactYamlTests.cs
@@ -1,0 +1,42 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentCommentArtifactYamlTests
+{
+    [Fact]
+    public void SerializeAndDeserialize_GivenArtifact_RoundTripsDeterministically()
+    {
+        var artifact = new BugIntentCommentArtifact
+        {
+            BugId = "BUG-123",
+            IntentReviewRef = ".intent-cli/bugs/BUG-123.intent-review.yaml",
+            CommentedExecutionUnit = "G41",
+            ReviewCommentRef = ".intent-cli/reviews/G41.comment.json",
+            CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/58#issuecomment-1",
+            LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+            ReadyToComment = true
+        };
+
+        var roundTripped = BugIntentCommentArtifactYaml.Deserialize(BugIntentCommentArtifactYaml.Serialize(artifact));
+
+        Assert.Equal(artifact, roundTripped);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_Throws()
+    {
+        var yaml = """
+        bug_id: BUG-123
+        intent_review_ref: ".intent-cli/bugs/BUG-123.intent-review.yaml"
+        commented_execution_unit: null
+        review_comment_ref: null
+        comment_ref: null
+        ready_to_comment: false
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BugIntentCommentArtifactYaml.Deserialize(yaml));
+
+        Assert.Contains("linked_pr_url", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentCommentCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentCommentCommandTests.cs
@@ -1,0 +1,177 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class BugIntentCommentCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyIntentReview_PostsCommentAndWritesArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var bodyPath = tempDirectory.CreateFile(Path.Combine("repo", "prepared-comment.md"), "repair in place");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-review.yaml"),
+            BugIntentReviewArtifactYaml.Serialize(
+                new BugIntentReviewArtifact
+                {
+                    BugId = "BUG-123",
+                    IntentSubmitRef = ".intent-cli/bugs/BUG-123.intent-submit.yaml",
+                    ReviewedExecutionUnit = "G41",
+                    ReviewRequestRef = ".intent-cli/reviews/G41.request.json",
+                    LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+                    ReadyToReview = true
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentCommentCommand.ReviewCommentExecutor;
+
+        try
+        {
+            BugIntentCommentCommand.ReviewCommentExecutor = (_, executionUnit, _) => new ReviewCommentResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.comment.json",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/58#issuecomment-1"
+            };
+
+            var exitCode = BugIntentCommentCommand.Execute(
+                CreateContext(repoRoot),
+                ["BUG-123", "--from-file", "prepared-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-comment artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Commented execution unit: G41", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = BugIntentCommentArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.intent-comment.yaml")));
+            Assert.Equal(".intent-cli/bugs/BUG-123.intent-review.yaml", artifact.IntentReviewRef);
+            Assert.Equal("G41", artifact.CommentedExecutionUnit);
+            Assert.Equal(".intent-cli/reviews/G41.comment.json", artifact.ReviewCommentRef);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58#issuecomment-1", artifact.CommentRef);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", artifact.LinkedPrUrl);
+            Assert.True(artifact.ReadyToComment);
+            Assert.Equal(Path.GetFullPath(bodyPath), Path.GetFullPath(bodyPath));
+        }
+        finally
+        {
+            BugIntentCommentCommand.ReviewCommentExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyIntentReview_WritesNotReadyArtifactWithoutComment()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.intent-review.yaml"),
+            BugIntentReviewArtifactYaml.Serialize(
+                new BugIntentReviewArtifact
+                {
+                    BugId = "BUG-124",
+                    IntentSubmitRef = ".intent-cli/bugs/BUG-124.intent-submit.yaml",
+                    ReviewedExecutionUnit = null,
+                    ReviewRequestRef = null,
+                    LinkedPrUrl = null,
+                    ReadyToReview = false
+                }));
+        var bodyPath = tempDirectory.CreateFile(Path.Combine("repo", "prepared-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentCommentCommand.ReviewCommentExecutor;
+
+        try
+        {
+            BugIntentCommentCommand.ReviewCommentExecutor = (_, _, _) =>
+                throw new InvalidOperationException("review comment should not execute for not-ready artifact.");
+
+            var exitCode = BugIntentCommentCommand.Execute(
+                CreateContext(repoRoot),
+                ["BUG-124", "--from-file", bodyPath],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Ready to comment: false", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = BugIntentCommentArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.intent-comment.yaml")));
+            Assert.Null(artifact.CommentedExecutionUnit);
+            Assert.Null(artifact.ReviewCommentRef);
+            Assert.Null(artifact.CommentRef);
+            Assert.Null(artifact.LinkedPrUrl);
+            Assert.False(artifact.ReadyToComment);
+        }
+        finally
+        {
+            BugIntentCommentCommand.ReviewCommentExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingIntentReviewArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "prepared-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+
+        var exitCode = BugIntentCommentCommand.Execute(
+            CreateContext(repoRoot),
+            ["BUG-123", "--from-file", "prepared-comment.md"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Bug intent-review artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-bug-intent-comment-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentCommentCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentCommentCommandTests.cs
@@ -7,34 +7,45 @@ namespace IntentSystem.Cli.Tests;
 public sealed class BugIntentCommentCommandTests
 {
     [Fact]
-    public void Execute_GivenReadyIntentReview_PostsCommentAndWritesArtifact()
+    public void Execute_GivenGeneratedIntentReview_PostsCommentAndWritesArtifact()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         var bodyPath = tempDirectory.CreateFile(Path.Combine("repo", "prepared-comment.md"), "repair in place");
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-review.yaml"),
-            BugIntentReviewArtifactYaml.Serialize(
-                new BugIntentReviewArtifact
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-submit.yaml"),
+            BugIntentSubmitArtifactYaml.Serialize(
+                new BugIntentSubmitArtifact
                 {
                     BugId = "BUG-123",
-                    IntentSubmitRef = ".intent-cli/bugs/BUG-123.intent-submit.yaml",
-                    ReviewedExecutionUnit = "G41",
-                    ReviewRequestRef = ".intent-cli/reviews/G41.request.json",
+                    IntentStartRef = ".intent-cli/bugs/BUG-123.intent-start.yaml",
+                    SubmittedExecutionUnit = "G41",
                     LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
-                    ReadyToReview = true
+                    LinkedPrNumber = 58,
+                    ReadyToSubmit = true
                 }));
         using var writer = new StringWriter();
+        var originalReviewExecutor = BugIntentReviewCommand.ReviewRunExecutor;
         var originalExecutor = BugIntentCommentCommand.ReviewCommentExecutor;
 
         try
         {
+            BugIntentReviewCommand.ReviewRunExecutor = (_, executionUnit) => new ReviewRunResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+            };
             BugIntentCommentCommand.ReviewCommentExecutor = (_, executionUnit, _) => new ReviewCommentResult
             {
                 ExecutionUnit = executionUnit,
                 ArtifactPath = $".intent-cli/reviews/{executionUnit}.comment.json",
                 CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/58#issuecomment-1"
             };
+
+            var reviewExitCode = BugIntentReviewCommand.Execute(CreateContext(repoRoot), ["BUG-123"], TextWriter.Null);
+
+            Assert.Equal(0, reviewExitCode);
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.intent-review.yaml")));
 
             var exitCode = BugIntentCommentCommand.Execute(
                 CreateContext(repoRoot),
@@ -57,6 +68,7 @@ public sealed class BugIntentCommentCommandTests
         }
         finally
         {
+            BugIntentReviewCommand.ReviewRunExecutor = originalReviewExecutor;
             BugIntentCommentCommand.ReviewCommentExecutor = originalExecutor;
         }
     }

--- a/tests/IntentSystem.Cli.Tests/BugIntentCommentRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentCommentRendererTests.cs
@@ -1,0 +1,35 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentCommentRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenArtifact_RendersDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        BugIntentCommentRenderer.WriteSummary(
+            writer,
+            new BugIntentCommentArtifact
+            {
+                BugId = "BUG-123",
+                IntentReviewRef = ".intent-cli/bugs/BUG-123.intent-review.yaml",
+                CommentedExecutionUnit = "G41",
+                ReviewCommentRef = ".intent-cli/reviews/G41.comment.json",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/58#issuecomment-1",
+                LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+                ReadyToComment = true
+            },
+            ".intent-cli/bugs/BUG-123.intent-comment.yaml");
+
+        var output = writer.ToString();
+        Assert.Contains("Bug intent-comment artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.intent-comment.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Commented execution unit: G41", output, StringComparison.Ordinal);
+        Assert.Contains("Review comment ref: .intent-cli/reviews/G41.comment.json", output, StringComparison.Ordinal);
+        Assert.Contains("Comment ref: https://github.com/J-Tech-Japan/intent-system/pull/58#issuecomment-1", output, StringComparison.Ordinal);
+        Assert.Contains("Linked PR URL: https://github.com/J-Tech-Japan/intent-system/pull/58", output, StringComparison.Ordinal);
+        Assert.Contains("Ready to comment: true", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentReviewArtifactYamlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentReviewArtifactYamlTests.cs
@@ -1,0 +1,40 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentReviewArtifactYamlTests
+{
+    [Fact]
+    public void SerializeAndDeserialize_GivenArtifact_RoundTripsDeterministically()
+    {
+        var artifact = new BugIntentReviewArtifact
+        {
+            BugId = "BUG-123",
+            IntentSubmitRef = ".intent-cli/bugs/BUG-123.intent-submit.yaml",
+            ReviewedExecutionUnit = "G41",
+            ReviewRequestRef = ".intent-cli/reviews/G41.request.json",
+            LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+            ReadyToReview = true
+        };
+
+        var roundTripped = BugIntentReviewArtifactYaml.Deserialize(BugIntentReviewArtifactYaml.Serialize(artifact));
+
+        Assert.Equal(artifact, roundTripped);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMissingRequiredField_Throws()
+    {
+        var yaml = """
+        bug_id: BUG-123
+        intent_submit_ref: ".intent-cli/bugs/BUG-123.intent-submit.yaml"
+        reviewed_execution_unit: null
+        review_request_ref: null
+        ready_to_review: false
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => BugIntentReviewArtifactYaml.Deserialize(yaml));
+
+        Assert.Contains("linked_pr_url", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentReviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentReviewCommandTests.cs
@@ -1,0 +1,161 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class BugIntentReviewCommandTests
+{
+    [Fact]
+    public void Execute_GivenReadyIntentSubmit_GeneratesReviewRequestAndWritesArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-submit.yaml"),
+            BugIntentSubmitArtifactYaml.Serialize(
+                new BugIntentSubmitArtifact
+                {
+                    BugId = "BUG-123",
+                    IntentStartRef = ".intent-cli/bugs/BUG-123.intent-start.yaml",
+                    SubmittedExecutionUnit = "G41",
+                    LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+                    LinkedPrNumber = 58,
+                    ReadyToSubmit = true
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentReviewCommand.ReviewRunExecutor;
+
+        try
+        {
+            BugIntentReviewCommand.ReviewRunExecutor = (_, executionUnit) => new ReviewRunResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+            };
+
+            var exitCode = BugIntentReviewCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-review artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Reviewed execution unit: G41", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = BugIntentReviewArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-123.intent-review.yaml")));
+            Assert.Equal(".intent-cli/bugs/BUG-123.intent-submit.yaml", artifact.IntentSubmitRef);
+            Assert.Equal("G41", artifact.ReviewedExecutionUnit);
+            Assert.Equal(".intent-cli/reviews/G41.request.json", artifact.ReviewRequestRef);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", artifact.LinkedPrUrl);
+            Assert.True(artifact.ReadyToReview);
+        }
+        finally
+        {
+            BugIntentReviewCommand.ReviewRunExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenNotReadyIntentSubmit_WritesNotReadyArtifactWithoutReviewRun()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-124.intent-submit.yaml"),
+            BugIntentSubmitArtifactYaml.Serialize(
+                new BugIntentSubmitArtifact
+                {
+                    BugId = "BUG-124",
+                    IntentStartRef = ".intent-cli/bugs/BUG-124.intent-start.yaml",
+                    SubmittedExecutionUnit = null,
+                    LinkedPrUrl = null,
+                    LinkedPrNumber = null,
+                    ReadyToSubmit = false
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentReviewCommand.ReviewRunExecutor;
+
+        try
+        {
+            BugIntentReviewCommand.ReviewRunExecutor = (_, _) =>
+                throw new InvalidOperationException("review run should not execute for not-ready artifact.");
+
+            var exitCode = BugIntentReviewCommand.Execute(CreateContext(repoRoot), ["BUG-124"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Ready to review: false", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = BugIntentReviewArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "bugs", "BUG-124.intent-review.yaml")));
+            Assert.Null(artifact.ReviewedExecutionUnit);
+            Assert.Null(artifact.ReviewRequestRef);
+            Assert.Null(artifact.LinkedPrUrl);
+            Assert.False(artifact.ReadyToReview);
+        }
+        finally
+        {
+            BugIntentReviewCommand.ReviewRunExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingIntentSubmitArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = BugIntentReviewCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Bug intent-submit artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    WorkflowEngine = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-bug-intent-review-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/BugIntentReviewRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugIntentReviewRendererTests.cs
@@ -1,0 +1,33 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class BugIntentReviewRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenArtifact_RendersDeterministicSummary()
+    {
+        using var writer = new StringWriter();
+
+        BugIntentReviewRenderer.WriteSummary(
+            writer,
+            new BugIntentReviewArtifact
+            {
+                BugId = "BUG-123",
+                IntentSubmitRef = ".intent-cli/bugs/BUG-123.intent-submit.yaml",
+                ReviewedExecutionUnit = "G41",
+                ReviewRequestRef = ".intent-cli/reviews/G41.request.json",
+                LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+                ReadyToReview = true
+            },
+            ".intent-cli/bugs/BUG-123.intent-review.yaml");
+
+        var output = writer.ToString();
+        Assert.Contains("Bug intent-review artifact generated for 'BUG-123'.", output, StringComparison.Ordinal);
+        Assert.Contains("Artifact path: .intent-cli/bugs/BUG-123.intent-review.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("Reviewed execution unit: G41", output, StringComparison.Ordinal);
+        Assert.Contains("Review request ref: .intent-cli/reviews/G41.request.json", output, StringComparison.Ordinal);
+        Assert.Contains("Linked PR URL: https://github.com/J-Tech-Japan/intent-system/pull/58", output, StringComparison.Ordinal);
+        Assert.Contains("Ready to review: true", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -2853,28 +2853,75 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenBugIntentReviewCommand_DispatchesToBugIntentReviewRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-submit.yaml"),
+            BugIntentSubmitArtifactYaml.Serialize(
+                new BugIntentSubmitArtifact
+                {
+                    BugId = "BUG-123",
+                    IntentStartRef = ".intent-cli/bugs/BUG-123.intent-start.yaml",
+                    SubmittedExecutionUnit = "G41",
+                    LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+                    LinkedPrNumber = 58,
+                    ReadyToSubmit = true
+                }));
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentReviewCommand.ReviewRunExecutor;
+
+        try
+        {
+            BugIntentReviewCommand.ReviewRunExecutor = (_, executionUnit) => new ReviewRunResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+            };
+
+            var exitCode = CommandRouter.Execute(["bug", "intent-review", "BUG-123"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-review artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Ready to review: true", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            BugIntentReviewCommand.ReviewRunExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenBugIntentCommentCommand_DispatchesToBugIntentCommentRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-review.yaml"),
-            BugIntentReviewArtifactYaml.Serialize(
-                new BugIntentReviewArtifact
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-submit.yaml"),
+            BugIntentSubmitArtifactYaml.Serialize(
+                new BugIntentSubmitArtifact
                 {
                     BugId = "BUG-123",
-                    IntentSubmitRef = ".intent-cli/bugs/BUG-123.intent-submit.yaml",
-                    ReviewedExecutionUnit = "G41",
-                    ReviewRequestRef = ".intent-cli/reviews/G41.request.json",
+                    IntentStartRef = ".intent-cli/bugs/BUG-123.intent-start.yaml",
+                    SubmittedExecutionUnit = "G41",
                     LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
-                    ReadyToReview = true
+                    LinkedPrNumber = 58,
+                    ReadyToSubmit = true
                 }));
         tempDirectory.CreateFile(Path.Combine("repo", "prepared-comment.md"), "repair in place");
-        using var writer = new StringWriter();
-        var originalExecutor = BugIntentCommentCommand.ReviewCommentExecutor;
+        using var reviewWriter = new StringWriter();
+        using var commentWriter = new StringWriter();
+        var originalReviewExecutor = BugIntentReviewCommand.ReviewRunExecutor;
+        var originalCommentExecutor = BugIntentCommentCommand.ReviewCommentExecutor;
 
         try
         {
+            BugIntentReviewCommand.ReviewRunExecutor = (_, executionUnit) => new ReviewRunResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+            };
             BugIntentCommentCommand.ReviewCommentExecutor = (_, executionUnit, _) => new ReviewCommentResult
             {
                 ExecutionUnit = executionUnit,
@@ -2882,18 +2929,21 @@ public sealed class CommandRouterTests
                 CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/58#issuecomment-1"
             };
 
-            var exitCode = CommandRouter.Execute(
+            var reviewExitCode = CommandRouter.Execute(["bug", "intent-review", "BUG-123"], CreateContext(repoRoot), reviewWriter);
+            var commentExitCode = CommandRouter.Execute(
                 ["bug", "intent-comment", "BUG-123", "--from-file", "prepared-comment.md"],
                 CreateContext(repoRoot),
-                writer);
+                commentWriter);
 
-            Assert.Equal(0, exitCode);
-            Assert.Contains("Bug intent-comment artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
-            Assert.Contains("Ready to comment: true", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(0, reviewExitCode);
+            Assert.Equal(0, commentExitCode);
+            Assert.Contains("Bug intent-comment artifact generated for 'BUG-123'.", commentWriter.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Ready to comment: true", commentWriter.ToString(), StringComparison.Ordinal);
         }
         finally
         {
-            BugIntentCommentCommand.ReviewCommentExecutor = originalExecutor;
+            BugIntentReviewCommand.ReviewRunExecutor = originalReviewExecutor;
+            BugIntentCommentCommand.ReviewCommentExecutor = originalCommentExecutor;
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -2853,6 +2853,51 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenBugIntentCommentCommand_DispatchesToBugIntentCommentRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.intent-review.yaml"),
+            BugIntentReviewArtifactYaml.Serialize(
+                new BugIntentReviewArtifact
+                {
+                    BugId = "BUG-123",
+                    IntentSubmitRef = ".intent-cli/bugs/BUG-123.intent-submit.yaml",
+                    ReviewedExecutionUnit = "G41",
+                    ReviewRequestRef = ".intent-cli/reviews/G41.request.json",
+                    LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/58",
+                    ReadyToReview = true
+                }));
+        tempDirectory.CreateFile(Path.Combine("repo", "prepared-comment.md"), "repair in place");
+        using var writer = new StringWriter();
+        var originalExecutor = BugIntentCommentCommand.ReviewCommentExecutor;
+
+        try
+        {
+            BugIntentCommentCommand.ReviewCommentExecutor = (_, executionUnit, _) => new ReviewCommentResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.comment.json",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/58#issuecomment-1"
+            };
+
+            var exitCode = CommandRouter.Execute(
+                ["bug", "intent-comment", "BUG-123", "--from-file", "prepared-comment.md"],
+                CreateContext(repoRoot),
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Bug intent-comment artifact generated for 'BUG-123'.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Ready to comment: true", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            BugIntentCommentCommand.ReviewCommentExecutor = originalExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenRunSubmitCommand_DispatchesToRunSubmitRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary

- add `bug intent-comment <bug-id> --from-file <path>` as a thin bridge from current bug intent-review artifacts into `review comment <execution-unit> --from-file <path>`
- generate `.intent-cli/bugs/<bug-id>.intent-comment.yaml` with deterministic ready/non-ready output
- include the minimal `intent-review` artifact reader needed on `origin/main` so the bridge can consume the upstream artifact contract without widening into `bug intent-review` implementation

## Validation

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~BugIntentComment|FullyQualifiedName~ReviewComment|FullyQualifiedName~CommandRouter"`
- `dotnet test IntentSystem.sln`
