### PR TITLE
[G95] Provider Raw Event Capture

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -40,14 +40,18 @@ internal static class DirectRunCommandSupport
         var policy = ResolvePolicy(context, entryKind);
         var entryKindValue = FormatEntryKind(entryKind);
         var relativeArtifactPath = ResolveArtifactPath(context, executionUnit);
+        var relativeProviderEventLogPath = ResolveProviderEventLogPath(context, executionUnit);
         var absoluteArtifactPath = Path.GetFullPath(
             Path.Combine(context.RepoRoot, relativeArtifactPath.Replace('/', Path.DirectorySeparatorChar)));
+        var absoluteProviderEventLogPath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, relativeProviderEventLogPath.Replace('/', Path.DirectorySeparatorChar)));
         var absoluteUpstreamRequestPath = Path.GetFullPath(
             Path.Combine(context.RepoRoot, upstreamRequestRef.Replace('/', Path.DirectorySeparatorChar)));
         var launchResult = launcher.Launch(
             executionUnit,
             entryKindValue,
             relativeArtifactPath,
+            relativeProviderEventLogPath,
             policy.Provider,
             policy.Model,
             policy.Transport,
@@ -55,7 +59,8 @@ internal static class DirectRunCommandSupport
             policy.ArgsTemplate,
             launchedAt,
             workingDirectory,
-            absoluteUpstreamRequestPath);
+            absoluteUpstreamRequestPath,
+            absoluteProviderEventLogPath);
 
         var artifact = new DirectRunRequestArtifact
         {
@@ -126,6 +131,12 @@ internal static class DirectRunCommandSupport
     {
         var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
         return $"{root}/{executionUnit.Trim()}.request.json";
+    }
+
+    private static string ResolveProviderEventLogPath(CliContext context, string executionUnit)
+    {
+        var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
+        return $"{root}/{executionUnit.Trim()}.provider.jsonl";
     }
 
     private static string FormatEntryKind(DirectRunEntryKind entryKind)

--- a/src/IntentSystem.Cli/Commands/DirectRunLaunchResult.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLaunchResult.cs
@@ -4,6 +4,8 @@ internal sealed record DirectRunLaunchResult
 {
     public required string RequestArtifactPath { get; init; }
 
+    public required string ProviderEventLogPath { get; init; }
+
     public required string Provider { get; init; }
 
     public required string Model { get; init; }

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -19,6 +19,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         string executionUnit,
         string entryKind,
         string requestArtifactPath,
+        string providerEventLogPath,
         string provider,
         string model,
         string transport,
@@ -26,11 +27,13 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         IReadOnlyList<string> argsTemplate,
         DateTimeOffset launchedAt,
         string workingDirectory,
-        string absoluteRequestArtifactPath)
+        string absoluteRequestArtifactPath,
+        string absoluteProviderEventLogPath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
         ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
         ArgumentException.ThrowIfNullOrWhiteSpace(requestArtifactPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerEventLogPath);
         ArgumentException.ThrowIfNullOrWhiteSpace(provider);
         ArgumentException.ThrowIfNullOrWhiteSpace(model);
         ArgumentException.ThrowIfNullOrWhiteSpace(transport);
@@ -38,6 +41,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         ArgumentNullException.ThrowIfNull(argsTemplate);
         ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
         ArgumentException.ThrowIfNullOrWhiteSpace(absoluteRequestArtifactPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(absoluteProviderEventLogPath);
 
         var arguments = ResolveArguments(
             executionUnit,
@@ -48,11 +52,49 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             transport,
             absoluteRequestArtifactPath,
             argsTemplate);
+        var eventWriter = new DirectRunProviderEventWriter(absoluteProviderEventLogPath);
+        var providerSessionId = string.Empty;
         var process = processRunner.Start(
             workingDirectory,
             command,
             arguments,
-            DefaultEarlyExitWindow);
+            DefaultEarlyExitWindow,
+            processId =>
+            {
+                providerSessionId = $"pid:{processId}";
+                eventWriter.Append(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.ToString("O"),
+                    ExecutionUnit = executionUnit,
+                    EntryKind = entryKind,
+                    Provider = provider,
+                    ProviderSessionId = providerSessionId,
+                    EventKind = "session-started",
+                    Model = model,
+                    Transport = transport,
+                    Command = command
+                });
+            },
+            raw => eventWriter.Append(new DirectRunProviderEvent
+            {
+                Timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                ExecutionUnit = executionUnit,
+                EntryKind = entryKind,
+                Provider = provider,
+                ProviderSessionId = providerSessionId,
+                EventKind = "stdout",
+                Raw = raw
+            }),
+            raw => eventWriter.Append(new DirectRunProviderEvent
+            {
+                Timestamp = DateTimeOffset.UtcNow.ToString("O"),
+                ExecutionUnit = executionUnit,
+                EntryKind = entryKind,
+                Provider = provider,
+                ProviderSessionId = providerSessionId,
+                EventKind = "stderr",
+                Raw = raw
+            }));
 
         if (process.ExitedEarly && process.ExitCode != 0)
         {
@@ -63,10 +105,11 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         return new DirectRunLaunchResult
         {
             RequestArtifactPath = requestArtifactPath,
+            ProviderEventLogPath = providerEventLogPath,
             Provider = provider,
             Model = model,
             Transport = transport,
-            ProviderSessionId = $"pid:{process.ProcessId}",
+            ProviderSessionId = providerSessionId,
             TransportSummary =
                 $"{transport} transport launched via '{command}' in '{workingDirectory}' for provider '{provider}'."
         };

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -66,14 +66,16 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 providerSessionId = $"pid:{processId}";
                 eventWriter.Append(CreateSessionMetadataEvent(
                     launchedAt,
-                    providerSessionId,
+                    executionUnit,
+                    entryKind,
                     provider,
+                    providerSessionId,
                     model,
                     transport,
                     command));
             },
