### PR TITLE
[G96] Add normalized run result synthesis

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -277,9 +277,19 @@ internal static class DirectRunCommandSupport
             RawLogRef = launchResult.ProviderEventLogPath,
             PacketRef = queueItem.PacketPaths.Yaml,
             ReviewContextRef = queueItem.PacketPaths.ReviewContext,
-            LinkedIssueUrl = queueItem.LinkedIssue?.Url,
-            LinkedPrUrl = latestLinkedPr,
-            WorktreePath = worktreePath
+            LinkedIssue = queueItem.LinkedIssue is null
+                ? null
+                : new DirectRunLinkedIssueContext
+                {
+                    Repo = queueItem.LinkedIssue.Repo,
+                    Number = queueItem.LinkedIssue.Number,
+                    Url = queueItem.LinkedIssue.Url
+                },
+            LinkedPr = CreateLinkedPullRequestContext(latestLinkedPr),
+            Worktree = new DirectRunWorktreeContext
+            {
+                Path = worktreePath
+            }
         };
 
         var resultDirectoryPath = Path.GetDirectoryName(absoluteResultArtifactPath)
@@ -298,8 +308,8 @@ internal static class DirectRunCommandSupport
                 ExecutionUnit = executionUnit,
                 Event = LifecycleEventName,
                 By = LifecycleEventActor,
-                LinkedIssue = artifact.LinkedIssueUrl,
-                LinkedPr = artifact.LinkedPrUrl,
+                LinkedIssue = artifact.LinkedIssue?.Url,
+                LinkedPr = artifact.LinkedPr?.Url,
                 EntryKind = entryKind,
                 Provider = provider,
                 Model = model,
@@ -309,7 +319,7 @@ internal static class DirectRunCommandSupport
                 ResultRef = resultArtifactPath,
                 PacketRef = artifact.PacketRef,
                 ReviewContextRef = artifact.ReviewContextRef,
-                WorktreePath = artifact.WorktreePath
+                WorktreePath = artifact.Worktree.Path
             }) + Environment.NewLine);
 
         return new DirectRunSynthesisResult
@@ -441,6 +451,55 @@ internal static class DirectRunCommandSupport
             var normalized when !string.IsNullOrWhiteSpace(normalized) => normalized,
             _ => "running"
         };
