### PR TITLE
Add intake init greenfield bootstrap command

### DIFF
--- a/src/IntentSystem.Cli/CliContext.cs
+++ b/src/IntentSystem.Cli/CliContext.cs
@@ -50,6 +50,22 @@ internal sealed record CliContext
         return Path.GetFullPath(Path.Combine(RepoRoot, worktreeRoot));
     }
 
+    public string? ResolveWorkRepoPath()
+    {
+        var workRepoPath = Config.Project.WorkRepoPath;
+        if (string.IsNullOrWhiteSpace(workRepoPath))
+        {
+            return null;
+        }
+
+        if (Path.IsPathRooted(workRepoPath))
+        {
+            return Path.GetFullPath(workRepoPath);
+        }
+
+        return Path.GetFullPath(Path.Combine(RepoRoot, workRepoPath));
+    }
+
     public string ResolveSupervisionArtifactRootPath()
     {
         var supervisionArtifactRoot = Config.Supervision.ArtifactRoot;

--- a/src/IntentSystem.Cli/CliRuntimeContracts.cs
+++ b/src/IntentSystem.Cli/CliRuntimeContracts.cs
@@ -11,6 +11,7 @@ internal static class CliRuntimeContracts
     public const string DomainKey = "domain";
     public const string ArtifactRootKey = "artifact_root";
     public const string WorktreeRootKey = "worktree_root";
+    public const string WorkRepoPathKey = "work_repo_path";
     public const string ParentIntentRepoRootKey = "parent_intent_repo_root";
     public const string RolesSectionName = "roles";
     public const string SupervisionSectionName = "supervision";

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -86,6 +86,7 @@ internal static class CommandRouter
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
+                ["init"] = IntakeInitCommand.Execute,
                 ["concept"] = IntakeConceptCommand.Execute,
                 ["interview"] = IntakeInterviewCommand.Execute,
                 ["compile"] = IntakeCompileCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/IntakeInitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeInitCommand.cs
@@ -1,0 +1,298 @@
+using IntentSystem.ConceptIntake.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeInitCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, writer, out var request))
+        {
+            return 1;
+        }
+
+        try
+        {
+            var result = ExecuteCore(context.RepoRoot, request);
+            IntakeInitRenderer.WriteSummary(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static IntakeInitResult ExecuteCore(string repoRoot, IntakeInitRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var resolvedWorkRepoPath = ResolvePath(repoRoot, request.WorkRepoPath);
+        if (!Directory.Exists(resolvedWorkRepoPath))
+        {
+            throw new InvalidOperationException($"Work repo path was not found at {resolvedWorkRepoPath}");
+        }
+
+        var conceptText = request.Text is not null
+            ? NormalizeInlineText(request.Text)
+            : ReadConceptFile(repoRoot, request.FromFilePath!);
+        var generatedPaths = new List<string>();
+        var skippedPaths = new List<string>();
+
+        TryWriteFile(
+            repoRoot,
+            $"{CliRuntimeContracts.IntentCliDirectoryName}/{CliRuntimeContracts.ConfigFileName}",
+            RenderConfigToml(request.Domain, request.WorkRepoPath),
+            generatedPaths,
+            skippedPaths);
+        TryWriteFile(
+            repoRoot,
+            $"intents/{request.Domain}/README.md",
+            RenderDomainReadme(request.Domain, request.WorkRepoPath),
+            generatedPaths,
+            skippedPaths);
+        TryWriteFile(
+            repoRoot,
+            $"intents/{request.Domain}/clarifications/open.md",
+            RenderOpenClarifications(),
+            generatedPaths,
+            skippedPaths);
+        TryWriteFile(
+            repoRoot,
+            $"intents/{request.Domain}/intent-tree/00-map.md",
+            RenderIntentMap(request.Domain, request.WorkRepoPath),
+            generatedPaths,
+            skippedPaths);
+
+        var packet = new ConceptIntakePacket
+        {
+            DomainSlug = request.Domain,
+            ConceptSource = request.Text is null ? "from-file" : "text",
+            ConceptText = conceptText,
+            UpstreamPaths = [],
+            InitialGoal = DeriveInitialGoal(conceptText),
+            Constraints = [],
+            KnownUnknowns = []
+        };
+
+        TryWriteFile(
+            repoRoot,
+            IntakeConceptArtifactPathResolver.Resolve(request.Domain),
+            IntakeConceptArtifactYaml.Serialize(packet),
+            generatedPaths,
+            skippedPaths);
+
+        var interviewResult = IntakeInterviewCommand.ExecuteCore(repoRoot, [request.Domain]);
+        generatedPaths.AddRange(interviewResult.GeneratedArtifactPaths);
+        skippedPaths.AddRange(interviewResult.ExistingArtifactPaths);
+
+        return new IntakeInitResult
+        {
+            Domain = request.Domain,
+            WorkRepoPath = resolvedWorkRepoPath,
+            InterviewWasSkipped = interviewResult.WasSkipped,
+            CreatedQuestionIds = interviewResult.CreatedQuestionIds,
+            GeneratedPaths = generatedPaths,
+            SkippedPaths = skippedPaths
+        };
+    }
+
+    private static bool TryParseArguments(string[] args, TextWriter writer, out IntakeInitRequest request)
+    {
+        request = default!;
+
+        if (args.Length < 5 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine(
+                "Intake init command requires '<domain> --work-repo-path <path>' and exactly one of '--text <value>' or '--from-file <path>'.");
+            return false;
+        }
+
+        var domain = args[0].Trim();
+        string? text = null;
+        string? fromFilePath = null;
+        string? workRepoPath = null;
+
+        for (var index = 1; index < args.Length; index += 2)
+        {
+            if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+            {
+                writer.WriteLine($"Missing value for '{args[index]}'.");
+                return false;
+            }
+
+            switch (args[index])
+            {
+                case "--text":
+                    text = args[index + 1];
+                    break;
+                case "--from-file":
+                    fromFilePath = args[index + 1];
+                    break;
+                case "--work-repo-path":
+                    workRepoPath = args[index + 1];
+                    break;
+                default:
+                    writer.WriteLine($"Unknown intake init option '{args[index]}'.");
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(workRepoPath))
+        {
+            writer.WriteLine("Intake init command requires '--work-repo-path <path>'.");
+            return false;
+        }
+
+        if ((text is null && fromFilePath is null) || (text is not null && fromFilePath is not null))
+        {
+            writer.WriteLine(
+                "Intake init command requires exactly one of '--text <value>' or '--from-file <path>'.");
+            return false;
+        }
+
+        request = new IntakeInitRequest
+        {
+            Domain = domain,
+            Text = text,
+            FromFilePath = fromFilePath,
+            WorkRepoPath = workRepoPath.Trim()
+        };
+        return true;
+    }
+
+    private static string ReadConceptFile(string repoRoot, string conceptFilePath)
+    {
+        var resolvedPath = ResolvePath(repoRoot, conceptFilePath);
+        if (!File.Exists(resolvedPath))
+        {
+            throw new InvalidOperationException($"Intake concept file was not found at {resolvedPath}");
+        }
+
+        var fileConcept = File.ReadAllText(resolvedPath);
+        if (string.IsNullOrWhiteSpace(fileConcept))
+        {
+            throw new InvalidOperationException("Intake concept file must not be empty.");
+        }
+
+        return fileConcept.TrimEnd();
+    }
+
+    private static string NormalizeInlineText(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            throw new InvalidOperationException("Intake init text input must not be empty.");
+        }
+
+        return text.TrimEnd('\r', '\n');
+    }
+
+    private static string ResolvePath(string repoRoot, string path)
+    {
+        return Path.IsPathRooted(path)
+            ? Path.GetFullPath(path)
+            : Path.GetFullPath(Path.Combine(repoRoot, path.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static bool TryWriteFile(
+        string repoRoot,
+        string relativePath,
+        string contents,
+        ICollection<string> generatedPaths,
+        ICollection<string> skippedPaths)
+    {
+        var absolutePath = Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        if (File.Exists(absolutePath))
+        {
+            skippedPaths.Add(relativePath);
+            return false;
+        }
+
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException($"Path '{absolutePath}' did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, contents);
+        generatedPaths.Add(relativePath);
+        return true;
+    }
+
+    private static string RenderConfigToml(string domain, string workRepoPath)
+    {
+        return $$"""
+        [project]
+        domain = "{{EscapeTomlString(domain)}}"
+        artifact_root = ".intent-cli"
+        worktree_root = ".intent-cli/worktrees"
+        work_repo_path = "{{EscapeTomlString(workRepoPath)}}"
+        """;
+    }
+
+    private static string RenderDomainReadme(string domain, string workRepoPath)
+    {
+        return $$"""
+        # {{domain}}
+
+        Work repo path: `{{workRepoPath}}`
+
+        Bootstrapped by `intent-cli intake init`.
+        """;
+    }
+
+    private static string RenderOpenClarifications()
+    {
+        return """
+        # Open Clarifications
+
+        - none
+        """;
+    }
+
+    private static string RenderIntentMap(string domain, string workRepoPath)
+    {
+        return $$"""
+        # Intent Map
+
+        - Domain: `{{domain}}`
+        - Work repo path: `{{workRepoPath}}`
+        - Initial map: pending
+        """;
+    }
+
+    private static string EscapeTomlString(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
+    }
+
+    private static string DeriveInitialGoal(string conceptText)
+    {
+        var firstLine = conceptText
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.None)
+            .FirstOrDefault(line => !string.IsNullOrWhiteSpace(line));
+
+        return string.IsNullOrWhiteSpace(firstLine)
+            ? conceptText
+            : firstLine.Trim();
+    }
+
+    internal sealed record IntakeInitRequest
+    {
+        public required string Domain { get; init; }
+
+        public string? Text { get; init; }
+
+        public string? FromFilePath { get; init; }
+
+        public required string WorkRepoPath { get; init; }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeInitRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeInitRenderer.cs
@@ -1,0 +1,39 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntakeInitRenderer
+{
+    public static void WriteSummary(TextWriter writer, IntakeInitResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Intake init processed for domain '{result.Domain}'.");
+        writer.WriteLine($"Work repo path: {result.WorkRepoPath}");
+        writer.WriteLine($"Interview bootstrap: {(result.InterviewWasSkipped ? "skipped" : "generated")}");
+
+        if (result.CreatedQuestionIds.Count > 0)
+        {
+            writer.WriteLine("Created question ids:");
+            WriteList(writer, result.CreatedQuestionIds);
+        }
+
+        writer.WriteLine("Generated paths:");
+        WriteList(writer, result.GeneratedPaths);
+        writer.WriteLine("Skipped paths:");
+        WriteList(writer, result.SkippedPaths);
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- none");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- {value}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeInitResult.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeInitResult.cs
@@ -1,0 +1,16 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntakeInitResult
+{
+    public required string Domain { get; init; }
+
+    public required string WorkRepoPath { get; init; }
+
+    public required bool InterviewWasSkipped { get; init; }
+
+    public required IReadOnlyList<string> CreatedQuestionIds { get; init; }
+
+    public required IReadOnlyList<string> GeneratedPaths { get; init; }
+
+    public required IReadOnlyList<string> SkippedPaths { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/ProjectStatusCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ProjectStatusCommand.cs
@@ -12,6 +12,12 @@ internal static class ProjectStatusCommand
         writer.WriteLine($"Repo root: {context.RepoRoot}");
         writer.WriteLine($"Intent CLI root: {context.GetIntentCliDirectoryPath()}");
         writer.WriteLine($"Artifact root: {context.ResolveArtifactRootPath()}");
+        var workRepoPath = context.ResolveWorkRepoPath();
+        if (workRepoPath is not null)
+        {
+            writer.WriteLine($"Work repo path: {workRepoPath}");
+        }
+
         writer.WriteLine($"Config path: {context.GetConfigPath()}");
 
         return 0;

--- a/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
+++ b/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
@@ -52,6 +52,8 @@ internal static class CliConfigLoader
 
         var worktreeRoot = TryGetOptionalString(rootTable, CliRuntimeContracts.WorktreeRootKey)
             ?? CliRuntimeContracts.DefaultWorktreeRoot;
+        var workRepoPath = TryGetOptionalString(rootTable, CliRuntimeContracts.WorkRepoPathKey)
+            ?? string.Empty;
         var parentIntentRepoRoot = TryGetOptionalString(rootTable, CliRuntimeContracts.ParentIntentRepoRootKey)
             ?? string.Empty;
         var roles = ReadRoles(rootTable);
@@ -62,6 +64,7 @@ internal static class CliConfigLoader
             domain,
             artifactRoot,
             worktreeRoot,
+            workRepoPath,
             parentIntentRepoRoot,
             roles,
             supervision,
@@ -91,6 +94,8 @@ internal static class CliConfigLoader
 
         var worktreeRoot = TryGetOptionalString(projectTable, CliRuntimeContracts.WorktreeRootKey)
             ?? CliRuntimeContracts.DefaultWorktreeRoot;
+        var workRepoPath = TryGetOptionalString(projectTable, CliRuntimeContracts.WorkRepoPathKey)
+            ?? string.Empty;
         var parentIntentRepoRoot = TryGetOptionalString(projectTable, CliRuntimeContracts.ParentIntentRepoRootKey)
             ?? string.Empty;
         var roles = ReadRoles(rootTable);
@@ -101,6 +106,7 @@ internal static class CliConfigLoader
             domain,
             artifactRoot,
             worktreeRoot,
+            workRepoPath,
             parentIntentRepoRoot,
             roles,
             supervision,
@@ -112,6 +118,7 @@ internal static class CliConfigLoader
         string domain,
         string artifactRoot,
         string worktreeRoot,
+        string workRepoPath,
         string parentIntentRepoRoot,
         RoleMappings roles,
         SupervisionConfig supervision,
@@ -124,6 +131,7 @@ internal static class CliConfigLoader
                 Domain = domain,
                 ArtifactRoot = artifactRoot,
                 WorktreeRoot = worktreeRoot,
+                WorkRepoPath = workRepoPath,
                 ParentIntentRepoRoot = parentIntentRepoRoot
             },
             Roles = roles,

--- a/src/IntentSystem.Cli/Models/CliConfig.cs
+++ b/src/IntentSystem.Cli/Models/CliConfig.cs
@@ -19,6 +19,8 @@ internal sealed record ProjectConfig
 
     public string WorktreeRoot { get; init; } = ".intent-cli/worktrees";
 
+    public string WorkRepoPath { get; init; } = string.Empty;
+
     public string ParentIntentRepoRoot { get; init; } = string.Empty;
 }
 

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -1,5 +1,6 @@
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Infrastructure;
+using IntentSystem.Cli.Models;
 
 namespace IntentSystem.Cli;
 
@@ -10,6 +11,11 @@ internal static class Program
         try
         {
             var currentDirectory = Directory.GetCurrentDirectory();
+            if (IsIntakeInitCommand(args))
+            {
+                return CommandRouter.Execute(args, CreateBootstrapContext(currentDirectory, args), Console.Out);
+            }
+
             var repoRoot = RepoRootResolver.Resolve(currentDirectory)
                 ?? throw new InvalidOperationException(
                     $"Could not find {CliRuntimeContracts.IntentCliDirectoryName} directory from '{currentDirectory}'.");
@@ -30,5 +36,33 @@ internal static class Program
             Console.Error.WriteLine(exception.Message);
             return 1;
         }
+    }
+
+    private static bool IsIntakeInitCommand(string[] args)
+    {
+        return args.Length >= 2
+            && string.Equals(args[0], "intake", StringComparison.Ordinal)
+            && string.Equals(args[1], "init", StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateBootstrapContext(string currentDirectory, string[] args)
+    {
+        var domain = args.Length >= 3 && !string.IsNullOrWhiteSpace(args[2])
+            ? args[2].Trim()
+            : "bootstrap";
+
+        return new CliContext
+        {
+            RepoRoot = currentDirectory,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = domain,
+                    ArtifactRoot = CliRuntimeContracts.IntentCliDirectoryName,
+                    WorktreeRoot = CliRuntimeContracts.DefaultWorktreeRoot
+                }
+            }
+        };
     }
 }

--- a/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
@@ -11,6 +11,7 @@ public sealed class CliConfigLoaderTests
         default_domain = "intent-cli"
         artifact_root = ".intent-cli"
         worktree_root = ".intent-cli/worktrees"
+        work_repo_path = "../Sekiban-dcb/dcb"
         parent_intent_repo_root = "../MyIntentHost"
         """;
 
@@ -19,6 +20,7 @@ public sealed class CliConfigLoaderTests
         Assert.Equal("intent-cli", config.Project.Domain);
         Assert.Equal(".intent-cli", config.Project.ArtifactRoot);
         Assert.Equal(".intent-cli/worktrees", config.Project.WorktreeRoot);
+        Assert.Equal("../Sekiban-dcb/dcb", config.Project.WorkRepoPath);
         Assert.Equal("../MyIntentHost", config.Project.ParentIntentRepoRoot);
         Assert.Equal("Claude", config.Roles.Implement);
         Assert.Equal("Codex", config.Roles.Review);
@@ -44,6 +46,7 @@ public sealed class CliConfigLoaderTests
             default_domain = "intent-cli"
             artifact_root = ".intent-cli"
             worktree_root = ".intent-cli/worktrees"
+            work_repo_path = "../Sekiban-dcb/dcb"
             parent_intent_repo_root = "../MyIntentHost"
             """);
 
@@ -52,6 +55,7 @@ public sealed class CliConfigLoaderTests
         Assert.Equal("intent-cli", config.Project.Domain);
         Assert.Equal(".intent-cli", config.Project.ArtifactRoot);
         Assert.Equal(".intent-cli/worktrees", config.Project.WorktreeRoot);
+        Assert.Equal("../Sekiban-dcb/dcb", config.Project.WorkRepoPath);
         Assert.Equal("../MyIntentHost", config.Project.ParentIntentRepoRoot);
         Assert.Equal("Claude", config.Roles.Implement);
     }
@@ -64,6 +68,7 @@ public sealed class CliConfigLoaderTests
         domain = "intent-cli"
         artifact_root = ".intent-cli"
         worktree_root = ".intent-cli/worktrees"
+        work_repo_path = "../Sekiban-dcb/dcb"
         parent_intent_repo_root = "../MyIntentHost"
         """;
 
@@ -72,6 +77,7 @@ public sealed class CliConfigLoaderTests
         Assert.Equal("intent-cli", config.Project.Domain);
         Assert.Equal(".intent-cli", config.Project.ArtifactRoot);
         Assert.Equal(".intent-cli/worktrees", config.Project.WorktreeRoot);
+        Assert.Equal("../Sekiban-dcb/dcb", config.Project.WorkRepoPath);
         Assert.Equal("../MyIntentHost", config.Project.ParentIntentRepoRoot);
         Assert.Equal("Claude", config.Roles.Implement);
     }

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -58,6 +58,24 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIntakeInitCommand_DispatchesToInitRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        _ = tempDirectory.CreateDirectory("work-repo");
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(
+            ["intake", "init", "auth", "--text", "Bootstrap auth intake.", "--work-repo-path", "../work-repo"],
+            CreateContext(repoRoot),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Intake init processed for domain 'auth'.", writer.ToString(), StringComparison.Ordinal);
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "config.toml")));
+    }
+
+    [Fact]
     public void Execute_GivenRootRunCommand_DispatchesToRunRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntakeInitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeInitCommandTests.cs
@@ -1,0 +1,192 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Infrastructure;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeInitCommandTests
+{
+    [Fact]
+    public void Execute_GivenTextAndWorkRepoPath_ScaffoldsBootstrapAndConnectsExistingCommands()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        _ = tempDirectory.CreateDirectory("work-repo");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeInitCommand.Execute(
+            CreateContext(repoRoot),
+            ["billing", "--text", "Bootstrap billing intake.", "--work-repo-path", "../work-repo"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake init processed for domain 'billing'.", output, StringComparison.Ordinal);
+        Assert.Contains("Generated paths:", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped paths:", output, StringComparison.Ordinal);
+
+        var config = CliConfigLoader.LoadFromFile(Path.Combine(repoRoot, ".intent-cli", "config.toml"));
+        Assert.Equal("billing", config.Project.Domain);
+        Assert.Equal("../work-repo", config.Project.WorkRepoPath);
+
+        var conceptPacket = IntakeConceptArtifactYaml.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "intake", "billing.concept.yaml")));
+        Assert.Equal("billing", conceptPacket.DomainSlug);
+        Assert.Equal("text", conceptPacket.ConceptSource);
+        Assert.Equal("Bootstrap billing intake.", conceptPacket.InitialGoal);
+
+        Assert.True(File.Exists(Path.Combine(repoRoot, "intents", "billing", "README.md")));
+        Assert.True(File.Exists(Path.Combine(repoRoot, "intents", "billing", "clarifications", "open.md")));
+        Assert.True(File.Exists(Path.Combine(repoRoot, "intents", "billing", "intent-tree", "00-map.md")));
+
+        using var statusWriter = new StringWriter();
+        var statusExitCode = ProjectStatusCommand.Execute(
+            new CliContext
+            {
+                RepoRoot = repoRoot,
+                Config = config
+            },
+            [],
+            statusWriter);
+        Assert.Equal(0, statusExitCode);
+        Assert.Contains("Work repo path:", statusWriter.ToString(), StringComparison.Ordinal);
+
+        using var interviewWriter = new StringWriter();
+        var interviewExitCode = IntakeInterviewCommand.Execute(CreateContext(repoRoot), ["billing"], interviewWriter);
+        Assert.Equal(0, interviewExitCode);
+        Assert.Contains("Bootstrap status: skipped", interviewWriter.ToString(), StringComparison.Ordinal);
+
+        using var interviewStartWriter = new StringWriter();
+        var interviewStartExitCode = InterviewStartCommand.Execute(CreateContext(repoRoot), ["billing"], interviewStartWriter);
+        Assert.Equal(0, interviewStartExitCode);
+        Assert.Contains("Question id: iq-goal", interviewStartWriter.ToString(), StringComparison.Ordinal);
+
+        using var compileWriter = new StringWriter();
+        var compileExitCode = IntakeCompileCommand.Execute(CreateContext(repoRoot), ["billing"], compileWriter);
+        Assert.Equal(0, compileExitCode);
+        Assert.Contains("Intake compile is not ready for domain 'billing'.", compileWriter.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenFromFileInput_UsesFileContentsForConceptArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        _ = tempDirectory.CreateDirectory("work-repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "billing.txt"), "Bootstrap billing from file.");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeInitCommand.Execute(
+            CreateContext(repoRoot),
+            ["billing", "--from-file", "billing.txt", "--work-repo-path", "../work-repo"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var conceptPacket = IntakeConceptArtifactYaml.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "intake", "billing.concept.yaml")));
+        Assert.Equal("from-file", conceptPacket.ConceptSource);
+        Assert.Equal("Bootstrap billing from file.", conceptPacket.ConceptText);
+    }
+
+    [Fact]
+    public void Execute_GivenExistingFiles_SkipsWithoutOverwrite()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        _ = tempDirectory.CreateDirectory("work-repo");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent-cli", "config.toml"), "kept-config");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "billing.concept.yaml"),
+            IntakeConceptArtifactYaml.Serialize(new IntentSystem.ConceptIntake.Models.ConceptIntakePacket
+            {
+                DomainSlug = "billing",
+                ConceptSource = "text",
+                ConceptText = "Existing billing concept.",
+                UpstreamPaths = [],
+                InitialGoal = "Existing billing concept.",
+                Constraints = [],
+                KnownUnknowns = []
+            }));
+        tempDirectory.CreateFile(Path.Combine("repo", "intents", "billing", "README.md"), "kept-readme");
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent-cli", "interviews", "billing", "iq-existing.yaml"), "kept-interview");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeInitCommand.Execute(
+            CreateContext(repoRoot),
+            ["billing", "--text", "New billing concept.", "--work-repo-path", "../work-repo"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains(".intent-cli/config.toml", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/interviews/billing/iq-existing.yaml", output, StringComparison.Ordinal);
+        Assert.Equal("kept-config", File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "config.toml")));
+        Assert.Equal("kept-readme", File.ReadAllText(Path.Combine(repoRoot, "intents", "billing", "README.md")));
+    }
+
+    [Fact]
+    public void Execute_GivenBothTextAndFromFile_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        _ = tempDirectory.CreateDirectory("work-repo");
+        tempDirectory.CreateFile(Path.Combine("repo", "billing.txt"), "ignored");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeInitCommand.Execute(
+            CreateContext(repoRoot),
+            ["billing", "--text", "inline", "--from-file", "billing.txt", "--work-repo-path", "../work-repo"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("exactly one", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intake-init-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntakeInitRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeInitRendererTests.cs
@@ -1,0 +1,60 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntakeInitRendererTests
+{
+    [Fact]
+    public void WriteSummary_GivenGeneratedResult_RendersQuestionIdsAndPaths()
+    {
+        var result = new IntakeInitResult
+        {
+            Domain = "auth",
+            WorkRepoPath = "/tmp/work-repo",
+            InterviewWasSkipped = false,
+            CreatedQuestionIds = ["iq-goal", "iq-constraints"],
+            GeneratedPaths =
+            [
+                ".intent-cli/config.toml",
+                ".intent-cli/interviews/auth/iq-goal.yaml"
+            ],
+            SkippedPaths = []
+        };
+        using var writer = new StringWriter();
+
+        IntakeInitRenderer.WriteSummary(writer, result);
+
+        var output = writer.ToString();
+        Assert.Contains("Intake init processed for domain 'auth'.", output, StringComparison.Ordinal);
+        Assert.Contains("Interview bootstrap: generated", output, StringComparison.Ordinal);
+        Assert.Contains("- iq-goal", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/config.toml", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- none", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WriteSummary_GivenSkippedArtifacts_RendersSkippedPaths()
+    {
+        var result = new IntakeInitResult
+        {
+            Domain = "auth",
+            WorkRepoPath = "/tmp/work-repo",
+            InterviewWasSkipped = true,
+            CreatedQuestionIds = [],
+            GeneratedPaths = [],
+            SkippedPaths =
+            [
+                ".intent-cli/config.toml",
+                ".intent-cli/interviews/auth/iq-existing.yaml"
+            ]
+        };
+        using var writer = new StringWriter();
+
+        IntakeInitRenderer.WriteSummary(writer, result);
+
+        var output = writer.ToString();
+        Assert.Contains("Interview bootstrap: skipped", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/interviews/auth/iq-existing.yaml", output, StringComparison.Ordinal);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/ProgramTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ProgramTests.cs
@@ -83,6 +83,29 @@ public sealed class ProgramTests
         }
     }
 
+    [Fact]
+    public void Main_GivenIntakeInitCommandWithoutIntentCliRoot_BootstrapsCurrentDirectory()
+    {
+        lock (ProcessStateLock)
+        {
+            using var tempDirectory = new TemporaryDirectory();
+            var repoRoot = tempDirectory.CreateDirectory("repo");
+            var workRepoRoot = tempDirectory.CreateDirectory("work-repo");
+            using var consoleScope = new ConsoleScope();
+            using var currentDirectoryScope = new CurrentDirectoryScope(repoRoot);
+
+            var exitCode = Program.Main(
+                ["intake", "init", "billing", "--text", "Bootstrap billing intake.", "--work-repo-path", workRepoRoot]);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Intake init processed for domain 'billing'.", consoleScope.Out.ToString(), StringComparison.Ordinal);
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "config.toml")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "billing.concept.yaml")));
+            Assert.True(File.Exists(Path.Combine(repoRoot, "intents", "billing", "README.md")));
+            Assert.Equal(string.Empty, consoleScope.Error.ToString());
+        }
+    }
+
     private sealed class CurrentDirectoryScope : IDisposable
     {
         private readonly string originalCurrentDirectory = Directory.GetCurrentDirectory();

--- a/tests/IntentSystem.Cli.Tests/ProjectStatusCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ProjectStatusCommandTests.cs
@@ -37,6 +37,33 @@ public sealed class ProjectStatusCommandTests
             StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Execute_GivenRelativeWorkRepoPath_ResolvesAgainstRepoRoot()
+    {
+        var repoRoot = Path.Combine(Path.DirectorySeparatorChar.ToString(), "tmp", "intent-system");
+        var context = new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorkRepoPath = "../Sekiban-dcb/dcb"
+                }
+            }
+        };
+        using var writer = new StringWriter();
+
+        _ = ProjectStatusCommand.Execute(context, [], writer);
+
+        Assert.Contains(
+            $"Work repo path: {Path.GetFullPath(Path.Combine(repoRoot, "..", "Sekiban-dcb", "dcb"))}",
+            writer.ToString(),
+            StringComparison.Ordinal);
+    }
+
     private static CliContext CreateContext(string repoRoot, string artifactRoot)
     {
         return new CliContext


### PR DESCRIPTION
## Summary
- add `intent-cli intake init <domain>` for greenfield bootstrap from current cwd
- scaffold minimal `.intent-cli` and `intents/<domain>/` files without overwriting existing sources of truth
- connect bootstrap output to the existing concept/interview/start/compile flow and cover it with runtime, renderer, and contract tests

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IntakeInit|FullyQualifiedName~ProgramTests|FullyQualifiedName~CliConfigLoaderTests|FullyQualifiedName~ProjectStatusCommandTests|FullyQualifiedName~CommandRouterTests"`
- `dotnet test IntentSystem.sln`

Refs #233