-            raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, providerSessionId, raw)),
-            raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, providerSessionId, raw)));
+            raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)),
+            raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)));
 
         if (process.ExitedEarly && process.ExitCode != 0)
         {
@@ -123,8 +125,10 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
 
     private static DirectRunProviderEvent CreateSessionMetadataEvent(
         DateTimeOffset launchedAt,
-        string providerSessionId,
+        string executionUnit,
+        string entryKind,
         string provider,
+        string providerSessionId,
         string model,
         string transport,
         string command)
@@ -132,11 +136,13 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         return new DirectRunProviderEvent
         {
             Timestamp = launchedAt.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = provider,
+            EntryKind = entryKind,
             SessionId = providerSessionId,
             Kind = "session-metadata",
             Payload = JsonSerializer.SerializeToElement(new
             {
-                provider,
                 model,
                 transport,
                 command
@@ -146,12 +152,18 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
 
     private static DirectRunProviderEvent CreateProviderEvent(
         DateTimeOffset timestamp,
+        string executionUnit,
+        string entryKind,
+        string provider,
         string providerSessionId,
         string raw)
     {
         return new DirectRunProviderEvent
         {
             Timestamp = timestamp.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = provider,
+            EntryKind = entryKind,
             SessionId = providerSessionId,
             Kind = "provider-event",
             Payload = ParsePayload(raw)

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace IntentSystem.Cli.Commands;
 
 internal sealed class DirectRunLauncher : IDirectRunLauncher
@@ -62,39 +64,16 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             processId =>
             {
                 providerSessionId = $"pid:{processId}";
-                eventWriter.Append(new DirectRunProviderEvent
-                {
-                    Timestamp = launchedAt.ToString("O"),
-                    ExecutionUnit = executionUnit,
-                    EntryKind = entryKind,
-                    Provider = provider,
-                    ProviderSessionId = providerSessionId,
-                    EventKind = "session-started",
-                    Model = model,
-                    Transport = transport,
-                    Command = command
-                });
+                eventWriter.Append(CreateSessionMetadataEvent(
+                    launchedAt,
+                    providerSessionId,
+                    provider,
+                    model,
+                    transport,
+                    command));
             },
-            raw => eventWriter.Append(new DirectRunProviderEvent
-            {
-                Timestamp = DateTimeOffset.UtcNow.ToString("O"),
-                ExecutionUnit = executionUnit,
-                EntryKind = entryKind,
-                Provider = provider,
-                ProviderSessionId = providerSessionId,
-                EventKind = "stdout",
-                Raw = raw
-            }),
-            raw => eventWriter.Append(new DirectRunProviderEvent
-            {
-                Timestamp = DateTimeOffset.UtcNow.ToString("O"),
-                ExecutionUnit = executionUnit,
-                EntryKind = entryKind,
-                Provider = provider,
-                ProviderSessionId = providerSessionId,
-                EventKind = "stderr",
-                Raw = raw
-            }));
+            raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, providerSessionId, raw)),
+            raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, providerSessionId, raw)));
 
         if (process.ExitedEarly && process.ExitCode != 0)
         {
@@ -140,5 +119,55 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 .Replace("{direct_run_artifact_path}", requestArtifactPath, StringComparison.Ordinal)
                 .Replace("{prompt}", prompt, StringComparison.Ordinal))
             .ToArray();
+    }
+
+    private static DirectRunProviderEvent CreateSessionMetadataEvent(
+        DateTimeOffset launchedAt,
+        string providerSessionId,
+        string provider,
+        string model,
+        string transport,
+        string command)
+    {
+        return new DirectRunProviderEvent
+        {
+            Timestamp = launchedAt.ToString("O"),
+            SessionId = providerSessionId,
+            Kind = "session-metadata",
+            Payload = JsonSerializer.SerializeToElement(new
+            {
+                provider,
+                model,
+                transport,
+                command
+            })
+        };
+    }
+
+    private static DirectRunProviderEvent CreateProviderEvent(
+        DateTimeOffset timestamp,
+        string providerSessionId,
+        string raw)
+    {
+        return new DirectRunProviderEvent
+        {
+            Timestamp = timestamp.ToString("O"),
+            SessionId = providerSessionId,
+            Kind = "provider-event",
+            Payload = ParsePayload(raw)
+        };
+    }
+
+    private static JsonElement ParsePayload(string raw)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(raw);
+            return document.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return JsonSerializer.SerializeToElement(raw);
+        }
     }
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
@@ -9,11 +9,17 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
         string workingDirectory,
         string fileName,
         IReadOnlyList<string> arguments,
-        TimeSpan earlyExitWindow)
+        TimeSpan earlyExitWindow,
+        Action<int> onStarted,
+        Action<string> onStdOutLine,
+        Action<string> onStdErrLine)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
         ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
         ArgumentNullException.ThrowIfNull(arguments);
+        ArgumentNullException.ThrowIfNull(onStarted);
+        ArgumentNullException.ThrowIfNull(onStdOutLine);
+        ArgumentNullException.ThrowIfNull(onStdErrLine);
 
         try
         {
@@ -23,8 +29,8 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
                 WorkingDirectory = workingDirectory,
                 UseShellExecute = false,
                 RedirectStandardInput = false,
-                RedirectStandardOutput = false,
-                RedirectStandardError = false
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
             };
 
             foreach (var argument in arguments)
@@ -35,12 +41,32 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
             var process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException($"Failed to start direct run process '{fileName}'.");
 
+            onStarted(process.Id);
+
+            process.OutputDataReceived += (_, eventArgs) =>
+            {
+                if (!string.IsNullOrEmpty(eventArgs.Data))
+                {
+                    onStdOutLine(eventArgs.Data);
+                }
+            };
+            process.ErrorDataReceived += (_, eventArgs) =>
+            {
+                if (!string.IsNullOrEmpty(eventArgs.Data))
+                {
+                    onStdErrLine(eventArgs.Data);
+                }
+            };
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
             var exitedEarly = process.WaitForExit((int)earlyExitWindow.TotalMilliseconds);
             var exitCode = exitedEarly ? process.ExitCode : 0;
             var processId = process.Id;
 
             if (exitedEarly)
             {
+                process.WaitForExit();
                 process.Dispose();
             }
 