+    }
+
+    private static DirectRunLinkedPullRequestContext? CreateLinkedPullRequestContext(string? linkedPrUrl)
+    {
+        if (string.IsNullOrWhiteSpace(linkedPrUrl))
+        {
+            return null;
+        }
+
+        var repo = default(string);
+        var number = default(int?);
+
+        if (TryParseGitHubPullRequestUrl(linkedPrUrl, out var parsedRepo, out var parsedNumber))
+        {
+            repo = parsedRepo;
+            number = parsedNumber;
+        }
+
+        return new DirectRunLinkedPullRequestContext
+        {
+            Repo = repo,
+            Number = number,
+            Url = linkedPrUrl
+        };
+    }
+
+    private static bool TryParseGitHubPullRequestUrl(
+        string pullRequestUrl,
+        out string repo,
+        out int number)
+    {
+        repo = string.Empty;
+        number = 0;
+
+        if (!Uri.TryCreate(pullRequestUrl, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        var segments = uri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 4
+            || !string.Equals(segments[2], "pull", StringComparison.Ordinal)
+            || !int.TryParse(segments[3], out number))
+        {
+            return false;
+        }
+
+        repo = $"{segments[0]}/{segments[1]}";
+        return true;
     }
 
     private sealed record DirectRunSynthesisResult

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -1,3 +1,7 @@
+using IntentSystem.Review;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
 namespace IntentSystem.Cli.Commands;
 
 internal enum DirectRunEntryKind
@@ -22,6 +26,9 @@ internal sealed record DirectRunResolvedPolicy
 
 internal static class DirectRunCommandSupport
 {
+    private const string LifecycleEventActor = "intent-cli";
+    private const string LifecycleEventName = "provider-lifecycle";
+
     public static DirectRunLaunchResult CreateAndLaunch(
         CliContext context,
         DirectRunEntryKind entryKind,
@@ -81,7 +88,18 @@ internal static class DirectRunCommandSupport
         Directory.CreateDirectory(directoryPath);
         File.WriteAllText(absoluteArtifactPath, DirectRunRequestArtifactJson.Serialize(artifact));
 
-        return launchResult;
+        var synthesis = SynthesizeAndPersistResult(
+            context,
+            executionUnit,
+            entryKindValue,
+            launchedAt,
+            launchResult);
+
+        return launchResult with
+        {
+            ResultArtifactPath = synthesis.ResultArtifactPath,
+            RunStatus = synthesis.RunStatus
+        };
     }
 
     private static DirectRunResolvedPolicy ResolvePolicy(
@@ -139,6 +157,12 @@ internal static class DirectRunCommandSupport
         return $"{root}/{executionUnit.Trim()}.provider.jsonl";
     }
 
+    private static string ResolveResultArtifactPath(CliContext context, string executionUnit)
+    {
+        var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
+        return $"{root}/{executionUnit.Trim()}.result.json";
+    }
+
     private static string FormatEntryKind(DirectRunEntryKind entryKind)
     {
         return entryKind switch
@@ -194,5 +218,235 @@ internal static class DirectRunCommandSupport
             "claude" => ["--print", "--model", "{model}", "--output-format", "json", "{prompt}"],
             _ => ["{prompt}"]
         };
+    }
+
+    private static DirectRunSynthesisResult SynthesizeAndPersistResult(
+        CliContext context,
+        string executionUnit,
+        string entryKind,
+        DateTimeOffset launchedAt,
+        DirectRunLaunchResult launchResult)
+    {
+        var queueState = QueueCommandSupport.LoadQueueState(context, TextWriter.Null)
+            ?? throw new InvalidOperationException($"No queue state found at {context.GetQueueStatePath()}");
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+                            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+                        ?? throw new InvalidOperationException(
+                            $"Execution unit '{executionUnit}' was not found in queue state for direct run result synthesis.");
+
+        var providerEventLogPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            launchResult.ProviderEventLogPath.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(providerEventLogPath))
+        {
+            throw new InvalidOperationException(
+                $"Provider raw event log was not found at {providerEventLogPath}");
+        }
+
+        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        if (providerEvents.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Provider raw event log at {providerEventLogPath} did not contain any events.");
+        }
+
+        var runLogPath = context.GetRunLogPath();
+        var existingRunEvents = File.Exists(runLogPath)
+            ? RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath))
+            : [];
+        var latestLinkedPr = LatestLinkedPrResolver.TryResolve(existingRunEvents, executionUnit);
+        var model = ResolveModel(providerEvents, launchResult.Model);
+        var sessionId = ResolveSessionId(providerEvents, launchResult.ProviderSessionId);
+        var provider = ResolveProvider(providerEvents, launchResult.Provider);
+        var runStatus = ResolveRunStatus(providerEvents);
+        var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
+        var resultArtifactPath = ResolveResultArtifactPath(context, executionUnit);
+        var absoluteResultArtifactPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            resultArtifactPath.Replace('/', Path.DirectorySeparatorChar)));
+
+        var artifact = new DirectRunResultArtifact
+        {
+            SchemaVersion = "1",
+            ExecutionUnit = executionUnit,
+            EntryKind = entryKind,
+            Provider = provider,
+            Model = model,
+            SessionId = sessionId,
+            RunStatus = runStatus,
+            RawLogRef = launchResult.ProviderEventLogPath,
+            PacketRef = queueItem.PacketPaths.Yaml,
+            ReviewContextRef = queueItem.PacketPaths.ReviewContext,
+            LinkedIssueUrl = queueItem.LinkedIssue?.Url,
+            LinkedPrUrl = latestLinkedPr,
+            WorktreePath = worktreePath
+        };
+
+        var resultDirectoryPath = Path.GetDirectoryName(absoluteResultArtifactPath)
+            ?? throw new InvalidOperationException("Direct run result artifact path did not contain a directory.");
+        Directory.CreateDirectory(resultDirectoryPath);
+        File.WriteAllText(absoluteResultArtifactPath, DirectRunResultArtifactJson.Serialize(artifact));
+
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(
+            runLogPath,
+            RunLogSerializer.SerializeLine(new RunEvent
+            {
+                Ts = launchedAt,
+                ExecutionUnit = executionUnit,
+                Event = LifecycleEventName,
+                By = LifecycleEventActor,
+                LinkedIssue = artifact.LinkedIssueUrl,
+                LinkedPr = artifact.LinkedPrUrl,
+                EntryKind = entryKind,
+                Provider = provider,
+                Model = model,
+                SessionId = sessionId,
+                RunStatus = runStatus,
+                RawLogRef = artifact.RawLogRef,
+                ResultRef = resultArtifactPath,
+                PacketRef = artifact.PacketRef,
+                ReviewContextRef = artifact.ReviewContextRef,
+                WorktreePath = artifact.WorktreePath
+            }) + Environment.NewLine);
+
+        return new DirectRunSynthesisResult
+        {
+            ResultArtifactPath = resultArtifactPath,
+            RunStatus = runStatus
+        };
+    }
+
+    private static string ResolveProvider(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string fallbackProvider)
+    {
+        foreach (var providerEvent in providerEvents)
+        {
+            if (!string.IsNullOrWhiteSpace(providerEvent.Provider))
+            {
+                return providerEvent.Provider;
+            }
+        }
+
+        return fallbackProvider;
+    }
+
+    private static string ResolveSessionId(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string fallbackSessionId)
+    {
+        foreach (var providerEvent in providerEvents)
+        {
+            if (!string.IsNullOrWhiteSpace(providerEvent.SessionId))
+            {
+                return providerEvent.SessionId;
+            }
+        }
+
+        return fallbackSessionId;
+    }
+
+    private static string ResolveModel(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string fallbackModel)
+    {
+        foreach (var providerEvent in providerEvents)
+        {
+            if (!string.Equals(providerEvent.Kind, "session-metadata", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("model", out var modelElement)
+                && modelElement.ValueKind == System.Text.Json.JsonValueKind.String)
+            {
+                var model = modelElement.GetString();
+                if (!string.IsNullOrWhiteSpace(model))
+                {
+                    return model;
+                }
+            }
+        }
+
+        return fallbackModel;
+    }
+
+    private static string ResolveRunStatus(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            var payload = providerEvents[index].Payload;
+            var runStatus = TryNormalizeRunStatusFromPayload(payload);
+            if (!string.IsNullOrWhiteSpace(runStatus))
+            {
+                return runStatus;
+            }
+        }
+
+        return "running";
+    }
+
+    private static string? TryNormalizeRunStatusFromPayload(System.Text.Json.JsonElement payload)
+    {
+        if (payload.ValueKind != System.Text.Json.JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (TryReadString(payload, "run_status", out var runStatus))
+        {
+            return NormalizeRunStatus(runStatus);
+        }
+
+        if (TryReadString(payload, "status", out var status))
+        {
+            return NormalizeRunStatus(status);
+        }
+
+        if (TryReadString(payload, "disposition", out var disposition))
+        {
+            return NormalizeRunStatus(disposition);
+        }
+
+        return null;
+    }
+
+    private static bool TryReadString(
+        System.Text.Json.JsonElement payload,
+        string propertyName,
+        out string value)
+    {
+        value = string.Empty;
+
+        if (!payload.TryGetProperty(propertyName, out var element)
+            || element.ValueKind != System.Text.Json.JsonValueKind.String)
+        {
+            return false;
+        }
+
+        value = element.GetString() ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static string NormalizeRunStatus(string status)
+    {
+        return status.Trim().ToLowerInvariant() switch
+        {
+            "success" or "completed" => "succeeded",
+            "error" => "failed",
+            var normalized when !string.IsNullOrWhiteSpace(normalized) => normalized,
+            _ => "running"
+        };
+    }
+
+    private sealed record DirectRunSynthesisResult
+    {
+        public required string ResultArtifactPath { get; init; }
+
+        public required string RunStatus { get; init; }
     }
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunLaunchResult.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLaunchResult.cs
@@ -6,6 +6,8 @@ internal sealed record DirectRunLaunchResult
 
     public required string ProviderEventLogPath { get; init; }
 
+    public string? ResultArtifactPath { get; init; }
+
     public required string Provider { get; init; }
 
     public required string Model { get; init; }
@@ -13,6 +15,8 @@ internal sealed record DirectRunLaunchResult
     public required string Transport { get; init; }
 
     public required string ProviderSessionId { get; init; }
+
+    public string? RunStatus { get; init; }
 
     public required string TransportSummary { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record DirectRunResultArtifact
+{
+    [JsonPropertyName("schema_version")]
+    public required string SchemaVersion { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("entry_kind")]
+    public required string EntryKind { get; init; }
+
+    [JsonPropertyName("provider")]
+    public required string Provider { get; init; }
+
+    [JsonPropertyName("model")]
+    public required string Model { get; init; }
+
+    [JsonPropertyName("session_id")]
+    public required string SessionId { get; init; }
+
+    [JsonPropertyName("run_status")]
+    public required string RunStatus { get; init; }
+
+    [JsonPropertyName("raw_log_ref")]
+    public required string RawLogRef { get; init; }
+
+    [JsonPropertyName("packet_ref")]
+    public required string PacketRef { get; init; }
+
+    [JsonPropertyName("review_context_ref")]
+    public required string ReviewContextRef { get; init; }
+
+    [JsonPropertyName("linked_issue_url")]
+    public string? LinkedIssueUrl { get; init; }
+
+    [JsonPropertyName("linked_pr_url")]
+    public string? LinkedPrUrl { get; init; }
+
+    [JsonPropertyName("worktree_path")]
+    public required string WorktreePath { get; init; }
+}
+
+internal static class DirectRunResultArtifactJson
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = null,
+        WriteIndented = true
+    };
+
+    public static string Serialize(DirectRunResultArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        return JsonSerializer.Serialize(artifact, Options);
+    }
+
+    public static DirectRunResultArtifact Deserialize(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        return JsonSerializer.Deserialize<DirectRunResultArtifact>(json, Options)
+            ?? throw new InvalidOperationException("Direct run result artifact deserialized to null.");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
@@ -35,14 +35,44 @@ internal sealed record DirectRunResultArtifact
     [JsonPropertyName("review_context_ref")]
     public required string ReviewContextRef { get; init; }
 
-    [JsonPropertyName("linked_issue_url")]
-    public string? LinkedIssueUrl { get; init; }
+    [JsonPropertyName("linked_issue")]
+    public DirectRunLinkedIssueContext? LinkedIssue { get; init; }
 
-    [JsonPropertyName("linked_pr_url")]
-    public string? LinkedPrUrl { get; init; }
+    [JsonPropertyName("linked_pr")]
+    public DirectRunLinkedPullRequestContext? LinkedPr { get; init; }
 
-    [JsonPropertyName("worktree_path")]
-    public required string WorktreePath { get; init; }
+    [JsonPropertyName("worktree")]
+    public required DirectRunWorktreeContext Worktree { get; init; }
+}
+
+internal sealed record DirectRunLinkedIssueContext
+{
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("number")]
+    public required int Number { get; init; }
+
+    [JsonPropertyName("url")]
+    public required string Url { get; init; }
+}
+
+internal sealed record DirectRunLinkedPullRequestContext
+{
+    [JsonPropertyName("repo")]
+    public string? Repo { get; init; }
+
+    [JsonPropertyName("number")]
+    public int? Number { get; init; }
+
+    [JsonPropertyName("url")]
+    public required string Url { get; init; }
+}
+
+internal sealed record DirectRunWorktreeContext
+{
+    [JsonPropertyName("path")]
+    public required string Path { get; init; }
 }
 
 internal static class DirectRunResultArtifactJson

--- a/src/IntentSystem.Cli/Commands/ReviewRunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewRunCommand.cs
@@ -29,10 +29,18 @@ internal static class ReviewRunCommand
             {
                 writer.WriteLine($"Direct run request artifact: {result.DirectRun.RequestArtifactPath}");
                 writer.WriteLine($"Provider raw event log: {result.DirectRun.ProviderEventLogPath}");
+                if (!string.IsNullOrWhiteSpace(result.DirectRun.ResultArtifactPath))
+                {
+                    writer.WriteLine($"Normalized run result: {result.DirectRun.ResultArtifactPath}");
+                }
                 writer.WriteLine($"Direct provider: {result.DirectRun.Provider}");
                 writer.WriteLine($"Direct model: {result.DirectRun.Model}");
                 writer.WriteLine($"Direct transport: {result.DirectRun.Transport}");
                 writer.WriteLine($"Provider session: {result.DirectRun.ProviderSessionId}");
+                if (!string.IsNullOrWhiteSpace(result.DirectRun.RunStatus))
+                {
+                    writer.WriteLine($"Run status: {result.DirectRun.RunStatus}");
+                }
             }
             return 0;
         }

