### PR TITLE
Add root run orchestration command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -120,6 +120,11 @@ internal static class CommandRouter
             return GenerateFromCurrentCommand.Execute(context, args[1..], writer);
         }
 
+        if (args.Length == 1 && string.Equals(args[0], "run", StringComparison.Ordinal))
+        {
+            return RunCommand.Execute(context, [], writer);
+        }
+
         if (args.Length < 2)
         {
             writer.WriteLine("A command group and subcommand are required.");

--- a/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
@@ -25,20 +25,45 @@ internal static class QueueDispatchCommand
             return 1;
         }
 
-        var queueState = QueueCommandSupport.LoadQueueState(context, writer);
-        if (queueState is null)
+        try
         {
+            var result = ExecuteCore(context, args[0].Trim());
+            if (result.ReusedExistingIssue)
+            {
+                writer.WriteLine($"Queue item {result.ExecutionUnit} reused existing linked issue {result.LinkedIssueUrl}.");
+            }
+            else
+            {
+                writer.WriteLine($"Queue item {result.ExecutionUnit} dispatched to {result.LinkedIssueUrl}.");
+            }
+
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
             return 1;
         }
+    }
 
-        var executionUnit = args[0];
+    internal static QueueDispatchCommandResult ExecuteCore(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var queueStatePath = context.GetQueueStatePath();
+        var queueState = QueueCommandSupport.LoadQueueState(context, TextWriter.Null);
+        if (queueState is null)
+        {
+            throw new InvalidOperationException($"No queue state found at {queueStatePath}");
+        }
+
         var queueItem = queueState.Items.FirstOrDefault(item =>
             string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
 
         if (queueItem is null)
         {
-            writer.WriteLine($"Execution unit '{executionUnit}' was not found in queue state.");
-            return 1;
+            throw new InvalidOperationException($"Execution unit '{executionUnit}' was not found in queue state.");
         }
 
         if (queueItem.LinkedIssue is not null)
@@ -54,62 +79,60 @@ internal static class QueueDispatchCommand
                     LinkedIssue = queueItem.LinkedIssue.Url
                 });
 
-            writer.WriteLine($"Queue item {executionUnit} reused existing linked issue {queueItem.LinkedIssue.Url}.");
-            return 0;
+            return new QueueDispatchCommandResult
+            {
+                ExecutionUnit = executionUnit,
+                LinkedIssueUrl = queueItem.LinkedIssue.Url,
+                ReusedExistingIssue = true
+            };
         }
 
         var packetPath = ResolveArtifactPath(context.RepoRoot, queueItem.PacketPaths.Yaml);
         if (!File.Exists(packetPath))
         {
-            writer.WriteLine($"Projection packet artifact was not found at {packetPath}");
-            return 1;
+            throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
         }
 
         var githubBodyPath = ResolveGitHubBodyPath(context.RepoRoot, queueItem.PacketPaths.Yaml);
         if (!File.Exists(githubBodyPath))
         {
-            writer.WriteLine($"GitHub issue body artifact was not found at {githubBodyPath}");
-            return 1;
+            throw new InvalidOperationException($"GitHub issue body artifact was not found at {githubBodyPath}");
         }
 
-        try
+        var packet = ProjectionPacketRuntimeReader.Read(File.ReadAllText(packetPath));
+        var packetTargetRepo = packet.TargetRepo;
+        if (string.IsNullOrWhiteSpace(packetTargetRepo))
         {
-            var packet = ProjectionPacketRuntimeReader.Read(File.ReadAllText(packetPath));
-            var packetTargetRepo = packet.TargetRepo;
-            if (string.IsNullOrWhiteSpace(packetTargetRepo))
-            {
-                throw new InvalidOperationException("Projection packet must contain a target repo.");
-            }
-
-            var issueTitle = packet.IssueTitle;
-            if (string.IsNullOrWhiteSpace(issueTitle))
-            {
-                throw new InvalidOperationException("Projection packet must contain a non-empty issue title.");
-            }
-
-            var body = File.ReadAllText(githubBodyPath);
-            var githubTargetRepo = GitHubRepositoryTargetResolver.Resolve(
-                context.RepoRoot,
-                packetTargetRepo,
-                GitCommandRunnerFactory());
-            var linkedIssue = PublisherFactory().CreateIssue(githubTargetRepo, issueTitle, body);
-            var result = QueueManager.LinkIssue(
-                queueState,
-                executionUnit,
-                linkedIssue,
-                TransitionActor,
-                TimestampFactory());
-
-            PersistDispatch(context, result);
-
-            writer.WriteLine($"Queue item {executionUnit} dispatched to {linkedIssue.Url}.");
-            return 0;
+            throw new InvalidOperationException("Projection packet must contain a target repo.");
         }
-        catch (InvalidOperationException exception)
+
+        var issueTitle = packet.IssueTitle;
+        if (string.IsNullOrWhiteSpace(issueTitle))
         {
-            writer.WriteLine(exception.Message);
-            return 1;
+            throw new InvalidOperationException("Projection packet must contain a non-empty issue title.");
         }
+
+        var body = File.ReadAllText(githubBodyPath);
+        var githubTargetRepo = GitHubRepositoryTargetResolver.Resolve(
+            context.RepoRoot,
+            packetTargetRepo,
+            GitCommandRunnerFactory());
+        var linkedIssue = PublisherFactory().CreateIssue(githubTargetRepo, issueTitle, body);
+        var result = QueueManager.LinkIssue(
+            queueState,
+            executionUnit,
+            linkedIssue,
+            TransitionActor,
+            TimestampFactory());
+
+        PersistDispatch(context, result);
+
+        return new QueueDispatchCommandResult
+        {
+            ExecutionUnit = executionUnit,
+            LinkedIssueUrl = linkedIssue.Url,
+            ReusedExistingIssue = false
+        };
     }
 
     private static string ResolveArtifactPath(string repoRoot, string artifactRef)

--- a/src/IntentSystem.Cli/Commands/QueueDispatchCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/QueueDispatchCommandResult.cs
@@ -1,0 +1,10 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record QueueDispatchCommandResult
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required string LinkedIssueUrl { get; init; }
+
+    public required bool ReusedExistingIssue { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -68,6 +68,7 @@ internal static class RunCommand
         try
         {
             var result = ExecuteCore(context);
+            result = PersistResultArtifact(context, result);
             RunCommandRenderer.WriteSummary(writer, result);
             return 0;
         }
@@ -619,12 +620,70 @@ internal static class RunCommand
         string? executionUnit = null,
         string? detail = null)
     {
+        var touchedExecutionUnits = new List<string>();
+        foreach (var action in actions)
+        {
+            if (!touchedExecutionUnits.Contains(action.ExecutionUnit, StringComparer.Ordinal))
+            {
+                touchedExecutionUnits.Add(action.ExecutionUnit);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(executionUnit)
+            && !touchedExecutionUnits.Contains(executionUnit, StringComparer.Ordinal))
+        {
+            touchedExecutionUnits.Add(executionUnit);
+        }
+
+        var reusedChildCommandRefs = new List<string>();
+        foreach (var action in actions)
+        {
+            if (!reusedChildCommandRefs.Contains(action.Name, StringComparer.Ordinal))
+            {
+                reusedChildCommandRefs.Add(action.Name);
+            }
+        }
+
         return new RunCommandResult
         {
             StopReason = stopReason,
             Actions = actions.ToArray(),
+            TouchedExecutionUnits = touchedExecutionUnits,
+            ReusedChildCommandRefs = reusedChildCommandRefs,
             ExecutionUnit = executionUnit,
             Detail = detail
+        };
+    }
+
+    private static RunCommandResult PersistResultArtifact(CliContext context, RunCommandResult result)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(result);
+
+        var artifactPath = RunRootResultArtifactPathResolver.Resolve(context);
+        var absoluteArtifactPath = Path.IsPathRooted(artifactPath)
+            ? artifactPath
+            : Path.GetFullPath(Path.Combine(context.RepoRoot, artifactPath.Replace('/', Path.DirectorySeparatorChar)));
+        var directoryPath = Path.GetDirectoryName(absoluteArtifactPath)
+            ?? throw new InvalidOperationException("Run root result artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(
+            absoluteArtifactPath,
+            RunRootResultArtifactJson.Serialize(
+                new RunRootResultArtifact
+                {
+                    SchemaVersion = "1",
+                    StopReason = result.StopReason,
+                    TouchedExecutionUnits = result.TouchedExecutionUnits,
+                    ReusedChildCommandRefs = result.ReusedChildCommandRefs,
+                    ExecutionUnit = result.ExecutionUnit,
+                    Detail = result.Detail
+                }));
+
+        return result with
+        {
+            ArtifactPath = artifactPath
         };
     }
 

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using IntentSystem.Review;
 using IntentSystem.Supervisor;
 using IntentSystem.Supervisor.Models;