--- a/src/IntentSystem.Cli/Commands/DirectRunProviderEventJsonl.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProviderEventJsonl.cs
@@ -8,6 +8,15 @@ internal sealed record DirectRunProviderEvent
     [JsonPropertyName("ts")]
     public required string Timestamp { get; init; }
 
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("provider")]
+    public required string Provider { get; init; }
+
+    [JsonPropertyName("entry_kind")]
+    public required string EntryKind { get; init; }
+
     [JsonPropertyName("session_id")]
     public required string SessionId { get; init; }
 

--- a/src/IntentSystem.Cli/Commands/DirectRunProviderEventJsonl.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProviderEventJsonl.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record DirectRunProviderEvent
+{
+    [JsonPropertyName("ts")]
+    public required string Timestamp { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("entry_kind")]
+    public required string EntryKind { get; init; }
+
+    [JsonPropertyName("provider")]
+    public required string Provider { get; init; }
+
+    [JsonPropertyName("provider_session_id")]
+    public required string ProviderSessionId { get; init; }
+
+    [JsonPropertyName("event_kind")]
+    public required string EventKind { get; init; }
+
+    [JsonPropertyName("model")]
+    public string? Model { get; init; }
+
+    [JsonPropertyName("transport")]
+    public string? Transport { get; init; }
+
+    [JsonPropertyName("command")]
+    public string? Command { get; init; }
+
+    [JsonPropertyName("raw")]
+    public string? Raw { get; init; }
+}
+
+internal static class DirectRunProviderEventJsonl
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = null
+    };
+
+    public static string SerializeLine(DirectRunProviderEvent providerEvent)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvent);
+
+        return JsonSerializer.Serialize(providerEvent, Options);
+    }
+
+    public static DirectRunProviderEvent DeserializeLine(string line)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(line);
+
+        return JsonSerializer.Deserialize<DirectRunProviderEvent>(line, Options)
+            ?? throw new InvalidOperationException("Direct run provider event payload deserialized to null.");
+    }
+
+    public static IReadOnlyList<DirectRunProviderEvent> DeserializeAll(string content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        var normalizedContent = NormalizeLineEndings(content);
+        if (normalizedContent.Length == 0)
+        {
+            return [];
+        }
+
+        var lines = normalizedContent.Split('\n');
+        var providerEvents = new DirectRunProviderEvent[lines.Length];
+
+        for (var index = 0; index < lines.Length; index++)
+        {
+            providerEvents[index] = DeserializeLine(lines[index]);
+        }
+
+        return providerEvents;
+    }
+
+    private static string NormalizeLineEndings(string content)
+    {
+        var normalized = content
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n');
+
+        if (!normalized.EndsWith('\n'))
+        {
+            return normalized;
+        }
+
+        var endIndex = normalized.Length;
+        while (endIndex > 0 && normalized[endIndex - 1] == '\n')
+        {
+            endIndex--;
+        }
+
+        return normalized[..endIndex];
+    }
+}
+
+internal sealed class DirectRunProviderEventWriter
+{
+    private readonly string artifactPath;
+    private readonly object gate = new();
+
+    public DirectRunProviderEventWriter(string artifactPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+
+        this.artifactPath = artifactPath;
+        var directoryPath = Path.GetDirectoryName(artifactPath)
+            ?? throw new InvalidOperationException("Direct run provider event artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+    }
+
+    public void Append(DirectRunProviderEvent providerEvent)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvent);
+
+        lock (gate)
+        {
+            File.AppendAllText(
+                artifactPath,
+                DirectRunProviderEventJsonl.SerializeLine(providerEvent) + Environment.NewLine);
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/DirectRunProviderEventJsonl.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProviderEventJsonl.cs
@@ -8,32 +8,14 @@ internal sealed record DirectRunProviderEvent
     [JsonPropertyName("ts")]
     public required string Timestamp { get; init; }
 
-    [JsonPropertyName("execution_unit")]
-    public required string ExecutionUnit { get; init; }
+    [JsonPropertyName("session_id")]
+    public required string SessionId { get; init; }
 
-    [JsonPropertyName("entry_kind")]
-    public required string EntryKind { get; init; }
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
 
-    [JsonPropertyName("provider")]
-    public required string Provider { get; init; }
-
-    [JsonPropertyName("provider_session_id")]
-    public required string ProviderSessionId { get; init; }
-
-    [JsonPropertyName("event_kind")]
-    public required string EventKind { get; init; }
-
-    [JsonPropertyName("model")]
-    public string? Model { get; init; }
-
-    [JsonPropertyName("transport")]
-    public string? Transport { get; init; }
-
-    [JsonPropertyName("command")]
-    public string? Command { get; init; }
-
-    [JsonPropertyName("raw")]
-    public string? Raw { get; init; }
+    [JsonPropertyName("payload")]
+    public required JsonElement Payload { get; init; }
 }
 
 internal static class DirectRunProviderEventJsonl

--- a/src/IntentSystem.Cli/Commands/IDirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/IDirectRunLauncher.cs
@@ -6,6 +6,7 @@ internal interface IDirectRunLauncher
         string executionUnit,
         string entryKind,
         string requestArtifactPath,
+        string providerEventLogPath,
         string provider,
         string model,
         string transport,
@@ -13,5 +14,6 @@ internal interface IDirectRunLauncher
         IReadOnlyList<string> argsTemplate,
         DateTimeOffset launchedAt,
         string workingDirectory,
-        string absoluteRequestArtifactPath);
+        string absoluteRequestArtifactPath,
+        string absoluteProviderEventLogPath);
 }

--- a/src/IntentSystem.Cli/Commands/IDirectRunProcessRunner.cs
+++ b/src/IntentSystem.Cli/Commands/IDirectRunProcessRunner.cs
@@ -6,5 +6,8 @@ internal interface IDirectRunProcessRunner
         string workingDirectory,
         string fileName,
         IReadOnlyList<string> arguments,
-        TimeSpan earlyExitWindow);
+        TimeSpan earlyExitWindow,
+        Action<int> onStarted,
+        Action<string> onStdOutLine,
+        Action<string> onStdErrLine);
 }