--- a/src/IntentSystem.Cli/Commands/RunFixRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixRenderer.cs
@@ -93,10 +93,18 @@ internal static class RunFixRenderer
         {
             writer.WriteLine($"Direct run request artifact: {directRun.RequestArtifactPath}");
             writer.WriteLine($"Provider raw event log: {directRun.ProviderEventLogPath}");
+            if (!string.IsNullOrWhiteSpace(directRun.ResultArtifactPath))
+            {
+                writer.WriteLine($"Normalized run result: {directRun.ResultArtifactPath}");
+            }
             writer.WriteLine($"Direct provider: {directRun.Provider}");
             writer.WriteLine($"Direct model: {directRun.Model}");
             writer.WriteLine($"Direct transport: {directRun.Transport}");
             writer.WriteLine($"Provider session: {directRun.ProviderSessionId}");
+            if (!string.IsNullOrWhiteSpace(directRun.RunStatus))
+            {
+                writer.WriteLine($"Run status: {directRun.RunStatus}");
+            }
         }
     }
 

--- a/src/IntentSystem.Cli/Commands/RunImplementRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementRenderer.cs
@@ -96,10 +96,18 @@ internal static class RunImplementRenderer
         {
             writer.WriteLine($"Direct run request artifact: {directRun.RequestArtifactPath}");
             writer.WriteLine($"Provider raw event log: {directRun.ProviderEventLogPath}");
+            if (!string.IsNullOrWhiteSpace(directRun.ResultArtifactPath))
+            {
+                writer.WriteLine($"Normalized run result: {directRun.ResultArtifactPath}");
+            }
             writer.WriteLine($"Direct provider: {directRun.Provider}");
             writer.WriteLine($"Direct model: {directRun.Model}");
             writer.WriteLine($"Direct transport: {directRun.Transport}");
             writer.WriteLine($"Provider session: {directRun.ProviderSessionId}");
+            if (!string.IsNullOrWhiteSpace(directRun.RunStatus))
+            {
+                writer.WriteLine($"Run status: {directRun.RunStatus}");
+            }
         }
     }
 