@@ -13,14 +14,11 @@ internal static class RunCommand
     }
 
     private const int IterationBudget = 128;
-    private const string NoActionableWorkStopReason = "no-actionable-work";
+    private const string NoActionableItemStopReason = "no-actionable-item";
     private const string ClarificationRequiredStopReason = "clarification-required";
-    private const string ParentPlanningRequiredStopReason = "parent-planning-required";
-    private const string ReviewDecisionRequiredStopReason = "review-decision-required";
-    private const string WorkerMonitoringStopReason = "worker-monitoring";
-    private const string ParallelWorkDetectedStopReason = "parallel-work-detected";
-    private const string IterationBudgetExhaustedStopReason = "iteration-budget-exhausted";
+    private const string ParentIntentUpdateRequiredStopReason = "parent-intent-update-required";
     private const string DeterministicContractGapStopReason = "deterministic-contract-gap";
+    private const string NonRetryableFailureStopReason = "non-retryable-failure";
 
     public static Func<CliContext, string, QueueDispatchCommandResult> QueueDispatchExecutor { get; set; } =
         QueueDispatchCommand.ExecuteCore;
@@ -34,11 +32,26 @@ internal static class RunCommand
     public static Func<CliContext, string, RunFixResult> RunFixExecutor { get; set; } =
         RunFixCommand.ExecuteCore;
 
+    public static Func<CliContext, string, RunSubmitResult> RunSubmitExecutor { get; set; } =
+        RunSubmitCommand.ExecuteCore;
+
+    public static Func<CliContext, string, RunResubmitResult> RunResubmitExecutor { get; set; } =
+        RunResubmitCommand.ExecuteCore;
+
+    public static Func<CliContext, string, RunRereviewResult> RunRereviewExecutor { get; set; } =
+        RunRereviewCommand.ExecuteCore;
+
     public static Func<CliContext, string, RunSuperviseResult> RunSuperviseExecutor { get; set; } =
         RunSuperviseCommand.ExecuteCore;
 
     public static Func<CliContext, string, ReviewRunResult> ReviewRunExecutor { get; set; } =
         ReviewRunCommand.ExecuteCore;
+
+    public static Func<CliContext, string, string, ReviewCommentResult> ReviewCommentExecutor { get; set; } =
+        ReviewCommentCommand.ExecuteCore;
+
+    public static Func<CliContext, string, ReviewAcceptResult> ReviewAcceptExecutor { get; set; } =
+        ReviewAcceptCommand.ExecuteCore;
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -83,7 +96,7 @@ internal static class RunCommand
                 if (inProgressItems.Count > 1)
                 {
                     return CreateStopResult(
-                        ParallelWorkDetectedStopReason,
+                        DeterministicContractGapStopReason,
                         actions,
                         detail: $"Multiple in-progress items detected: {string.Join(", ", inProgressItems.Select(item => item.ExecutionUnit))}.");
                 }
@@ -93,6 +106,27 @@ internal static class RunCommand
                     var inProgressItem = inProgressItems[0];
                     if (inProgressItem.State == QueueItemState.Active)
                     {
+                        var implementRunStatus = TryReadDirectRunStatus(context, inProgressItem.ExecutionUnit);
+                        if (string.Equals(implementRunStatus, "succeeded", StringComparison.Ordinal))
+                        {
+                            ExecuteAction(
+                                context,
+                                actions,
+                                "run submit",
+                                inProgressItem.ExecutionUnit,
+                                () => RunSubmitExecutor(context, inProgressItem.ExecutionUnit));
+                            continue;
+                        }
+
+                        if (string.Equals(implementRunStatus, "failed", StringComparison.Ordinal))
+                        {
+                            return CreateStopResult(
+                                NonRetryableFailureStopReason,
+                                actions,
+                                inProgressItem.ExecutionUnit,
+                                $"Implement direct run failed for '{inProgressItem.ExecutionUnit}'.");
+                        }
+
                         if (!ArtifactExists(context, RunImplementArtifactPathResolver.Resolve(inProgressItem.ExecutionUnit)))
                         {
                             ExecuteAction(
@@ -116,11 +150,7 @@ internal static class RunCommand
                             continue;
                         }
 
-                        return CreateStopResult(
-                            WorkerMonitoringStopReason,
-                            actions,
-                            inProgressItem.ExecutionUnit,
-                            DescribeSupervisionResult(superviseResult));
+                        return CreateMonitoringStopResult(actions, inProgressItem.ExecutionUnit, superviseResult);
                     }
 
                     if (inProgressItem.State == QueueItemState.Fixing)
@@ -145,6 +175,33 @@ internal static class RunCommand
                             continue;
                         }
 
+                        var fixRunStatus = TryReadDirectRunStatus(context, inProgressItem.ExecutionUnit);
+                        if (string.Equals(fixRunStatus, "succeeded", StringComparison.Ordinal))
+                        {
+                            ExecuteAction(
+                                context,
+                                actions,
+                                "run resubmit",
+                                inProgressItem.ExecutionUnit,
+                                () => RunResubmitExecutor(context, inProgressItem.ExecutionUnit));
+                            ExecuteAction(
+                                context,
+                                actions,
+                                "run rereview",
+                                inProgressItem.ExecutionUnit,
+                                () => RunRereviewExecutor(context, inProgressItem.ExecutionUnit));
+                            continue;
+                        }
+
+                        if (string.Equals(fixRunStatus, "failed", StringComparison.Ordinal))
+                        {
+                            return CreateStopResult(
+                                NonRetryableFailureStopReason,
+                                actions,
+                                inProgressItem.ExecutionUnit,
+                                $"Fix direct run failed for '{inProgressItem.ExecutionUnit}'.");
+                        }
+
                         var superviseResult = ExecuteAction(
                             context,
                             actions,
@@ -157,11 +214,7 @@ internal static class RunCommand
                             continue;
                         }
 
-                        return CreateStopResult(
-                            WorkerMonitoringStopReason,
-                            actions,
-                            inProgressItem.ExecutionUnit,
-                            DescribeSupervisionResult(superviseResult));
+                        return CreateMonitoringStopResult(actions, inProgressItem.ExecutionUnit, superviseResult);
                     }
 
                     if (!ArtifactExists(context, ReviewArtifactPathResolver.Resolve(inProgressItem.ExecutionUnit)))
