### PR TITLE
Repair stale review run result handling

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -107,7 +107,10 @@ internal static class RunCommand
                     var inProgressItem = inProgressItems[0];
                     if (inProgressItem.State == QueueItemState.Active)
                     {
-                        var implementRunStatus = TryReadDirectRunStatus(context, inProgressItem.ExecutionUnit);
+                        var implementRunStatus = TryReadDirectRunStatus(
+                            context,
+                            inProgressItem.ExecutionUnit,
+                            "implement");
                         if (string.Equals(implementRunStatus, "succeeded", StringComparison.Ordinal))
                         {
                             ExecuteAction(
@@ -176,7 +179,10 @@ internal static class RunCommand
                             continue;
                         }
 
-                        var fixRunStatus = TryReadDirectRunStatus(context, inProgressItem.ExecutionUnit);
+                        var fixRunStatus = TryReadDirectRunStatus(
+                            context,
+                            inProgressItem.ExecutionUnit,
+                            "fix");
                         if (string.Equals(fixRunStatus, "succeeded", StringComparison.Ordinal))
                         {
                             ExecuteAction(
@@ -427,13 +433,19 @@ internal static class RunCommand
             DescribeSupervisionResult(superviseResult));
     }
 
-    private static string? TryReadDirectRunStatus(CliContext context, string executionUnit)
+    private static string? TryReadDirectRunStatus(
+        CliContext context,
+        string executionUnit,
+        string expectedEntryKind)
     {
-        var resultArtifact = TryReadDirectRunResultArtifact(context, executionUnit);
+        var resultArtifact = TryReadDirectRunResultArtifact(context, executionUnit, expectedEntryKind);
         return resultArtifact?.RunStatus;
     }
 
-    private static DirectRunResultArtifact? TryReadDirectRunResultArtifact(CliContext context, string executionUnit)
+    private static DirectRunResultArtifact? TryReadDirectRunResultArtifact(
+        CliContext context,
+        string executionUnit,
+        string expectedEntryKind)
     {
         var resultArtifactRef = ResolveDirectRunResultArtifactRef(context, executionUnit);
         var resultArtifactPath = Path.GetFullPath(Path.Combine(
@@ -444,7 +456,10 @@ internal static class RunCommand
             return null;
         }
 
-        return DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        var artifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        return string.Equals(artifact.EntryKind, expectedEntryKind, StringComparison.Ordinal)
+            ? artifact
+            : null;
     }
 
     private static IReadOnlyList<DirectRunProviderEvent> TryReadDirectRunProviderEvents(CliContext context, string executionUnit)
@@ -475,7 +490,7 @@ internal static class RunCommand
 
     private static RunReviewDecision ResolveReviewDecision(CliContext context, string executionUnit)
     {
-        var resultArtifact = TryReadDirectRunResultArtifact(context, executionUnit);
+        var resultArtifact = TryReadDirectRunResultArtifact(context, executionUnit, "review");
         if (resultArtifact is null)
         {
             return new RunReviewDecision

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -252,6 +252,39 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenReviewLaunchAndStaleImplementResult_IgnoresStaleArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        WriteDirectRunResult(repoRoot, "G226", "implement", "succeeded");
+        var originalReviewRunExecutor = RunCommand.ReviewRunExecutor;
+
+        try
+        {
+            RunCommand.ReviewRunExecutor = (_, executionUnit) => new ReviewRunResult
+            {
+                ExecutionUnit = executionUnit,
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review run", action.Name);
+            Assert.Contains("no direct run result is available yet", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunCommand.ReviewRunExecutor = originalReviewRunExecutor;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenSucceededImplementRun_ReusesRunSubmitBoundary()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- ignore stale direct-run result artifacts whose `entry_kind` does not match the current run boundary
- make review decision resolution wait for a real `review` result instead of reusing an older `implement` result
- add regression coverage for the stale review-launch path

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests"`
- `dotnet test IntentSystem.sln`

Refs #235
