### PR TITLE
Add G93 direct run backend

### DIFF
--- a/src/IntentSystem.Cli/CliContext.cs
+++ b/src/IntentSystem.Cli/CliContext.cs
@@ -61,6 +61,17 @@ internal sealed record CliContext
         return Path.GetFullPath(Path.Combine(RepoRoot, supervisionArtifactRoot));
     }
 
+    public string ResolveDirectRunArtifactRootPath()
+    {
+        var directRunArtifactRoot = Config.DirectRun.ArtifactRoot;
+        if (Path.IsPathRooted(directRunArtifactRoot))
+        {
+            return directRunArtifactRoot;
+        }
+
+        return Path.GetFullPath(Path.Combine(RepoRoot, directRunArtifactRoot));
+    }
+
     public string? ResolveParentIntentRepoRootPath()
     {
         var parentIntentRepoRoot = Config.Project.ParentIntentRepoRoot;

--- a/src/IntentSystem.Cli/CliRuntimeContracts.cs
+++ b/src/IntentSystem.Cli/CliRuntimeContracts.cs
@@ -23,6 +23,8 @@ internal static class CliRuntimeContracts
     public const string ProviderKey = "provider";
     public const string ModelKey = "model";
     public const string TransportKey = "transport";
+    public const string CommandKey = "command";
+    public const string ArgsKey = "args";
     public const string StaleHeartbeatTimeoutMinutesKey = "stale_heartbeat_timeout_minutes";
     public const string RetryDelayMinutesKey = "retry_delay_minutes";
     public const string RetryBudgetKey = "retry_budget";

--- a/src/IntentSystem.Cli/CliRuntimeContracts.cs
+++ b/src/IntentSystem.Cli/CliRuntimeContracts.cs
@@ -15,15 +15,20 @@ internal static class CliRuntimeContracts
     public const string ParentIntentRepoRootKey = "parent_intent_repo_root";
     public const string RolesSectionName = "roles";
     public const string SupervisionSectionName = "supervision";
+    public const string DirectRunSectionName = "direct_backend";
     public const string ImplementRoleKey = "implement";
     public const string ReviewRoleKey = "review";
     public const string InterviewRoleKey = "interview";
     public const string ClarifyRoleKey = "clarify";
+    public const string ProviderKey = "provider";
+    public const string ModelKey = "model";
+    public const string TransportKey = "transport";
     public const string StaleHeartbeatTimeoutMinutesKey = "stale_heartbeat_timeout_minutes";
     public const string RetryDelayMinutesKey = "retry_delay_minutes";
     public const string RetryBudgetKey = "retry_budget";
     public const string DefaultWorktreeRoot = ".intent-cli/worktrees";
     public const string DefaultSupervisionArtifactRoot = ".intent-cli/supervision";
+    public const string DefaultDirectRunArtifactRoot = ".intent-cli/runs";
     public const int DefaultSupervisionStaleHeartbeatTimeoutMinutes = 15;
     public const int DefaultSupervisionRetryDelayMinutes = 5;
     public const int DefaultSupervisionRetryBudget = 3;
@@ -31,6 +36,8 @@ internal static class CliRuntimeContracts
     public const string DefaultReviewRole = "Codex";
     public const string DefaultInterviewRole = "Claude";
     public const string DefaultClarifyRole = "Codex";
+    public const string DefaultDirectRunModel = "default";
+    public const string DefaultDirectRunTransport = "stdio";
 
     public static string GetIntentCliDirectoryPath(string repoRoot)
     {

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -14,12 +14,14 @@ internal static class DirectRunCommandSupport
         DirectRunEntryKind entryKind,
         string executionUnit,
         string upstreamRequestRef,
+        string workingDirectory,
         IDirectRunLauncher launcher,
         DateTimeOffset launchedAt)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
         ArgumentException.ThrowIfNullOrWhiteSpace(upstreamRequestRef);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
         ArgumentNullException.ThrowIfNull(launcher);
 
         var policy = ResolvePolicy(context, entryKind);
@@ -27,6 +29,8 @@ internal static class DirectRunCommandSupport
         var relativeArtifactPath = ResolveArtifactPath(context, executionUnit);
         var absoluteArtifactPath = Path.GetFullPath(
             Path.Combine(context.RepoRoot, relativeArtifactPath.Replace('/', Path.DirectorySeparatorChar)));
+        var absoluteUpstreamRequestPath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, upstreamRequestRef.Replace('/', Path.DirectorySeparatorChar)));
         var launchResult = launcher.Launch(
             executionUnit,
             entryKindValue,
@@ -34,7 +38,9 @@ internal static class DirectRunCommandSupport
             policy.Provider,
             policy.Model,
             policy.Transport,
-            launchedAt);
+            launchedAt,
+            workingDirectory,
+            absoluteUpstreamRequestPath);
 
         var artifact = new DirectRunRequestArtifact
         {

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -7,6 +7,19 @@ internal enum DirectRunEntryKind
     Review
 }
 
+internal sealed record DirectRunResolvedPolicy
+{
+    public required string Provider { get; init; }
+
+    public required string Model { get; init; }
+
+    public required string Transport { get; init; }
+
+    public required string Command { get; init; }
+
+    public required IReadOnlyList<string> ArgsTemplate { get; init; }
+}
+
 internal static class DirectRunCommandSupport
 {
     public static DirectRunLaunchResult CreateAndLaunch(
@@ -38,6 +51,8 @@ internal static class DirectRunCommandSupport
             policy.Provider,
             policy.Model,
             policy.Transport,
+            policy.Command,
+            policy.ArgsTemplate,
             launchedAt,
             workingDirectory,
             absoluteUpstreamRequestPath);
@@ -64,7 +79,7 @@ internal static class DirectRunCommandSupport
         return launchResult;
     }
 
-    private static (string Provider, string Model, string Transport) ResolvePolicy(
+    private static DirectRunResolvedPolicy ResolvePolicy(
         CliContext context,
         DirectRunEntryKind entryKind)
     {
@@ -91,8 +106,20 @@ internal static class DirectRunCommandSupport
             entryConfig.Transport,
             directRun.Transport,
             CliRuntimeContracts.DefaultDirectRunTransport);
+        var command = FirstNonEmpty(entryConfig.Command, directRun.Command, ResolveDefaultCommand(provider));
+        var argsTemplate = FirstNonEmptyList(
+            entryConfig.Args,
+            directRun.Args,
+            ResolveDefaultArgsTemplate(provider));
 
-        return (provider, model, transport);
+        return new DirectRunResolvedPolicy
+        {
+            Provider = provider,
+            Model = model,
+            Transport = transport,
+            Command = command,
+            ArgsTemplate = argsTemplate
+        };
     }
 
     private static string ResolveArtifactPath(CliContext context, string executionUnit)
@@ -123,5 +150,38 @@ internal static class DirectRunCommandSupport
         }
 
         throw new InvalidOperationException("Direct run policy resolution must produce a non-empty value.");
+    }
+
+    private static IReadOnlyList<string> FirstNonEmptyList(params IReadOnlyList<string>[] values)
+    {
+        foreach (var value in values)
+        {
+            if (value.Count > 0)
+            {
+                return value;
+            }
+        }
+
+        throw new InvalidOperationException("Direct run policy resolution must produce a non-empty args template.");
+    }
+
+    private static string ResolveDefaultCommand(string provider)
+    {
+        return provider.Trim().ToLowerInvariant() switch
+        {
+            "codex" => "codex",
+            "claude" => "claude",
+            _ => provider
+        };
+    }
+
+    private static IReadOnlyList<string> ResolveDefaultArgsTemplate(string provider)
+    {
+        return provider.Trim().ToLowerInvariant() switch
+        {
+            "codex" => ["exec", "--model", "{model}", "{prompt}"],
+            "claude" => ["--print", "--model", "{model}", "--output-format", "json", "{prompt}"],
+            _ => ["{prompt}"]
+        };
     }
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -1,0 +1,121 @@
+namespace IntentSystem.Cli.Commands;
+
+internal enum DirectRunEntryKind
+{
+    Implement,
+    Fix,
+    Review
+}
+
+internal static class DirectRunCommandSupport
+{
+    public static DirectRunLaunchResult CreateAndLaunch(
+        CliContext context,
+        DirectRunEntryKind entryKind,
+        string executionUnit,
+        string upstreamRequestRef,
+        IDirectRunLauncher launcher,
+        DateTimeOffset launchedAt)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(upstreamRequestRef);
+        ArgumentNullException.ThrowIfNull(launcher);
+
+        var policy = ResolvePolicy(context, entryKind);
+        var entryKindValue = FormatEntryKind(entryKind);
+        var relativeArtifactPath = ResolveArtifactPath(context, executionUnit);
+        var absoluteArtifactPath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, relativeArtifactPath.Replace('/', Path.DirectorySeparatorChar)));
+        var launchResult = launcher.Launch(
+            executionUnit,
+            entryKindValue,
+            relativeArtifactPath,
+            policy.Provider,
+            policy.Model,
+            policy.Transport,
+            launchedAt);
+
+        var artifact = new DirectRunRequestArtifact
+        {
+            SchemaVersion = "1",
+            ExecutionUnit = executionUnit,
+            EntryKind = entryKindValue,
+            UpstreamRequestRef = upstreamRequestRef,
+            Provider = launchResult.Provider,
+            Model = launchResult.Model,
+            Transport = launchResult.Transport,
+            LaunchedAt = launchedAt.ToString("O"),
+            ProviderSessionId = launchResult.ProviderSessionId,
+            TransportSummary = launchResult.TransportSummary
+        };
+
+        var directoryPath = Path.GetDirectoryName(absoluteArtifactPath)
+            ?? throw new InvalidOperationException("Direct run request artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absoluteArtifactPath, DirectRunRequestArtifactJson.Serialize(artifact));
+
+        return launchResult;
+    }
+
+    private static (string Provider, string Model, string Transport) ResolvePolicy(
+        CliContext context,
+        DirectRunEntryKind entryKind)
+    {
+        var directRun = context.Config.DirectRun;
+        var entryConfig = entryKind switch
+        {
+            DirectRunEntryKind.Implement => directRun.Implement,
+            DirectRunEntryKind.Fix => directRun.Fix,
+            DirectRunEntryKind.Review => directRun.Review,
+            _ => throw new InvalidOperationException($"Unsupported direct run entry kind '{entryKind}'.")
+        };
+
+        var fallbackProvider = entryKind switch
+        {
+            DirectRunEntryKind.Implement => context.Config.Roles.Implement,
+            DirectRunEntryKind.Fix => context.Config.Roles.Implement,
+            DirectRunEntryKind.Review => context.Config.Roles.Review,
+            _ => throw new InvalidOperationException($"Unsupported direct run entry kind '{entryKind}'.")
+        };
+
+        var provider = FirstNonEmpty(entryConfig.Provider, directRun.Provider, fallbackProvider);
+        var model = FirstNonEmpty(entryConfig.Model, directRun.Model, CliRuntimeContracts.DefaultDirectRunModel);
+        var transport = FirstNonEmpty(
+            entryConfig.Transport,
+            directRun.Transport,
+            CliRuntimeContracts.DefaultDirectRunTransport);
+
+        return (provider, model, transport);
+    }
+
+    private static string ResolveArtifactPath(CliContext context, string executionUnit)
+    {
+        var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
+        return $"{root}/{executionUnit.Trim()}.request.json";
+    }
+
+    private static string FormatEntryKind(DirectRunEntryKind entryKind)
+    {
+        return entryKind switch
+        {
+            DirectRunEntryKind.Implement => "implement",
+            DirectRunEntryKind.Fix => "fix",
+            DirectRunEntryKind.Review => "review",
+            _ => throw new InvalidOperationException($"Unsupported direct run entry kind '{entryKind}'.")
+        };
+    }
+
+    private static string FirstNonEmpty(params string[] values)
+    {
+        foreach (var value in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        throw new InvalidOperationException("Direct run policy resolution must produce a non-empty value.");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/DirectRunLaunchResult.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLaunchResult.cs
@@ -1,0 +1,16 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record DirectRunLaunchResult
+{
+    public required string RequestArtifactPath { get; init; }
+
+    public required string Provider { get; init; }
+
+    public required string Model { get; init; }
+
+    public required string Transport { get; init; }
+
+    public required string ProviderSessionId { get; init; }
+
+    public required string TransportSummary { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -22,6 +22,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         string provider,
         string model,
         string transport,
+        string command,
+        IReadOnlyList<string> argsTemplate,
         DateTimeOffset launchedAt,
         string workingDirectory,
         string absoluteRequestArtifactPath)
@@ -32,20 +34,30 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         ArgumentException.ThrowIfNullOrWhiteSpace(provider);
         ArgumentException.ThrowIfNullOrWhiteSpace(model);
         ArgumentException.ThrowIfNullOrWhiteSpace(transport);
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+        ArgumentNullException.ThrowIfNull(argsTemplate);
         ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
         ArgumentException.ThrowIfNullOrWhiteSpace(absoluteRequestArtifactPath);
 
-        var command = ResolveCommand(provider, model, absoluteRequestArtifactPath);
+        var arguments = ResolveArguments(
+            executionUnit,
+            entryKind,
+            requestArtifactPath,
+            provider,
+            model,
+            transport,
+            absoluteRequestArtifactPath,
+            argsTemplate);
         var process = processRunner.Start(
             workingDirectory,
-            command.FileName,
-            command.Arguments,
+            command,
+            arguments,
             DefaultEarlyExitWindow);
 
         if (process.ExitedEarly && process.ExitCode != 0)
         {
             throw new InvalidOperationException(
-                $"Direct run launch failed for provider '{provider}' using command '{command.FileName}' with exit code {process.ExitCode}.");
+                $"Direct run launch failed for provider '{provider}' using command '{command}' with exit code {process.ExitCode}.");
         }
 
         return new DirectRunLaunchResult
@@ -56,23 +68,34 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             Transport = transport,
             ProviderSessionId = $"pid:{process.ProcessId}",
             TransportSummary =
-                $"{transport} transport launched via '{command.FileName}' in '{workingDirectory}' for provider '{provider}'."
+                $"{transport} transport launched via '{command}' in '{workingDirectory}' for provider '{provider}'."
         };
     }
 