@@ -174,11 +227,52 @@ internal static class RunCommand
                             () => ReviewRunExecutor(context, inProgressItem.ExecutionUnit));
                     }
 
+                    var reviewDecision = ResolveReviewDecision(context, inProgressItem.ExecutionUnit);
+                    if (reviewDecision.Kind == RunReviewDecisionKind.Accept)
+                    {
+                        ExecuteAction(
+                            context,
+                            actions,
+                            "review accept",
+                            inProgressItem.ExecutionUnit,
+                            () => ReviewAcceptExecutor(context, inProgressItem.ExecutionUnit));
+                        continue;
+                    }
+
+                    if (reviewDecision.Kind == RunReviewDecisionKind.Comment)
+                    {
+                        ExecuteAction(
+                            context,
+                            actions,
+                            "review comment",
+                            inProgressItem.ExecutionUnit,
+                            () => ReviewCommentExecutor(context, inProgressItem.ExecutionUnit, reviewDecision.CommentBodyPath!));
+                        continue;
+                    }
+
+                    if (reviewDecision.Kind == RunReviewDecisionKind.Failure)
+                    {
+                        return CreateStopResult(
+                            NonRetryableFailureStopReason,
+                            actions,
+                            inProgressItem.ExecutionUnit,
+                            reviewDecision.Detail);
+                    }
+
+                    if (reviewDecision.Kind == RunReviewDecisionKind.ContractGap)
+                    {
+                        return CreateStopResult(
+                            DeterministicContractGapStopReason,
+                            actions,
+                            inProgressItem.ExecutionUnit,
+                            reviewDecision.Detail);
+                    }
+
                     return CreateStopResult(
-                        ReviewDecisionRequiredStopReason,
+                        NoActionableItemStopReason,
                         actions,
                         inProgressItem.ExecutionUnit,
-                        "Review outcome requires an explicit accept/comment decision.");
+                        reviewDecision.Detail);
                 }
 
                 var nextQueuedItem = QueueSelection.SelectNext(queueState);
@@ -218,13 +312,13 @@ internal static class RunCommand
                 if (blockedItem is not null)
                 {
                     return CreateStopResult(
-                        ParentPlanningRequiredStopReason,
+                        ParentIntentUpdateRequiredStopReason,
                         actions,
                         blockedItem.ExecutionUnit,
                         $"Blocked item '{blockedItem.ExecutionUnit}' requires parent-side planning.");
                 }
 
-                return CreateStopResult(NoActionableWorkStopReason, actions);
+                return CreateStopResult(NoActionableItemStopReason, actions);
             }
             catch (RunDeterministicGapException exception)
             {
@@ -237,7 +331,7 @@ internal static class RunCommand
         }
 
         return CreateStopResult(
-            IterationBudgetExhaustedStopReason,
+            DeterministicContractGapStopReason,
             actions,
             detail: $"Run orchestration exceeded {IterationBudget} iterations.");
     }
@@ -311,6 +405,214 @@ internal static class RunCommand
         return "Worker remains under supervision.";
     }
 
