### PR TITLE
G99 Intake Interview Bootstrap Command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -87,6 +87,7 @@ internal static class CommandRouter
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["concept"] = IntakeConceptCommand.Execute,
+                ["interview"] = IntakeInterviewCommand.Execute,
                 ["compile"] = IntakeCompileCommand.Execute,
                 ["foldin"] = IntakeFoldinCommand.Execute,
                 ["patch"] = IntakePatchCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GenerateFromCurrentBridgeCommand.cs
@@ -216,50 +216,15 @@ internal static class GenerateFromCurrentBridgeCommand
                 RecommendedUpdates = recommendedUpdates
             };
 
-            var yamlPath = Path.Combine(interviewsRoot, $"{bridgeQuestion.QuestionId}.yaml");
-            var markdownPath = Path.Combine(interviewsRoot, $"{bridgeQuestion.QuestionId}.md");
-            File.WriteAllText(yamlPath, InterviewArtifactYaml.Serialize(item));
-            File.WriteAllText(
-                markdownPath,
-                RenderInterviewMarkdown(item, recommendedUpdates, reconstructedInterview.Gaps));
-
-            artifactPaths.Add(ToRelativePath(repoRoot, yamlPath));
-            artifactPaths.Add(ToRelativePath(repoRoot, markdownPath));
+            artifactPaths.AddRange(
+                InterviewArtifactFileWriter.Write(
+                    repoRoot,
+                    item,
+                    recommendedUpdates,
+                    reconstructedInterview.Gaps));
         }
 
         return artifactPaths;
-    }
-
-    private static string RenderInterviewMarkdown(
-        InterviewQueueItem item,
-        IReadOnlyList<string> recommendedUpdates,
-        IReadOnlyList<string> gaps)
-    {
-        var lines = new List<string>
-        {
-            "# Interview Question",
-            string.Empty,
-            "## Domain",
-            string.Empty,
-            $"`{item.DomainSlug}`",
-            string.Empty,
-            $"question_id: {item.QuestionId}",
-            $"question_text: {item.QuestionText}",
-            $"reason: {item.Reason}",
-            $"blocking_or_nonblocking: {item.BlockingOrNonblocking}",
-            string.Empty,
-            "return_to_intent_paths:"
-        };
-
-        AppendBullets(lines, item.ReturnToIntentPaths);
-        lines.Add(string.Empty);
-        lines.Add("recommended_updates:");
-        AppendBullets(lines, recommendedUpdates);
-        lines.Add(string.Empty);
-        lines.Add("gaps:");
-        AppendBullets(lines, gaps);
-
-        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
     }
 
     private static void AppendSection(List<string> lines, string title, IReadOnlyList<string> values)
@@ -275,17 +240,6 @@ internal static class GenerateFromCurrentBridgeCommand
         }
 
         lines.Add(string.Empty);
-    }
-
-    private static void AppendBullets(List<string> lines, IReadOnlyList<string> values)
-    {
-        if (values.Count == 0)
-        {
-            lines.Add("- none");
-            return;
-        }
-
-        lines.AddRange(values.Select(value => $"- {value}"));
     }
 
     internal static string ToRelativePath(string repoRoot, string absolutePath)

