### PR TITLE
Fix generated intake review context contract

### DIFF
--- a/src/IntentSystem.Projection/Rendering/ReviewContextMarkdownRenderer.cs
+++ b/src/IntentSystem.Projection/Rendering/ReviewContextMarkdownRenderer.cs
@@ -11,28 +11,28 @@ public static class ReviewContextMarkdownRenderer
 
         var sb = new StringBuilder();
 
-        AppendHeader(sb, packet);
-        AppendSection(sb, "Parent Intent Root", packet.ParentIntentRoot);
+        AppendExecutionUnitSection(sb, packet.SourceExecutionUnit);
+        AppendScalarSection(sb, "Parent Intent Root", packet.ParentIntentRoot);
         AppendListSection(sb, "Intent References", packet.IntentReferences);
         AppendListSection(sb, "Rules And Specs", packet.RulesAndSpecs);
         AppendListSection(sb, "Acceptance Criteria", packet.AcceptanceCriteria);
         AppendListSection(sb, "Deterministic Review Checks", packet.DeterministicReviewChecks);
-        AppendSection(sb, "Clarification Return Path", packet.ClarificationReturnPath);
+        AppendScalarSection(sb, "Clarification Return Path", packet.ClarificationReturnPath);
 
         return sb.ToString();
     }
 
-    private static void AppendHeader(StringBuilder sb, ReviewContextPacket packet)
+    private static void AppendExecutionUnitSection(StringBuilder sb, string executionUnit)
     {
-        sb.AppendLine("# Review Context");
+        sb.AppendLine("# Execution Unit");
         sb.AppendLine();
-        sb.AppendLine($"- **execution-unit**: `{packet.SourceExecutionUnit}`");
+        sb.AppendLine($"`{executionUnit}`");
         sb.AppendLine();
     }
 
-    private static void AppendSection(StringBuilder sb, string heading, string content)
+    private static void AppendScalarSection(StringBuilder sb, string heading, string content)
     {
-        sb.AppendLine($"## {heading}");
+        sb.AppendLine($"# {heading}");
         sb.AppendLine();
         sb.AppendLine(content);
         sb.AppendLine();
@@ -40,7 +40,7 @@ public static class ReviewContextMarkdownRenderer
 
     private static void AppendListSection(StringBuilder sb, string heading, IReadOnlyList<string> items)
     {
-        sb.AppendLine($"## {heading}");
+        sb.AppendLine($"# {heading}");
         sb.AppendLine();
 
         if (items.Count == 0)

--- a/tests/IntentSystem.Cli.Tests/IntakeIssueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeIssueCommandTests.cs
@@ -1,6 +1,7 @@
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
 using IntentSystem.Projection.Serialization;
+using IntentSystem.Review;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -45,6 +46,9 @@ public sealed class IntakeIssueCommandTests
 
         var reviewMarkdown = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "review-context.md"));
         Assert.Contains("intents/intent-cli/intent-tree/00-map.md", reviewMarkdown, StringComparison.Ordinal);
+        var parsedReviewContext = ReviewContextMarkdownParser.Parse(reviewMarkdown);
+        Assert.Equal("AUTH-01", parsedReviewContext.SourceExecutionUnit);
+        Assert.NotEmpty(parsedReviewContext.DeterministicReviewChecks);
 
         var packet = ProjectionPacketSerializer.Deserialize(
             File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "packet.yaml")));