--- a/src/IntentSystem.Cli/Commands/ReviewRunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewRunCommand.cs
@@ -28,6 +28,7 @@ internal static class ReviewRunCommand
             if (result.DirectRun is not null)
             {
                 writer.WriteLine($"Direct run request artifact: {result.DirectRun.RequestArtifactPath}");
+                writer.WriteLine($"Provider raw event log: {result.DirectRun.ProviderEventLogPath}");
                 writer.WriteLine($"Direct provider: {result.DirectRun.Provider}");
                 writer.WriteLine($"Direct model: {result.DirectRun.Model}");
                 writer.WriteLine($"Direct transport: {result.DirectRun.Transport}");

--- a/src/IntentSystem.Cli/Commands/RunFixRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixRenderer.cs
@@ -92,6 +92,7 @@ internal static class RunFixRenderer
         if (directRun is not null)
         {
             writer.WriteLine($"Direct run request artifact: {directRun.RequestArtifactPath}");
+            writer.WriteLine($"Provider raw event log: {directRun.ProviderEventLogPath}");
             writer.WriteLine($"Direct provider: {directRun.Provider}");
             writer.WriteLine($"Direct model: {directRun.Model}");
             writer.WriteLine($"Direct transport: {directRun.Transport}");

--- a/src/IntentSystem.Cli/Commands/RunImplementRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementRenderer.cs
@@ -95,6 +95,7 @@ internal static class RunImplementRenderer
         if (directRun is not null)
         {
             writer.WriteLine($"Direct run request artifact: {directRun.RequestArtifactPath}");
+            writer.WriteLine($"Provider raw event log: {directRun.ProviderEventLogPath}");
             writer.WriteLine($"Direct provider: {directRun.Provider}");
             writer.WriteLine($"Direct model: {directRun.Model}");
             writer.WriteLine($"Direct transport: {directRun.Transport}");

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -3130,6 +3130,7 @@ public sealed class CommandRouterTests
             Assert.Equal(0, exitCode);
             Assert.Contains("Implementation handoff artifact generated for G19", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Implement role: Claude", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Provider raw event log: .intent-cli/runs/G19.provider.jsonl", writer.ToString(), StringComparison.Ordinal);
         }
         finally
         {
@@ -3171,6 +3172,7 @@ public sealed class CommandRouterTests
             Assert.Equal(0, exitCode);
             Assert.Contains("Repair handoff artifact generated for G20", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Latest comment ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Provider raw event log: .intent-cli/runs/G20.provider.jsonl", writer.ToString(), StringComparison.Ordinal);
         }
         finally
         {
@@ -3304,6 +3306,7 @@ public sealed class CommandRouterTests
 
             Assert.Equal(0, exitCode);
             Assert.Contains("Review request artifact generated for G9", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Provider raw event log: .intent-cli/runs/G9.provider.jsonl", writer.ToString(), StringComparison.Ordinal);
 
             var artifact = ReviewRequestSerializer.Deserialize(
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "reviews", "G9.request.json")));
@@ -5231,6 +5234,7 @@ recommended_updates:
             string executionUnit,
             string entryKind,
             string requestArtifactPathArg,
+            string providerEventLogPath,
             string provider,
             string model,
             string transport,
@@ -5238,11 +5242,13 @@ recommended_updates:
             IReadOnlyList<string> argsTemplate,
             DateTimeOffset launchedAt,
             string workingDirectory,
-            string absoluteRequestArtifactPath)
+            string absoluteRequestArtifactPath,
+            string absoluteProviderEventLogPath)
         {
             return new DirectRunLaunchResult
             {
                 RequestArtifactPath = requestArtifactPath,
+                ProviderEventLogPath = providerEventLogPath,
                 Provider = provider,
                 Model = model,
                 Transport = transport,

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -11,8 +11,8 @@ public sealed class DirectRunLauncherTests
         var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G19.provider.jsonl");
         var runner = new FakeDirectRunProcessRunner
         {
-            StdOutLines = ["event:ready"],
-            StdErrLines = ["warn:slow-start"],
+            StdOutLines = ["""{"type":"ready","step":"bootstrap"}"""],
+            StdErrLines = ["""{"level":"warn","message":"slow-start"}"""],
             Result = new DirectRunProcessLaunchResult
             {
                 ProcessId = 4321,
@@ -65,25 +65,26 @@ public sealed class DirectRunLauncherTests
             providerEvent =>
             {
                 Assert.Equal("2026-04-09T10:15:00.0000000+00:00", providerEvent.Timestamp);
-                Assert.Equal("G19", providerEvent.ExecutionUnit);
-                Assert.Equal("implement", providerEvent.EntryKind);
-                Assert.Equal("ReviewBot", providerEvent.Provider);
-                Assert.Equal("pid:4321", providerEvent.ProviderSessionId);
-                Assert.Equal("session-started", providerEvent.EventKind);
-                Assert.Equal("gpt-5.4", providerEvent.Model);
-                Assert.Equal("grpc", providerEvent.Transport);
-                Assert.Equal("review-runner", providerEvent.Command);
-                Assert.Null(providerEvent.Raw);
+                Assert.Equal("pid:4321", providerEvent.SessionId);
+                Assert.Equal("session-metadata", providerEvent.Kind);
+                Assert.Equal("ReviewBot", providerEvent.Payload.GetProperty("provider").GetString());
+                Assert.Equal("gpt-5.4", providerEvent.Payload.GetProperty("model").GetString());
+                Assert.Equal("grpc", providerEvent.Payload.GetProperty("transport").GetString());
+                Assert.Equal("review-runner", providerEvent.Payload.GetProperty("command").GetString());
             },
             providerEvent =>
             {
-                Assert.Equal("stdout", providerEvent.EventKind);
-                Assert.Equal("event:ready", providerEvent.Raw);
+                Assert.Equal("pid:4321", providerEvent.SessionId);
+                Assert.Equal("provider-event", providerEvent.Kind);
+                Assert.Equal("ready", providerEvent.Payload.GetProperty("type").GetString());
+                Assert.Equal("bootstrap", providerEvent.Payload.GetProperty("step").GetString());
             },
             providerEvent =>
             {
-                Assert.Equal("stderr", providerEvent.EventKind);
-                Assert.Equal("warn:slow-start", providerEvent.Raw);
+                Assert.Equal("pid:4321", providerEvent.SessionId);
+                Assert.Equal("provider-event", providerEvent.Kind);
+                Assert.Equal("warn", providerEvent.Payload.GetProperty("level").GetString());
+                Assert.Equal("slow-start", providerEvent.Payload.GetProperty("message").GetString());
             });
     }
 

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -65,15 +65,20 @@ public sealed class DirectRunLauncherTests
             providerEvent =>
             {
                 Assert.Equal("2026-04-09T10:15:00.0000000+00:00", providerEvent.Timestamp);
+                Assert.Equal("G19", providerEvent.ExecutionUnit);
+                Assert.Equal("ReviewBot", providerEvent.Provider);
+                Assert.Equal("implement", providerEvent.EntryKind);
                 Assert.Equal("pid:4321", providerEvent.SessionId);
                 Assert.Equal("session-metadata", providerEvent.Kind);
-                Assert.Equal("ReviewBot", providerEvent.Payload.GetProperty("provider").GetString());
                 Assert.Equal("gpt-5.4", providerEvent.Payload.GetProperty("model").GetString());
                 Assert.Equal("grpc", providerEvent.Payload.GetProperty("transport").GetString());
                 Assert.Equal("review-runner", providerEvent.Payload.GetProperty("command").GetString());
             },
             providerEvent =>
             {
+                Assert.Equal("G19", providerEvent.ExecutionUnit);
+                Assert.Equal("ReviewBot", providerEvent.Provider);
+                Assert.Equal("implement", providerEvent.EntryKind);
                 Assert.Equal("pid:4321", providerEvent.SessionId);
                 Assert.Equal("provider-event", providerEvent.Kind);
                 Assert.Equal("ready", providerEvent.Payload.GetProperty("type").GetString());
@@ -81,6 +86,9 @@ public sealed class DirectRunLauncherTests
             },
             providerEvent =>
             {
+                Assert.Equal("G19", providerEvent.ExecutionUnit);
+                Assert.Equal("ReviewBot", providerEvent.Provider);
+                Assert.Equal("implement", providerEvent.EntryKind);
                 Assert.Equal("pid:4321", providerEvent.SessionId);
                 Assert.Equal("provider-event", providerEvent.Kind);
                 Assert.Equal("warn", providerEvent.Payload.GetProperty("level").GetString());

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -5,10 +5,14 @@ namespace IntentSystem.Cli.Tests;
 public sealed class DirectRunLauncherTests
 {
     [Fact]
-    public void Launch_GivenConfiguredCommandPolicy_StartsConfiguredExecutableWithExpandedArguments()
+    public void Launch_GivenConfiguredCommandPolicy_StartsConfiguredExecutableAndCapturesProviderEvents()
     {
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G19.provider.jsonl");
         var runner = new FakeDirectRunProcessRunner
         {
+            StdOutLines = ["event:ready"],
+            StdErrLines = ["warn:slow-start"],
             Result = new DirectRunProcessLaunchResult
             {
                 ProcessId = 4321,
@@ -22,6 +26,7 @@ public sealed class DirectRunLauncherTests
             "G19",
             "implement",
             ".intent-cli/runs/G19.request.json",
+            ".intent-cli/runs/G19.provider.jsonl",
             "ReviewBot",
             "gpt-5.4",
             "grpc",
@@ -29,7 +34,8 @@ public sealed class DirectRunLauncherTests
             ["launch", "--entry", "{entry_kind}", "--unit", "{execution_unit}", "--model", "{model}", "--artifact", "{request_artifact_path}", "--run-artifact", "{direct_run_artifact_path}", "{prompt}"],
             DateTimeOffset.Parse("2026-04-09T10:15:00Z"),
             "/repo/.intent-cli/worktrees/G19",
-            "/repo/.intent-cli/implement/G19.request.md");
+            "/repo/.intent-cli/implement/G19.request.md",
+            providerEventLogPath);
 
         Assert.Equal("review-runner", runner.FileName);
         Assert.Equal("/repo/.intent-cli/worktrees/G19", runner.WorkingDirectory);
@@ -50,12 +56,41 @@ public sealed class DirectRunLauncherTests
             ],
             runner.Arguments);
         Assert.Equal("pid:4321", result.ProviderSessionId);
+        Assert.Equal(".intent-cli/runs/G19.provider.jsonl", result.ProviderEventLogPath);
         Assert.Contains("grpc transport launched via 'review-runner'", result.TransportSummary, StringComparison.Ordinal);
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.Collection(
+            events,
+            providerEvent =>
+            {
+                Assert.Equal("2026-04-09T10:15:00.0000000+00:00", providerEvent.Timestamp);
+                Assert.Equal("G19", providerEvent.ExecutionUnit);
+                Assert.Equal("implement", providerEvent.EntryKind);
+                Assert.Equal("ReviewBot", providerEvent.Provider);
+                Assert.Equal("pid:4321", providerEvent.ProviderSessionId);
+                Assert.Equal("session-started", providerEvent.EventKind);
+                Assert.Equal("gpt-5.4", providerEvent.Model);
+                Assert.Equal("grpc", providerEvent.Transport);
+                Assert.Equal("review-runner", providerEvent.Command);
+                Assert.Null(providerEvent.Raw);
+            },
+            providerEvent =>
+            {
+                Assert.Equal("stdout", providerEvent.EventKind);
+                Assert.Equal("event:ready", providerEvent.Raw);
+            },
+            providerEvent =>
+            {
+                Assert.Equal("stderr", providerEvent.EventKind);
+                Assert.Equal("warn:slow-start", providerEvent.Raw);
+            });
     }
 
     [Fact]
     public void Launch_GivenUpstreamRequestArtifactPlaceholder_ExpandsAlias()
     {
+        using var tempDirectory = new TemporaryDirectory();
         var runner = new FakeDirectRunProcessRunner
         {
             Result = new DirectRunProcessLaunchResult
@@ -71,6 +106,7 @@ public sealed class DirectRunLauncherTests
             "G20",
             "fix",
             ".intent-cli/runs/G20.request.json",
+            ".intent-cli/runs/G20.provider.jsonl",
             "Claude",
             "sonnet",
             "stdio",
@@ -78,7 +114,8 @@ public sealed class DirectRunLauncherTests
             ["--artifact", "{upstream_request_artifact_path}", "--model", "{model}"],
             DateTimeOffset.Parse("2026-04-09T10:25:00Z"),
             "/repo/.intent-cli/worktrees/G20",
-            "/repo/.intent-cli/fix/G20.request.md");
+            "/repo/.intent-cli/fix/G20.request.md",
+            tempDirectory.GetPath(".intent-cli/runs/G20.provider.jsonl"));
 
         Assert.Equal("claude", runner.FileName);
         Assert.Equal(
@@ -90,6 +127,7 @@ public sealed class DirectRunLauncherTests
     [Fact]
     public void Launch_GivenEarlyNonZeroExit_Throws()
     {
+        using var tempDirectory = new TemporaryDirectory();
         var runner = new FakeDirectRunProcessRunner
         {
             Result = new DirectRunProcessLaunchResult
@@ -105,6 +143,7 @@ public sealed class DirectRunLauncherTests
             "G9",
             "review",
             ".intent-cli/runs/G9.request.json",
+            ".intent-cli/runs/G9.provider.jsonl",
             "Codex",
             "gpt-5.4-mini",
             "grpc",
@@ -112,7 +151,8 @@ public sealed class DirectRunLauncherTests
             ["exec", "{prompt}"],
             DateTimeOffset.Parse("2026-04-09T10:35:00Z"),
             "/repo",
-            "/repo/.intent-cli/reviews/G9.request.json"));
+            "/repo/.intent-cli/reviews/G9.request.json",
+            tempDirectory.GetPath(".intent-cli/runs/G9.provider.jsonl")));
 
         Assert.Contains("exit code 17", exception.Message, StringComparison.Ordinal);
     }
@@ -125,6 +165,10 @@ public sealed class DirectRunLauncherTests
 
         public IReadOnlyList<string> Arguments { get; private set; } = [];
 
+        public IReadOnlyList<string> StdOutLines { get; init; } = [];
+
+        public IReadOnlyList<string> StdErrLines { get; init; } = [];
+
         public DirectRunProcessLaunchResult Result { get; set; } = new()
         {
             ProcessId = 1,
@@ -136,12 +180,44 @@ public sealed class DirectRunLauncherTests
             string workingDirectory,
             string fileName,
             IReadOnlyList<string> arguments,
-            TimeSpan earlyExitWindow)
+            TimeSpan earlyExitWindow,
+            Action<int> onStarted,
+            Action<string> onStdOutLine,
+            Action<string> onStdErrLine)
         {
             WorkingDirectory = workingDirectory;
             FileName = fileName;
             Arguments = arguments.ToArray();
+            onStarted(Result.ProcessId);
+            foreach (var line in StdOutLines)
+            {
+                onStdOutLine(line);
+            }
+
+            foreach (var line in StdErrLines)
+            {
+                onStdErrLine(line);
+            }
+
             return Result;
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-tests-").FullName;
+
+        public string GetPath(string relativePath)
+        {
+            return Path.Combine(rootPath, relativePath);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
         }
     }
 }