-    private static (string FileName, IReadOnlyList<string> Arguments) ResolveCommand(
+    private static IReadOnlyList<string> ResolveArguments(
+        string executionUnit,
+        string entryKind,
+        string requestArtifactPath,
         string provider,
         string model,
-        string absoluteRequestArtifactPath)
+        string transport,
+        string absoluteRequestArtifactPath,
+        IReadOnlyList<string> argsTemplate)
     {
         var prompt =
             $"Use the request artifact at '{absoluteRequestArtifactPath}' as the bounded source of truth for this direct run.";
 
-        return provider.Trim().ToLowerInvariant() switch
-        {
-            "codex" => ("codex", ["exec", "--model", model, prompt]),
-            "claude" => ("claude", ["--print", "--model", model, "--output-format", "json", prompt]),
-            _ => (provider, [prompt])
-        };
+        return argsTemplate
+            .Select(argument => argument
+                .Replace("{execution_unit}", executionUnit, StringComparison.Ordinal)
+                .Replace("{entry_kind}", entryKind, StringComparison.Ordinal)
+                .Replace("{provider}", provider, StringComparison.Ordinal)
+                .Replace("{model}", model, StringComparison.Ordinal)
+                .Replace("{transport}", transport, StringComparison.Ordinal)
+                .Replace("{request_artifact_path}", absoluteRequestArtifactPath, StringComparison.Ordinal)
+                .Replace("{upstream_request_artifact_path}", absoluteRequestArtifactPath, StringComparison.Ordinal)
+                .Replace("{direct_run_artifact_path}", requestArtifactPath, StringComparison.Ordinal)
+                .Replace("{prompt}", prompt, StringComparison.Ordinal))
+            .ToArray();
     }
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -2,6 +2,19 @@ namespace IntentSystem.Cli.Commands;
 
 internal sealed class DirectRunLauncher : IDirectRunLauncher
 {
+    private static readonly TimeSpan DefaultEarlyExitWindow = TimeSpan.FromMilliseconds(500);
+    private readonly IDirectRunProcessRunner processRunner;
+
+    public DirectRunLauncher()
+        : this(new DirectRunProcessRunner())
+    {
+    }
+
+    internal DirectRunLauncher(IDirectRunProcessRunner processRunner)
+    {
+        this.processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
+    }
+
     public DirectRunLaunchResult Launch(
         string executionUnit,
         string entryKind,
@@ -9,7 +22,9 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         string provider,
         string model,
         string transport,
-        DateTimeOffset launchedAt)
+        DateTimeOffset launchedAt,
+        string workingDirectory,
+        string absoluteRequestArtifactPath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
         ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
@@ -17,6 +32,21 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         ArgumentException.ThrowIfNullOrWhiteSpace(provider);
         ArgumentException.ThrowIfNullOrWhiteSpace(model);
         ArgumentException.ThrowIfNullOrWhiteSpace(transport);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(absoluteRequestArtifactPath);
+
+        var command = ResolveCommand(provider, model, absoluteRequestArtifactPath);
+        var process = processRunner.Start(
+            workingDirectory,
+            command.FileName,
+            command.Arguments,
+            DefaultEarlyExitWindow);
+
+        if (process.ExitedEarly && process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Direct run launch failed for provider '{provider}' using command '{command.FileName}' with exit code {process.ExitCode}.");
+        }
 
         return new DirectRunLaunchResult
         {
@@ -24,35 +54,25 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             Provider = provider,
             Model = model,
             Transport = transport,
-            ProviderSessionId = $"{Normalize(provider)}-{Normalize(entryKind)}-{Normalize(executionUnit)}-{launchedAt:yyyyMMddHHmmss}",
-            TransportSummary = $"{transport} transport selected for provider '{provider}' with model '{model}'."
+            ProviderSessionId = $"pid:{process.ProcessId}",
+            TransportSummary =
+                $"{transport} transport launched via '{command.FileName}' in '{workingDirectory}' for provider '{provider}'."
         };
     }
 
-    private static string Normalize(string value)
+    private static (string FileName, IReadOnlyList<string> Arguments) ResolveCommand(
+        string provider,
+        string model,
+        string absoluteRequestArtifactPath)
     {
-        var builder = new List<char>(value.Length);
-        foreach (var character in value)
+        var prompt =
+            $"Use the request artifact at '{absoluteRequestArtifactPath}' as the bounded source of truth for this direct run.";
+
+        return provider.Trim().ToLowerInvariant() switch
         {
-            if (char.IsLetterOrDigit(character))
-            {
-                builder.Add(char.ToLowerInvariant(character));
-                continue;
-            }
-
-            if (builder.Count == 0 || builder[^1] == '-')
-            {
-                continue;
-            }
-
-            builder.Add('-');
-        }
-
-        while (builder.Count > 0 && builder[^1] == '-')
-        {
-            builder.RemoveAt(builder.Count - 1);
-        }
-
-        return builder.Count == 0 ? "session" : new string(builder.ToArray());
+            "codex" => ("codex", ["exec", "--model", model, prompt]),
+            "claude" => ("claude", ["--print", "--model", model, "--output-format", "json", prompt]),
+            _ => (provider, [prompt])
+        };
     }
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -1,0 +1,58 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed class DirectRunLauncher : IDirectRunLauncher
+{
+    public DirectRunLaunchResult Launch(
+        string executionUnit,
+        string entryKind,
+        string requestArtifactPath,
+        string provider,
+        string model,
+        string transport,
+        DateTimeOffset launchedAt)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(requestArtifactPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(model);
+        ArgumentException.ThrowIfNullOrWhiteSpace(transport);
+
+        return new DirectRunLaunchResult
+        {
+            RequestArtifactPath = requestArtifactPath,
+            Provider = provider,
+            Model = model,
+            Transport = transport,
+            ProviderSessionId = $"{Normalize(provider)}-{Normalize(entryKind)}-{Normalize(executionUnit)}-{launchedAt:yyyyMMddHHmmss}",
+            TransportSummary = $"{transport} transport selected for provider '{provider}' with model '{model}'."
+        };
+    }
+
+    private static string Normalize(string value)
+    {
+        var builder = new List<char>(value.Length);
+        foreach (var character in value)
+        {
+            if (char.IsLetterOrDigit(character))
+            {
+                builder.Add(char.ToLowerInvariant(character));
+                continue;
+            }
+
+            if (builder.Count == 0 || builder[^1] == '-')
+            {
+                continue;
+            }
+
+            builder.Add('-');
+        }
+
+        while (builder.Count > 0 && builder[^1] == '-')
+        {
+            builder.RemoveAt(builder.Count - 1);
+        }
+
+        return builder.Count == 0 ? "session" : new string(builder.ToArray());
+    }
+}

--- a/src/IntentSystem.Cli/Commands/DirectRunProcessLaunchResult.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProcessLaunchResult.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record DirectRunProcessLaunchResult
+{
+    public required int ProcessId { get; init; }
+
+    public required bool ExitedEarly { get; init; }
+
+    public required int ExitCode { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace IntentSystem.Cli.Commands;
+
+internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
+{
+    public DirectRunProcessLaunchResult Start(
+        string workingDirectory,
+        string fileName,
+        IReadOnlyList<string> arguments,
+        TimeSpan earlyExitWindow)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                WorkingDirectory = workingDirectory,
+                UseShellExecute = false,
+                RedirectStandardInput = false,
+                RedirectStandardOutput = false,
+                RedirectStandardError = false
+            };
+
+            foreach (var argument in arguments)
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+
+            var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException($"Failed to start direct run process '{fileName}'.");
+
+            var exitedEarly = process.WaitForExit((int)earlyExitWindow.TotalMilliseconds);
+            var exitCode = exitedEarly ? process.ExitCode : 0;
+            var processId = process.Id;
+
+            if (exitedEarly)
+            {
+                process.Dispose();
+            }
+
+            return new DirectRunProcessLaunchResult
+            {
+                ProcessId = processId,
+                ExitedEarly = exitedEarly,
+                ExitCode = exitCode
+            };
+        }
+        catch (Win32Exception exception)
+        {
+            throw new InvalidOperationException(
+                $"Failed to start direct run process '{fileName}': {exception.Message}",
+                exception);
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/DirectRunRequestArtifactJson.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunRequestArtifactJson.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record DirectRunRequestArtifact
+{
+    [JsonPropertyName("schema_version")]
+    public required string SchemaVersion { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("entry_kind")]
+    public required string EntryKind { get; init; }
+
+    [JsonPropertyName("upstream_request_ref")]
+    public required string UpstreamRequestRef { get; init; }
+
+    [JsonPropertyName("provider")]
+    public required string Provider { get; init; }
+
+    [JsonPropertyName("model")]
+    public required string Model { get; init; }
+
+    [JsonPropertyName("transport")]
+    public required string Transport { get; init; }
+
+    [JsonPropertyName("launched_at")]
+    public required string LaunchedAt { get; init; }
+
+    [JsonPropertyName("provider_session_id")]
+    public required string ProviderSessionId { get; init; }
+
+    [JsonPropertyName("transport_summary")]
+    public required string TransportSummary { get; init; }
+}
+
+internal static class DirectRunRequestArtifactJson
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = null,
+        WriteIndented = true
+    };
+
+    public static string Serialize(DirectRunRequestArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        return JsonSerializer.Serialize(artifact, Options);
+    }
+
+    public static DirectRunRequestArtifact Deserialize(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        return JsonSerializer.Deserialize<DirectRunRequestArtifact>(json, Options)
+            ?? throw new InvalidOperationException("Direct run request artifact deserialized to null.");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IDirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/IDirectRunLauncher.cs
@@ -1,0 +1,13 @@
+namespace IntentSystem.Cli.Commands;
+
+internal interface IDirectRunLauncher
+{
+    DirectRunLaunchResult Launch(
+        string executionUnit,
+        string entryKind,
+        string requestArtifactPath,
+        string provider,
+        string model,
+        string transport,
+        DateTimeOffset launchedAt);
+}

--- a/src/IntentSystem.Cli/Commands/IDirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/IDirectRunLauncher.cs
@@ -9,6 +9,8 @@ internal interface IDirectRunLauncher
         string provider,
         string model,
         string transport,
+        string command,
+        IReadOnlyList<string> argsTemplate,
         DateTimeOffset launchedAt,
         string workingDirectory,
         string absoluteRequestArtifactPath);

--- a/src/IntentSystem.Cli/Commands/IDirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/IDirectRunLauncher.cs
@@ -9,5 +9,7 @@ internal interface IDirectRunLauncher
         string provider,
         string model,
         string transport,
-        DateTimeOffset launchedAt);
+        DateTimeOffset launchedAt,
+        string workingDirectory,
+        string absoluteRequestArtifactPath);
 }