--- a/tests/IntentSystem.Cli.Tests/ProjectionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ProjectionCommandTests.cs
@@ -27,7 +27,7 @@ public sealed class ProjectionCommandTests
             File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "G2", "implementation.md")),
             StringComparison.Ordinal);
         Assert.Contains(
-            "# Review Context",
+            "# Execution Unit",
             File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "G2", "review-context.md")),
             StringComparison.Ordinal);
         Assert.Contains(
@@ -128,7 +128,7 @@ public sealed class ProjectionCommandTests
             File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "G2", "implementation.md")),
             StringComparison.Ordinal);
         Assert.Contains(
-            "## Deterministic Review Checks",
+            "# Deterministic Review Checks",
             File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "G2", "review-context.md")),
             StringComparison.Ordinal);
         Assert.Contains(

--- a/tests/IntentSystem.Projection.Tests/PacketGeneratorTests.cs
+++ b/tests/IntentSystem.Projection.Tests/PacketGeneratorTests.cs
@@ -24,10 +24,10 @@ public sealed class PacketGeneratorTests
     {
         var result = PacketGenerator.Generate(CreateRow(), CreateContext());
 
-        Assert.Contains("# Review Context", result.ReviewContextMarkdown, StringComparison.Ordinal);
-        Assert.Contains("## Parent Intent Root", result.ReviewContextMarkdown, StringComparison.Ordinal);
-        Assert.Contains("## Acceptance Criteria", result.ReviewContextMarkdown, StringComparison.Ordinal);
-        Assert.Contains("## Deterministic Review Checks", result.ReviewContextMarkdown, StringComparison.Ordinal);
+        Assert.Contains("# Execution Unit", result.ReviewContextMarkdown, StringComparison.Ordinal);
+        Assert.Contains("# Parent Intent Root", result.ReviewContextMarkdown, StringComparison.Ordinal);
+        Assert.Contains("# Acceptance Criteria", result.ReviewContextMarkdown, StringComparison.Ordinal);
+        Assert.Contains("# Deterministic Review Checks", result.ReviewContextMarkdown, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Projection.Tests/ReviewContextMarkdownRendererTests.cs
+++ b/tests/IntentSystem.Projection.Tests/ReviewContextMarkdownRendererTests.cs
@@ -6,19 +6,19 @@ namespace IntentSystem.Projection.Tests;
 public sealed class ReviewContextMarkdownRendererTests
 {
     [Fact]
-    public void Render_GivenPacket_StartsWithReviewContextH1()
+    public void Render_GivenPacket_StartsWithExecutionUnitSection()
     {
         var markdown = ReviewContextMarkdownRenderer.Render(CreatePacket());
 
-        Assert.StartsWith("# Review Context", markdown, StringComparison.Ordinal);
+        Assert.StartsWith("# Execution Unit", markdown, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void Render_GivenPacket_IncludesExecutionUnitInHeader()
+    public void Render_GivenPacket_IncludesExecutionUnitSectionValue()
     {
         var markdown = ReviewContextMarkdownRenderer.Render(CreatePacket());
 
-        Assert.Contains("**execution-unit**: `A2`", markdown, StringComparison.Ordinal);
+        Assert.Contains("`A2`", markdown, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -26,12 +26,12 @@ public sealed class ReviewContextMarkdownRendererTests
     {
         var markdown = ReviewContextMarkdownRenderer.Render(CreatePacket());
 
-        Assert.Contains("## Parent Intent Root", markdown, StringComparison.Ordinal);
-        Assert.Contains("## Intent References", markdown, StringComparison.Ordinal);
-        Assert.Contains("## Rules And Specs", markdown, StringComparison.Ordinal);
-        Assert.Contains("## Acceptance Criteria", markdown, StringComparison.Ordinal);
-        Assert.Contains("## Deterministic Review Checks", markdown, StringComparison.Ordinal);
-        Assert.Contains("## Clarification Return Path", markdown, StringComparison.Ordinal);
+        Assert.Contains("# Parent Intent Root", markdown, StringComparison.Ordinal);
+        Assert.Contains("# Intent References", markdown, StringComparison.Ordinal);
+        Assert.Contains("# Rules And Specs", markdown, StringComparison.Ordinal);
+        Assert.Contains("# Acceptance Criteria", markdown, StringComparison.Ordinal);
+        Assert.Contains("# Deterministic Review Checks", markdown, StringComparison.Ordinal);
+        Assert.Contains("# Clarification Return Path", markdown, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -52,6 +52,16 @@ public sealed class ReviewContextMarkdownRendererTests
         var second = ReviewContextMarkdownRenderer.Render(packet);
 
         Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Render_GivenPacket_UsesParserCompatibleTopLevelSections()
+    {
+        var markdown = ReviewContextMarkdownRenderer.Render(CreatePacket());
+
+        Assert.Contains("# Execution Unit", markdown, StringComparison.Ordinal);
+        Assert.Contains("# Acceptance Criteria", markdown, StringComparison.Ordinal);
+        Assert.Contains("# Deterministic Review Checks", markdown, StringComparison.Ordinal);
     }
 
     private static ReviewContextPacket CreatePacket()


### PR DESCRIPTION
## Summary
- make generated review-context markdown use the parser-compatible top-level section shape expected by run implement
- keep the existing review-context payload, but render execution unit and review sections in the canonical heading format
- lock the repaired contract in projection and intake issue generation tests

## Validation
- dotnet test tests/IntentSystem.Projection.Tests/IntentSystem.Projection.Tests.csproj --filter "FullyQualifiedName~ReviewContextMarkdownRendererTests"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IntakeIssueCommandTests|FullyQualifiedName~RunImplementCommandTests"
- dotnet test IntentSystem.sln

Closes #229