+    private static RunCommandResult CreateMonitoringStopResult(
+        IReadOnlyList<RunCommandAction> actions,
+        string executionUnit,
+        RunSuperviseResult superviseResult)
+    {
+        if (superviseResult.Blocked)
+        {
+            return CreateStopResult(
+                NonRetryableFailureStopReason,
+                actions,
+                executionUnit,
+                $"Supervisor blocked '{executionUnit}' after non-retryable failure.");
+        }
+
+        return CreateStopResult(
+            NoActionableItemStopReason,
+            actions,
+            executionUnit,
+            DescribeSupervisionResult(superviseResult));
+    }
+
+    private static string? TryReadDirectRunStatus(CliContext context, string executionUnit)
+    {
+        var resultArtifact = TryReadDirectRunResultArtifact(context, executionUnit);
+        return resultArtifact?.RunStatus;
+    }
+
+    private static DirectRunResultArtifact? TryReadDirectRunResultArtifact(CliContext context, string executionUnit)
+    {
+        var resultArtifactRef = ResolveDirectRunResultArtifactRef(context, executionUnit);
+        var resultArtifactPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            resultArtifactRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(resultArtifactPath))
+        {
+            return null;
+        }
+
+        return DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> TryReadDirectRunProviderEvents(CliContext context, string executionUnit)
+    {
+        var providerLogRef = ResolveDirectRunProviderLogRef(context, executionUnit);
+        var providerLogPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            providerLogRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(providerLogPath))
+        {
+            return [];
+        }
+
+        return DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerLogPath));
+    }
+
+    private static string ResolveDirectRunResultArtifactRef(CliContext context, string executionUnit)
+    {
+        var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
+        return $"{root}/{executionUnit.Trim()}.result.json";
+    }
+
+    private static string ResolveDirectRunProviderLogRef(CliContext context, string executionUnit)
+    {
+        var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
+        return $"{root}/{executionUnit.Trim()}.provider.jsonl";
+    }
+
+    private static RunReviewDecision ResolveReviewDecision(CliContext context, string executionUnit)
+    {
+        var resultArtifact = TryReadDirectRunResultArtifact(context, executionUnit);
+        if (resultArtifact is null)
+        {
+            return new RunReviewDecision
+            {
+                Kind = RunReviewDecisionKind.Waiting,
+                Detail = $"Review request exists for '{executionUnit}' but no direct run result is available yet."
+            };
+        }
+
+        var runStatus = resultArtifact.RunStatus;
+        if (string.Equals(runStatus, "failed", StringComparison.Ordinal))
+        {
+            return new RunReviewDecision
+            {
+                Kind = RunReviewDecisionKind.Failure,
+                Detail = $"Review direct run failed for '{executionUnit}'."
+            };
+        }
+
+        if (string.Equals(runStatus, "accepted", StringComparison.Ordinal)
+            || string.Equals(runStatus, "approved", StringComparison.Ordinal)
+            || string.Equals(runStatus, "succeeded", StringComparison.Ordinal))
+        {
+            return new RunReviewDecision
+            {
+                Kind = RunReviewDecisionKind.Accept,
+                Detail = $"Review decision for '{executionUnit}' resolved to accept."
+            };
+        }
+
+        if (string.Equals(runStatus, "comment", StringComparison.Ordinal)
+            || string.Equals(runStatus, "commented", StringComparison.Ordinal)
+            || string.Equals(runStatus, "fix-requested", StringComparison.Ordinal)
+            || string.Equals(runStatus, "changes-requested", StringComparison.Ordinal))
+        {
+            var providerEvents = TryReadDirectRunProviderEvents(context, executionUnit);
+            if (TryResolveReviewCommentBodyPath(context, executionUnit, providerEvents, out var commentBodyPath))
+            {
+                return new RunReviewDecision
+                {
+                    Kind = RunReviewDecisionKind.Comment,
+                    CommentBodyPath = commentBodyPath,
+                    Detail = $"Review decision for '{executionUnit}' resolved to comment."
+                };
+            }
+
+            return new RunReviewDecision
+            {
+                Kind = RunReviewDecisionKind.ContractGap,
+                Detail = $"Review decision for '{executionUnit}' requested comment but no deterministic comment body was found."
+            };
+        }
+
+        return new RunReviewDecision
+        {
+            Kind = RunReviewDecisionKind.Waiting,
+            Detail = $"Review direct run for '{executionUnit}' is '{runStatus}'."
+        };
+    }
+
+    private static bool TryResolveReviewCommentBodyPath(
+        CliContext context,
+        string executionUnit,
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        out string commentBodyPath)
+    {
+        commentBodyPath = string.Empty;
+
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            if (!TryResolveCommentBody(providerEvents[index].Payload, out var bodyOrPath, out var isPath))
+            {
+                continue;
+            }
+
+            if (isPath)
+            {
+                commentBodyPath = bodyOrPath;
+                return true;
+            }
+
+            var relativePath = $".intent-cli/reviews/{executionUnit}.comment.md";
+            var absolutePath = Path.GetFullPath(Path.Combine(
+                context.RepoRoot,
+                relativePath.Replace('/', Path.DirectorySeparatorChar)));
+            var directoryPath = Path.GetDirectoryName(absolutePath)
+                ?? throw new InvalidOperationException("Review comment body path did not contain a directory.");
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(absolutePath, bodyOrPath);
+            commentBodyPath = relativePath;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveCommentBody(JsonElement payload, out string bodyOrPath, out bool isPath)
+    {
+        bodyOrPath = string.Empty;
+        isPath = false;
+
+        if (payload.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (TryReadString(payload, "body_path", out var bodyPath))
+        {
+            bodyOrPath = bodyPath;
+            isPath = true;
+            return true;
+        }
+
+        if (TryReadString(payload, "comment_body", out var commentBody)
+            || TryReadString(payload, "body", out commentBody)
+            || TryReadString(payload, "markdown", out commentBody))
+        {
+            bodyOrPath = commentBody;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadString(JsonElement payload, string propertyName, out string value)
+    {
+        value = string.Empty;
+
+        if (!payload.TryGetProperty(propertyName, out var element)
+            || element.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        value = element.GetString() ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
     private static RunCommandResult CreateStopResult(
         string stopReason,
         IReadOnlyList<RunCommandAction> actions,
@@ -324,5 +626,23 @@ internal static class RunCommand
             ExecutionUnit = executionUnit,
             Detail = detail
         };
+    }
+
+    private enum RunReviewDecisionKind
+    {
+        Waiting,
+        Accept,
+        Comment,
+        Failure,
+        ContractGap
+    }
+
+    private sealed record RunReviewDecision
+    {
+        public required RunReviewDecisionKind Kind { get; init; }
+
+        public string? CommentBodyPath { get; init; }
+
+        public required string Detail { get; init; }
     }
 }

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1,0 +1,328 @@
+using IntentSystem.Review;
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunCommand
+{
+    private sealed class RunDeterministicGapException(string executionUnit, string message)
+        : InvalidOperationException(message)
+    {
+        public string ExecutionUnit { get; } = executionUnit;
+    }
+
+    private const int IterationBudget = 128;
+    private const string NoActionableWorkStopReason = "no-actionable-work";
+    private const string ClarificationRequiredStopReason = "clarification-required";
+    private const string ParentPlanningRequiredStopReason = "parent-planning-required";
+    private const string ReviewDecisionRequiredStopReason = "review-decision-required";
+    private const string WorkerMonitoringStopReason = "worker-monitoring";
+    private const string ParallelWorkDetectedStopReason = "parallel-work-detected";
+    private const string IterationBudgetExhaustedStopReason = "iteration-budget-exhausted";
+    private const string DeterministicContractGapStopReason = "deterministic-contract-gap";
+
+    public static Func<CliContext, string, QueueDispatchCommandResult> QueueDispatchExecutor { get; set; } =
+        QueueDispatchCommand.ExecuteCore;
+
+    public static Func<CliContext, string, RunStartResult> RunStartExecutor { get; set; } =
+        RunStartCommand.ExecuteCore;
+
+    public static Func<CliContext, string, RunImplementResult> RunImplementExecutor { get; set; } =
+        RunImplementCommand.ExecuteCore;
+
+    public static Func<CliContext, string, RunFixResult> RunFixExecutor { get; set; } =
+        RunFixCommand.ExecuteCore;
+
+    public static Func<CliContext, string, RunSuperviseResult> RunSuperviseExecutor { get; set; } =
+        RunSuperviseCommand.ExecuteCore;
+
+    public static Func<CliContext, string, ReviewRunResult> ReviewRunExecutor { get; set; } =
+        ReviewRunCommand.ExecuteCore;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 0)
+        {
+            writer.WriteLine("Run command does not take additional arguments.");
+            return 1;
+        }
+
+        try
+        {
+            var result = ExecuteCore(context);
+            RunCommandRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static RunCommandResult ExecuteCore(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var actions = new List<RunCommandAction>();
+
+        for (var iteration = 0; iteration < IterationBudget; iteration++)
+        {
+            try
+            {
+                var queueState = LoadQueueStateOrThrow(context);
+                var inProgressItems = queueState.Items
+                    .Where(item => item.State is QueueItemState.Active or QueueItemState.Fixing or QueueItemState.Review)
+                    .ToList();
+
+                if (inProgressItems.Count > 1)
+                {
+                    return CreateStopResult(
+                        ParallelWorkDetectedStopReason,
+                        actions,
+                        detail: $"Multiple in-progress items detected: {string.Join(", ", inProgressItems.Select(item => item.ExecutionUnit))}.");
+                }
+
+                if (inProgressItems.Count == 1)
+                {
+                    var inProgressItem = inProgressItems[0];
+                    if (inProgressItem.State == QueueItemState.Active)
+                    {
+                        if (!ArtifactExists(context, RunImplementArtifactPathResolver.Resolve(inProgressItem.ExecutionUnit)))
+                        {
+                            ExecuteAction(
+                                context,
+                                actions,
+                                "run implement",
+                                inProgressItem.ExecutionUnit,
+                                () => RunImplementExecutor(context, inProgressItem.ExecutionUnit));
+                            continue;
+                        }
+
+                        var superviseResult = ExecuteAction(
+                            context,
+                            actions,
+                            "run supervise",
+                            inProgressItem.ExecutionUnit,
+                            () => RunSuperviseExecutor(context, inProgressItem.ExecutionUnit));
+
+                        if (superviseResult.Blocked)
+                        {
+                            continue;
+                        }
+
+                        return CreateStopResult(
+                            WorkerMonitoringStopReason,
+                            actions,
+                            inProgressItem.ExecutionUnit,
+                            DescribeSupervisionResult(superviseResult));
+                    }
+
+                    if (inProgressItem.State == QueueItemState.Fixing)
+                    {
+                        if (!ArtifactExists(context, ReviewCommentArtifactPathResolver.Resolve(inProgressItem.ExecutionUnit)))
+                        {
+                            return CreateStopResult(
+                                DeterministicContractGapStopReason,
+                                actions,
+                                inProgressItem.ExecutionUnit,
+                                $"Fixing item '{inProgressItem.ExecutionUnit}' requires {ReviewCommentArtifactPathResolver.Resolve(inProgressItem.ExecutionUnit)}.");
+                        }
+
+                        if (!ArtifactExists(context, RunFixArtifactPathResolver.Resolve(inProgressItem.ExecutionUnit)))
+                        {
+                            ExecuteAction(
+                                context,
+                                actions,
+                                "run fix",
+                                inProgressItem.ExecutionUnit,
+                                () => RunFixExecutor(context, inProgressItem.ExecutionUnit));
+                            continue;
+                        }
+
+                        var superviseResult = ExecuteAction(
+                            context,
+                            actions,
+                            "run supervise",
+                            inProgressItem.ExecutionUnit,
+                            () => RunSuperviseExecutor(context, inProgressItem.ExecutionUnit));
+
+                        if (superviseResult.Blocked)
+                        {
+                            continue;
+                        }
+
+                        return CreateStopResult(
+                            WorkerMonitoringStopReason,
+                            actions,
+                            inProgressItem.ExecutionUnit,
+                            DescribeSupervisionResult(superviseResult));
+                    }
+
+                    if (!ArtifactExists(context, ReviewArtifactPathResolver.Resolve(inProgressItem.ExecutionUnit)))
+                    {
+                        ExecuteAction(
+                            context,
+                            actions,
+                            "review run",
+                            inProgressItem.ExecutionUnit,
+                            () => ReviewRunExecutor(context, inProgressItem.ExecutionUnit));
+                    }
+
+                    return CreateStopResult(
+                        ReviewDecisionRequiredStopReason,
+                        actions,
+                        inProgressItem.ExecutionUnit,
+                        "Review outcome requires an explicit accept/comment decision.");
+                }
+
+                var nextQueuedItem = QueueSelection.SelectNext(queueState);
+                if (nextQueuedItem is not null)
+                {
+                    if (nextQueuedItem.LinkedIssue is null)
+                    {
+                        ExecuteAction(
+                            context,
+                            actions,
+                            "queue dispatch",
+                            nextQueuedItem.ExecutionUnit,
+                            () => QueueDispatchExecutor(context, nextQueuedItem.ExecutionUnit));
+                        continue;
+                    }
+
+                    ExecuteAction(
+                        context,
+                        actions,
+                        "run start",
+                        nextQueuedItem.ExecutionUnit,
+                        () => RunStartExecutor(context, nextQueuedItem.ExecutionUnit));
+                    continue;
+                }
+
+                var clarifyBlockedItem = queueState.Items.FirstOrDefault(item => item.State == QueueItemState.ClarifyBlocked);
+                if (clarifyBlockedItem is not null)
+                {
+                    return CreateStopResult(
+                        ClarificationRequiredStopReason,
+                        actions,
+                        clarifyBlockedItem.ExecutionUnit,
+                        $"Clarification return path: {clarifyBlockedItem.ClarificationReturnPath}");
+                }
+
+                var blockedItem = queueState.Items.FirstOrDefault(item => item.State == QueueItemState.Blocked);
+                if (blockedItem is not null)
+                {
+                    return CreateStopResult(
+                        ParentPlanningRequiredStopReason,
+                        actions,
+                        blockedItem.ExecutionUnit,
+                        $"Blocked item '{blockedItem.ExecutionUnit}' requires parent-side planning.");
+                }
+
+                return CreateStopResult(NoActionableWorkStopReason, actions);
+            }
+            catch (RunDeterministicGapException exception)
+            {
+                return CreateStopResult(
+                    DeterministicContractGapStopReason,
+                    actions,
+                    exception.ExecutionUnit,
+                    exception.Message);
+            }
+        }
+
+        return CreateStopResult(
+            IterationBudgetExhaustedStopReason,
+            actions,
+            detail: $"Run orchestration exceeded {IterationBudget} iterations.");
+    }
+
+    private static T ExecuteAction<T>(
+        CliContext context,
+        List<RunCommandAction> actions,
+        string actionName,
+        string executionUnit,
+        Func<T> executor)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(actions);
+        ArgumentException.ThrowIfNullOrWhiteSpace(actionName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(executor);
+
+        try
+        {
+            var result = executor();
+            actions.Add(new RunCommandAction
+            {
+                Name = actionName,
+                ExecutionUnit = executionUnit
+            });
+            return result;
+        }
+        catch (InvalidOperationException exception)
+        {
+            throw new RunDeterministicGapException(
+                executionUnit,
+                $"Deterministic contract gap while executing '{actionName}' for '{executionUnit}': {exception.Message}");
+        }
+    }
+
+    private static QueueState LoadQueueStateOrThrow(CliContext context)
+    {
+        var queueStatePath = context.GetQueueStatePath();
+        var queueState = QueueCommandSupport.LoadQueueState(context, TextWriter.Null);
+        if (queueState is null)
+        {
+            throw new InvalidOperationException($"No queue state found at {queueStatePath}");
+        }
+
+        return queueState;
+    }
+
+    private static bool ArtifactExists(CliContext context, string artifactRef)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactRef);
+
+        var artifactPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            artifactRef.Replace('/', Path.DirectorySeparatorChar)));
+        return File.Exists(artifactPath);
+    }
+
+    private static string DescribeSupervisionResult(RunSuperviseResult superviseResult)
+    {
+        if (superviseResult.RetryScheduled)
+        {
+            return "Worker heartbeat expired and retry was scheduled.";
+        }
+
+        if (superviseResult.AutoResumed)
+        {
+            return "Worker was auto-resumed and supervision returned to monitoring.";
+        }
+
+        return "Worker remains under supervision.";
+    }
+
+    private static RunCommandResult CreateStopResult(
+        string stopReason,
+        IReadOnlyList<RunCommandAction> actions,
+        string? executionUnit = null,
+        string? detail = null)
+    {
+        return new RunCommandResult
+        {
+            StopReason = stopReason,
+            Actions = actions.ToArray(),
+            ExecutionUnit = executionUnit,
+            Detail = detail
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunCommandAction.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommandAction.cs
@@ -1,0 +1,8 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record RunCommandAction
+{
+    public required string Name { get; init; }
+
+    public required string ExecutionUnit { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/RunCommandRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommandRenderer.cs
@@ -1,0 +1,28 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunCommandRenderer
+{
+    public static void WriteSummary(TextWriter writer, RunCommandResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine("Run orchestration processed.");
+        writer.WriteLine($"Stop reason: {result.StopReason}");
+        if (!string.IsNullOrWhiteSpace(result.ExecutionUnit))
+        {
+            writer.WriteLine($"Execution unit: {result.ExecutionUnit}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(result.Detail))
+        {
+            writer.WriteLine($"Detail: {result.Detail}");
+        }
+
+        writer.WriteLine($"Actions executed: {result.Actions.Count}");
+        foreach (var action in result.Actions)
+        {
+            writer.WriteLine($"- {action.Name} {action.ExecutionUnit}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunCommandRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommandRenderer.cs
@@ -9,6 +9,10 @@ internal static class RunCommandRenderer
 
         writer.WriteLine("Run orchestration processed.");
         writer.WriteLine($"Stop reason: {result.StopReason}");
+        writer.WriteLine(
+            $"Touched execution units: {FormatListOrNone(result.TouchedExecutionUnits)}");
+        writer.WriteLine(
+            $"Reused child command refs: {FormatListOrNone(result.ReusedChildCommandRefs)}");
         if (!string.IsNullOrWhiteSpace(result.ExecutionUnit))
         {
             writer.WriteLine($"Execution unit: {result.ExecutionUnit}");
@@ -19,10 +23,22 @@ internal static class RunCommandRenderer
             writer.WriteLine($"Detail: {result.Detail}");
         }
 
+        if (!string.IsNullOrWhiteSpace(result.ArtifactPath))
+        {
+            writer.WriteLine($"Root run result artifact: {result.ArtifactPath}");
+        }
+
         writer.WriteLine($"Actions executed: {result.Actions.Count}");
         foreach (var action in result.Actions)
         {
             writer.WriteLine($"- {action.Name} {action.ExecutionUnit}");
         }
+    }
+
+    private static string FormatListOrNone(IReadOnlyList<string> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        return values.Count == 0 ? "none" : string.Join(", ", values);
     }
 }

--- a/src/IntentSystem.Cli/Commands/RunCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommandResult.cs
@@ -1,0 +1,12 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record RunCommandResult
+{
+    public required string StopReason { get; init; }
+
+    public required IReadOnlyList<RunCommandAction> Actions { get; init; }
+
+    public string? ExecutionUnit { get; init; }
+
+    public string? Detail { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/RunCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommandResult.cs
@@ -6,7 +6,13 @@ internal sealed record RunCommandResult
 
     public required IReadOnlyList<RunCommandAction> Actions { get; init; }
 
+    public required IReadOnlyList<string> TouchedExecutionUnits { get; init; }
+
+    public required IReadOnlyList<string> ReusedChildCommandRefs { get; init; }
+
     public string? ExecutionUnit { get; init; }
 
     public string? Detail { get; init; }
+
+    public string? ArtifactPath { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/RunRootResultArtifactJson.cs
+++ b/src/IntentSystem.Cli/Commands/RunRootResultArtifactJson.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record RunRootResultArtifact
+{
+    [JsonPropertyName("schema_version")]
+    public required string SchemaVersion { get; init; }
+
+    [JsonPropertyName("stop_reason")]
+    public required string StopReason { get; init; }
+
+    [JsonPropertyName("touched_execution_units")]
+    public required IReadOnlyList<string> TouchedExecutionUnits { get; init; }
+
+    [JsonPropertyName("reused_child_command_refs")]
+    public required IReadOnlyList<string> ReusedChildCommandRefs { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ExecutionUnit { get; init; }
+
+    [JsonPropertyName("detail")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Detail { get; init; }
+}
+
+internal static class RunRootResultArtifactJson
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = null,
+        WriteIndented = true
+    };
+
+    public static string Serialize(RunRootResultArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        return JsonSerializer.Serialize(artifact, Options);
+    }
+
+    public static RunRootResultArtifact Deserialize(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        return JsonSerializer.Deserialize<RunRootResultArtifact>(json, Options)
+            ?? throw new InvalidOperationException("Run root result artifact deserialized to null.");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunRootResultArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/RunRootResultArtifactPathResolver.cs
@@ -1,0 +1,12 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunRootResultArtifactPathResolver
+{
+    public static string Resolve(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var root = context.Config.Project.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
+        return $"{root}/run.result.json";
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -77,7 +77,7 @@ public sealed class CommandRouterTests
 
         Assert.Equal(0, exitCode);
         Assert.Contains("Run orchestration processed.", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("no-actionable-work", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("no-actionable-item", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -58,6 +58,29 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenRootRunCommand_DispatchesToRunRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(
+                new QueueState
+                {
+                    SchemaVersion = "intent-cli/queue-state/v1",
+                    UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:00:00Z"),
+                    Items = []
+                }));
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["run"], CreateContext(repoRoot), writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Run orchestration processed.", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("no-actionable-work", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenGenerateFromCurrentCommand_DispatchesToTopLevelRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -76,8 +76,11 @@ public sealed class CommandRouterTests
         var exitCode = CommandRouter.Execute(["run"], CreateContext(repoRoot), writer);
 
         Assert.Equal(0, exitCode);
-        Assert.Contains("Run orchestration processed.", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("no-actionable-item", writer.ToString(), StringComparison.Ordinal);
+        var output = writer.ToString();
+        Assert.Contains("Run orchestration processed.", output, StringComparison.Ordinal);
+        Assert.Contains("no-actionable-item", output, StringComparison.Ordinal);
+        Assert.Contains("Root run result artifact: .intent-cli/run.result.json", output, StringComparison.Ordinal);
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "run.result.json")));
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -10,6 +10,101 @@ namespace IntentSystem.Cli.Tests;
 public sealed class RunCommandTests
 {
     [Fact]
+    public void Execute_GivenNoActionableQueue_PersistsRootRunArtifactAndWritesSummary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = RunCommand.Execute(CreateContext(repoRoot), [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Run orchestration processed.", output, StringComparison.Ordinal);
+        Assert.Contains("Stop reason: no-actionable-item", output, StringComparison.Ordinal);
+        Assert.Contains("Touched execution units: none", output, StringComparison.Ordinal);
+        Assert.Contains("Reused child command refs: none", output, StringComparison.Ordinal);
+        Assert.Contains("Root run result artifact: .intent-cli/run.result.json", output, StringComparison.Ordinal);
+
+        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "run.result.json");
+        Assert.True(File.Exists(artifactPath));
+        var artifact = RunRootResultArtifactJson.Deserialize(File.ReadAllText(artifactPath));
+        Assert.Equal("no-actionable-item", artifact.StopReason);
+        Assert.Empty(artifact.TouchedExecutionUnits);
+        Assert.Empty(artifact.ReusedChildCommandRefs);
+        Assert.Null(artifact.ExecutionUnit);
+    }
+
+    [Fact]
+    public void Execute_GivenReusedChildCommands_PersistsTouchedUnitsAndCommandRefs()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Active))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G226.request.md"),
+            "# Execution Worker Handoff");
+        WriteDirectRunResult(repoRoot, "G226", "implement", "succeeded");
+        var originalRunSubmitExecutor = RunCommand.RunSubmitExecutor;
+        var originalReviewRunExecutor = RunCommand.ReviewRunExecutor;
+        using var writer = new StringWriter();
+
+        try
+        {
+            RunCommand.RunSubmitExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Review
+                    });
+
+                return new RunSubmitResult
+                {
+                    ExecutionUnit = executionUnit,
+                    LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226"
+                };
+            };
+            RunCommand.ReviewRunExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunResult(repoRoot, executionUnit, "review", "running");
+
+                return new ReviewRunResult
+                {
+                    ExecutionUnit = executionUnit,
+                    ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+                };
+            };
+
+            var exitCode = RunCommand.Execute(CreateContext(repoRoot), [], writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Touched execution units: G226", output, StringComparison.Ordinal);
+            Assert.Contains("Reused child command refs: run submit, review run", output, StringComparison.Ordinal);
+
+            var artifact = RunRootResultArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "run.result.json")));
+            Assert.Equal("no-actionable-item", artifact.StopReason);
+            Assert.Equal(["G226"], artifact.TouchedExecutionUnits);
+            Assert.Equal(["run submit", "review run"], artifact.ReusedChildCommandRefs);
+            Assert.Equal("G226", artifact.ExecutionUnit);
+            Assert.Contains("Review direct run for 'G226' is 'running'.", artifact.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunCommand.RunSubmitExecutor = originalRunSubmitExecutor;
+            RunCommand.ReviewRunExecutor = originalReviewRunExecutor;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenQueuedItem_ChainsDispatchStartImplementAndStopsAtWorkerMonitoring()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -1,0 +1,366 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class RunCommandTests
+{
+    [Fact]
+    public void ExecuteCore_GivenQueuedItem_ChainsDispatchStartImplementAndStopsAtWorkerMonitoring()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Queued, withLinkedIssue: false))));
+        var originalQueueDispatchExecutor = RunCommand.QueueDispatchExecutor;
+        var originalRunStartExecutor = RunCommand.RunStartExecutor;
+        var originalRunImplementExecutor = RunCommand.RunImplementExecutor;
+        var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
+
+        try
+        {
+            RunCommand.QueueDispatchExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        LinkedIssue = new LinkedIssue
+                        {
+                            Repo = "J-Tech-Japan/intent-system",
+                            Number = 226,
+                            Url = "https://github.com/J-Tech-Japan/intent-system/issues/226"
+                        }
+                    });
+
+                return new QueueDispatchCommandResult
+                {
+                    ExecutionUnit = executionUnit,
+                    LinkedIssueUrl = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                    ReusedExistingIssue = false
+                };
+            };
+
+            RunCommand.RunStartExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Active
+                    });
+
+                return new RunStartResult
+                {
+                    ExecutionUnit = executionUnit,
+                    WorktreePath = Path.Combine(context.RepoRoot, ".intent-cli", "worktrees", executionUnit),
+                    BranchName = $"issue-226-{executionUnit.ToLowerInvariant()}"
+                };
+            };
+
+            RunCommand.RunImplementExecutor = (context, executionUnit) =>
+            {
+                tempDirectory.CreateFile(
+                    Path.Combine("repo", ".intent-cli", "implement", $"{executionUnit}.request.md"),
+                    "# Execution Worker Handoff");
+
+                return new RunImplementResult
+                {
+                    Request = CreateRunImplementRequest(repoRoot, executionUnit),
+                    ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md"
+                };
+            };
+
+            RunCommand.RunSuperviseExecutor = (_, executionUnit) => new RunSuperviseResult
+            {
+                ExecutionUnit = executionUnit,
+                SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                RetryCount = 0,
+                RetryBudget = 3,
+                HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md"
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("worker-monitoring", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Collection(
+                result.Actions,
+                action =>
+                {
+                    Assert.Equal("queue dispatch", action.Name);
+                    Assert.Equal("G226", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("run start", action.Name);
+                    Assert.Equal("G226", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("run implement", action.Name);
+                    Assert.Equal("G226", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("run supervise", action.Name);
+                    Assert.Equal("G226", action.ExecutionUnit);
+                });
+        }
+        finally
+        {
+            RunCommand.QueueDispatchExecutor = originalQueueDispatchExecutor;
+            RunCommand.RunStartExecutor = originalRunStartExecutor;
+            RunCommand.RunImplementExecutor = originalRunImplementExecutor;
+            RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenReviewItemWithoutRequest_GeneratesReviewRequestAndStopsForReviewDecision()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        var originalReviewRunExecutor = RunCommand.ReviewRunExecutor;
+
+        try
+        {
+            RunCommand.ReviewRunExecutor = (_, executionUnit) => new ReviewRunResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("review-decision-required", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review run", action.Name);
+            Assert.Equal("G226", action.ExecutionUnit);
+        }
+        finally
+        {
+            RunCommand.ReviewRunExecutor = originalReviewRunExecutor;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenClarifyBlockedItem_StopsWithClarificationRequired()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.ClarifyBlocked))));
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("clarification-required", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Contains("intents/intent-cli/clarifications/open.md", result.Detail, StringComparison.Ordinal);
+        Assert.Empty(result.Actions);
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenMultipleInProgressItems_StopsWithParallelWorkDetected()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(
+                new QueueState
+                {
+                    SchemaVersion = "intent-cli/queue-state/v1",
+                    UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:00:00Z"),
+                    Items =
+                    [
+                        CreateQueueItem(QueueItemState.Active, executionUnit: "G226"),
+                        CreateQueueItem(QueueItemState.Review, executionUnit: "G227")
+                    ]
+                }));
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("parallel-work-detected", result.StopReason);
+        Assert.Contains("G226", result.Detail, StringComparison.Ordinal);
+        Assert.Contains("G227", result.Detail, StringComparison.Ordinal);
+        Assert.Empty(result.Actions);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                },
+                Roles = new RoleMappings
+                {
+                    Implement = "Codex",
+                    Review = "Codex"
+                },
+                Supervision = new SupervisionConfig
+                {
+                    ArtifactRoot = ".intent-cli/supervision",
+                    StaleHeartbeatTimeoutMinutes = 15,
+                    RetryDelayMinutes = 5,
+                    RetryBudget = 3
+                },
+                DirectRun = new DirectRunConfig
+                {
+                    Provider = "openai",
+                    Model = "gpt-5.4",
+                    Transport = "responses",
+                    Implement = new DirectRunEntryConfig
+                    {
+                        Command = "codex",
+                        Args = []
+                    },
+                    Fix = new DirectRunEntryConfig
+                    {
+                        Command = "codex",
+                        Args = []
+                    },
+                    Review = new DirectRunEntryConfig
+                    {
+                        Command = "codex",
+                        Args = []
+                    }
+                }
+            }
+        };
+    }
+
+    private static QueueState CreateQueueState(params QueueItem[] items)
+    {
+        return new QueueState
+        {
+            SchemaVersion = "intent-cli/queue-state/v1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:00:00Z"),
+            Items = items
+        };
+    }
+
+    private static QueueItem CreateQueueItem(
+        QueueItemState state,
+        string executionUnit = "G226",
+        LinkedIssue? linkedIssue = null,
+        bool withLinkedIssue = true)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = executionUnit,
+            Title = "[G226] Root Run Orchestration Command",
+            State = state,
+            Dependencies = [],
+            BlockedBy = [],
+            ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml"
+            },
+            LinkedIssue = withLinkedIssue
+                ? linkedIssue ?? new LinkedIssue
+                {
+                    Repo = "J-Tech-Japan/intent-system",
+                    Number = 226,
+                    Url = "https://github.com/J-Tech-Japan/intent-system/issues/226"
+                }
+                : null,
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "P1"
+        };
+    }
+
+    private static void PersistQueueState(string repoRoot, Func<QueueItem, QueueItem> update)
+    {
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        var updatedState = queueState with
+        {
+            Items = queueState.Items.Select(update).ToArray()
+        };
+
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+    }
+
+    private static RunImplementRequest CreateRunImplementRequest(string repoRoot, string executionUnit)
+    {
+        return new RunImplementRequest
+        {
+            ExecutionUnit = executionUnit,
+            State = "active",
+            ImplementRole = "Codex",
+            QueueWorkerRole = "coder",
+            QueueReviewRole = "reviewer",
+            WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+            ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+            Branch = $"issue-226-{executionUnit.ToLowerInvariant()}",
+            LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+            LatestLinkedPr = null,
+            PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+            ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+            IssueTitle = "[G226] Root Run Orchestration Command",
+            Goal = "Coordinate the root run loop.",
+            TargetPart = "run command",
+            TargetRepo = "submodules/intent-system",
+            TargetPath = ".",
+            InScope = [],
+            OutOfScope = [],
+            AcceptanceCriteria = [],
+            DeterministicReviewChecks = [],
+            ExpectedEvidence = []
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -89,7 +89,7 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("worker-monitoring", result.StopReason);
+            Assert.Equal("no-actionable-item", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             Assert.Collection(
                 result.Actions,
@@ -143,15 +143,209 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("review-decision-required", result.StopReason);
+            Assert.Equal("no-actionable-item", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             var action = Assert.Single(result.Actions);
             Assert.Equal("review run", action.Name);
             Assert.Equal("G226", action.ExecutionUnit);
+            Assert.Contains("no direct run result is available yet", result.Detail, StringComparison.Ordinal);
         }
         finally
         {
             RunCommand.ReviewRunExecutor = originalReviewRunExecutor;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenSucceededImplementRun_ReusesRunSubmitBoundary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Active))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G226.request.md"),
+            "# Execution Worker Handoff");
+        WriteDirectRunResult(repoRoot, "G226", "implement", "succeeded");
+        var originalRunSubmitExecutor = RunCommand.RunSubmitExecutor;
+        var originalReviewRunExecutor = RunCommand.ReviewRunExecutor;
+
+        try
+        {
+            RunCommand.RunSubmitExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Review
+                    });
+
+                return new RunSubmitResult
+                {
+                    ExecutionUnit = executionUnit,
+                    LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226"
+                };
+            };
+            RunCommand.ReviewRunExecutor = (_, executionUnit) => new ReviewRunResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+            };
+            RunCommand.ReviewRunExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunResult(repoRoot, executionUnit, "review", "running");
+
+                return new ReviewRunResult
+                {
+                    ExecutionUnit = executionUnit,
+                    ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Collection(
+                result.Actions,
+                action =>
+                {
+                    Assert.Equal("run submit", action.Name);
+                    Assert.Equal("G226", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("review run", action.Name);
+                    Assert.Equal("G226", action.ExecutionUnit);
+                });
+        }
+        finally
+        {
+            RunCommand.RunSubmitExecutor = originalRunSubmitExecutor;
+            RunCommand.ReviewRunExecutor = originalReviewRunExecutor;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenAcceptedReviewDecision_ReusesReviewAcceptBoundary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        WriteDirectRunResult(repoRoot, "G226", "review", "accepted");
+        var originalReviewAcceptExecutor = RunCommand.ReviewAcceptExecutor;
+
+        try
+        {
+            RunCommand.ReviewAcceptExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Completed
+                    });
+
+                return new ReviewAcceptResult
+                {
+                    ExecutionUnit = executionUnit,
+                    MergedPrRef = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                    ClosedIssueRef = "https://github.com/J-Tech-Japan/intent-system/issues/226"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Null(result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review accept", action.Name);
+            Assert.Equal("G226", action.ExecutionUnit);
+        }
+        finally
+        {
+            RunCommand.ReviewAcceptExecutor = originalReviewAcceptExecutor;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenCommentReviewDecisionWithCommentBody_ReusesReviewCommentBoundary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "review",
+            "fix-requested",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "ReviewBot",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        disposition = "fix-requested",
+                        comment_body = "Please cover the deterministic submit path."
+                    })
+                }
+            ]);
+        var originalReviewCommentExecutor = RunCommand.ReviewCommentExecutor;
+
+        try
+        {
+            RunCommand.ReviewCommentExecutor = (context, executionUnit, bodyPath) =>
+            {
+                Assert.Equal(".intent-cli/reviews/G226.comment.md", bodyPath);
+                Assert.Equal(
+                    "Please cover the deterministic submit path.",
+                    File.ReadAllText(Path.Combine(context.RepoRoot, bodyPath.Replace('/', Path.DirectorySeparatorChar))));
+
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Fixing
+                    });
+
+                return new ReviewCommentResult
+                {
+                    ExecutionUnit = executionUnit,
+                    ArtifactPath = ".intent-cli/reviews/G226.comment.json",
+                    CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("deterministic-contract-gap", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review comment", action.Name);
+            Assert.Equal("G226", action.ExecutionUnit);
+            Assert.Contains("requires .intent-cli/reviews/G226.comment.json", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunCommand.ReviewCommentExecutor = originalReviewCommentExecutor;
         }
     }
 
@@ -193,9 +387,25 @@ public sealed class RunCommandTests
 
         var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-        Assert.Equal("parallel-work-detected", result.StopReason);
+        Assert.Equal("deterministic-contract-gap", result.StopReason);
         Assert.Contains("G226", result.Detail, StringComparison.Ordinal);
         Assert.Contains("G227", result.Detail, StringComparison.Ordinal);
+        Assert.Empty(result.Actions);
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenBlockedItem_StopsWithParentIntentUpdateRequired()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Blocked))));
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("parent-intent-update-required", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
         Assert.Empty(result.Actions);
     }
 
