### PR TITLE
G97 Packaged Invocation And Distribution Baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,17 @@ Local package smoke path:
 
 ```bash
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -o .artifacts/packages
-dotnet tool exec --yes --source .artifacts/packages --version 0.1.0 intent-cli project status
+mkdir -p .artifacts/smoke-repo/.intent-cli
+cat > .artifacts/smoke-repo/.intent-cli/config.toml <<'EOF'
+default_domain = "intent-cli"
+artifact_root = ".intent-cli"
+worktree_root = ".intent-cli/worktrees"
+EOF
+(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version 0.1.0 intent-cli project status)
 ```
 
 Equivalent `dnx` path:
 
 ```bash
-dnx --yes --source .artifacts/packages --version 0.1.0 intent-cli project status
+(cd .artifacts/smoke-repo && dnx --yes --source ../packages --version 0.1.0 intent-cli project status)
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # intent-system
+
+## Packaged invocation
+
+The CLI is packaged as a .NET tool with:
+
+- package id: `intent-cli`
+- command name: `intent-cli`
+
+Local package smoke path:
+
+```bash
+dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -o .artifacts/packages
+dotnet tool exec --yes --source .artifacts/packages --version 0.1.0 intent-cli project status
+```
+
+Equivalent `dnx` path:
+
+```bash
+dnx --yes --source .artifacts/packages --version 0.1.0 intent-cli project status
+```

--- a/src/IntentSystem.Cli/Commands/DirectRunProviderEventJsonl.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProviderEventJsonl.cs
@@ -94,6 +94,7 @@ internal static class DirectRunProviderEventJsonl
 internal sealed class DirectRunProviderEventWriter
 {
     private readonly string artifactPath;
+    private readonly string directoryPath;
     private readonly object gate = new();
 
     public DirectRunProviderEventWriter(string artifactPath)
@@ -101,7 +102,7 @@ internal sealed class DirectRunProviderEventWriter
         ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
 
         this.artifactPath = artifactPath;
-        var directoryPath = Path.GetDirectoryName(artifactPath)
+        directoryPath = Path.GetDirectoryName(artifactPath)
             ?? throw new InvalidOperationException("Direct run provider event artifact path did not contain a directory.");
 
         Directory.CreateDirectory(directoryPath);
@@ -113,9 +114,23 @@ internal sealed class DirectRunProviderEventWriter
 
         lock (gate)
         {
-            File.AppendAllText(
-                artifactPath,
-                DirectRunProviderEventJsonl.SerializeLine(providerEvent) + Environment.NewLine);
+            var line = DirectRunProviderEventJsonl.SerializeLine(providerEvent) + Environment.NewLine;
+            AppendWithDirectoryRecovery(line);
+        }
+    }
+
+    private void AppendWithDirectoryRecovery(string line)
+    {
+        Directory.CreateDirectory(directoryPath);
+
+        try
+        {
+            File.AppendAllText(artifactPath, line);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            Directory.CreateDirectory(directoryPath);
+            File.AppendAllText(artifactPath, line);
         }
     }
 }

--- a/src/IntentSystem.Cli/IntentSystem.Cli.csproj
+++ b/src/IntentSystem.Cli/IntentSystem.Cli.csproj
@@ -5,6 +5,15 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>intent-cli</ToolCommandName>
+    <PackageId>intent-cli</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>J-Tech-Japan</Authors>
+    <Description>Intent System CLI packaged as a .NET tool.</Description>
+    <PackageTags>intent-cli;dotnet-tool</PackageTags>
+    <RepositoryUrl>https://github.com/J-Tech-Japan/intent-system</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +26,10 @@
 
   <ItemGroup>
     <PackageReference Include="Tomlyn" Version="2.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" Link="README.md" />
   </ItemGroup>
 
 </Project>

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -2,6 +2,7 @@ using IntentSystem.Cli.Commands;
 
 namespace IntentSystem.Cli.Tests;
 
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class DirectRunLauncherTests
 {
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/DirectRunProviderEventJsonlTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunProviderEventJsonlTests.cs
@@ -62,4 +62,55 @@ public sealed class DirectRunProviderEventJsonlTests
         Assert.Equal(events[1].Payload.GetProperty("type").GetString(), roundTripped[1].Payload.GetProperty("type").GetString());
         Assert.Equal(events[1].Payload.GetProperty("sequence").GetInt32(), roundTripped[1].Payload.GetProperty("sequence").GetInt32());
     }
+
+    [Fact]
+    public void Append_GivenDeletedArtifactDirectory_RecreatesDirectoryAndAppendsEvent()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var artifactPath = tempDirectory.GetPath(Path.Combine(".intent-cli", "runs", "G19.provider.jsonl"));
+        var writer = new DirectRunProviderEventWriter(artifactPath);
+
+        Directory.Delete(
+            Path.GetDirectoryName(artifactPath)
+            ?? throw new InvalidOperationException("Artifact path did not contain a directory."),
+            recursive: true);
+
+        writer.Append(new DirectRunProviderEvent
+        {
+            Timestamp = "2026-04-09T10:16:00.0000000+00:00",
+            ExecutionUnit = "G19",
+            Provider = "Claude",
+            EntryKind = "implement",
+            SessionId = "pid:4321",
+            Kind = "provider-event",
+            Payload = JsonSerializer.SerializeToElement(new
+            {
+                type = "delta"
+            })
+        });
+
+        Assert.True(File.Exists(artifactPath));
+        var appendedEvent = Assert.Single(DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(artifactPath)));
+        Assert.Equal("G19", appendedEvent.ExecutionUnit);
+        Assert.Equal("provider-event", appendedEvent.Kind);
+        Assert.Equal("delta", appendedEvent.Payload.GetProperty("type").GetString());
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-provider-events-").FullName;
+
+        public string GetPath(string relativePath)
+        {
+            return Path.Combine(rootPath, relativePath);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
@@ -1,0 +1,44 @@
+using System.Xml.Linq;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class PackagedInvocationSmokeTests
+{
+    [Fact]
+    public void CliProject_DeclaresDotNetToolPackagingMetadata()
+    {
+        var document = XDocument.Load(Path.Combine(GetSolutionRoot(), "src", "IntentSystem.Cli", "IntentSystem.Cli.csproj"));
+        var propertyGroup = document.Root?
+            .Elements()
+            .FirstOrDefault(element => string.Equals(element.Name.LocalName, "PropertyGroup", StringComparison.Ordinal));
+
+        Assert.NotNull(propertyGroup);
+        Assert.Equal("true", GetPropertyValue(propertyGroup!, "PackAsTool"));
+        Assert.Equal("intent-cli", GetPropertyValue(propertyGroup, "ToolCommandName"));
+        Assert.Equal("intent-cli", GetPropertyValue(propertyGroup, "PackageId"));
+        Assert.Equal("0.1.0", GetPropertyValue(propertyGroup, "Version"));
+        Assert.Equal("README.md", GetPropertyValue(propertyGroup, "PackageReadmeFile"));
+    }
+
+    [Fact]
+    public void Readme_DocumentsToolExecAndDnxPackagedInvocationPaths()
+    {
+        var readme = File.ReadAllText(Path.Combine(GetSolutionRoot(), "README.md"));
+
+        Assert.Contains("dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -o .artifacts/packages", readme, StringComparison.Ordinal);
+        Assert.Contains("dotnet tool exec --yes --source .artifacts/packages --version 0.1.0 intent-cli project status", readme, StringComparison.Ordinal);
+        Assert.Contains("dnx --yes --source .artifacts/packages --version 0.1.0 intent-cli project status", readme, StringComparison.Ordinal);
+    }
+
+    private static string? GetPropertyValue(XElement propertyGroup, string propertyName)
+    {
+        return propertyGroup.Elements()
+            .FirstOrDefault(element => string.Equals(element.Name.LocalName, propertyName, StringComparison.Ordinal))?
+            .Value;
+    }
+
+    private static string GetSolutionRoot()
+    {
+        return Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
@@ -1,8 +1,10 @@
 using System.Diagnostics;
 using System.Xml.Linq;
+using Xunit;
 
 namespace IntentSystem.Cli.Tests;
 
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class PackagedInvocationSmokeTests
 {
     private static readonly Lock ProcessStateLock = new();

--- a/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
@@ -1,9 +1,12 @@
+using System.Diagnostics;
 using System.Xml.Linq;
 
 namespace IntentSystem.Cli.Tests;
 
 public sealed class PackagedInvocationSmokeTests
 {
+    private static readonly Lock ProcessStateLock = new();
+
     [Fact]
     public void CliProject_DeclaresDotNetToolPackagingMetadata()
     {
@@ -21,13 +24,81 @@ public sealed class PackagedInvocationSmokeTests
     }
 
     [Fact]
-    public void Readme_DocumentsToolExecAndDnxPackagedInvocationPaths()
+    public void DotnetToolExec_RunsPackagedCliAgainstHermeticFixture()
+    {
+        lock (ProcessStateLock)
+        {
+            using var tempDirectory = new TemporaryDirectory();
+            var packageOutputDirectory = tempDirectory.CreateDirectory("packages");
+            var fixtureRoot = tempDirectory.CreateDirectory(Path.Combine("smoke-repo"));
+            tempDirectory.CreateDirectory(Path.Combine("smoke-repo", ".intent-cli"));
+            tempDirectory.CreateFile(
+                Path.Combine("smoke-repo", ".intent-cli", "config.toml"),
+                """
+                default_domain = "intent-cli"
+                artifact_root = ".intent-cli"
+                worktree_root = ".intent-cli/worktrees"
+                """);
+
+            var packOutputPath = tempDirectory.GetPath("pack.stdout.txt");
+            var packErrorPath = tempDirectory.GetPath("pack.stderr.txt");
+            var packResult = RunShellCommand(
+                $"dotnet pack {QuoteForShell(Path.Combine(GetSolutionRoot(), "src", "IntentSystem.Cli", "IntentSystem.Cli.csproj"))} -o {QuoteForShell(packageOutputDirectory)} > {QuoteForShell(packOutputPath)} 2> {QuoteForShell(packErrorPath)}",
+                GetSolutionRoot());
+
+            var packLog = File.ReadAllText(packOutputPath) + File.ReadAllText(packErrorPath);
+
+            Assert.Equal(0, packResult.ExitCode);
+            Assert.Contains("Successfully created package", packLog, StringComparison.Ordinal);
+
+            var invokeOutputPath = tempDirectory.GetPath("invoke.stdout.txt");
+            var invokeErrorPath = tempDirectory.GetPath("invoke.stderr.txt");
+            var invokeResult = RunShellCommand(
+                $"dotnet tool exec --yes --source {QuoteForShell(packageOutputDirectory)} --version 0.1.0 intent-cli project status > {QuoteForShell(invokeOutputPath)} 2> {QuoteForShell(invokeErrorPath)}",
+                fixtureRoot);
+
+            var invokeOutput = File.ReadAllText(invokeOutputPath);
+            var invokeError = File.ReadAllText(invokeErrorPath);
+
+            Assert.Equal(0, invokeResult.ExitCode);
+            Assert.Contains("Domain: intent-cli", invokeOutput, StringComparison.Ordinal);
+            Assert.Contains("Config path:", invokeOutput, StringComparison.Ordinal);
+            Assert.Equal(string.Empty, invokeError.Trim(), ignoreCase: false);
+        }
+    }
+
+    [Fact]
+    public void Readme_DocumentsHermeticPackagedInvocationPaths()
     {
         var readme = File.ReadAllText(Path.Combine(GetSolutionRoot(), "README.md"));
 
-        Assert.Contains("dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -o .artifacts/packages", readme, StringComparison.Ordinal);
-        Assert.Contains("dotnet tool exec --yes --source .artifacts/packages --version 0.1.0 intent-cli project status", readme, StringComparison.Ordinal);
-        Assert.Contains("dnx --yes --source .artifacts/packages --version 0.1.0 intent-cli project status", readme, StringComparison.Ordinal);
+        Assert.Contains("mkdir -p .artifacts/smoke-repo/.intent-cli", readme, StringComparison.Ordinal);
+        Assert.Contains("cat > .artifacts/smoke-repo/.intent-cli/config.toml <<'EOF'", readme, StringComparison.Ordinal);
+        Assert.Contains("(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version 0.1.0 intent-cli project status)", readme, StringComparison.Ordinal);
+        Assert.Contains("(cd .artifacts/smoke-repo && dnx --yes --source ../packages --version 0.1.0 intent-cli project status)", readme, StringComparison.Ordinal);
+    }
+
+    private static ProcessResult RunShellCommand(string script, string workingDirectory)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "/bin/zsh",
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("-lc");
+        startInfo.ArgumentList.Add(script);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start shell process.");
+
+        if (!process.WaitForExit(milliseconds: 120000))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("Shell command did not exit within the timeout.");
+        }
+
+        return new ProcessResult(process.ExitCode);
     }
 
     private static string? GetPropertyValue(XElement propertyGroup, string propertyName)
@@ -40,5 +111,48 @@ public sealed class PackagedInvocationSmokeTests
     private static string GetSolutionRoot()
     {
         return Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+    }
+
+    private static string QuoteForShell(string value)
+    {
+        return $"'{value.Replace("'", "'\"'\"'")}'";
+    }
+
+    private sealed record ProcessResult(int ExitCode);
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-tool-pack-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public string GetPath(string relativePath)
+        {
+            return Path.Combine(rootPath, relativePath);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
     }
 }

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -7,6 +7,7 @@ using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class ReviewRunCommandTests
 {
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -5,6 +5,7 @@ using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class RunFixCommandTests
 {
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -5,6 +5,7 @@ using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class RunImplementCommandTests
 {
     [Fact]


### PR DESCRIPTION
## Summary
- add .NET tool packaging metadata for the CLI package and command surface
- document local packaged invocation using `dotnet tool exec` and `dnx`
- add packaging metadata tests and validate local packaged smoke execution

Closes #221