--- a/src/IntentSystem.Cli/Commands/IDirectRunProcessRunner.cs
+++ b/src/IntentSystem.Cli/Commands/IDirectRunProcessRunner.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli.Commands;
+
+internal interface IDirectRunProcessRunner
+{
+    DirectRunProcessLaunchResult Start(
+        string workingDirectory,
+        string fileName,
+        IReadOnlyList<string> arguments,
+        TimeSpan earlyExitWindow);
+}

--- a/src/IntentSystem.Cli/Commands/ReviewRunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewRunCommand.cs
@@ -94,6 +94,7 @@ internal static class ReviewRunCommand
             DirectRunEntryKind.Review,
             executionUnit,
             artifactPath,
+            context.RepoRoot,
             DirectRunLauncherFactory(),
             TimestampFactory());
 

--- a/src/IntentSystem.Cli/Commands/ReviewRunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewRunCommand.cs
@@ -5,6 +5,10 @@ namespace IntentSystem.Cli.Commands;
 
 internal static class ReviewRunCommand
 {
+    public static Func<IDirectRunLauncher> DirectRunLauncherFactory { get; set; } = () => new DirectRunLauncher();
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -21,6 +25,14 @@ internal static class ReviewRunCommand
         {
             var result = ExecuteCore(context, args[0]);
             writer.WriteLine($"Review request artifact generated for {result.ExecutionUnit}.");
+            if (result.DirectRun is not null)
+            {
+                writer.WriteLine($"Direct run request artifact: {result.DirectRun.RequestArtifactPath}");
+                writer.WriteLine($"Direct provider: {result.DirectRun.Provider}");
+                writer.WriteLine($"Direct model: {result.DirectRun.Model}");
+                writer.WriteLine($"Direct transport: {result.DirectRun.Transport}");
+                writer.WriteLine($"Provider session: {result.DirectRun.ProviderSessionId}");
+            }
             return 0;
         }
         catch (InvalidOperationException exception)
@@ -77,11 +89,19 @@ internal static class ReviewRunCommand
         var request = ReviewRequestFactory.Create(executionUnit, reviewContextRef, linkedPr, reviewContext);
         ReviewArtifactWriter.Write(request, executionUnit, context.RepoRoot, overwrite: true);
         var artifactPath = Review.ReviewArtifactPathResolver.Resolve(executionUnit);
+        var directRun = DirectRunCommandSupport.CreateAndLaunch(
+            context,
+            DirectRunEntryKind.Review,
+            executionUnit,
+            artifactPath,
+            DirectRunLauncherFactory(),
+            TimestampFactory());
 
         return new ReviewRunResult
         {
             ExecutionUnit = executionUnit,
-            ArtifactPath = artifactPath
+            ArtifactPath = artifactPath,
+            DirectRun = directRun
         };
     }
 }

--- a/src/IntentSystem.Cli/Commands/ReviewRunResult.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewRunResult.cs
@@ -5,4 +5,6 @@ internal sealed record ReviewRunResult
     public required string ExecutionUnit { get; init; }
 
     public required string ArtifactPath { get; init; }
+
+    public DirectRunLaunchResult? DirectRun { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/RunFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixCommand.cs
@@ -8,6 +8,10 @@ namespace IntentSystem.Cli.Commands;
 
 internal static class RunFixCommand
 {
+    public static Func<IDirectRunLauncher> DirectRunLauncherFactory { get; set; } = () => new DirectRunLauncher();
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -23,7 +27,7 @@ internal static class RunFixCommand
         try
         {
             var result = ExecuteCore(context, args[0]);
-            RunFixRenderer.WriteSummary(writer, result.Request, result.ArtifactPath);
+            RunFixRenderer.WriteSummary(writer, result.Request, result.ArtifactPath, result.DirectRun);
             return 0;
         }
         catch (InvalidOperationException exception)
@@ -137,11 +141,20 @@ internal static class RunFixCommand
             latestLinkedPr);
         var markdown = RunFixRenderer.RenderMarkdown(request);
         var artifactPath = RunFixArtifactWriter.Write(markdown, executionUnit, context.RepoRoot, overwrite: true);
+        var relativeArtifactPath = ToRelativePath(context.RepoRoot, artifactPath);
+        var directRun = DirectRunCommandSupport.CreateAndLaunch(
+            context,
+            DirectRunEntryKind.Fix,
+            executionUnit,
+            relativeArtifactPath,
+            DirectRunLauncherFactory(),
+            TimestampFactory());
 
         return new RunFixResult
         {
             Request = request,
-            ArtifactPath = ToRelativePath(context.RepoRoot, artifactPath)
+            ArtifactPath = relativeArtifactPath,
+            DirectRun = directRun
         };
     }
 

--- a/src/IntentSystem.Cli/Commands/RunFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixCommand.cs
@@ -147,6 +147,7 @@ internal static class RunFixCommand
             DirectRunEntryKind.Fix,
             executionUnit,
             relativeArtifactPath,
+            worktreePath,
             DirectRunLauncherFactory(),
             TimestampFactory());
 

--- a/src/IntentSystem.Cli/Commands/RunFixRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixRenderer.cs
@@ -71,7 +71,11 @@ internal static class RunFixRenderer
         return string.Join(Environment.NewLine, lines);
     }
 
-    public static void WriteSummary(TextWriter writer, RunFixRequest request, string artifactPath)
+    public static void WriteSummary(
+        TextWriter writer,
+        RunFixRequest request,
+        string artifactPath,
+        DirectRunLaunchResult? directRun = null)
     {
         ArgumentNullException.ThrowIfNull(writer);
         ArgumentNullException.ThrowIfNull(request);
@@ -84,6 +88,15 @@ internal static class RunFixRenderer
         writer.WriteLine($"Branch: {request.Branch}");
         writer.WriteLine($"Latest linked PR: {request.LatestLinkedPr}");
         writer.WriteLine($"Latest comment ref: {request.LatestCommentRef}");
+
+        if (directRun is not null)
+        {
+            writer.WriteLine($"Direct run request artifact: {directRun.RequestArtifactPath}");
+            writer.WriteLine($"Direct provider: {directRun.Provider}");
+            writer.WriteLine($"Direct model: {directRun.Model}");
+            writer.WriteLine($"Direct transport: {directRun.Transport}");
+            writer.WriteLine($"Provider session: {directRun.ProviderSessionId}");
+        }
     }
 
     private static IReadOnlyList<string> FormatList(IReadOnlyList<string> values)

--- a/src/IntentSystem.Cli/Commands/RunFixResult.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixResult.cs
@@ -5,4 +5,6 @@ internal sealed record RunFixResult
     public required RunFixRequest Request { get; init; }
 
     public required string ArtifactPath { get; init; }
+
+    public DirectRunLaunchResult? DirectRun { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
@@ -123,6 +123,7 @@ internal static class RunImplementCommand
             DirectRunEntryKind.Implement,
             executionUnit,
             relativeArtifactPath,
+            worktreePath,
             DirectRunLauncherFactory(),
             TimestampFactory());
 

--- a/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
@@ -7,6 +7,10 @@ namespace IntentSystem.Cli.Commands;
 
 internal static class RunImplementCommand
 {
+    public static Func<IDirectRunLauncher> DirectRunLauncherFactory { get; set; } = () => new DirectRunLauncher();
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -22,7 +26,7 @@ internal static class RunImplementCommand
         try
         {
             var result = ExecuteCore(context, args[0]);
-            RunImplementRenderer.WriteSummary(writer, result.Request, result.ArtifactPath);
+            RunImplementRenderer.WriteSummary(writer, result.Request, result.ArtifactPath, result.DirectRun);
             return 0;
         }
         catch (InvalidOperationException exception)
@@ -113,11 +117,20 @@ internal static class RunImplementCommand
             latestLinkedPr);
         var markdown = RunImplementRenderer.RenderMarkdown(request);
         var artifactPath = RunImplementArtifactWriter.Write(markdown, executionUnit, context.RepoRoot, overwrite: true);
+        var relativeArtifactPath = ToRelativePath(context.RepoRoot, artifactPath);
+        var directRun = DirectRunCommandSupport.CreateAndLaunch(
+            context,
+            DirectRunEntryKind.Implement,
+            executionUnit,
+            relativeArtifactPath,
+            DirectRunLauncherFactory(),
+            TimestampFactory());
 
         return new RunImplementResult
         {
             Request = request,
-            ArtifactPath = ToRelativePath(context.RepoRoot, artifactPath)
+            ArtifactPath = relativeArtifactPath,
+            DirectRun = directRun
         };
     }
 

--- a/src/IntentSystem.Cli/Commands/RunImplementRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementRenderer.cs
@@ -71,7 +71,11 @@ internal static class RunImplementRenderer
         return string.Join(Environment.NewLine, lines);
     }
 
-    public static void WriteSummary(TextWriter writer, RunImplementRequest request, string artifactPath)
+    public static void WriteSummary(
+        TextWriter writer,
+        RunImplementRequest request,
+        string artifactPath,
+        DirectRunLaunchResult? directRun = null)
     {
         ArgumentNullException.ThrowIfNull(writer);
         ArgumentNullException.ThrowIfNull(request);
@@ -86,6 +90,15 @@ internal static class RunImplementRenderer
         if (!string.IsNullOrWhiteSpace(request.LatestLinkedPr))
         {
             writer.WriteLine($"Latest linked PR: {request.LatestLinkedPr}");
+        }
+
+        if (directRun is not null)
+        {
+            writer.WriteLine($"Direct run request artifact: {directRun.RequestArtifactPath}");
+            writer.WriteLine($"Direct provider: {directRun.Provider}");
+            writer.WriteLine($"Direct model: {directRun.Model}");
+            writer.WriteLine($"Direct transport: {directRun.Transport}");
+            writer.WriteLine($"Provider session: {directRun.ProviderSessionId}");
         }
     }
 