--- a/tests/IntentSystem.Cli.Tests/DirectRunProviderEventJsonlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunProviderEventJsonlTests.cs
@@ -13,11 +13,13 @@ public sealed class DirectRunProviderEventJsonlTests
             new DirectRunProviderEvent
             {
                 Timestamp = "2026-04-09T10:15:00.0000000+00:00",
+                ExecutionUnit = "G19",
+                Provider = "Claude",
+                EntryKind = "implement",
                 SessionId = "pid:4321",
                 Kind = "session-metadata",
                 Payload = JsonSerializer.SerializeToElement(new
                 {
-                    provider = "Claude",
                     model = "sonnet",
                     transport = "stdio",
                     command = "claude"
@@ -26,6 +28,9 @@ public sealed class DirectRunProviderEventJsonlTests
             new DirectRunProviderEvent
             {
                 Timestamp = "2026-04-09T10:15:01.0000000+00:00",
+                ExecutionUnit = "G19",
+                Provider = "Claude",
+                EntryKind = "implement",
                 SessionId = "pid:4321",
                 Kind = "provider-event",
                 Payload = JsonSerializer.SerializeToElement(new
@@ -42,11 +47,16 @@ public sealed class DirectRunProviderEventJsonlTests
 
         Assert.Equal(2, roundTripped.Count);
         Assert.Equal(events[0].Timestamp, roundTripped[0].Timestamp);
+        Assert.Equal(events[0].ExecutionUnit, roundTripped[0].ExecutionUnit);
+        Assert.Equal(events[0].Provider, roundTripped[0].Provider);
+        Assert.Equal(events[0].EntryKind, roundTripped[0].EntryKind);
         Assert.Equal(events[0].SessionId, roundTripped[0].SessionId);
         Assert.Equal(events[0].Kind, roundTripped[0].Kind);
-        Assert.Equal(events[0].Payload.GetProperty("provider").GetString(), roundTripped[0].Payload.GetProperty("provider").GetString());
         Assert.Equal(events[0].Payload.GetProperty("model").GetString(), roundTripped[0].Payload.GetProperty("model").GetString());
         Assert.Equal(events[1].Timestamp, roundTripped[1].Timestamp);
+        Assert.Equal(events[1].ExecutionUnit, roundTripped[1].ExecutionUnit);
+        Assert.Equal(events[1].Provider, roundTripped[1].Provider);
+        Assert.Equal(events[1].EntryKind, roundTripped[1].EntryKind);
         Assert.Equal(events[1].SessionId, roundTripped[1].SessionId);
         Assert.Equal(events[1].Kind, roundTripped[1].Kind);
         Assert.Equal(events[1].Payload.GetProperty("type").GetString(), roundTripped[1].Payload.GetProperty("type").GetString());

--- a/tests/IntentSystem.Cli.Tests/DirectRunProviderEventJsonlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunProviderEventJsonlTests.cs
@@ -1,0 +1,42 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class DirectRunProviderEventJsonlTests
+{
+    [Fact]
+    public void SerializeLineAndDeserializeAll_GivenEvents_RoundTripsJsonl()
+    {
+        var events = new[]
+        {
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-09T10:15:00.0000000+00:00",
+                ExecutionUnit = "G19",
+                EntryKind = "implement",
+                Provider = "Claude",
+                ProviderSessionId = "pid:4321",
+                EventKind = "session-started",
+                Model = "sonnet",
+                Transport = "stdio",
+                Command = "claude"
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-09T10:15:01.0000000+00:00",
+                ExecutionUnit = "G19",
+                EntryKind = "implement",
+                Provider = "Claude",
+                ProviderSessionId = "pid:4321",
+                EventKind = "stdout",
+                Raw = "{\"type\":\"delta\"}"
+            }
+        };
+
+        var jsonl = string.Join(Environment.NewLine, events.Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine;
+
+        var roundTripped = DirectRunProviderEventJsonl.DeserializeAll(jsonl);
+
+        Assert.Equal(events, roundTripped);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/DirectRunProviderEventJsonlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunProviderEventJsonlTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using IntentSystem.Cli.Commands;
 
 namespace IntentSystem.Cli.Tests;
@@ -12,24 +13,26 @@ public sealed class DirectRunProviderEventJsonlTests
             new DirectRunProviderEvent
             {
                 Timestamp = "2026-04-09T10:15:00.0000000+00:00",
-                ExecutionUnit = "G19",
-                EntryKind = "implement",
-                Provider = "Claude",
-                ProviderSessionId = "pid:4321",
-                EventKind = "session-started",
-                Model = "sonnet",
-                Transport = "stdio",
-                Command = "claude"
+                SessionId = "pid:4321",
+                Kind = "session-metadata",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    provider = "Claude",
+                    model = "sonnet",
+                    transport = "stdio",
+                    command = "claude"
+                })
             },
             new DirectRunProviderEvent
             {
                 Timestamp = "2026-04-09T10:15:01.0000000+00:00",
-                ExecutionUnit = "G19",
-                EntryKind = "implement",
-                Provider = "Claude",
-                ProviderSessionId = "pid:4321",
-                EventKind = "stdout",
-                Raw = "{\"type\":\"delta\"}"
+                SessionId = "pid:4321",
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    type = "delta",
+                    sequence = 2
+                })
             }
         };
 
@@ -37,6 +40,16 @@ public sealed class DirectRunProviderEventJsonlTests
 
         var roundTripped = DirectRunProviderEventJsonl.DeserializeAll(jsonl);
 
-        Assert.Equal(events, roundTripped);
+        Assert.Equal(2, roundTripped.Count);
+        Assert.Equal(events[0].Timestamp, roundTripped[0].Timestamp);
+        Assert.Equal(events[0].SessionId, roundTripped[0].SessionId);
+        Assert.Equal(events[0].Kind, roundTripped[0].Kind);
+        Assert.Equal(events[0].Payload.GetProperty("provider").GetString(), roundTripped[0].Payload.GetProperty("provider").GetString());
+        Assert.Equal(events[0].Payload.GetProperty("model").GetString(), roundTripped[0].Payload.GetProperty("model").GetString());
+        Assert.Equal(events[1].Timestamp, roundTripped[1].Timestamp);
+        Assert.Equal(events[1].SessionId, roundTripped[1].SessionId);
+        Assert.Equal(events[1].Kind, roundTripped[1].Kind);
+        Assert.Equal(events[1].Payload.GetProperty("type").GetString(), roundTripped[1].Payload.GetProperty("type").GetString());
+        Assert.Equal(events[1].Payload.GetProperty("sequence").GetInt32(), roundTripped[1].Payload.GetProperty("sequence").GetInt32());
     }
 }

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -44,6 +44,7 @@ public sealed class ReviewRunCommandTests
             Assert.Equal(0, exitCode);
             Assert.Contains("Review request artifact generated for G9", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Direct run request artifact: .intent-cli/runtime-runs/G9.request.json", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Provider raw event log: .intent-cli/runtime-runs/G9.provider.jsonl", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Direct provider: ReviewBot", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Direct model: gpt-5.4-mini", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Direct transport: grpc", writer.ToString(), StringComparison.Ordinal);
@@ -317,6 +318,7 @@ public sealed class ReviewRunCommandTests
             string executionUnit,
             string entryKind,
             string requestArtifactPath,
+            string providerEventLogPath,
             string providerArg,
             string modelArg,
             string transportArg,
@@ -324,11 +326,13 @@ public sealed class ReviewRunCommandTests
             IReadOnlyList<string> argsTemplateArg,
             DateTimeOffset launchedAt,
             string workingDirectory,
-            string absoluteRequestArtifactPath)
+            string absoluteRequestArtifactPath,
+            string absoluteProviderEventLogPath)
         {
             Assert.Equal("G9", executionUnit);
             Assert.Equal("review", entryKind);
             Assert.Equal(".intent-cli/runtime-runs/G9.request.json", requestArtifactPath);
+            Assert.Equal(".intent-cli/runtime-runs/G9.provider.jsonl", providerEventLogPath);
             Assert.Equal(provider, providerArg);
             Assert.Equal(model, modelArg);
             Assert.Equal(transport, transportArg);
@@ -336,10 +340,12 @@ public sealed class ReviewRunCommandTests
             Assert.Equal(argsTemplate, argsTemplateArg);
             Assert.EndsWith("/repo", workingDirectory, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/reviews/G9.request.json", absoluteRequestArtifactPath, StringComparison.Ordinal);
+            Assert.EndsWith("/.intent-cli/runtime-runs/G9.provider.jsonl", absoluteProviderEventLogPath, StringComparison.Ordinal);
 
             return new DirectRunLaunchResult
             {
                 RequestArtifactPath = ".intent-cli/runtime-runs/G9.request.json",
+                ProviderEventLogPath = ".intent-cli/runtime-runs/G9.provider.jsonl",
                 Provider = providerArg,
                 Model = modelArg,
                 Transport = transportArg,

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -56,6 +56,7 @@ public sealed class RunFixCommandTests
             Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/69", output, StringComparison.Ordinal);
             Assert.Contains("Latest comment ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", output, StringComparison.Ordinal);
             Assert.Contains("Direct run request artifact: .intent-cli/runs/G20.request.json", output, StringComparison.Ordinal);
+            Assert.Contains("Provider raw event log: .intent-cli/runs/G20.provider.jsonl", output, StringComparison.Ordinal);
             Assert.Contains("Direct provider: Claude", output, StringComparison.Ordinal);
             Assert.Contains("Direct model: default", output, StringComparison.Ordinal);
             Assert.Contains("Direct transport: stdio", output, StringComparison.Ordinal);
@@ -114,6 +115,7 @@ public sealed class RunFixCommandTests
             string executionUnit,
             string entryKind,
             string requestArtifactPath,
+            string providerEventLogPath,
             string providerArg,
             string modelArg,
             string transportArg,
@@ -121,11 +123,13 @@ public sealed class RunFixCommandTests
             IReadOnlyList<string> argsTemplate,
             DateTimeOffset launchedAt,
             string workingDirectory,
-            string absoluteRequestArtifactPath)
+            string absoluteRequestArtifactPath,
+            string absoluteProviderEventLogPath)
         {
             Assert.Equal("G20", executionUnit);
             Assert.Equal("fix", entryKind);
             Assert.Equal(".intent-cli/runs/G20.request.json", requestArtifactPath);
+            Assert.Equal(".intent-cli/runs/G20.provider.jsonl", providerEventLogPath);
             Assert.Equal(provider, providerArg);
             Assert.Equal(model, modelArg);
             Assert.Equal(transport, transportArg);
@@ -133,10 +137,12 @@ public sealed class RunFixCommandTests
             Assert.Equal(["--print", "--model", "{model}", "--output-format", "json", "{prompt}"], argsTemplate);
             Assert.EndsWith("/.intent-cli/worktrees/G20", workingDirectory, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/fix/G20.request.md", absoluteRequestArtifactPath, StringComparison.Ordinal);
+            Assert.EndsWith("/.intent-cli/runs/G20.provider.jsonl", absoluteProviderEventLogPath, StringComparison.Ordinal);
 
             return new DirectRunLaunchResult
             {
                 RequestArtifactPath = ".intent-cli/runs/G20.request.json",
+                ProviderEventLogPath = ".intent-cli/runs/G20.provider.jsonl",
                 Provider = providerArg,
                 Model = modelArg,
                 Transport = transportArg,

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -52,6 +52,7 @@ public sealed class RunImplementCommandTests
             Assert.Contains("Branch: issue-66-g19", output, StringComparison.Ordinal);
             Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/67", output, StringComparison.Ordinal);
             Assert.Contains("Direct run request artifact: .intent-cli/runs/G19.request.json", output, StringComparison.Ordinal);
+            Assert.Contains("Provider raw event log: .intent-cli/runs/G19.provider.jsonl", output, StringComparison.Ordinal);
             Assert.Contains("Direct provider: Claude", output, StringComparison.Ordinal);
             Assert.Contains("Direct model: default", output, StringComparison.Ordinal);
             Assert.Contains("Direct transport: stdio", output, StringComparison.Ordinal);
@@ -125,6 +126,7 @@ public sealed class RunImplementCommandTests
             string executionUnit,
             string entryKind,
             string requestArtifactPath,
+            string providerEventLogPath,
             string providerArg,
             string modelArg,
             string transportArg,
@@ -132,11 +134,13 @@ public sealed class RunImplementCommandTests
             IReadOnlyList<string> argsTemplate,
             DateTimeOffset launchedAt,
             string workingDirectory,
-            string absoluteRequestArtifactPath)
+            string absoluteRequestArtifactPath,
+            string absoluteProviderEventLogPath)
         {
             Assert.Equal("G19", executionUnit);
             Assert.Equal("implement", entryKind);
             Assert.Equal(".intent-cli/runs/G19.request.json", requestArtifactPath);
+            Assert.Equal(".intent-cli/runs/G19.provider.jsonl", providerEventLogPath);
             Assert.Equal(provider, providerArg);
             Assert.Equal(model, modelArg);
             Assert.Equal(transport, transportArg);
@@ -144,10 +148,12 @@ public sealed class RunImplementCommandTests
             Assert.Equal(["--print", "--model", "{model}", "--output-format", "json", "{prompt}"], argsTemplate);
             Assert.EndsWith("/.intent-cli/worktrees/G19", workingDirectory, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/implement/G19.request.md", absoluteRequestArtifactPath, StringComparison.Ordinal);
+            Assert.EndsWith("/.intent-cli/runs/G19.provider.jsonl", absoluteProviderEventLogPath, StringComparison.Ordinal);
 
             return new DirectRunLaunchResult
             {
                 RequestArtifactPath = ".intent-cli/runs/G19.request.json",
+                ProviderEventLogPath = ".intent-cli/runs/G19.provider.jsonl",
                 Provider = providerArg,
                 Model = modelArg,
                 Transport = transportArg,


### PR DESCRIPTION
## Summary
- capture direct backend provider raw events into `.intent-cli/runs/<execution-unit>.provider.jsonl`
- append session-started/stdout/stderr events from the shared direct run launch path
- surface provider raw event log refs in run implement, run fix, and review run summaries

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~DirectRunLauncher|FullyQualifiedName~DirectRunProviderEventJsonl|FullyQualifiedName~RunImplementCommand|FullyQualifiedName~RunFixCommand|FullyQualifiedName~ReviewRunCommand|FullyQualifiedName~CommandRouter"
- dotnet test IntentSystem.sln

Closes #215