### PR TITLE
Derive intake issue parent refs dynamically

### DIFF
--- a/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
@@ -8,17 +8,7 @@ internal static class IntakeIssueCommand
 {
     private const string IntakeIssueMarker = "`intake issue <domain>`";
     private const string IssueBaselineExecutionUnit = "G37";
-    private const string ParentIntentRoot = "intents/intent-cli/intent-tree/00-map.md";
-    private const string ClarificationReturnPath = "intents/intent-cli/clarifications/open.md";
-
-    private static readonly string[] RulesAndSpecs =
-    [
-        "intents/intent-cli/specs/04-concept-intake-and-interview.md",
-        "intents/intent-cli/specs/05-intent-cli-surface.md",
-        "intents/rules/feature-request-intake-and-autostart.md",
-        "intents/rules/issue-compilation-and-execution.md",
-        "intents/rules/issue-projection-format.md"
-    ];
+    private const string GenericClarificationReturnPath = "intents/rules/issue-template-and-review-context.md";
 
     private static readonly string[] TechnicalBaseline =
     [
@@ -154,7 +144,10 @@ internal static class IntakeIssueCommand
 
         foreach (var unit in units.OrderBy(item => item.ExecutionUnitId, StringComparer.Ordinal))
         {
-            var packet = PacketGenerator.Generate(CreateRow(unit, baseline), CreateContext(unit, baseline));
+            var parentRefs = ResolveParentRefs(repoRoot, unit, baseline);
+            var packet = PacketGenerator.Generate(
+                CreateRow(unit, baseline, parentRefs),
+                CreateContext(unit, baseline, parentRefs));
             var githubBodyPath = QueueDispatchCommand.ResolveGitHubBodyPath(repoRoot, packet.Paths.Yaml);
             var githubBodyRelativePath = Path.GetRelativePath(repoRoot, githubBodyPath).Replace(Path.DirectorySeparatorChar, '/');
 
@@ -319,7 +312,10 @@ internal static class IntakeIssueCommand
         };
     }
 
-    private static SubSliceRow CreateRow(IntakeOriginExecutionUnit unit, IntakeIssueBaseline baseline)
+    private static SubSliceRow CreateRow(
+        IntakeOriginExecutionUnit unit,
+        IntakeIssueBaseline baseline,
+        IntakeIssueParentRefs parentRefs)
     {
         return new SubSliceRow
         {
@@ -331,13 +327,12 @@ internal static class IntakeIssueCommand
             DependsOnSubslices = unit.Dependencies,
             RelatedIntents =
             [
-                ParentIntentRoot,
+                parentRefs.ParentIntentRoot,
                 baseline.ExecutionFilePath
             ],
             SourceConcepts =
             [
-                unit.SourceFilePath,
-                .. RulesAndSpecs
+                unit.SourceFilePath
             ],
             SuccessSignal = $"Updated intake-origin source `{unit.SourceFilePath}` is reflected within `{unit.TargetPart}`.",
             ReviewMode = "deterministic-review",
@@ -346,7 +341,10 @@ internal static class IntakeIssueCommand
         };
     }
 
-    private static ProjectionContext CreateContext(IntakeOriginExecutionUnit unit, IntakeIssueBaseline baseline)
+    private static ProjectionContext CreateContext(
+        IntakeOriginExecutionUnit unit,
+        IntakeIssueBaseline baseline,
+        IntakeIssueParentRefs parentRefs)
     {
         var title = ResolveTitle(unit);
 
@@ -354,8 +352,8 @@ internal static class IntakeIssueCommand
         {
             IssueTitle = $"[{unit.ExecutionUnitId}] {title}",
             IssueKind = IssueKind.Feature,
-            ParentIntentRoot = ParentIntentRoot,
-            ClarificationReturnPath = ClarificationReturnPath,
+            ParentIntentRoot = parentRefs.ParentIntentRoot,
+            ClarificationReturnPath = parentRefs.ClarificationReturnPath,
             AcceptanceCriteria =
             [
                 $"Updated intake-origin source `{unit.SourceFilePath}` is reflected within `{unit.TargetPart}`.",
@@ -399,6 +397,62 @@ internal static class IntakeIssueCommand
         return checks;
     }
 
+    private static IntakeIssueParentRefs ResolveParentRefs(
+        string repoRoot,
+        IntakeOriginExecutionUnit unit,
+        IntakeIssueBaseline baseline)
+    {
+        var namespaceRoot = ResolveIntentNamespaceRoot(unit.SourceFilePath)
+            ?? ResolveIntentNamespaceRoot(baseline.ExecutionFilePath)
+            ?? throw new InvalidOperationException(
+                $"Intake issue parent refs could not be derived from '{unit.SourceFilePath}' or '{baseline.ExecutionFilePath}'.");
+
+        var parentIntentRoot = $"{namespaceRoot}/intent-tree/00-map.md";
+        var absoluteParentIntentRoot = Path.Combine(repoRoot, parentIntentRoot.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(absoluteParentIntentRoot))
+        {
+            throw new InvalidOperationException(
+                $"Intake issue parent intent root was not found at {absoluteParentIntentRoot}");
+        }
+
+        var clarificationReturnPath = $"{namespaceRoot}/clarifications/open.md";
+        var absoluteClarificationReturnPath = Path.Combine(
+            repoRoot,
+            clarificationReturnPath.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(absoluteClarificationReturnPath))
+        {
+            var absoluteGenericClarificationPath = Path.Combine(
+                repoRoot,
+                GenericClarificationReturnPath.Replace('/', Path.DirectorySeparatorChar));
+            clarificationReturnPath = File.Exists(absoluteGenericClarificationPath)
+                ? GenericClarificationReturnPath
+                : clarificationReturnPath;
+        }
+
+        return new IntakeIssueParentRefs
+        {
+            ParentIntentRoot = parentIntentRoot,
+            ClarificationReturnPath = clarificationReturnPath
+        };
+    }
+
+    private static string? ResolveIntentNamespaceRoot(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        var normalizedPath = path.Replace('\\', '/');
+        var segments = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length < 2 || !string.Equals(segments[0], "intents", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return $"{segments[0]}/{segments[1]}";
+    }
+
     private static string ResolveTitle(IntakeOriginExecutionUnit unit)
     {
         var heading = unit.ReadinessNotes
@@ -427,6 +481,13 @@ internal static class IntakeIssueCommand
         public required string TargetPath { get; init; }
 
         public required IReadOnlyList<string> IntentBaseline { get; init; }
+    }
+
+    private readonly record struct IntakeIssueParentRefs
+    {
+        public required string ParentIntentRoot { get; init; }
+
+        public required string ClarificationReturnPath { get; init; }
     }
 
     private readonly record struct IssueBaselineRow

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -2337,6 +2337,12 @@ public sealed class CommandRouterTests
             - dotnet test IntentSystem.sln
             """);
         tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "00-map.md"),
+            "# Intent CLI Map");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "clarifications", "open.md"),
+            "# Clarifications");
+        tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
             "# Auth Concept");
         using var writer = new StringWriter();
@@ -2609,6 +2615,12 @@ public sealed class CommandRouterTests
             verification_hints:
             - dotnet test IntentSystem.sln
             """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "00-map.md"),
+            "# Intent CLI Map");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "clarifications", "open.md"),
+            "# Clarifications");
         tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
             "# Auth Concept");