--- a/src/IntentSystem.Cli/Commands/RunImplementResult.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementResult.cs
@@ -5,4 +5,6 @@ internal sealed record RunImplementResult
     public required RunImplementRequest Request { get; init; }
 
     public required string ArtifactPath { get; init; }
+
+    public DirectRunLaunchResult? DirectRun { get; init; }
 }

--- a/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
+++ b/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
@@ -204,6 +204,10 @@ internal static class CliConfigLoader
                 ?? CliRuntimeContracts.DefaultDirectRunModel,
             Transport = TryGetOptionalString(directRunTable, CliRuntimeContracts.TransportKey)
                 ?? CliRuntimeContracts.DefaultDirectRunTransport,
+            Command = TryGetOptionalString(directRunTable, CliRuntimeContracts.CommandKey)
+                ?? string.Empty,
+            Args = TryGetOptionalStringArray(directRunTable, CliRuntimeContracts.ArgsKey)
+                ?? [],
             Implement = ReadDirectRunEntry(directRunTable, CliRuntimeContracts.ImplementRoleKey),
             Fix = ReadDirectRunEntry(directRunTable, "fix"),
             Review = ReadDirectRunEntry(directRunTable, CliRuntimeContracts.ReviewRoleKey)
@@ -225,7 +229,9 @@ internal static class CliConfigLoader
         {
             Provider = TryGetOptionalString(entryTable, CliRuntimeContracts.ProviderKey) ?? string.Empty,
             Model = TryGetOptionalString(entryTable, CliRuntimeContracts.ModelKey) ?? string.Empty,
-            Transport = TryGetOptionalString(entryTable, CliRuntimeContracts.TransportKey) ?? string.Empty
+            Transport = TryGetOptionalString(entryTable, CliRuntimeContracts.TransportKey) ?? string.Empty,
+            Command = TryGetOptionalString(entryTable, CliRuntimeContracts.CommandKey) ?? string.Empty,
+            Args = TryGetOptionalStringArray(entryTable, CliRuntimeContracts.ArgsKey) ?? []
         };
     }
 
@@ -290,5 +296,36 @@ internal static class CliConfigLoader
 
         throw new InvalidOperationException(
             $"CLI config value '{key}' must be a positive integer.");
+    }
+
+    private static IReadOnlyList<string>? TryGetOptionalStringArray(TomlTable table, string key)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+
+        if (!table.TryGetValue(key, out var rawValue))
+        {
+            return null;
+        }
+
+        if (rawValue is not TomlArray arrayValue)
+        {
+            throw new InvalidOperationException(
+                $"CLI config value '{key}' must be an array of non-empty strings.");
+        }
+
+        var values = new List<string>(arrayValue.Count);
+        foreach (var item in arrayValue)
+        {
+            if (item is not string textValue || string.IsNullOrWhiteSpace(textValue))
+            {
+                throw new InvalidOperationException(
+                    $"CLI config value '{key}' must be an array of non-empty strings.");
+            }
+
+            values.Add(textValue);
+        }
+
+        return values;
     }
 }

--- a/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
+++ b/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
@@ -55,6 +55,7 @@ internal static class CliConfigLoader
             ?? string.Empty;
         var roles = ReadRoles(rootTable);
         var supervision = ReadSupervision(rootTable);
+        var directRun = ReadDirectRun(rootTable);
 
         config = CreateConfig(
             domain,
@@ -63,7 +64,8 @@ internal static class CliConfigLoader
             worktreeRoot,
             parentIntentRepoRoot,
             roles,
-            supervision);
+            supervision,
+            directRun);
         return true;
     }
 
@@ -92,6 +94,7 @@ internal static class CliConfigLoader
             ?? string.Empty;
         var roles = ReadRoles(rootTable);
         var supervision = ReadSupervision(rootTable);
+        var directRun = ReadDirectRun(rootTable);
 
         config = CreateConfig(
             domain,
@@ -100,7 +103,8 @@ internal static class CliConfigLoader
             worktreeRoot,
             parentIntentRepoRoot,
             roles,
-            supervision);
+            supervision,
+            directRun);
         return true;
     }
 
@@ -111,7 +115,8 @@ internal static class CliConfigLoader
         string worktreeRoot,
         string parentIntentRepoRoot,
         RoleMappings roles,
-        SupervisionConfig supervision)
+        SupervisionConfig supervision,
+        DirectRunConfig directRun)
     {
         return new CliConfig
         {
@@ -124,7 +129,8 @@ internal static class CliConfigLoader
                 ParentIntentRepoRoot = parentIntentRepoRoot
             },
             Roles = roles,
-            Supervision = supervision
+            Supervision = supervision,
+            DirectRun = directRun
         };
     }
 
@@ -175,6 +181,51 @@ internal static class CliConfigLoader
                 ?? CliRuntimeContracts.DefaultSupervisionRetryDelayMinutes,
             RetryBudget = TryGetOptionalInt32(supervisionTable, CliRuntimeContracts.RetryBudgetKey)
                 ?? CliRuntimeContracts.DefaultSupervisionRetryBudget
+        };
+    }
+
+    private static DirectRunConfig ReadDirectRun(TomlTable rootTable)
+    {
+        ArgumentNullException.ThrowIfNull(rootTable);
+
+        if (!rootTable.TryGetValue(CliRuntimeContracts.DirectRunSectionName, out var section)
+            || section is not TomlTable directRunTable)
+        {
+            return new DirectRunConfig();
+        }
+
+        return new DirectRunConfig
+        {
+            ArtifactRoot = TryGetOptionalString(directRunTable, CliRuntimeContracts.ArtifactRootKey)
+                ?? CliRuntimeContracts.DefaultDirectRunArtifactRoot,
+            Provider = TryGetOptionalString(directRunTable, CliRuntimeContracts.ProviderKey)
+                ?? string.Empty,
+            Model = TryGetOptionalString(directRunTable, CliRuntimeContracts.ModelKey)
+                ?? CliRuntimeContracts.DefaultDirectRunModel,
+            Transport = TryGetOptionalString(directRunTable, CliRuntimeContracts.TransportKey)
+                ?? CliRuntimeContracts.DefaultDirectRunTransport,
+            Implement = ReadDirectRunEntry(directRunTable, CliRuntimeContracts.ImplementRoleKey),
+            Fix = ReadDirectRunEntry(directRunTable, "fix"),
+            Review = ReadDirectRunEntry(directRunTable, CliRuntimeContracts.ReviewRoleKey)
+        };
+    }
+
+    private static DirectRunEntryConfig ReadDirectRunEntry(TomlTable parentTable, string sectionKey)
+    {
+        ArgumentNullException.ThrowIfNull(parentTable);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sectionKey);
+
+        if (!parentTable.TryGetValue(sectionKey, out var section)
+            || section is not TomlTable entryTable)
+        {
+            return new DirectRunEntryConfig();
+        }
+
+        return new DirectRunEntryConfig
+        {
+            Provider = TryGetOptionalString(entryTable, CliRuntimeContracts.ProviderKey) ?? string.Empty,
+            Model = TryGetOptionalString(entryTable, CliRuntimeContracts.ModelKey) ?? string.Empty,
+            Transport = TryGetOptionalString(entryTable, CliRuntimeContracts.TransportKey) ?? string.Empty
         };
     }
 

--- a/src/IntentSystem.Cli/Models/CliConfig.cs
+++ b/src/IntentSystem.Cli/Models/CliConfig.cs
@@ -57,6 +57,10 @@ internal sealed record DirectRunConfig
 
     public string Transport { get; init; } = CliRuntimeContracts.DefaultDirectRunTransport;
 
+    public string Command { get; init; } = string.Empty;
+
+    public IReadOnlyList<string> Args { get; init; } = [];
+
     public DirectRunEntryConfig Implement { get; init; } = new();
 
     public DirectRunEntryConfig Fix { get; init; } = new();
@@ -71,4 +75,8 @@ internal sealed record DirectRunEntryConfig
     public string Model { get; init; } = string.Empty;
 
     public string Transport { get; init; } = string.Empty;
+
+    public string Command { get; init; } = string.Empty;
+
+    public IReadOnlyList<string> Args { get; init; } = [];
 }

--- a/src/IntentSystem.Cli/Models/CliConfig.cs
+++ b/src/IntentSystem.Cli/Models/CliConfig.cs
@@ -7,6 +7,8 @@ internal sealed record CliConfig
     public RoleMappings Roles { get; init; } = new();
 
     public SupervisionConfig Supervision { get; init; } = new();
+
+    public DirectRunConfig DirectRun { get; init; } = new();
 }
 
 internal sealed record ProjectConfig
@@ -43,4 +45,30 @@ internal sealed record SupervisionConfig
     public int RetryDelayMinutes { get; init; } = CliRuntimeContracts.DefaultSupervisionRetryDelayMinutes;
 
     public int RetryBudget { get; init; } = CliRuntimeContracts.DefaultSupervisionRetryBudget;
+}
+
+internal sealed record DirectRunConfig
+{
+    public string ArtifactRoot { get; init; } = CliRuntimeContracts.DefaultDirectRunArtifactRoot;
+
+    public string Provider { get; init; } = string.Empty;
+
+    public string Model { get; init; } = CliRuntimeContracts.DefaultDirectRunModel;
+
+    public string Transport { get; init; } = CliRuntimeContracts.DefaultDirectRunTransport;
+
+    public DirectRunEntryConfig Implement { get; init; } = new();
+
+    public DirectRunEntryConfig Fix { get; init; } = new();
+
+    public DirectRunEntryConfig Review { get; init; } = new();
+}
+
+internal sealed record DirectRunEntryConfig
+{
+    public string Provider { get; init; } = string.Empty;
+
+    public string Model { get; init; } = string.Empty;
+
+    public string Transport { get; init; } = string.Empty;
 }

--- a/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
@@ -28,6 +28,10 @@ public sealed class CliConfigLoaderTests
         Assert.Equal(15, config.Supervision.StaleHeartbeatTimeoutMinutes);
         Assert.Equal(5, config.Supervision.RetryDelayMinutes);
         Assert.Equal(3, config.Supervision.RetryBudget);
+        Assert.Equal(".intent-cli/runs", config.DirectRun.ArtifactRoot);
+        Assert.Equal(string.Empty, config.DirectRun.Provider);
+        Assert.Equal("default", config.DirectRun.Model);
+        Assert.Equal("stdio", config.DirectRun.Transport);
     }
 
     [Fact]
@@ -120,6 +124,50 @@ public sealed class CliConfigLoaderTests
         Assert.Equal(30, config.Supervision.StaleHeartbeatTimeoutMinutes);
         Assert.Equal(12, config.Supervision.RetryDelayMinutes);
         Assert.Equal(7, config.Supervision.RetryBudget);