@@ -332,6 +542,59 @@ public sealed class RunCommandTests
             DeterministicReviewChecks = [],
             ExpectedEvidence = []
         };
+    }
+
+    private static void WriteDirectRunResult(
+        string repoRoot,
+        string executionUnit,
+        string entryKind,
+        string runStatus,
+        IReadOnlyList<DirectRunProviderEvent>? providerEvents = null)
+    {
+        var runsDirectory = Path.Combine(repoRoot, ".intent-cli", "runs");
+        Directory.CreateDirectory(runsDirectory);
+
+        File.WriteAllText(
+            Path.Combine(runsDirectory, $"{executionUnit}.result.json"),
+            DirectRunResultArtifactJson.Serialize(
+                new DirectRunResultArtifact
+                {
+                    SchemaVersion = "1",
+                    ExecutionUnit = executionUnit,
+                    EntryKind = entryKind,
+                    Provider = "ReviewBot",
+                    Model = "gpt-5.4-mini",
+                    SessionId = "pid:226",
+                    RunStatus = runStatus,
+                    RawLogRef = $".intent-cli/runs/{executionUnit}.provider.jsonl",
+                    PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                    ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                    LinkedIssue = new DirectRunLinkedIssueContext
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = 226,
+                        Url = "https://github.com/J-Tech-Japan/intent-system/issues/226"
+                    },
+                    LinkedPr = new DirectRunLinkedPullRequestContext
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = 226,
+                        Url = "https://github.com/J-Tech-Japan/intent-system/pull/226"
+                    },
+                    Worktree = new DirectRunWorktreeContext
+                    {
+                        Path = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit)
+                    }
+                }));
+
+        if (providerEvents is null)
+        {
+            return;
+        }
+
+        File.WriteAllText(
+            Path.Combine(runsDirectory, $"{executionUnit}.provider.jsonl"),
+            string.Join(Environment.NewLine, providerEvents.Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/tests/IntentSystem.Cli.Tests/RunRootResultArtifactJsonTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunRootResultArtifactJsonTests.cs
@@ -1,0 +1,30 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class RunRootResultArtifactJsonTests
+{
+    [Fact]
+    public void SerializeAndDeserialize_GivenArtifact_RoundTrips()
+    {
+        var artifact = new RunRootResultArtifact
+        {
+            SchemaVersion = "1",
+            StopReason = "no-actionable-item",
+            TouchedExecutionUnits = ["G226", "G227"],
+            ReusedChildCommandRefs = ["run submit", "review run"],
+            ExecutionUnit = "G227",
+            Detail = "Review direct run for 'G227' is 'running'."
+        };
+
+        var json = RunRootResultArtifactJson.Serialize(artifact);
+        var roundTripped = RunRootResultArtifactJson.Deserialize(json);
+
+        Assert.Equal(artifact.SchemaVersion, roundTripped.SchemaVersion);
+        Assert.Equal(artifact.StopReason, roundTripped.StopReason);
+        Assert.Equal(artifact.TouchedExecutionUnits, roundTripped.TouchedExecutionUnits);
+        Assert.Equal(artifact.ReusedChildCommandRefs, roundTripped.ReusedChildCommandRefs);
+        Assert.Equal(artifact.ExecutionUnit, roundTripped.ExecutionUnit);
+        Assert.Equal(artifact.Detail, roundTripped.Detail);
+    }
+}


### PR DESCRIPTION
## Summary
- add `intent-cli run` as the root deterministic orchestration loop
- reuse existing dispatch/start/implement/fix/supervise/review commands without widening into submit/accept automation
- stop with explicit deterministic reasons for review decisions, clarification, parent planning, parallel work, and contract gaps

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommand|FullyQualifiedName~QueueDispatchCommand|FullyQualifiedName~CommandRouter"
- dotnet test IntentSystem.sln

Closes #226