--- a/tests/IntentSystem.Cli.Tests/IntakeActivateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeActivateCommandTests.cs
@@ -32,6 +32,12 @@ public sealed class IntakeActivateCommandTests
             Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
             "# Auth Means" + Environment.NewLine + Environment.NewLine + "- Existing rule" + Environment.NewLine);
         tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "00-map.md"),
+            "# Intent CLI Map");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "clarifications", "open.md"),
+            "# Clarifications");
+        tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
             CreateExecutionBaselineMarkdown());
         tempDirectory.CreateFile(

--- a/tests/IntentSystem.Cli.Tests/IntakeIssueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeIssueCommandTests.cs
@@ -19,6 +19,12 @@ public sealed class IntakeIssueCommandTests
             Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
             CreateExecutionArtifactMarkdown("auth"));
         tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "00-map.md"),
+            "# Intent CLI Map");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "clarifications", "open.md"),
+            "# Clarifications");
+        tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
             "# Auth Concept");
         tempDirectory.CreateFile(
@@ -62,6 +68,50 @@ public sealed class IntakeIssueCommandTests
     }
 
     [Fact]
+    public void Execute_GivenGenericIntentNamespace_DerivesParentRefsFromSourceFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "payments", "execution", "05-post-mvp-sub-slices.md"),
+            CreateExecutionBaselineMarkdown("payments"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "payments.execution.md"),
+            CreateSingleExecutionArtifactMarkdown(
+                "payments",
+                "PAY-01",
+                "intents/payments/concepts/checkout.md",
+                "concepts",
+                "Checkout"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "payments", "intent-tree", "00-map.md"),
+            "# Payments Map");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "payments", "clarifications", "open.md"),
+            "# Payments Clarifications");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "payments", "concepts", "checkout.md"),
+            "# Checkout");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeIssueCommand.Execute(CreateContext(repoRoot), ["payments"], writer);
+
+        Assert.Equal(0, exitCode);
+        var reviewMarkdown = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "PAY-01", "review-context.md"));
+        Assert.Contains("intents/payments/intent-tree/00-map.md", reviewMarkdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("intents/intent-cli/intent-tree/00-map.md", reviewMarkdown, StringComparison.Ordinal);
+
+        var packet = ProjectionPacketSerializer.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "PAY-01", "packet.yaml")));
+        Assert.Equal("intents/payments/intent-tree/00-map.md", packet.ReviewContextPacket.ParentIntentRoot);
+        Assert.Equal("intents/payments/clarifications/open.md", packet.ReviewContextPacket.ClarificationReturnPath);
+        Assert.DoesNotContain(
+            "intents/intent-cli/specs/04-concept-intake-and-interview.md",
+            packet.ImplementationIssuePacket.RulesAndSpecs,
+            StringComparer.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenExistingArtifacts_SkipsExecutionUnit()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -72,6 +122,12 @@ public sealed class IntakeIssueCommandTests
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
             CreateExecutionArtifactMarkdown("auth"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "00-map.md"),
+            "# Intent CLI Map");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "clarifications", "open.md"),
+            "# Clarifications");
         tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
             "# Auth Concept");