+    }
+
+    [Fact]
+    public void Load_GivenDirectBackendSection_RestoresDefaultAndEntrySpecificPolicies()
+    {
+        var toml = """
+        default_domain = "intent-cli"
+        workflow_engine = "takt"
+        artifact_root = ".intent-cli"
+
+        [direct_backend]
+        artifact_root = ".intent-cli/runtime-runs"
+        provider = "Codex"
+        model = "gpt-5.4"
+        transport = "stdio"
+
+        [direct_backend.implement]
+        model = "gpt-5.4-codex"
+
+        [direct_backend.fix]
+        provider = "Claude"
+        transport = "http"
+
+        [direct_backend.review]
+        provider = "ReviewBot"
+        model = "gpt-5.4-mini"
+        transport = "grpc"
+        """;
+
+        var config = CliConfigLoader.Load(toml);
+
+        Assert.Equal(".intent-cli/runtime-runs", config.DirectRun.ArtifactRoot);
+        Assert.Equal("Codex", config.DirectRun.Provider);
+        Assert.Equal("gpt-5.4", config.DirectRun.Model);
+        Assert.Equal("stdio", config.DirectRun.Transport);
+        Assert.Equal(string.Empty, config.DirectRun.Implement.Provider);
+        Assert.Equal("gpt-5.4-codex", config.DirectRun.Implement.Model);
+        Assert.Equal(string.Empty, config.DirectRun.Implement.Transport);
+        Assert.Equal("Claude", config.DirectRun.Fix.Provider);
+        Assert.Equal(string.Empty, config.DirectRun.Fix.Model);
+        Assert.Equal("http", config.DirectRun.Fix.Transport);
+        Assert.Equal("ReviewBot", config.DirectRun.Review.Provider);
+        Assert.Equal("gpt-5.4-mini", config.DirectRun.Review.Model);
+        Assert.Equal("grpc", config.DirectRun.Review.Transport);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
@@ -32,6 +32,8 @@ public sealed class CliConfigLoaderTests
         Assert.Equal(string.Empty, config.DirectRun.Provider);
         Assert.Equal("default", config.DirectRun.Model);
         Assert.Equal("stdio", config.DirectRun.Transport);
+        Assert.Equal(string.Empty, config.DirectRun.Command);
+        Assert.Empty(config.DirectRun.Args);
     }
 
     [Fact]
@@ -139,18 +141,25 @@ public sealed class CliConfigLoaderTests
         provider = "Codex"
         model = "gpt-5.4"
         transport = "stdio"
+        command = "codex"
+        args = ["exec", "--model", "{model}", "{prompt}"]
 
         [direct_backend.implement]
         model = "gpt-5.4-codex"
+        command = "codex-experimental"
+        args = ["run", "--input", "{request_artifact_path}"]
 
         [direct_backend.fix]
         provider = "Claude"
         transport = "http"
+        command = "claude"
 
         [direct_backend.review]
         provider = "ReviewBot"
         model = "gpt-5.4-mini"
         transport = "grpc"