--- a/src/IntentSystem.Cli/Commands/RunLogRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/RunLogRenderer.cs
@@ -34,6 +34,16 @@ internal static class RunLogRenderer
             AppendOptionalPart(parts, "linked_pr", runEvent.LinkedPr);
             AppendOptionalPart(parts, "comment_ref", runEvent.CommentRef);
             AppendOptionalPart(parts, "reason", runEvent.Reason);
+            AppendOptionalPart(parts, "entry_kind", runEvent.EntryKind);
+            AppendOptionalPart(parts, "provider", runEvent.Provider);
+            AppendOptionalPart(parts, "model", runEvent.Model);
+            AppendOptionalPart(parts, "session_id", runEvent.SessionId);
+            AppendOptionalPart(parts, "run_status", runEvent.RunStatus);
+            AppendOptionalPart(parts, "raw_log_ref", runEvent.RawLogRef);
+            AppendOptionalPart(parts, "result_ref", runEvent.ResultRef);
+            AppendOptionalPart(parts, "packet_ref", runEvent.PacketRef);
+            AppendOptionalPart(parts, "review_context_ref", runEvent.ReviewContextRef);
+            AppendOptionalPart(parts, "worktree_path", runEvent.WorktreePath);
 
             writer.WriteLine($"- {string.Join(" | ", parts)}");
         }

--- a/src/IntentSystem.Supervisor/Models/RunEvent.cs
+++ b/src/IntentSystem.Supervisor/Models/RunEvent.cs
@@ -17,4 +17,24 @@ public sealed record RunEvent
     public string? CommentRef { get; init; }
 
     public string? Reason { get; init; }
+
+    public string? EntryKind { get; init; }
+
+    public string? Provider { get; init; }
+
+    public string? Model { get; init; }
+
+    public string? SessionId { get; init; }
+
+    public string? RunStatus { get; init; }
+
+    public string? RawLogRef { get; init; }
+
+    public string? ResultRef { get; init; }
+
+    public string? PacketRef { get; init; }
+
+    public string? ReviewContextRef { get; init; }
+
+    public string? WorktreePath { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -5245,6 +5245,44 @@ recommended_updates:
             string absoluteRequestArtifactPath,
             string absoluteProviderEventLogPath)
         {
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(absoluteProviderEventLogPath)
+                ?? throw new InvalidOperationException("Provider event log path did not contain a directory."));
+            var providerEvents = string.Join(
+                                     Environment.NewLine,
+                                     new[]
+                                     {
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = provider,
+                                             EntryKind = entryKind,
+                                             SessionId = "pid:1234",
+                                             Kind = "session-metadata",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 model,
+                                                 transport,
+                                                 command
+                                             })
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(1).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = provider,
+                                             EntryKind = entryKind,
+                                             SessionId = "pid:1234",
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 type = "ready"
+                                             })
+                                         })
+                                     }) + Environment.NewLine;
+            File.WriteAllText(absoluteProviderEventLogPath, providerEvents);
+
             return new DirectRunLaunchResult
             {
                 RequestArtifactPath = requestArtifactPath,

--- a/tests/IntentSystem.Cli.Tests/DirectRunResultArtifactJsonTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunResultArtifactJsonTests.cs
@@ -1,0 +1,43 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class DirectRunResultArtifactJsonTests
+{
+    [Fact]
+    public void SerializeAndDeserialize_RoundTripsNormalizedRunResult()
+    {
+        var artifact = new DirectRunResultArtifact
+        {
+            SchemaVersion = "1",
+            ExecutionUnit = "G19",
+            EntryKind = "implement",
+            Provider = "Claude",
+            Model = "default",
+            SessionId = "pid:4321",
+            RunStatus = "running",
+            RawLogRef = ".intent-cli/runs/G19.provider.jsonl",
+            PacketRef = ".intent-cli/issues/G19/packet.yaml",
+            ReviewContextRef = ".intent-cli/issues/G19/review-context.md",
+            LinkedIssueUrl = "https://github.com/J-Tech-Japan/intent-system/issues/66",
+            LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/67",
+            WorktreePath = "/repo/.intent-cli/worktrees/G19"
+        };
+
+        var json = DirectRunResultArtifactJson.Serialize(artifact);
+        var roundTripped = DirectRunResultArtifactJson.Deserialize(json);
+
+        Assert.Equal("G19", roundTripped.ExecutionUnit);
+        Assert.Equal("implement", roundTripped.EntryKind);
+        Assert.Equal("Claude", roundTripped.Provider);
+        Assert.Equal("default", roundTripped.Model);
+        Assert.Equal("pid:4321", roundTripped.SessionId);
+        Assert.Equal("running", roundTripped.RunStatus);
+        Assert.Equal(".intent-cli/runs/G19.provider.jsonl", roundTripped.RawLogRef);
+        Assert.Equal(".intent-cli/issues/G19/packet.yaml", roundTripped.PacketRef);
+        Assert.Equal(".intent-cli/issues/G19/review-context.md", roundTripped.ReviewContextRef);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/66", roundTripped.LinkedIssueUrl);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/67", roundTripped.LinkedPrUrl);
+        Assert.Equal("/repo/.intent-cli/worktrees/G19", roundTripped.WorktreePath);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/DirectRunResultArtifactJsonTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunResultArtifactJsonTests.cs
@@ -19,9 +19,22 @@ public sealed class DirectRunResultArtifactJsonTests
             RawLogRef = ".intent-cli/runs/G19.provider.jsonl",
             PacketRef = ".intent-cli/issues/G19/packet.yaml",
             ReviewContextRef = ".intent-cli/issues/G19/review-context.md",
-            LinkedIssueUrl = "https://github.com/J-Tech-Japan/intent-system/issues/66",
-            LinkedPrUrl = "https://github.com/J-Tech-Japan/intent-system/pull/67",
-            WorktreePath = "/repo/.intent-cli/worktrees/G19"
+            LinkedIssue = new DirectRunLinkedIssueContext
+            {
+                Repo = "J-Tech-Japan/intent-system",
+                Number = 66,
+                Url = "https://github.com/J-Tech-Japan/intent-system/issues/66"
+            },
+            LinkedPr = new DirectRunLinkedPullRequestContext
+            {
+                Repo = "J-Tech-Japan/intent-system",
+                Number = 67,
+                Url = "https://github.com/J-Tech-Japan/intent-system/pull/67"
+            },
+            Worktree = new DirectRunWorktreeContext
+            {
+                Path = "/repo/.intent-cli/worktrees/G19"
+            }
         };
 
         var json = DirectRunResultArtifactJson.Serialize(artifact);
@@ -36,8 +49,12 @@ public sealed class DirectRunResultArtifactJsonTests
         Assert.Equal(".intent-cli/runs/G19.provider.jsonl", roundTripped.RawLogRef);
         Assert.Equal(".intent-cli/issues/G19/packet.yaml", roundTripped.PacketRef);
         Assert.Equal(".intent-cli/issues/G19/review-context.md", roundTripped.ReviewContextRef);
-        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/66", roundTripped.LinkedIssueUrl);
-        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/67", roundTripped.LinkedPrUrl);
-        Assert.Equal("/repo/.intent-cli/worktrees/G19", roundTripped.WorktreePath);
+        Assert.Equal("J-Tech-Japan/intent-system", roundTripped.LinkedIssue?.Repo);
+        Assert.Equal(66, roundTripped.LinkedIssue?.Number);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/66", roundTripped.LinkedIssue?.Url);
+        Assert.Equal("J-Tech-Japan/intent-system", roundTripped.LinkedPr?.Repo);
+        Assert.Equal(67, roundTripped.LinkedPr?.Number);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/67", roundTripped.LinkedPr?.Url);
+        Assert.Equal("/repo/.intent-cli/worktrees/G19", roundTripped.Worktree.Path);
     }
 }

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -89,9 +89,11 @@ public sealed class ReviewRunCommandTests
             Assert.Equal(".intent-cli/runtime-runs/G9.provider.jsonl", resultArtifact.RawLogRef);
             Assert.Equal(".intent-cli/issues/G9/review-context.md", resultArtifact.ReviewContextRef);
             Assert.Equal(".intent-cli/issues/G9/packet.yaml", resultArtifact.PacketRef);