--- a/src/IntentSystem.Cli/Commands/IntakeInterviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeInterviewCommand.cs
@@ -1,0 +1,179 @@
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeInterviewCommand
+{
+    internal static readonly DateTimeOffset CreatedAtBase = DateTimeOffset.Parse("2026-01-01T00:00:00Z");
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        try
+        {
+            var result = ExecuteCore(context.RepoRoot, args);
+            IntakeInterviewRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static IntakeInterviewResult ExecuteCore(string repoRoot, string[] args)
+    {
+        var domain = ParseDomain(args);
+        var conceptArtifactRelativePath = IntakeConceptArtifactPathResolver.Resolve(domain);
+        var conceptArtifactPath = Path.Combine(
+            repoRoot,
+            conceptArtifactRelativePath.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(conceptArtifactPath))
+        {
+            throw new InvalidOperationException($"Intake concept artifact was not found at {conceptArtifactPath}");
+        }
+
+        var conceptPacket = IntakeConceptArtifactYaml.Deserialize(File.ReadAllText(conceptArtifactPath));
+        if (!string.Equals(conceptPacket.DomainSlug, domain, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Intake concept artifact domain '{conceptPacket.DomainSlug}' must match requested domain '{domain}'.");
+        }
+
+        var interviewsRoot = ResolveInterviewsRoot(repoRoot, domain);
+        var existingArtifactPaths = DiscoverExistingArtifacts(repoRoot, interviewsRoot);
+        if (existingArtifactPaths.Count > 0)
+        {
+            return new IntakeInterviewResult
+            {
+                Domain = domain,
+                ConceptArtifactPath = conceptArtifactRelativePath,
+                WasSkipped = true,
+                GeneratedArtifactPaths = [],
+                ExistingArtifactPaths = existingArtifactPaths,
+                CreatedQuestionIds = []
+            };
+        }
+
+        var generatedArtifactPaths = new List<string>();
+        var createdQuestionIds = new List<string>();
+        var questions = BuildBootstrapQuestions(conceptPacket, conceptArtifactRelativePath);
+
+        foreach (var question in questions.Select((value, index) => (value, index)))
+        {
+            var item = new InterviewQueueItem
+            {
+                DomainSlug = domain,
+                SourceConceptRef = conceptArtifactRelativePath,
+                QuestionId = question.value.QuestionId,
+                QuestionText = question.value.QuestionText,
+                Reason = question.value.Reason,
+                Affects = question.value.Affects,
+                BlockingOrNonblocking = question.value.BlockingOrNonblocking,
+                Status = InterviewQueueItemStatus.Open,
+                ReturnToIntentPaths = conceptPacket.UpstreamPaths,
+                CreatedAt = CreatedAtBase.AddMinutes(question.index),
+                Answer = null
+            };
+
+            generatedArtifactPaths.AddRange(
+                InterviewArtifactFileWriter.Write(repoRoot, item, [], conceptPacket.KnownUnknowns));
+            createdQuestionIds.Add(item.QuestionId);
+        }
+
+        return new IntakeInterviewResult
+        {
+            Domain = domain,
+            ConceptArtifactPath = conceptArtifactRelativePath,
+            WasSkipped = false,
+            GeneratedArtifactPaths = generatedArtifactPaths,
+            ExistingArtifactPaths = [],
+            CreatedQuestionIds = createdQuestionIds
+        };
+    }
+
+    private static string ParseDomain(string[] args)
+    {
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            throw new InvalidOperationException("Intake interview command requires a domain.");
+        }
+
+        return args[0].Trim();
+    }
+
+    private static string ResolveInterviewsRoot(string repoRoot, string domain)
+    {
+        return Path.Combine(
+            repoRoot,
+            ".intent-cli",
+            "interviews",
+            domain.Replace('/', Path.DirectorySeparatorChar));
+    }
+
+    private static IReadOnlyList<string> DiscoverExistingArtifacts(string repoRoot, string interviewsRoot)
+    {
+        if (!Directory.Exists(interviewsRoot))
+        {
+            return [];
+        }
+
+        return Directory.EnumerateFiles(interviewsRoot, "*", SearchOption.AllDirectories)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .Select(path => Path.GetRelativePath(repoRoot, path).Replace(Path.DirectorySeparatorChar, '/'))
+            .ToArray();
+    }
+
+    private static IReadOnlyList<BootstrapQuestion> BuildBootstrapQuestions(
+        ConceptIntakePacket conceptPacket,
+        string conceptArtifactRelativePath)
+    {
+        var domain = conceptPacket.DomainSlug;
+        var initialGoalPreview = conceptPacket.InitialGoal;
+        var constraintPreview = FormatPreview(conceptPacket.Constraints);
+        var unknownsPreview = FormatPreview(conceptPacket.KnownUnknowns);
+
+        return
+        [
+            new BootstrapQuestion(
+                "iq-goal",
+                $"Initial goal is '{initialGoalPreview}'. What concrete outcome should this intake treat as the first shippable success for '{domain}'?",
+                $"Clarify the initial goal captured in '{conceptArtifactRelativePath}' before standard interview flow resumes.",
+                [domain],
+                "blocking"),
+            new BootstrapQuestion(
+                "iq-constraints",
+                $"Current constraints are {constraintPreview}. Which hard constraints or invariants must stay true for '{domain}'?",
+                $"Clarify repo-local constraints from '{conceptArtifactRelativePath}' so later intake updates stay bounded.",
+                [domain, "constraints"],
+                "nonblocking"),
+            new BootstrapQuestion(
+                "iq-unknowns",
+                $"Known unknowns are {unknownsPreview}. Which unresolved unknown should this intake resolve first for '{domain}'?",
+                $"Clarify the highest-priority unknown captured in '{conceptArtifactRelativePath}' before compile/fold-in work continues.",
+                [domain, "unknowns"],
+                "blocking")
+        ];
+    }
+
+    private static string FormatPreview(IReadOnlyList<string> values)
+    {
+        return values.Count switch
+        {
+            0 => "'none'",
+            1 => $"'{values[0]}'",
+            _ => $"'{string.Join("; ", values)}'"
+        };
+    }
+
+    private sealed record BootstrapQuestion(
+        string QuestionId,
+        string QuestionText,
+        string Reason,
+        IReadOnlyList<string> Affects,
+        string BlockingOrNonblocking);
+}

--- a/src/IntentSystem.Cli/Commands/IntakeInterviewRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeInterviewRenderer.cs
@@ -1,0 +1,41 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeInterviewRenderer
+{
+    public static void WriteSummary(TextWriter writer, IntakeInterviewResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Intake interview bootstrap processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Concept artifact: {result.ConceptArtifactPath}");
+
+        if (result.WasSkipped)
+        {
+            writer.WriteLine("Bootstrap status: skipped");
+            writer.WriteLine("Existing interview artifacts:");
+            WriteList(writer, result.ExistingArtifactPaths);
+            return;
+        }
+
+        writer.WriteLine("Bootstrap status: generated");
+        writer.WriteLine("Created question ids:");
+        WriteList(writer, result.CreatedQuestionIds);
+        writer.WriteLine("Generated interview artifacts:");
+        WriteList(writer, result.GeneratedArtifactPaths);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeInterviewResult.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeInterviewResult.cs
@@ -1,0 +1,16 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeInterviewResult
+{
+    public required string Domain { get; init; }
+
+    public required string ConceptArtifactPath { get; init; }
+
+    public required bool WasSkipped { get; init; }
+
+    public required IReadOnlyList<string> GeneratedArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> ExistingArtifactPaths { get; init; }
+
+    public required IReadOnlyList<string> CreatedQuestionIds { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/InterviewArtifactFileWriter.cs
+++ b/src/IntentSystem.Cli/Commands/InterviewArtifactFileWriter.cs
@@ -1,0 +1,91 @@
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class InterviewArtifactFileWriter
+{
+    public static IReadOnlyList<string> Write(
+        string repoRoot,
+        InterviewQueueItem item,
+        IReadOnlyList<string> recommendedUpdates,
+        IReadOnlyList<string> gaps)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(recommendedUpdates);
+        ArgumentNullException.ThrowIfNull(gaps);
+
+        var interviewsRoot = Path.Combine(
+            repoRoot,
+            ".intent-cli",
+            "interviews",
+            item.DomainSlug.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(interviewsRoot);
+
+        var yamlPath = Path.Combine(interviewsRoot, $"{item.QuestionId}.yaml");
+        var markdownPath = Path.Combine(interviewsRoot, $"{item.QuestionId}.md");
+
+        File.WriteAllText(yamlPath, InterviewArtifactYaml.Serialize(item));
+        File.WriteAllText(
+            markdownPath,
+            RenderMarkdown(item, recommendedUpdates, gaps));
+
+        return
+        [
+            ToRelativePath(repoRoot, yamlPath),
+            ToRelativePath(repoRoot, markdownPath)
+        ];
+    }
+
+    public static string RenderMarkdown(
+        InterviewQueueItem item,
+        IReadOnlyList<string> recommendedUpdates,
+        IReadOnlyList<string> gaps)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(recommendedUpdates);
+        ArgumentNullException.ThrowIfNull(gaps);
+
+        var lines = new List<string>
+        {
+            "# Interview Question",
+            string.Empty,
+            "## Domain",
+            string.Empty,
+            $"`{item.DomainSlug}`",
+            string.Empty,
+            $"question_id: {item.QuestionId}",
+            $"question_text: {item.QuestionText}",
+            $"reason: {item.Reason}",
+            $"blocking_or_nonblocking: {item.BlockingOrNonblocking}",
+            string.Empty,
+            "return_to_intent_paths:"
+        };
+
+        AppendBullets(lines, item.ReturnToIntentPaths);
+        lines.Add(string.Empty);
+        lines.Add("recommended_updates:");
+        AppendBullets(lines, recommendedUpdates);
+        lines.Add(string.Empty);
+        lines.Add("gaps:");
+        AppendBullets(lines, gaps);
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    private static void AppendBullets(List<string> lines, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            lines.Add("- none");
+            return;
+        }
+
+        lines.AddRange(values.Select(value => $"- {value}"));
+    }
+
+    private static string ToRelativePath(string repoRoot, string absolutePath)
+    {
+        return Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -2020,6 +2020,34 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeInterviewCommand_DispatchesToBootstrapRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
+            """
+            domain_slug: auth
+            concept_source: interactive
+            concept_text: "Add OAuth2 provider support."
+            upstream_paths:
+              - "README.md"
+            initial_goal: "Add OAuth2 provider support."
+            constraints:
+              - "Preserve packaged invocation."
+            known_unknowns:
+              - "Which auth flow is canonical?"
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["intake", "interview", "auth"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Intake interview bootstrap processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("- iq-goal", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenIntakeCompileCommand_DispatchesToIntakeCompileRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeInterviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeInterviewCommandTests.cs
@@ -1,0 +1,167 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeInterviewCommandTests
+{
+    [Fact]
+    public void Execute_GivenConceptOnlyDomain_MaterializesBootstrapInterviewArtifacts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
+            IntakeConceptArtifactYaml.Serialize(CreateConceptPacket()));
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeInterviewCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake interview bootstrap processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Bootstrap status: generated", output, StringComparison.Ordinal);
+        Assert.Contains("- iq-goal", output, StringComparison.Ordinal);
+        Assert.Contains("- iq-constraints", output, StringComparison.Ordinal);
+        Assert.Contains("- iq-unknowns", output, StringComparison.Ordinal);
+
+        var goalArtifact = InterviewArtifactYaml.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-goal.yaml")));
+        Assert.Equal(".intent-cli/intake/auth.concept.yaml", goalArtifact.SourceConceptRef);
+        Assert.Equal("iq-goal", goalArtifact.QuestionId);
+        Assert.Equal("blocking", goalArtifact.BlockingOrNonblocking);
+        Assert.Equal(["auth"], goalArtifact.Affects);
+        Assert.Equal(DateTimeOffset.Parse("2026-01-01T00:00:00Z"), goalArtifact.CreatedAt);
+        Assert.Contains("Add OAuth2 provider support", goalArtifact.QuestionText, StringComparison.Ordinal);
+
+        var constraintArtifact = InterviewArtifactYaml.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-constraints.yaml")));
+        Assert.Equal("nonblocking", constraintArtifact.BlockingOrNonblocking);
+        Assert.Equal(["auth", "constraints"], constraintArtifact.Affects);
+
+        var unknownArtifact = InterviewArtifactYaml.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-unknowns.yaml")));
+        Assert.Equal("blocking", unknownArtifact.BlockingOrNonblocking);
+        Assert.Equal(["auth", "unknowns"], unknownArtifact.Affects);
+
+        using var interviewWriter = new StringWriter();
+        var interviewStartExitCode = InterviewStartCommand.Execute(CreateContext(repoRoot), ["auth"], interviewWriter);
+        Assert.Equal(0, interviewStartExitCode);
+        Assert.Contains("Question id: iq-goal", interviewWriter.ToString(), StringComparison.Ordinal);
+
+        using var compileWriter = new StringWriter();
+        var compileExitCode = IntakeCompileCommand.Execute(CreateContext(repoRoot), ["auth"], compileWriter);
+        Assert.Equal(0, compileExitCode);
+        Assert.Contains("Intake compile is not ready for domain 'auth'.", compileWriter.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Next interview question:", compileWriter.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("No interview artifacts found", compileWriter.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenExistingInterviewTree_SkipsWithoutOverwrite()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
+            IntakeConceptArtifactYaml.Serialize(CreateConceptPacket()));
+        var existingArtifactPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-existing.yaml"),
+            "kept");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeInterviewCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Bootstrap status: skipped", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/interviews/auth/iq-existing.yaml", output, StringComparison.Ordinal);
+        Assert.Equal("kept", File.ReadAllText(existingArtifactPath));
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "interviews", "auth", "iq-goal.yaml")));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingConceptArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeInterviewCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Intake concept artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeInterviewCommand.Execute(CreateContext("/tmp/intent-system"), [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static IntentSystem.ConceptIntake.Models.ConceptIntakePacket CreateConceptPacket()
+    {
+        return new IntentSystem.ConceptIntake.Models.ConceptIntakePacket
+        {
+            DomainSlug = "auth",
+            ConceptSource = "interactive",
+            ConceptText = "Add OAuth2 provider support.",
+            UpstreamPaths = ["README.md", "AGENTS.md"],
+            InitialGoal = "Add OAuth2 provider support.",
+            Constraints = ["Preserve packaged invocation.", "Do not add Node tooling."],
+            KnownUnknowns = ["Which auth flow is canonical?", "How should device-code fit?"]
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-interview-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeInterviewRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeInterviewRendererTests.cs
@@ -1,0 +1,55 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeInterviewRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenGeneratedResult_RendersCreatedQuestionIdsAndArtifacts()
+    {
+        var result = new IntakeInterviewResult
+        {
+            Domain = "auth",
+            ConceptArtifactPath = ".intent-cli/intake/auth.concept.yaml",
+            WasSkipped = false,
+            GeneratedArtifactPaths =
+            [
+                ".intent-cli/interviews/auth/iq-goal.yaml",
+                ".intent-cli/interviews/auth/iq-goal.md"
+            ],
+            ExistingArtifactPaths = [],
+            CreatedQuestionIds = ["iq-goal", "iq-constraints", "iq-unknowns"]
+        };
+        using var writer = new StringWriter();
+
+        IntakeInterviewRenderer.WriteSummary(writer, result);
+
+        var output = writer.ToString();
+        Assert.Contains("Intake interview bootstrap processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Bootstrap status: generated", output, StringComparison.Ordinal);
+        Assert.Contains("- iq-goal", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/interviews/auth/iq-goal.yaml", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenSkippedResult_RendersExistingArtifacts()
+    {
+        var result = new IntakeInterviewResult
+        {
+            Domain = "auth",
+            ConceptArtifactPath = ".intent-cli/intake/auth.concept.yaml",
+            WasSkipped = true,
+            GeneratedArtifactPaths = [],
+            ExistingArtifactPaths = [".intent-cli/interviews/auth/iq-goal.yaml"],
+            CreatedQuestionIds = []
+        };
+        using var writer = new StringWriter();
+
+        IntakeInterviewRenderer.WriteSummary(writer, result);
+
+        var output = writer.ToString();
+        Assert.Contains("Bootstrap status: skipped", output, StringComparison.Ordinal);
+        Assert.Contains("Existing interview artifacts:", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/interviews/auth/iq-goal.yaml", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add `intent-cli intake interview <domain>` as a thin bootstrap bridge from concept artifacts to standard interview artifacts
- materialize a deterministic first-pass interview set for concept-only domains without mutating hidden interview state
- keep existing `interview start` and `intake compile` baselines by reusing the same interview artifact contract

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IntakeInterview|FullyQualifiedName~InterviewStartCommandTests|FullyQualifiedName~IntakeCompileCommandTests|FullyQualifiedName~GenerateFromCurrentBridgeCommandTests|FullyQualifiedName~CommandRouterTests"
- dotnet test IntentSystem.sln

Closes #225