+        command = "reviewbot"
+        args = ["launch", "--model", "{model}", "--artifact", "{request_artifact_path}"]
         """;
 
         var config = CliConfigLoader.Load(toml);
@@ -159,15 +168,23 @@ public sealed class CliConfigLoaderTests
         Assert.Equal("Codex", config.DirectRun.Provider);
         Assert.Equal("gpt-5.4", config.DirectRun.Model);
         Assert.Equal("stdio", config.DirectRun.Transport);
+        Assert.Equal("codex", config.DirectRun.Command);
+        Assert.Equal(["exec", "--model", "{model}", "{prompt}"], config.DirectRun.Args);
         Assert.Equal(string.Empty, config.DirectRun.Implement.Provider);
         Assert.Equal("gpt-5.4-codex", config.DirectRun.Implement.Model);
         Assert.Equal(string.Empty, config.DirectRun.Implement.Transport);
+        Assert.Equal("codex-experimental", config.DirectRun.Implement.Command);
+        Assert.Equal(["run", "--input", "{request_artifact_path}"], config.DirectRun.Implement.Args);
         Assert.Equal("Claude", config.DirectRun.Fix.Provider);
         Assert.Equal(string.Empty, config.DirectRun.Fix.Model);
         Assert.Equal("http", config.DirectRun.Fix.Transport);
+        Assert.Equal("claude", config.DirectRun.Fix.Command);
+        Assert.Empty(config.DirectRun.Fix.Args);
         Assert.Equal("ReviewBot", config.DirectRun.Review.Provider);
         Assert.Equal("gpt-5.4-mini", config.DirectRun.Review.Model);
         Assert.Equal("grpc", config.DirectRun.Review.Transport);
+        Assert.Equal("reviewbot", config.DirectRun.Review.Command);
+        Assert.Equal(["launch", "--model", "{model}", "--artifact", "{request_artifact_path}"], config.DirectRun.Review.Args);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -5234,6 +5234,8 @@ recommended_updates:
             string provider,
             string model,
             string transport,
+            string command,
+            IReadOnlyList<string> argsTemplate,
             DateTimeOffset launchedAt,
             string workingDirectory,
             string absoluteRequestArtifactPath)
@@ -5245,7 +5247,7 @@ recommended_updates:
                 Model = model,
                 Transport = transport,
                 ProviderSessionId = "pid:1234",
-                TransportSummary = $"{transport} transport launched via '{provider}' in '{workingDirectory}' for provider '{provider}'."
+                TransportSummary = $"{transport} transport launched via '{command}' in '{workingDirectory}' for provider '{provider}'."
             };
         }
     }

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -3119,12 +3119,22 @@ public sealed class CommandRouterTests
             Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
             CreateRunImplementReviewContextMarkdown());
         using var writer = new StringWriter();
+        var originalLauncherFactory = RunImplementCommand.DirectRunLauncherFactory;
 
-        var exitCode = CommandRouter.Execute(["run", "implement", "G19"], CreateContext(repoRoot), writer);
+        try
+        {
+            RunImplementCommand.DirectRunLauncherFactory = () => new FakeRouterDirectRunLauncher(".intent-cli/runs/G19.request.json");
 
-        Assert.Equal(0, exitCode);
-        Assert.Contains("Implementation handoff artifact generated for G19", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("Implement role: Claude", writer.ToString(), StringComparison.Ordinal);
+            var exitCode = CommandRouter.Execute(["run", "implement", "G19"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Implementation handoff artifact generated for G19", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Implement role: Claude", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunImplementCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
     }
 
     [Fact]
@@ -3150,12 +3160,22 @@ public sealed class CommandRouterTests
             Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
             CreateRunFixReviewCommentArtifactJson());
         using var writer = new StringWriter();
+        var originalLauncherFactory = RunFixCommand.DirectRunLauncherFactory;
 
-        var exitCode = CommandRouter.Execute(["run", "fix", "G20"], CreateContext(repoRoot), writer);
+        try
+        {
+            RunFixCommand.DirectRunLauncherFactory = () => new FakeRouterDirectRunLauncher(".intent-cli/runs/G20.request.json");
 
-        Assert.Equal(0, exitCode);
-        Assert.Contains("Repair handoff artifact generated for G20", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("Latest comment ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", writer.ToString(), StringComparison.Ordinal);
+            var exitCode = CommandRouter.Execute(["run", "fix", "G20"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Repair handoff artifact generated for G20", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Latest comment ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunFixCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
     }
 
     [Fact]
@@ -3274,15 +3294,25 @@ public sealed class CommandRouterTests
             Path.Combine("repo", ".intent-cli", "runs.jsonl"),
             CreateReviewRunLog());
         using var writer = new StringWriter();
+        var originalLauncherFactory = ReviewRunCommand.DirectRunLauncherFactory;
 
-        var exitCode = CommandRouter.Execute(["review", "run", "G9"], CreateContext(repoRoot), writer);
+        try
+        {
+            ReviewRunCommand.DirectRunLauncherFactory = () => new FakeRouterDirectRunLauncher(".intent-cli/runs/G9.request.json");
 
-        Assert.Equal(0, exitCode);
-        Assert.Contains("Review request artifact generated for G9", writer.ToString(), StringComparison.Ordinal);
+            var exitCode = CommandRouter.Execute(["review", "run", "G9"], CreateContext(repoRoot), writer);
 
-        var artifact = ReviewRequestSerializer.Deserialize(
-            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "reviews", "G9.request.json")));
-        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/45", artifact.LinkedPr);
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Review request artifact generated for G9", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = ReviewRequestSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "reviews", "G9.request.json")));
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/45", artifact.LinkedPr);
+        }
+        finally
+        {
+            ReviewRunCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
     }
 
     [Fact]
@@ -5192,6 +5222,31 @@ recommended_updates:
             }
 
             throw new InvalidOperationException($"Unexpected gh arguments: {string.Join(' ', arguments)}");
+        }
+    }
+
+    private sealed class FakeRouterDirectRunLauncher(string requestArtifactPath) : IDirectRunLauncher
+    {
+        public DirectRunLaunchResult Launch(
+            string executionUnit,
+            string entryKind,
+            string requestArtifactPathArg,
+            string provider,
+            string model,
+            string transport,
+            DateTimeOffset launchedAt,
+            string workingDirectory,
+            string absoluteRequestArtifactPath)
+        {
+            return new DirectRunLaunchResult
+            {
+                RequestArtifactPath = requestArtifactPath,
+                Provider = provider,
+                Model = model,
+                Transport = transport,
+                ProviderSessionId = "pid:1234",
+                TransportSummary = $"{transport} transport launched via '{provider}' in '{workingDirectory}' for provider '{provider}'."
+            };
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -5,7 +5,7 @@ namespace IntentSystem.Cli.Tests;
 public sealed class DirectRunLauncherTests
 {
     [Fact]
-    public void Launch_GivenCodexProvider_StartsCodexExecWithPromptAgainstArtifact()
+    public void Launch_GivenConfiguredCommandPolicy_StartsConfiguredExecutableWithExpandedArguments()
     {
         var runner = new FakeDirectRunProcessRunner
         {
@@ -22,22 +22,39 @@ public sealed class DirectRunLauncherTests
             "G19",
             "implement",
             ".intent-cli/runs/G19.request.json",
-            "Codex",
+            "ReviewBot",
             "gpt-5.4",
-            "stdio",
+            "grpc",
+            "review-runner",
+            ["launch", "--entry", "{entry_kind}", "--unit", "{execution_unit}", "--model", "{model}", "--artifact", "{request_artifact_path}", "--run-artifact", "{direct_run_artifact_path}", "{prompt}"],
             DateTimeOffset.Parse("2026-04-09T10:15:00Z"),
             "/repo/.intent-cli/worktrees/G19",
             "/repo/.intent-cli/implement/G19.request.md");
 
-        Assert.Equal("codex", runner.FileName);
+        Assert.Equal("review-runner", runner.FileName);
         Assert.Equal("/repo/.intent-cli/worktrees/G19", runner.WorkingDirectory);
-        Assert.Equal(["exec", "--model", "gpt-5.4", "Use the request artifact at '/repo/.intent-cli/implement/G19.request.md' as the bounded source of truth for this direct run."], runner.Arguments);
+        Assert.Equal(
+            [
+                "launch",
+                "--entry",
+                "implement",
+                "--unit",
+                "G19",
+                "--model",
+                "gpt-5.4",
+                "--artifact",
+                "/repo/.intent-cli/implement/G19.request.md",
+                "--run-artifact",
+                ".intent-cli/runs/G19.request.json",
+                "Use the request artifact at '/repo/.intent-cli/implement/G19.request.md' as the bounded source of truth for this direct run."
+            ],
+            runner.Arguments);
         Assert.Equal("pid:4321", result.ProviderSessionId);
-        Assert.Contains("stdio transport launched via 'codex'", result.TransportSummary, StringComparison.Ordinal);
+        Assert.Contains("grpc transport launched via 'review-runner'", result.TransportSummary, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void Launch_GivenClaudeProvider_StartsClaudePrintWithPromptAgainstArtifact()
+    public void Launch_GivenUpstreamRequestArtifactPlaceholder_ExpandsAlias()
     {
         var runner = new FakeDirectRunProcessRunner
         {
@@ -57,13 +74,15 @@ public sealed class DirectRunLauncherTests
             "Claude",
             "sonnet",
             "stdio",
+            "claude",
+            ["--artifact", "{upstream_request_artifact_path}", "--model", "{model}"],
             DateTimeOffset.Parse("2026-04-09T10:25:00Z"),
             "/repo/.intent-cli/worktrees/G20",
             "/repo/.intent-cli/fix/G20.request.md");
 
         Assert.Equal("claude", runner.FileName);
         Assert.Equal(
-            ["--print", "--model", "sonnet", "--output-format", "json", "Use the request artifact at '/repo/.intent-cli/fix/G20.request.md' as the bounded source of truth for this direct run."],
+            ["--artifact", "/repo/.intent-cli/fix/G20.request.md", "--model", "sonnet"],
             runner.Arguments);
         Assert.Equal("pid:8765", result.ProviderSessionId);
     }
@@ -89,6 +108,8 @@ public sealed class DirectRunLauncherTests
             "Codex",
             "gpt-5.4-mini",
             "grpc",
+            "codex",
+            ["exec", "{prompt}"],
             DateTimeOffset.Parse("2026-04-09T10:35:00Z"),
             "/repo",
             "/repo/.intent-cli/reviews/G9.request.json"));

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -1,0 +1,126 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class DirectRunLauncherTests
+{
+    [Fact]
+    public void Launch_GivenCodexProvider_StartsCodexExecWithPromptAgainstArtifact()
+    {
+        var runner = new FakeDirectRunProcessRunner
+        {
+            Result = new DirectRunProcessLaunchResult
+            {
+                ProcessId = 4321,
+                ExitedEarly = false,
+                ExitCode = 0
+            }
+        };
+        var launcher = new DirectRunLauncher(runner);
+
+        var result = launcher.Launch(
+            "G19",
+            "implement",
+            ".intent-cli/runs/G19.request.json",
+            "Codex",
+            "gpt-5.4",
+            "stdio",
+            DateTimeOffset.Parse("2026-04-09T10:15:00Z"),
+            "/repo/.intent-cli/worktrees/G19",
+            "/repo/.intent-cli/implement/G19.request.md");
+
+        Assert.Equal("codex", runner.FileName);
+        Assert.Equal("/repo/.intent-cli/worktrees/G19", runner.WorkingDirectory);
+        Assert.Equal(["exec", "--model", "gpt-5.4", "Use the request artifact at '/repo/.intent-cli/implement/G19.request.md' as the bounded source of truth for this direct run."], runner.Arguments);
+        Assert.Equal("pid:4321", result.ProviderSessionId);
+        Assert.Contains("stdio transport launched via 'codex'", result.TransportSummary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Launch_GivenClaudeProvider_StartsClaudePrintWithPromptAgainstArtifact()
+    {
+        var runner = new FakeDirectRunProcessRunner
+        {
+            Result = new DirectRunProcessLaunchResult
+            {
+                ProcessId = 8765,
+                ExitedEarly = false,
+                ExitCode = 0
+            }
+        };
+        var launcher = new DirectRunLauncher(runner);
+
+        var result = launcher.Launch(
+            "G20",
+            "fix",
+            ".intent-cli/runs/G20.request.json",
+            "Claude",
+            "sonnet",
+            "stdio",
+            DateTimeOffset.Parse("2026-04-09T10:25:00Z"),
+            "/repo/.intent-cli/worktrees/G20",
+            "/repo/.intent-cli/fix/G20.request.md");
+
+        Assert.Equal("claude", runner.FileName);
+        Assert.Equal(
+            ["--print", "--model", "sonnet", "--output-format", "json", "Use the request artifact at '/repo/.intent-cli/fix/G20.request.md' as the bounded source of truth for this direct run."],
+            runner.Arguments);
+        Assert.Equal("pid:8765", result.ProviderSessionId);
+    }
+
+    [Fact]
+    public void Launch_GivenEarlyNonZeroExit_Throws()
+    {
+        var runner = new FakeDirectRunProcessRunner
+        {
+            Result = new DirectRunProcessLaunchResult
+            {
+                ProcessId = 999,
+                ExitedEarly = true,
+                ExitCode = 17
+            }
+        };
+        var launcher = new DirectRunLauncher(runner);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => launcher.Launch(
+            "G9",
+            "review",
+            ".intent-cli/runs/G9.request.json",
+            "Codex",
+            "gpt-5.4-mini",
+            "grpc",
+            DateTimeOffset.Parse("2026-04-09T10:35:00Z"),
+            "/repo",
+            "/repo/.intent-cli/reviews/G9.request.json"));
+
+        Assert.Contains("exit code 17", exception.Message, StringComparison.Ordinal);
+    }
+
+    private sealed class FakeDirectRunProcessRunner : IDirectRunProcessRunner
+    {
+        public string WorkingDirectory { get; private set; } = string.Empty;
+
+        public string FileName { get; private set; } = string.Empty;
+
+        public IReadOnlyList<string> Arguments { get; private set; } = [];
+
+        public DirectRunProcessLaunchResult Result { get; set; } = new()
+        {
+            ProcessId = 1,
+            ExitedEarly = false,
+            ExitCode = 0
+        };
+
+        public DirectRunProcessLaunchResult Start(
+            string workingDirectory,
+            string fileName,
+            IReadOnlyList<string> arguments,
+            TimeSpan earlyExitWindow)
+        {
+            WorkingDirectory = workingDirectory;
+            FileName = fileName;
+            Arguments = arguments.ToArray();
+            return Result;
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/DirectRunRequestArtifactJsonTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunRequestArtifactJsonTests.cs
@@ -1,0 +1,28 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class DirectRunRequestArtifactJsonTests
+{
+    [Fact]
+    public void SerializeAndDeserialize_GivenArtifact_RoundTrips()
+    {
+        var artifact = new DirectRunRequestArtifact
+        {
+            SchemaVersion = "1",
+            ExecutionUnit = "G19",
+            EntryKind = "implement",
+            UpstreamRequestRef = ".intent-cli/implement/G19.request.md",
+            Provider = "Claude",
+            Model = "sonnet",
+            Transport = "stdio",
+            LaunchedAt = "2026-04-09T10:15:00.0000000+00:00",
+            ProviderSessionId = "claude-implement-g19-20260409101500",
+            TransportSummary = "stdio transport selected for provider 'Claude' with model 'sonnet'."
+        };
+
+        var roundTripped = DirectRunRequestArtifactJson.Deserialize(DirectRunRequestArtifactJson.Serialize(artifact));
+
+        Assert.Equal(artifact, roundTripped);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -24,25 +24,51 @@ public sealed class ReviewRunCommandTests
             Path.Combine("repo", ".intent-cli", "runs.jsonl"),
             CreateRunLog());
         using var writer = new StringWriter();
+        var originalTimestampFactory = ReviewRunCommand.TimestampFactory;
 
-        var exitCode = ReviewRunCommand.Execute(CreateContext(repoRoot), ["G9"], writer);
+        try
+        {
+            ReviewRunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:35:00Z");
 
-        Assert.Equal(0, exitCode);
-        Assert.Contains("Review request artifact generated for G9", writer.ToString(), StringComparison.Ordinal);
+            var exitCode = ReviewRunCommand.Execute(CreateContext(repoRoot), ["G9"], writer);
 
-        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "reviews", "G9.request.json");
-        Assert.True(File.Exists(artifactPath));
-        var request = ReviewRequestSerializer.Deserialize(File.ReadAllText(artifactPath));
-        Assert.Equal("G9", request.ExecutionUnit);
-        Assert.Equal(".intent-cli/issues/G9/review-context.md", request.ReviewContextRef);
-        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/45", request.LinkedPr);
-        Assert.Equal(
-            ["review run command が PR comment 投稿や closeout の責務へ広がっていない"],
-            request.DeterministicReviewChecks);
-        Assert.Empty(request.AcceptanceCriteria);
-        Assert.Equal(
-            ["dotnet test IntentSystem.sln", "review run command tests"],
-            request.ExpectedEvidence);
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Review request artifact generated for G9", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Direct run request artifact: .intent-cli/runtime-runs/G9.request.json", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Direct provider: ReviewBot", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Direct model: gpt-5.4-mini", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Direct transport: grpc", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Provider session: reviewbot-review-g9-20260409103500", writer.ToString(), StringComparison.Ordinal);
+
+            var artifactPath = Path.Combine(repoRoot, ".intent-cli", "reviews", "G9.request.json");
+            Assert.True(File.Exists(artifactPath));
+            var request = ReviewRequestSerializer.Deserialize(File.ReadAllText(artifactPath));
+            Assert.Equal("G9", request.ExecutionUnit);
+            Assert.Equal(".intent-cli/issues/G9/review-context.md", request.ReviewContextRef);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/45", request.LinkedPr);
+            Assert.Equal(
+                ["review run command が PR comment 投稿や closeout の責務へ広がっていない"],
+                request.DeterministicReviewChecks);
+            Assert.Empty(request.AcceptanceCriteria);
+            Assert.Equal(
+                ["dotnet test IntentSystem.sln", "review run command tests"],
+                request.ExpectedEvidence);
+
+            var directRunArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.request.json");
+            Assert.True(File.Exists(directRunArtifactPath));
+            var directRunArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(directRunArtifactPath));
+            Assert.Equal("G9", directRunArtifact.ExecutionUnit);
+            Assert.Equal("review", directRunArtifact.EntryKind);
+            Assert.Equal(".intent-cli/reviews/G9.request.json", directRunArtifact.UpstreamRequestRef);
+            Assert.Equal("ReviewBot", directRunArtifact.Provider);
+            Assert.Equal("gpt-5.4-mini", directRunArtifact.Model);
+            Assert.Equal("grpc", directRunArtifact.Transport);
+            Assert.Equal("reviewbot-review-g9-20260409103500", directRunArtifact.ProviderSessionId);
+        }
+        finally
+        {
+            ReviewRunCommand.TimestampFactory = originalTimestampFactory;
+        }
     }
 
     [Fact]
@@ -150,6 +176,16 @@ public sealed class ReviewRunCommandTests
                     Domain = "intent-system",
                     WorkflowEngine = "intent-cli",
                     ArtifactRoot = ".intent-cli"
+                },
+                DirectRun = new DirectRunConfig
+                {
+                    ArtifactRoot = ".intent-cli/runtime-runs",
+                    Review = new DirectRunEntryConfig
+                    {
+                        Provider = "ReviewBot",
+                        Model = "gpt-5.4-mini",
+                        Transport = "grpc"
+                    }
                 }
             }
         };

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -35,6 +35,8 @@ public sealed class ReviewRunCommandTests
                 "ReviewBot",
                 "gpt-5.4-mini",
                 "grpc",
+                "reviewbot",
+                ["launch", "--model", "{model}", "--artifact", "{request_artifact_path}"],
                 "grpc transport launched via 'reviewbot' in '/repo' for provider 'ReviewBot'.");
 
             var exitCode = ReviewRunCommand.Execute(CreateContext(repoRoot), ["G9"], writer);
@@ -188,11 +190,15 @@ public sealed class ReviewRunCommandTests
                 DirectRun = new DirectRunConfig
                 {
                     ArtifactRoot = ".intent-cli/runtime-runs",
+                    Command = "fallback-review-launcher",
+                    Args = ["--prompt", "{prompt}"],
                     Review = new DirectRunEntryConfig
                     {
                         Provider = "ReviewBot",
                         Model = "gpt-5.4-mini",
-                        Transport = "grpc"
+                        Transport = "grpc",
+                        Command = "reviewbot",
+                        Args = ["launch", "--model", "{model}", "--artifact", "{request_artifact_path}"]
                     }
                 }
             }
@@ -303,6 +309,8 @@ public sealed class ReviewRunCommandTests
         string provider,
         string model,
         string transport,
+        string command,
+        IReadOnlyList<string> argsTemplate,
         string transportSummary) : IDirectRunLauncher
     {
         public DirectRunLaunchResult Launch(
@@ -312,6 +320,8 @@ public sealed class ReviewRunCommandTests
             string providerArg,
             string modelArg,
             string transportArg,
+            string commandArg,
+            IReadOnlyList<string> argsTemplateArg,
             DateTimeOffset launchedAt,
             string workingDirectory,
             string absoluteRequestArtifactPath)
@@ -322,6 +332,8 @@ public sealed class ReviewRunCommandTests
             Assert.Equal(provider, providerArg);
             Assert.Equal(model, modelArg);
             Assert.Equal(transport, transportArg);
+            Assert.Equal(command, commandArg);
+            Assert.Equal(argsTemplate, argsTemplateArg);
             Assert.EndsWith("/repo", workingDirectory, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/reviews/G9.request.json", absoluteRequestArtifactPath, StringComparison.Ordinal);
 

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -25,10 +25,17 @@ public sealed class ReviewRunCommandTests
             CreateRunLog());
         using var writer = new StringWriter();
         var originalTimestampFactory = ReviewRunCommand.TimestampFactory;
+        var originalLauncherFactory = ReviewRunCommand.DirectRunLauncherFactory;
 
         try
         {
             ReviewRunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:35:00Z");
+            ReviewRunCommand.DirectRunLauncherFactory = () => new FakeDirectRunLauncher(
+                "pid:9999",
+                "ReviewBot",
+                "gpt-5.4-mini",
+                "grpc",
+                "grpc transport launched via 'reviewbot' in '/repo' for provider 'ReviewBot'.");
 
             var exitCode = ReviewRunCommand.Execute(CreateContext(repoRoot), ["G9"], writer);
 
@@ -38,7 +45,7 @@ public sealed class ReviewRunCommandTests
             Assert.Contains("Direct provider: ReviewBot", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Direct model: gpt-5.4-mini", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Direct transport: grpc", writer.ToString(), StringComparison.Ordinal);
-            Assert.Contains("Provider session: reviewbot-review-g9-20260409103500", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Provider session: pid:9999", writer.ToString(), StringComparison.Ordinal);
 
             var artifactPath = Path.Combine(repoRoot, ".intent-cli", "reviews", "G9.request.json");
             Assert.True(File.Exists(artifactPath));
@@ -63,11 +70,12 @@ public sealed class ReviewRunCommandTests
             Assert.Equal("ReviewBot", directRunArtifact.Provider);
             Assert.Equal("gpt-5.4-mini", directRunArtifact.Model);
             Assert.Equal("grpc", directRunArtifact.Transport);
-            Assert.Equal("reviewbot-review-g9-20260409103500", directRunArtifact.ProviderSessionId);
+            Assert.Equal("pid:9999", directRunArtifact.ProviderSessionId);
         }
         finally
         {
             ReviewRunCommand.TimestampFactory = originalTimestampFactory;
+            ReviewRunCommand.DirectRunLauncherFactory = originalLauncherFactory;
         }
     }
 
@@ -287,6 +295,45 @@ public sealed class ReviewRunCommandTests
             {
                 Directory.Delete(rootPath, recursive: true);
             }
+        }
+    }
+
+    private sealed class FakeDirectRunLauncher(
+        string providerSessionId,
+        string provider,
+        string model,
+        string transport,
+        string transportSummary) : IDirectRunLauncher
+    {
+        public DirectRunLaunchResult Launch(
+            string executionUnit,
+            string entryKind,
+            string requestArtifactPath,
+            string providerArg,
+            string modelArg,
+            string transportArg,
+            DateTimeOffset launchedAt,
+            string workingDirectory,
+            string absoluteRequestArtifactPath)
+        {
+            Assert.Equal("G9", executionUnit);
+            Assert.Equal("review", entryKind);
+            Assert.Equal(".intent-cli/runtime-runs/G9.request.json", requestArtifactPath);
+            Assert.Equal(provider, providerArg);
+            Assert.Equal(model, modelArg);
+            Assert.Equal(transport, transportArg);
+            Assert.EndsWith("/repo", workingDirectory, StringComparison.Ordinal);
+            Assert.EndsWith("/.intent-cli/reviews/G9.request.json", absoluteRequestArtifactPath, StringComparison.Ordinal);
+
+            return new DirectRunLaunchResult
+            {
+                RequestArtifactPath = ".intent-cli/runtime-runs/G9.request.json",
+                Provider = providerArg,
+                Model = modelArg,
+                Transport = transportArg,
+                ProviderSessionId = providerSessionId,
+                TransportSummary = transportSummary
+            };
         }
     }
 }

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -31,6 +31,7 @@ public sealed class RunFixCommandTests
             CreateReviewCommentArtifactJson());
         using var writer = new StringWriter();
         var originalTimestampFactory = RunFixCommand.TimestampFactory;
+        var originalLauncherFactory = RunFixCommand.DirectRunLauncherFactory;
 
         var originalQueueState = File.ReadAllText(queueStatePath);
         var originalRunLog = File.ReadAllText(runLogPath);
@@ -38,6 +39,12 @@ public sealed class RunFixCommandTests
         try
         {
             RunFixCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:25:00Z");
+            RunFixCommand.DirectRunLauncherFactory = () => new FakeDirectRunLauncher(
+                "pid:8765",
+                "Claude",
+                "default",
+                "stdio",
+                "stdio transport launched via 'claude' in '/repo/.intent-cli/worktrees/G20' for provider 'Claude'.");
 
             var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
 
@@ -52,7 +59,7 @@ public sealed class RunFixCommandTests
             Assert.Contains("Direct provider: Claude", output, StringComparison.Ordinal);
             Assert.Contains("Direct model: default", output, StringComparison.Ordinal);
             Assert.Contains("Direct transport: stdio", output, StringComparison.Ordinal);
-            Assert.Contains("Provider session: claude-fix-g20-20260409102500", output, StringComparison.Ordinal);
+            Assert.Contains("Provider session: pid:8765", output, StringComparison.Ordinal);
 
             var artifactPath = Path.Combine(repoRoot, ".intent-cli", "fix", "G20.request.md");
             Assert.True(File.Exists(artifactPath));
@@ -73,7 +80,7 @@ public sealed class RunFixCommandTests
             Assert.Equal("Claude", directRunArtifact.Provider);
             Assert.Equal("default", directRunArtifact.Model);
             Assert.Equal("stdio", directRunArtifact.Transport);
-            Assert.Equal("claude-fix-g20-20260409102500", directRunArtifact.ProviderSessionId);
+            Assert.Equal("pid:8765", directRunArtifact.ProviderSessionId);
 
             Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
             Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
@@ -81,6 +88,7 @@ public sealed class RunFixCommandTests
         finally
         {
             RunFixCommand.TimestampFactory = originalTimestampFactory;
+            RunFixCommand.DirectRunLauncherFactory = originalLauncherFactory;
         }
     }
 
@@ -93,6 +101,45 @@ public sealed class RunFixCommandTests
 
         Assert.Equal(1, exitCode);
         Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class FakeDirectRunLauncher(
+        string providerSessionId,
+        string provider,
+        string model,
+        string transport,
+        string transportSummary) : IDirectRunLauncher
+    {
+        public DirectRunLaunchResult Launch(
+            string executionUnit,
+            string entryKind,
+            string requestArtifactPath,
+            string providerArg,
+            string modelArg,
+            string transportArg,
+            DateTimeOffset launchedAt,
+            string workingDirectory,
+            string absoluteRequestArtifactPath)
+        {
+            Assert.Equal("G20", executionUnit);
+            Assert.Equal("fix", entryKind);
+            Assert.Equal(".intent-cli/runs/G20.request.json", requestArtifactPath);
+            Assert.Equal(provider, providerArg);
+            Assert.Equal(model, modelArg);
+            Assert.Equal(transport, transportArg);
+            Assert.EndsWith("/.intent-cli/worktrees/G20", workingDirectory, StringComparison.Ordinal);
+            Assert.EndsWith("/.intent-cli/fix/G20.request.md", absoluteRequestArtifactPath, StringComparison.Ordinal);
+
+            return new DirectRunLaunchResult
+            {
+                RequestArtifactPath = ".intent-cli/runs/G20.request.json",
+                Provider = providerArg,
+                Model = modelArg,
+                Transport = transportArg,
+                ProviderSessionId = providerSessionId,
+                TransportSummary = transportSummary
+            };
+        }
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -30,31 +30,58 @@ public sealed class RunFixCommandTests
             Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
             CreateReviewCommentArtifactJson());
         using var writer = new StringWriter();
+        var originalTimestampFactory = RunFixCommand.TimestampFactory;
 
         var originalQueueState = File.ReadAllText(queueStatePath);
         var originalRunLog = File.ReadAllText(runLogPath);
 
-        var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+        try
+        {
+            RunFixCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:25:00Z");
 
-        Assert.Equal(0, exitCode);
-        var output = writer.ToString();
-        Assert.Contains("Repair handoff artifact generated for G20", output, StringComparison.Ordinal);
-        Assert.Contains("Implement role: Claude", output, StringComparison.Ordinal);
-        Assert.Contains("Branch: issue-68-g20", output, StringComparison.Ordinal);
-        Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/69", output, StringComparison.Ordinal);
-        Assert.Contains("Latest comment ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", output, StringComparison.Ordinal);
+            var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
 
-        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "fix", "G20.request.md");
-        Assert.True(File.Exists(artifactPath));
-        var markdown = File.ReadAllText(artifactPath);
-        Assert.Contains("- packet_ref: .intent-cli/issues/G20/packet.yaml", markdown, StringComparison.Ordinal);
-        Assert.Contains("- review_context_ref: .intent-cli/issues/G20/review-context.md", markdown, StringComparison.Ordinal);
-        Assert.Contains("- review_comment_artifact_ref: .intent-cli/reviews/G20.comment.json", markdown, StringComparison.Ordinal);
-        Assert.Contains("- review_request_ref: .intent-cli/reviews/G20.request.json", markdown, StringComparison.Ordinal);
-        Assert.Contains("- latest_linked_pr: https://github.com/J-Tech-Japan/intent-system/pull/69", markdown, StringComparison.Ordinal);
-        Assert.Contains("- latest_comment_ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", markdown, StringComparison.Ordinal);
-        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
-        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Repair handoff artifact generated for G20", output, StringComparison.Ordinal);
+            Assert.Contains("Implement role: Claude", output, StringComparison.Ordinal);
+            Assert.Contains("Branch: issue-68-g20", output, StringComparison.Ordinal);
+            Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/69", output, StringComparison.Ordinal);
+            Assert.Contains("Latest comment ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", output, StringComparison.Ordinal);
+            Assert.Contains("Direct run request artifact: .intent-cli/runs/G20.request.json", output, StringComparison.Ordinal);
+            Assert.Contains("Direct provider: Claude", output, StringComparison.Ordinal);
+            Assert.Contains("Direct model: default", output, StringComparison.Ordinal);
+            Assert.Contains("Direct transport: stdio", output, StringComparison.Ordinal);
+            Assert.Contains("Provider session: claude-fix-g20-20260409102500", output, StringComparison.Ordinal);
+
+            var artifactPath = Path.Combine(repoRoot, ".intent-cli", "fix", "G20.request.md");
+            Assert.True(File.Exists(artifactPath));
+            var markdown = File.ReadAllText(artifactPath);
+            Assert.Contains("- packet_ref: .intent-cli/issues/G20/packet.yaml", markdown, StringComparison.Ordinal);
+            Assert.Contains("- review_context_ref: .intent-cli/issues/G20/review-context.md", markdown, StringComparison.Ordinal);
+            Assert.Contains("- review_comment_artifact_ref: .intent-cli/reviews/G20.comment.json", markdown, StringComparison.Ordinal);
+            Assert.Contains("- review_request_ref: .intent-cli/reviews/G20.request.json", markdown, StringComparison.Ordinal);
+            Assert.Contains("- latest_linked_pr: https://github.com/J-Tech-Japan/intent-system/pull/69", markdown, StringComparison.Ordinal);
+            Assert.Contains("- latest_comment_ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", markdown, StringComparison.Ordinal);
+
+            var directRunArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.request.json");
+            Assert.True(File.Exists(directRunArtifactPath));
+            var directRunArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(directRunArtifactPath));
+            Assert.Equal("G20", directRunArtifact.ExecutionUnit);
+            Assert.Equal("fix", directRunArtifact.EntryKind);
+            Assert.Equal(".intent-cli/fix/G20.request.md", directRunArtifact.UpstreamRequestRef);
+            Assert.Equal("Claude", directRunArtifact.Provider);
+            Assert.Equal("default", directRunArtifact.Model);
+            Assert.Equal("stdio", directRunArtifact.Transport);
+            Assert.Equal("claude-fix-g20-20260409102500", directRunArtifact.ProviderSessionId);
+
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            RunFixCommand.TimestampFactory = originalTimestampFactory;
+        }
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -117,6 +117,8 @@ public sealed class RunFixCommandTests
             string providerArg,
             string modelArg,
             string transportArg,
+            string command,
+            IReadOnlyList<string> argsTemplate,
             DateTimeOffset launchedAt,
             string workingDirectory,
             string absoluteRequestArtifactPath)
@@ -127,6 +129,8 @@ public sealed class RunFixCommandTests
             Assert.Equal(provider, providerArg);
             Assert.Equal(model, modelArg);
             Assert.Equal(transport, transportArg);
+            Assert.Equal("claude", command);
+            Assert.Equal(["--print", "--model", "{model}", "--output-format", "json", "{prompt}"], argsTemplate);
             Assert.EndsWith("/.intent-cli/worktrees/G20", workingDirectory, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/fix/G20.request.md", absoluteRequestArtifactPath, StringComparison.Ordinal);
 

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -128,6 +128,8 @@ public sealed class RunImplementCommandTests
             string providerArg,
             string modelArg,
             string transportArg,
+            string command,
+            IReadOnlyList<string> argsTemplate,
             DateTimeOffset launchedAt,
             string workingDirectory,
             string absoluteRequestArtifactPath)
@@ -138,6 +140,8 @@ public sealed class RunImplementCommandTests
             Assert.Equal(provider, providerArg);
             Assert.Equal(model, modelArg);
             Assert.Equal(transport, transportArg);
+            Assert.Equal("claude", command);
+            Assert.Equal(["--print", "--model", "{model}", "--output-format", "json", "{prompt}"], argsTemplate);
             Assert.EndsWith("/.intent-cli/worktrees/G19", workingDirectory, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/implement/G19.request.md", absoluteRequestArtifactPath, StringComparison.Ordinal);
 

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -27,28 +27,55 @@ public sealed class RunImplementCommandTests
             Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
             CreateReviewContextMarkdown());
         using var writer = new StringWriter();
+        var originalTimestampFactory = RunImplementCommand.TimestampFactory;
 
         var originalQueueState = File.ReadAllText(queueStatePath);
         var originalRunLog = File.ReadAllText(runLogPath);
 
-        var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+        try
+        {
+            RunImplementCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:15:00Z");
 
-        Assert.Equal(0, exitCode);
-        var output = writer.ToString();
-        Assert.Contains("Implementation handoff artifact generated for G19", output, StringComparison.Ordinal);
-        Assert.Contains("Implement role: Claude", output, StringComparison.Ordinal);
-        Assert.Contains("Branch: issue-66-g19", output, StringComparison.Ordinal);
-        Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/67", output, StringComparison.Ordinal);
+            var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
 
-        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "implement", "G19.request.md");
-        Assert.True(File.Exists(artifactPath));
-        var markdown = File.ReadAllText(artifactPath);
-        Assert.Contains("- packet_ref: .intent-cli/issues/G19/packet.yaml", markdown, StringComparison.Ordinal);
-        Assert.Contains("- review_context_ref: .intent-cli/issues/G19/review-context.md", markdown, StringComparison.Ordinal);
-        Assert.Contains("- latest_linked_pr: https://github.com/J-Tech-Japan/intent-system/pull/67", markdown, StringComparison.Ordinal);
-        Assert.Contains("- implement: Claude", markdown, StringComparison.Ordinal);
-        Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
-        Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Implementation handoff artifact generated for G19", output, StringComparison.Ordinal);
+            Assert.Contains("Implement role: Claude", output, StringComparison.Ordinal);
+            Assert.Contains("Branch: issue-66-g19", output, StringComparison.Ordinal);
+            Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/67", output, StringComparison.Ordinal);
+            Assert.Contains("Direct run request artifact: .intent-cli/runs/G19.request.json", output, StringComparison.Ordinal);
+            Assert.Contains("Direct provider: Claude", output, StringComparison.Ordinal);
+            Assert.Contains("Direct model: default", output, StringComparison.Ordinal);
+            Assert.Contains("Direct transport: stdio", output, StringComparison.Ordinal);
+            Assert.Contains("Provider session: claude-implement-g19-20260409101500", output, StringComparison.Ordinal);
+
+            var artifactPath = Path.Combine(repoRoot, ".intent-cli", "implement", "G19.request.md");
+            Assert.True(File.Exists(artifactPath));
+            var markdown = File.ReadAllText(artifactPath);
+            Assert.Contains("- packet_ref: .intent-cli/issues/G19/packet.yaml", markdown, StringComparison.Ordinal);
+            Assert.Contains("- review_context_ref: .intent-cli/issues/G19/review-context.md", markdown, StringComparison.Ordinal);
+            Assert.Contains("- latest_linked_pr: https://github.com/J-Tech-Japan/intent-system/pull/67", markdown, StringComparison.Ordinal);
+            Assert.Contains("- implement: Claude", markdown, StringComparison.Ordinal);
+
+            var directRunArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G19.request.json");
+            Assert.True(File.Exists(directRunArtifactPath));
+            var directRunArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(directRunArtifactPath));
+            Assert.Equal("G19", directRunArtifact.ExecutionUnit);
+            Assert.Equal("implement", directRunArtifact.EntryKind);
+            Assert.Equal(".intent-cli/implement/G19.request.md", directRunArtifact.UpstreamRequestRef);
+            Assert.Equal("Claude", directRunArtifact.Provider);
+            Assert.Equal("default", directRunArtifact.Model);
+            Assert.Equal("stdio", directRunArtifact.Transport);
+            Assert.Equal("claude-implement-g19-20260409101500", directRunArtifact.ProviderSessionId);
+
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            RunImplementCommand.TimestampFactory = originalTimestampFactory;
+        }
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -28,6 +28,7 @@ public sealed class RunImplementCommandTests
             CreateReviewContextMarkdown());
         using var writer = new StringWriter();
         var originalTimestampFactory = RunImplementCommand.TimestampFactory;
+        var originalLauncherFactory = RunImplementCommand.DirectRunLauncherFactory;
 
         var originalQueueState = File.ReadAllText(queueStatePath);
         var originalRunLog = File.ReadAllText(runLogPath);
@@ -35,6 +36,12 @@ public sealed class RunImplementCommandTests
         try
         {
             RunImplementCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:15:00Z");
+            RunImplementCommand.DirectRunLauncherFactory = () => new FakeDirectRunLauncher(
+                "pid:4321",
+                "Claude",
+                "default",
+                "stdio",
+                "stdio transport launched via 'claude' in '/repo/.intent-cli/worktrees/G19' for provider 'Claude'.");
 
             var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
 
@@ -48,7 +55,7 @@ public sealed class RunImplementCommandTests
             Assert.Contains("Direct provider: Claude", output, StringComparison.Ordinal);
             Assert.Contains("Direct model: default", output, StringComparison.Ordinal);
             Assert.Contains("Direct transport: stdio", output, StringComparison.Ordinal);
-            Assert.Contains("Provider session: claude-implement-g19-20260409101500", output, StringComparison.Ordinal);
+            Assert.Contains("Provider session: pid:4321", output, StringComparison.Ordinal);
 
             var artifactPath = Path.Combine(repoRoot, ".intent-cli", "implement", "G19.request.md");
             Assert.True(File.Exists(artifactPath));
@@ -67,7 +74,7 @@ public sealed class RunImplementCommandTests
             Assert.Equal("Claude", directRunArtifact.Provider);
             Assert.Equal("default", directRunArtifact.Model);
             Assert.Equal("stdio", directRunArtifact.Transport);
-            Assert.Equal("claude-implement-g19-20260409101500", directRunArtifact.ProviderSessionId);
+            Assert.Equal("pid:4321", directRunArtifact.ProviderSessionId);
 
             Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
             Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
@@ -75,6 +82,7 @@ public sealed class RunImplementCommandTests
         finally
         {
             RunImplementCommand.TimestampFactory = originalTimestampFactory;
+            RunImplementCommand.DirectRunLauncherFactory = originalLauncherFactory;
         }
     }
 
@@ -104,6 +112,45 @@ public sealed class RunImplementCommandTests
         Assert.Equal(0, exitCode);
         Assert.DoesNotContain("Latest linked PR:", writer.ToString(), StringComparison.Ordinal);
         Assert.DoesNotContain("latest_linked_pr", File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "implement", "G19.request.md")), StringComparison.Ordinal);
+    }
+
+    private sealed class FakeDirectRunLauncher(
+        string providerSessionId,
+        string provider,
+        string model,
+        string transport,
+        string transportSummary) : IDirectRunLauncher
+    {
+        public DirectRunLaunchResult Launch(
+            string executionUnit,
+            string entryKind,
+            string requestArtifactPath,
+            string providerArg,
+            string modelArg,
+            string transportArg,
+            DateTimeOffset launchedAt,
+            string workingDirectory,
+            string absoluteRequestArtifactPath)
+        {
+            Assert.Equal("G19", executionUnit);
+            Assert.Equal("implement", entryKind);
+            Assert.Equal(".intent-cli/runs/G19.request.json", requestArtifactPath);
+            Assert.Equal(provider, providerArg);
+            Assert.Equal(model, modelArg);
+            Assert.Equal(transport, transportArg);
+            Assert.EndsWith("/.intent-cli/worktrees/G19", workingDirectory, StringComparison.Ordinal);
+            Assert.EndsWith("/.intent-cli/implement/G19.request.md", absoluteRequestArtifactPath, StringComparison.Ordinal);
+
+            return new DirectRunLaunchResult
+            {
+                RequestArtifactPath = ".intent-cli/runs/G19.request.json",
+                Provider = providerArg,
+                Model = modelArg,
+                Transport = transportArg,
+                ProviderSessionId = providerSessionId,
+                TransportSummary = transportSummary
+            };
+        }
     }
 
     [Fact]


### PR DESCRIPTION
# Summary
- add config-driven direct backend policy and shared direct launcher support
- connect run implement, run fix, and review run to generate .intent-cli/runs/<execution-unit>.request.json and launch summaries
- cover runtime policy parsing and request artifact serialization with CLI tests

Closes #213