-            Assert.Null(resultArtifact.LinkedIssueUrl);
-            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/45", resultArtifact.LinkedPrUrl);
-            Assert.EndsWith("/.intent-cli/worktrees/G9", resultArtifact.WorktreePath, StringComparison.Ordinal);
+            Assert.Null(resultArtifact.LinkedIssue);
+            Assert.Equal("J-Tech-Japan/intent-system", resultArtifact.LinkedPr?.Repo);
+            Assert.Equal(45, resultArtifact.LinkedPr?.Number);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/45", resultArtifact.LinkedPr?.Url);
+            Assert.EndsWith("/.intent-cli/worktrees/G9", resultArtifact.Worktree.Path, StringComparison.Ordinal);
 
             var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
             var lifecycleEvent = Assert.Single(runEvents, runEvent => runEvent.Event == "provider-lifecycle");

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -45,10 +45,12 @@ public sealed class ReviewRunCommandTests
             Assert.Contains("Review request artifact generated for G9", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Direct run request artifact: .intent-cli/runtime-runs/G9.request.json", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Provider raw event log: .intent-cli/runtime-runs/G9.provider.jsonl", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Normalized run result: .intent-cli/runtime-runs/G9.result.json", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Direct provider: ReviewBot", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Direct model: gpt-5.4-mini", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Direct transport: grpc", writer.ToString(), StringComparison.Ordinal);
             Assert.Contains("Provider session: pid:9999", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Run status: running", writer.ToString(), StringComparison.Ordinal);
 
             var artifactPath = Path.Combine(repoRoot, ".intent-cli", "reviews", "G9.request.json");
             Assert.True(File.Exists(artifactPath));
@@ -74,6 +76,38 @@ public sealed class ReviewRunCommandTests
             Assert.Equal("gpt-5.4-mini", directRunArtifact.Model);
             Assert.Equal("grpc", directRunArtifact.Transport);
             Assert.Equal("pid:9999", directRunArtifact.ProviderSessionId);
+
+            var resultArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json");
+            Assert.True(File.Exists(resultArtifactPath));
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+            Assert.Equal("G9", resultArtifact.ExecutionUnit);
+            Assert.Equal("review", resultArtifact.EntryKind);
+            Assert.Equal("ReviewBot", resultArtifact.Provider);
+            Assert.Equal("gpt-5.4-mini", resultArtifact.Model);
+            Assert.Equal("pid:9999", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+            Assert.Equal(".intent-cli/runtime-runs/G9.provider.jsonl", resultArtifact.RawLogRef);
+            Assert.Equal(".intent-cli/issues/G9/review-context.md", resultArtifact.ReviewContextRef);
+            Assert.Equal(".intent-cli/issues/G9/packet.yaml", resultArtifact.PacketRef);
+            Assert.Null(resultArtifact.LinkedIssueUrl);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/45", resultArtifact.LinkedPrUrl);
+            Assert.EndsWith("/.intent-cli/worktrees/G9", resultArtifact.WorktreePath, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            var lifecycleEvent = Assert.Single(runEvents, runEvent => runEvent.Event == "provider-lifecycle");
+            Assert.Equal("G9", lifecycleEvent.ExecutionUnit);
+            Assert.Equal("review", lifecycleEvent.EntryKind);
+            Assert.Equal("ReviewBot", lifecycleEvent.Provider);
+            Assert.Equal("gpt-5.4-mini", lifecycleEvent.Model);
+            Assert.Equal("pid:9999", lifecycleEvent.SessionId);
+            Assert.Equal("running", lifecycleEvent.RunStatus);
+            Assert.Equal(".intent-cli/runtime-runs/G9.provider.jsonl", lifecycleEvent.RawLogRef);
+            Assert.Equal(".intent-cli/runtime-runs/G9.result.json", lifecycleEvent.ResultRef);
+            Assert.Equal(".intent-cli/issues/G9/packet.yaml", lifecycleEvent.PacketRef);
+            Assert.Equal(".intent-cli/issues/G9/review-context.md", lifecycleEvent.ReviewContextRef);
+            Assert.Null(lifecycleEvent.LinkedIssue);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/45", lifecycleEvent.LinkedPr);
+            Assert.EndsWith("/.intent-cli/worktrees/G9", lifecycleEvent.WorktreePath, StringComparison.Ordinal);
         }
         finally
         {
@@ -341,6 +375,44 @@ public sealed class ReviewRunCommandTests
             Assert.EndsWith("/repo", workingDirectory, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/reviews/G9.request.json", absoluteRequestArtifactPath, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/runtime-runs/G9.provider.jsonl", absoluteProviderEventLogPath, StringComparison.Ordinal);
+
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(absoluteProviderEventLogPath)
+                ?? throw new InvalidOperationException("Provider event log path did not contain a directory."));
+            var providerEvents = string.Join(
+                                     Environment.NewLine,
+                                     new[]
+                                     {
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "session-metadata",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 model = modelArg,
+                                                 transport = transportArg,
+                                                 command
+                                             })
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(1).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 type = "ready"
+                                             })
+                                         })
+                                     }) + Environment.NewLine;
+            File.WriteAllText(absoluteProviderEventLogPath, providerEvents);
 
             return new DirectRunLaunchResult
             {

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -96,9 +96,13 @@ public sealed class RunFixCommandTests
             Assert.Equal(".intent-cli/runs/G20.provider.jsonl", resultArtifact.RawLogRef);
             Assert.Equal(".intent-cli/issues/G20/packet.yaml", resultArtifact.PacketRef);
             Assert.Equal(".intent-cli/issues/G20/review-context.md", resultArtifact.ReviewContextRef);
-            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/68", resultArtifact.LinkedIssueUrl);
-            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/69", resultArtifact.LinkedPrUrl);
-            Assert.EndsWith("/.intent-cli/worktrees/G20", resultArtifact.WorktreePath, StringComparison.Ordinal);
+            Assert.Equal("J-Tech-Japan/intent-system", resultArtifact.LinkedIssue?.Repo);
+            Assert.Equal(68, resultArtifact.LinkedIssue?.Number);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/68", resultArtifact.LinkedIssue?.Url);
+            Assert.Equal("J-Tech-Japan/intent-system", resultArtifact.LinkedPr?.Repo);
+            Assert.Equal(69, resultArtifact.LinkedPr?.Number);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/69", resultArtifact.LinkedPr?.Url);
+            Assert.EndsWith("/.intent-cli/worktrees/G20", resultArtifact.Worktree.Path, StringComparison.Ordinal);
 
             Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
             var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -8,7 +8,7 @@ namespace IntentSystem.Cli.Tests;
 public sealed class RunFixCommandTests
 {
     [Fact]
-    public void Execute_GivenFixingItemWithInputs_GeneratesRepairHandoffArtifactWithoutMutatingStateOrRunLog()
+    public void Execute_GivenFixingItemWithInputs_GeneratesRepairHandoffArtifactAndNormalizedRunResult()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -34,7 +34,6 @@ public sealed class RunFixCommandTests
         var originalLauncherFactory = RunFixCommand.DirectRunLauncherFactory;
 
         var originalQueueState = File.ReadAllText(queueStatePath);
-        var originalRunLog = File.ReadAllText(runLogPath);
 
         try
         {
@@ -57,10 +56,12 @@ public sealed class RunFixCommandTests
             Assert.Contains("Latest comment ref: https://github.com/J-Tech-Japan/intent-system/pull/69#issuecomment-2", output, StringComparison.Ordinal);
             Assert.Contains("Direct run request artifact: .intent-cli/runs/G20.request.json", output, StringComparison.Ordinal);
             Assert.Contains("Provider raw event log: .intent-cli/runs/G20.provider.jsonl", output, StringComparison.Ordinal);
+            Assert.Contains("Normalized run result: .intent-cli/runs/G20.result.json", output, StringComparison.Ordinal);
             Assert.Contains("Direct provider: Claude", output, StringComparison.Ordinal);
             Assert.Contains("Direct model: default", output, StringComparison.Ordinal);
             Assert.Contains("Direct transport: stdio", output, StringComparison.Ordinal);
             Assert.Contains("Provider session: pid:8765", output, StringComparison.Ordinal);
+            Assert.Contains("Run status: running", output, StringComparison.Ordinal);
 
             var artifactPath = Path.Combine(repoRoot, ".intent-cli", "fix", "G20.request.md");
             Assert.True(File.Exists(artifactPath));
@@ -83,8 +84,39 @@ public sealed class RunFixCommandTests
             Assert.Equal("stdio", directRunArtifact.Transport);
             Assert.Equal("pid:8765", directRunArtifact.ProviderSessionId);
 
+            var resultArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.result.json");
+            Assert.True(File.Exists(resultArtifactPath));
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+            Assert.Equal("G20", resultArtifact.ExecutionUnit);
+            Assert.Equal("fix", resultArtifact.EntryKind);
+            Assert.Equal("Claude", resultArtifact.Provider);
+            Assert.Equal("default", resultArtifact.Model);
+            Assert.Equal("pid:8765", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+            Assert.Equal(".intent-cli/runs/G20.provider.jsonl", resultArtifact.RawLogRef);
+            Assert.Equal(".intent-cli/issues/G20/packet.yaml", resultArtifact.PacketRef);
+            Assert.Equal(".intent-cli/issues/G20/review-context.md", resultArtifact.ReviewContextRef);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/68", resultArtifact.LinkedIssueUrl);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/69", resultArtifact.LinkedPrUrl);
+            Assert.EndsWith("/.intent-cli/worktrees/G20", resultArtifact.WorktreePath, StringComparison.Ordinal);
+
             Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
-            Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            var lifecycleEvent = Assert.Single(runEvents, runEvent => runEvent.Event == "provider-lifecycle");
+            Assert.Equal("G20", lifecycleEvent.ExecutionUnit);
+            Assert.Equal("intent-cli", lifecycleEvent.By);
+            Assert.Equal("fix", lifecycleEvent.EntryKind);
+            Assert.Equal("Claude", lifecycleEvent.Provider);
+            Assert.Equal("default", lifecycleEvent.Model);
+            Assert.Equal("pid:8765", lifecycleEvent.SessionId);
+            Assert.Equal("running", lifecycleEvent.RunStatus);
+            Assert.Equal(".intent-cli/runs/G20.provider.jsonl", lifecycleEvent.RawLogRef);
+            Assert.Equal(".intent-cli/runs/G20.result.json", lifecycleEvent.ResultRef);
+            Assert.Equal(".intent-cli/issues/G20/packet.yaml", lifecycleEvent.PacketRef);
+            Assert.Equal(".intent-cli/issues/G20/review-context.md", lifecycleEvent.ReviewContextRef);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/68", lifecycleEvent.LinkedIssue);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/69", lifecycleEvent.LinkedPr);
+            Assert.EndsWith("/.intent-cli/worktrees/G20", lifecycleEvent.WorktreePath, StringComparison.Ordinal);
         }
         finally
         {
@@ -138,6 +170,44 @@ public sealed class RunFixCommandTests
             Assert.EndsWith("/.intent-cli/worktrees/G20", workingDirectory, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/fix/G20.request.md", absoluteRequestArtifactPath, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/runs/G20.provider.jsonl", absoluteProviderEventLogPath, StringComparison.Ordinal);
+
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(absoluteProviderEventLogPath)
+                ?? throw new InvalidOperationException("Provider event log path did not contain a directory."));
+            var providerEvents = string.Join(
+                                     Environment.NewLine,
+                                     new[]
+                                     {
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "session-metadata",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 model = modelArg,
+                                                 transport = transportArg,
+                                                 command
+                                             })
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(1).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 type = "ready"
+                                             })
+                                         })
+                                     }) + Environment.NewLine;
+            File.WriteAllText(absoluteProviderEventLogPath, providerEvents);
 
             return new DirectRunLaunchResult
             {

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -90,9 +90,13 @@ public sealed class RunImplementCommandTests
             Assert.Equal(".intent-cli/runs/G19.provider.jsonl", resultArtifact.RawLogRef);
             Assert.Equal(".intent-cli/issues/G19/packet.yaml", resultArtifact.PacketRef);
             Assert.Equal(".intent-cli/issues/G19/review-context.md", resultArtifact.ReviewContextRef);
-            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/66", resultArtifact.LinkedIssueUrl);
-            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/67", resultArtifact.LinkedPrUrl);
-            Assert.EndsWith("/.intent-cli/worktrees/G19", resultArtifact.WorktreePath, StringComparison.Ordinal);
+            Assert.Equal("J-Tech-Japan/intent-system", resultArtifact.LinkedIssue?.Repo);
+            Assert.Equal(66, resultArtifact.LinkedIssue?.Number);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/66", resultArtifact.LinkedIssue?.Url);
+            Assert.Equal("J-Tech-Japan/intent-system", resultArtifact.LinkedPr?.Repo);
+            Assert.Equal(67, resultArtifact.LinkedPr?.Number);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/67", resultArtifact.LinkedPr?.Url);
+            Assert.EndsWith("/.intent-cli/worktrees/G19", resultArtifact.Worktree.Path, StringComparison.Ordinal);
 
             Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
             var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -8,7 +8,7 @@ namespace IntentSystem.Cli.Tests;
 public sealed class RunImplementCommandTests
 {
     [Fact]
-    public void Execute_GivenActiveItemWithInputs_GeneratesHandoffArtifactWithoutMutatingStateOrRunLog()
+    public void Execute_GivenActiveItemWithInputs_GeneratesHandoffArtifactAndNormalizedRunResult()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -31,7 +31,6 @@ public sealed class RunImplementCommandTests
         var originalLauncherFactory = RunImplementCommand.DirectRunLauncherFactory;
 
         var originalQueueState = File.ReadAllText(queueStatePath);
-        var originalRunLog = File.ReadAllText(runLogPath);
 
         try
         {
@@ -53,10 +52,12 @@ public sealed class RunImplementCommandTests
             Assert.Contains("Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/67", output, StringComparison.Ordinal);
             Assert.Contains("Direct run request artifact: .intent-cli/runs/G19.request.json", output, StringComparison.Ordinal);
             Assert.Contains("Provider raw event log: .intent-cli/runs/G19.provider.jsonl", output, StringComparison.Ordinal);
+            Assert.Contains("Normalized run result: .intent-cli/runs/G19.result.json", output, StringComparison.Ordinal);
             Assert.Contains("Direct provider: Claude", output, StringComparison.Ordinal);
             Assert.Contains("Direct model: default", output, StringComparison.Ordinal);
             Assert.Contains("Direct transport: stdio", output, StringComparison.Ordinal);
             Assert.Contains("Provider session: pid:4321", output, StringComparison.Ordinal);
+            Assert.Contains("Run status: running", output, StringComparison.Ordinal);
 
             var artifactPath = Path.Combine(repoRoot, ".intent-cli", "implement", "G19.request.md");
             Assert.True(File.Exists(artifactPath));
@@ -77,8 +78,39 @@ public sealed class RunImplementCommandTests
             Assert.Equal("stdio", directRunArtifact.Transport);
             Assert.Equal("pid:4321", directRunArtifact.ProviderSessionId);
 
+            var resultArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G19.result.json");
+            Assert.True(File.Exists(resultArtifactPath));
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+            Assert.Equal("G19", resultArtifact.ExecutionUnit);
+            Assert.Equal("implement", resultArtifact.EntryKind);
+            Assert.Equal("Claude", resultArtifact.Provider);
+            Assert.Equal("default", resultArtifact.Model);
+            Assert.Equal("pid:4321", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+            Assert.Equal(".intent-cli/runs/G19.provider.jsonl", resultArtifact.RawLogRef);
+            Assert.Equal(".intent-cli/issues/G19/packet.yaml", resultArtifact.PacketRef);
+            Assert.Equal(".intent-cli/issues/G19/review-context.md", resultArtifact.ReviewContextRef);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/66", resultArtifact.LinkedIssueUrl);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/67", resultArtifact.LinkedPrUrl);
+            Assert.EndsWith("/.intent-cli/worktrees/G19", resultArtifact.WorktreePath, StringComparison.Ordinal);
+
             Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
-            Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            var lifecycleEvent = Assert.Single(runEvents, runEvent => runEvent.Event == "provider-lifecycle");
+            Assert.Equal("G19", lifecycleEvent.ExecutionUnit);
+            Assert.Equal("intent-cli", lifecycleEvent.By);
+            Assert.Equal("implement", lifecycleEvent.EntryKind);
+            Assert.Equal("Claude", lifecycleEvent.Provider);
+            Assert.Equal("default", lifecycleEvent.Model);
+            Assert.Equal("pid:4321", lifecycleEvent.SessionId);
+            Assert.Equal("running", lifecycleEvent.RunStatus);
+            Assert.Equal(".intent-cli/runs/G19.provider.jsonl", lifecycleEvent.RawLogRef);
+            Assert.Equal(".intent-cli/runs/G19.result.json", lifecycleEvent.ResultRef);
+            Assert.Equal(".intent-cli/issues/G19/packet.yaml", lifecycleEvent.PacketRef);
+            Assert.Equal(".intent-cli/issues/G19/review-context.md", lifecycleEvent.ReviewContextRef);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/66", lifecycleEvent.LinkedIssue);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/67", lifecycleEvent.LinkedPr);
+            Assert.EndsWith("/.intent-cli/worktrees/G19", lifecycleEvent.WorktreePath, StringComparison.Ordinal);
         }
         finally
         {
@@ -149,6 +181,44 @@ public sealed class RunImplementCommandTests
             Assert.EndsWith("/.intent-cli/worktrees/G19", workingDirectory, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/implement/G19.request.md", absoluteRequestArtifactPath, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/runs/G19.provider.jsonl", absoluteProviderEventLogPath, StringComparison.Ordinal);
+
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(absoluteProviderEventLogPath)
+                ?? throw new InvalidOperationException("Provider event log path did not contain a directory."));
+            var providerEvents = string.Join(
+                                     Environment.NewLine,
+                                     new[]
+                                     {
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "session-metadata",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 model = modelArg,
+                                                 transport = transportArg,
+                                                 command
+                                             })
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(1).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 type = "ready"
+                                             })
+                                         })
+                                     }) + Environment.NewLine;
+            File.WriteAllText(absoluteProviderEventLogPath, providerEvents);
 
             return new DirectRunLaunchResult
             {

--- a/tests/IntentSystem.Cli.Tests/RunLogRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunLogRendererTests.cs
@@ -21,6 +21,11 @@ public sealed class RunLogRendererTests
         Assert.Contains("linked_pr=https://github.com/J-Tech-Japan/intent-system/pull/65", output, StringComparison.Ordinal);
         Assert.Contains("comment_ref=https://github.com/J-Tech-Japan/intent-system/pull/65#issuecomment-1", output, StringComparison.Ordinal);
         Assert.Contains("reason=contract mismatch", output, StringComparison.Ordinal);
+        Assert.Contains("entry_kind=fix", output, StringComparison.Ordinal);
+        Assert.Contains("provider=Claude", output, StringComparison.Ordinal);
+        Assert.Contains("run_status=running", output, StringComparison.Ordinal);
+        Assert.Contains("raw_log_ref=.intent-cli/runs/G18.provider.jsonl", output, StringComparison.Ordinal);
+        Assert.Contains("result_ref=.intent-cli/runs/G18.result.json", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -97,6 +102,25 @@ public sealed class RunLogRendererTests
                 By = "intent-cli",
                 CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/65#issuecomment-1",
                 Reason = "contract mismatch"
+            },
+            new RunEvent
+            {
+                Ts = DateTimeOffset.Parse("2026-04-07T08:40:00Z"),
+                ExecutionUnit = "G18",
+                Event = "provider-lifecycle",
+                By = "intent-cli",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/64",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/65",
+                EntryKind = "fix",
+                Provider = "Claude",
+                Model = "default",
+                SessionId = "pid:4321",
+                RunStatus = "running",
+                RawLogRef = ".intent-cli/runs/G18.provider.jsonl",
+                ResultRef = ".intent-cli/runs/G18.result.json",
+                PacketRef = ".intent-cli/issues/G18/packet.yaml",
+                ReviewContextRef = ".intent-cli/issues/G18/review-context.md",
+                WorktreePath = "/repo/.intent-cli/worktrees/G18"
             }
         ];
     }