@@ -148,9 +204,9 @@ public sealed class IntakeIssueCommandTests
         Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string CreateExecutionBaselineMarkdown()
+    private static string CreateExecutionBaselineMarkdown(string namespaceSegment = "intent-cli")
     {
-        return """
+        return $$"""
             # Post-MVP Sub-Slices
 
             | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
@@ -165,7 +221,12 @@ public sealed class IntakeIssueCommandTests
             """;
     }
 
-    private static string CreateExecutionArtifactMarkdown(string domain)
+    private static string CreateExecutionArtifactMarkdown(
+        string domain,
+        string firstExecutionUnit = "AUTH-01",
+        string firstSourceFilePath = "intents/intent-cli/concepts/oauth2.md",
+        string firstTargetPart = "concepts",
+        string firstHeading = "Auth Concept")
     {
         return $$"""
             # Intake Execution Draft
@@ -175,13 +236,13 @@ public sealed class IntakeIssueCommandTests
 
             ## Proposed Execution Units
 
-            ### `AUTH-01`
-            source_file_path: intents/intent-cli/concepts/oauth2.md
-            target_part: concepts
+            ### `{{firstExecutionUnit}}`
+            source_file_path: {{firstSourceFilePath}}
+            target_part: {{firstTargetPart}}
             dependencies:
             - none
             readiness_notes:
-            - Current heading: # Auth Concept
+            - Current heading: # {{firstHeading}}
             verification_hints:
             - dotnet test IntentSystem.sln
 
@@ -192,6 +253,34 @@ public sealed class IntakeIssueCommandTests
             - AUTH-01
             readiness_notes:
             - Current heading: # Device Code
+            verification_hints:
+            - dotnet test IntentSystem.sln
+
+            """;
+    }
+
+    private static string CreateSingleExecutionArtifactMarkdown(
+        string domain,
+        string executionUnit,
+        string sourceFilePath,
+        string targetPart,
+        string heading)
+    {
+        return $$"""
+            # Intake Execution Draft
+
+            ## Domain
+            `{{domain}}`
+
+            ## Proposed Execution Units
+
+            ### `{{executionUnit}}`
+            source_file_path: {{sourceFilePath}}
+            target_part: {{targetPart}}
+            dependencies:
+            - none
+            readiness_notes:
+            - Current heading: # {{heading}}
             verification_hints:
             - dotnet test IntentSystem.sln
 

--- a/tests/IntentSystem.Cli.Tests/IntakeStartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeStartCommandTests.cs
@@ -23,6 +23,12 @@ public sealed class IntakeStartCommandTests
             Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
             CreateExecutionArtifactMarkdown("auth"));
         tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "00-map.md"),
+            "# Intent CLI Map");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "clarifications", "open.md"),
+            "# Clarifications");
+        tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
             "# Auth Concept");
         tempDirectory.CreateFile(
@@ -117,6 +123,12 @@ public sealed class IntakeStartCommandTests
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
             CreateExecutionArtifactMarkdown("auth-single"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "00-map.md"),
+            "# Intent CLI Map");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "clarifications", "open.md"),
+            "# Clarifications");
         tempDirectory.CreateFile(
             Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
             "# Auth Concept");


### PR DESCRIPTION
## Summary
- remove hard-coded `intents/intent-cli/...` parent refs from `intake issue` artifact generation
- derive parent intent root and clarification return path from the selected intake source namespace, with generic clarification fallback
- lock generic namespace behavior in intake issue, intake start, intake activate, and router tests

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IntakeIssueCommandTests|FullyQualifiedName~CommandRouterTests"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IntakeStartCommandTests|FullyQualifiedName~IntakeActivateCommandTests"
- dotnet test IntentSystem.sln

Closes #230