--- a/tests/IntentSystem.Supervisor.Tests/RunLogSerializerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/RunLogSerializerTests.cs
@@ -73,6 +73,26 @@ public sealed class RunLogSerializerTests
     }
 
     [Fact]
+    public void DeserializeLine_GivenProviderLifecycleFields_ReadsNormalizedProviderContext()
+    {
+        var line =
+            """{"ts":"2026-04-09T10:15:00Z","execution_unit":"G19","event":"provider-lifecycle","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/66","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/67","entry_kind":"implement","provider":"Claude","model":"default","session_id":"pid:4321","run_status":"running","raw_log_ref":".intent-cli/runs/G19.provider.jsonl","result_ref":".intent-cli/runs/G19.result.json","packet_ref":".intent-cli/issues/G19/packet.yaml","review_context_ref":".intent-cli/issues/G19/review-context.md","worktree_path":"/repo/.intent-cli/worktrees/G19"}""";
+
+        var runEvent = RunLogSerializer.DeserializeLine(line);
+
+        Assert.Equal("implement", runEvent.EntryKind);
+        Assert.Equal("Claude", runEvent.Provider);
+        Assert.Equal("default", runEvent.Model);
+        Assert.Equal("pid:4321", runEvent.SessionId);
+        Assert.Equal("running", runEvent.RunStatus);
+        Assert.Equal(".intent-cli/runs/G19.provider.jsonl", runEvent.RawLogRef);
+        Assert.Equal(".intent-cli/runs/G19.result.json", runEvent.ResultRef);
+        Assert.Equal(".intent-cli/issues/G19/packet.yaml", runEvent.PacketRef);
+        Assert.Equal(".intent-cli/issues/G19/review-context.md", runEvent.ReviewContextRef);
+        Assert.Equal("/repo/.intent-cli/worktrees/G19", runEvent.WorktreePath);
+    }
+
+    [Fact]
     public void SerializeLine_GivenNullOptionalFields_OmitsThemFromCompactJson()
     {
         var runEvent = new RunEvent
@@ -94,6 +114,16 @@ public sealed class RunLogSerializerTests
         Assert.False(document.RootElement.TryGetProperty("linked_pr", out _));
         Assert.False(document.RootElement.TryGetProperty("comment_ref", out _));
         Assert.False(document.RootElement.TryGetProperty("reason", out _));
+        Assert.False(document.RootElement.TryGetProperty("entry_kind", out _));
+        Assert.False(document.RootElement.TryGetProperty("provider", out _));
+        Assert.False(document.RootElement.TryGetProperty("model", out _));
+        Assert.False(document.RootElement.TryGetProperty("session_id", out _));
+        Assert.False(document.RootElement.TryGetProperty("run_status", out _));
+        Assert.False(document.RootElement.TryGetProperty("raw_log_ref", out _));
+        Assert.False(document.RootElement.TryGetProperty("result_ref", out _));
+        Assert.False(document.RootElement.TryGetProperty("packet_ref", out _));
+        Assert.False(document.RootElement.TryGetProperty("review_context_ref", out _));
+        Assert.False(document.RootElement.TryGetProperty("worktree_path", out _));
         Assert.DoesNotContain("\n", serialized, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## Summary
- synthesize `.intent-cli/runs/<execution-unit>.result.json` from provider raw event logs after direct run launch
- append normalized provider lifecycle events to `.intent-cli/runs.jsonl` with packet, review-context, linked issue/PR, and worktree carry-forward
- cover the new result artifact and lifecycle append path with CLI and supervisor tests

Closes #217