### PR TITLE
Repair review result/request mismatch

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -92,6 +92,7 @@ internal static class DirectRunCommandSupport
             context,
             executionUnit,
             entryKindValue,
+            upstreamRequestRef,
             launchedAt,
             launchResult);
 
@@ -224,6 +225,7 @@ internal static class DirectRunCommandSupport
         CliContext context,
         string executionUnit,
         string entryKind,
+        string upstreamRequestRef,
         DateTimeOffset launchedAt,
         DirectRunLaunchResult launchResult)
     {
@@ -270,6 +272,7 @@ internal static class DirectRunCommandSupport
             SchemaVersion = "1",
             ExecutionUnit = executionUnit,
             EntryKind = entryKind,
+            UpstreamRequestRef = upstreamRequestRef,
             Provider = provider,
             Model = model,
             SessionId = sessionId,

--- a/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
@@ -14,6 +14,9 @@ internal sealed record DirectRunResultArtifact
     [JsonPropertyName("entry_kind")]
     public required string EntryKind { get; init; }
 
+    [JsonPropertyName("upstream_request_ref")]
+    public required string UpstreamRequestRef { get; init; }
+
     [JsonPropertyName("provider")]
     public required string Provider { get; init; }
 

--- a/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
@@ -15,7 +15,7 @@ internal sealed record DirectRunResultArtifact
     public required string EntryKind { get; init; }
 
     [JsonPropertyName("upstream_request_ref")]
-    public required string UpstreamRequestRef { get; init; }
+    public string UpstreamRequestRef { get; init; } = string.Empty;
 
     [JsonPropertyName("provider")]
     public required string Provider { get; init; }

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -476,6 +476,26 @@ internal static class RunCommand
         return DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerLogPath));
     }
 
+    private static DirectRunRequestArtifact? TryReadDirectRunRequestArtifact(CliContext context, string executionUnit)
+    {
+        var requestArtifactRef = ResolveDirectRunRequestArtifactRef(context, executionUnit);
+        var requestArtifactPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            requestArtifactRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(requestArtifactPath))
+        {
+            return null;
+        }
+
+        return DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+    }
+
+    private static string ResolveDirectRunRequestArtifactRef(CliContext context, string executionUnit)
+    {
+        var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
+        return $"{root}/{executionUnit.Trim()}.request.json";
+    }
+
     private static string ResolveDirectRunResultArtifactRef(CliContext context, string executionUnit)
     {
         var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
@@ -490,6 +510,16 @@ internal static class RunCommand
 
     private static RunReviewDecision ResolveReviewDecision(CliContext context, string executionUnit)
     {
+        var requestArtifact = TryReadDirectRunRequestArtifact(context, executionUnit);
+        if (requestArtifact is null)
+        {
+            return new RunReviewDecision
+            {
+                Kind = RunReviewDecisionKind.Waiting,
+                Detail = $"Review request exists for '{executionUnit}' but no direct run request boundary is available yet."
+            };
+        }
+
         var resultArtifact = TryReadDirectRunResultArtifact(context, executionUnit, "review");
         if (resultArtifact is null)
         {
@@ -497,6 +527,15 @@ internal static class RunCommand
             {
                 Kind = RunReviewDecisionKind.Waiting,
                 Detail = $"Review request exists for '{executionUnit}' but no direct run result is available yet."
+            };
+        }
+
+        if (!MatchesCurrentReviewRequestBoundary(requestArtifact, resultArtifact))
+        {
+            return new RunReviewDecision
+            {
+                Kind = RunReviewDecisionKind.Waiting,
+                Detail = $"Review direct run result for '{executionUnit}' does not match the current launched request boundary."
             };
         }
 
@@ -549,6 +588,20 @@ internal static class RunCommand
             Kind = RunReviewDecisionKind.Waiting,
             Detail = $"Review direct run for '{executionUnit}' is '{runStatus}'."
         };
+    }
+
+    private static bool MatchesCurrentReviewRequestBoundary(
+        DirectRunRequestArtifact requestArtifact,
+        DirectRunResultArtifact resultArtifact)
+    {
+        ArgumentNullException.ThrowIfNull(requestArtifact);
+        ArgumentNullException.ThrowIfNull(resultArtifact);
+
+        return string.Equals(resultArtifact.EntryKind, requestArtifact.EntryKind, StringComparison.Ordinal)
+            && string.Equals(resultArtifact.UpstreamRequestRef, requestArtifact.UpstreamRequestRef, StringComparison.Ordinal)
+            && string.Equals(resultArtifact.Provider, requestArtifact.Provider, StringComparison.Ordinal)
+            && string.Equals(resultArtifact.Model, requestArtifact.Model, StringComparison.Ordinal)
+            && string.Equals(resultArtifact.SessionId, requestArtifact.ProviderSessionId, StringComparison.Ordinal);
     }
 
     private static bool TryResolveReviewCommentBodyPath(

--- a/tests/IntentSystem.Cli.Tests/DirectRunResultArtifactJsonTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunResultArtifactJsonTests.cs
@@ -59,4 +59,33 @@ public sealed class DirectRunResultArtifactJsonTests
         Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/67", roundTripped.LinkedPr?.Url);
         Assert.Equal("/repo/.intent-cli/worktrees/G19", roundTripped.Worktree.Path);
     }
+
+    [Fact]
+    public void Deserialize_GivenLegacyArtifactWithoutUpstreamRequestRef_PreservesBackwardCompatibility()
+    {
+        var json = """
+        {
+          "schema_version": "1",
+          "execution_unit": "G19",
+          "entry_kind": "review",
+          "provider": "ReviewBot",
+          "model": "gpt-5.4-mini",
+          "session_id": "pid:legacy",
+          "run_status": "running",
+          "raw_log_ref": ".intent-cli/runs/G19.provider.jsonl",
+          "packet_ref": ".intent-cli/issues/G19/packet.yaml",
+          "review_context_ref": ".intent-cli/issues/G19/review-context.md",
+          "worktree": {
+            "path": "/repo/.intent-cli/worktrees/G19"
+          }
+        }
+        """;
+
+        var artifact = DirectRunResultArtifactJson.Deserialize(json);
+
+        Assert.Equal("G19", artifact.ExecutionUnit);
+        Assert.Equal("review", artifact.EntryKind);
+        Assert.Equal(string.Empty, artifact.UpstreamRequestRef);
+        Assert.Equal("pid:legacy", artifact.SessionId);
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/DirectRunResultArtifactJsonTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunResultArtifactJsonTests.cs
@@ -12,6 +12,7 @@ public sealed class DirectRunResultArtifactJsonTests
             SchemaVersion = "1",
             ExecutionUnit = "G19",
             EntryKind = "implement",
+            UpstreamRequestRef = ".intent-cli/implement/G19.request.md",
             Provider = "Claude",
             Model = "default",
             SessionId = "pid:4321",
@@ -42,6 +43,7 @@ public sealed class DirectRunResultArtifactJsonTests
 
         Assert.Equal("G19", roundTripped.ExecutionUnit);
         Assert.Equal("implement", roundTripped.EntryKind);
+        Assert.Equal(".intent-cli/implement/G19.request.md", roundTripped.UpstreamRequestRef);
         Assert.Equal("Claude", roundTripped.Provider);
         Assert.Equal("default", roundTripped.Model);
         Assert.Equal("pid:4321", roundTripped.SessionId);

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -83,6 +83,7 @@ public sealed class ReviewRunCommandTests
             var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
             Assert.Equal("G9", resultArtifact.ExecutionUnit);
             Assert.Equal("review", resultArtifact.EntryKind);
+            Assert.Equal(".intent-cli/reviews/G9.request.json", resultArtifact.UpstreamRequestRef);
             Assert.Equal("ReviewBot", resultArtifact.Provider);
             Assert.Equal("gpt-5.4-mini", resultArtifact.Model);
             Assert.Equal("pid:9999", resultArtifact.SessionId);

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -73,12 +73,14 @@ public sealed class RunCommandTests
             };
             RunCommand.ReviewRunExecutor = (_, executionUnit) =>
             {
+                WriteDirectRunRequest(repoRoot, executionUnit, "review", "pid:226");
                 WriteDirectRunResult(repoRoot, executionUnit, "review", "running");
 
                 return new ReviewRunResult
                 {
                     ExecutionUnit = executionUnit,
-                    ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+                    ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json",
+                    DirectRun = CreateDirectRunLaunchResult(executionUnit, "pid:226")
                 };
             };
 
@@ -233,8 +235,10 @@ public sealed class RunCommandTests
             RunCommand.ReviewRunExecutor = (_, executionUnit) => new ReviewRunResult
             {
                 ExecutionUnit = executionUnit,
-                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json",
+                DirectRun = CreateDirectRunLaunchResult(executionUnit, "pid:226")
             };
+            WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
@@ -267,8 +271,10 @@ public sealed class RunCommandTests
             RunCommand.ReviewRunExecutor = (_, executionUnit) => new ReviewRunResult
             {
                 ExecutionUnit = executionUnit,
-                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json"
+                ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json",
+                DirectRun = CreateDirectRunLaunchResult(executionUnit, "pid:226")
             };
+            WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
@@ -367,6 +373,7 @@ public sealed class RunCommandTests
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
             "{}");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
         WriteDirectRunResult(repoRoot, "G226", "review", "accepted");
         var originalReviewAcceptExecutor = RunCommand.ReviewAcceptExecutor;
 
@@ -414,6 +421,7 @@ public sealed class RunCommandTests
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
             "{}");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
         WriteDirectRunResult(
             repoRoot,
             "G226",
@@ -475,6 +483,28 @@ public sealed class RunCommandTests
         {
             RunCommand.ReviewCommentExecutor = originalReviewCommentExecutor;
         }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenStaleReviewResultForDifferentSession_WaitsForCurrentBoundary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:current");
+        WriteDirectRunResult(repoRoot, "G226", "review", "accepted", sessionId: "pid:stale");
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("no-actionable-item", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("does not match the current launched request boundary", result.Detail, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -677,7 +707,8 @@ public sealed class RunCommandTests
         string executionUnit,
         string entryKind,
         string runStatus,
-        IReadOnlyList<DirectRunProviderEvent>? providerEvents = null)
+        IReadOnlyList<DirectRunProviderEvent>? providerEvents = null,
+        string sessionId = "pid:226")
     {
         var runsDirectory = Path.Combine(repoRoot, ".intent-cli", "runs");
         Directory.CreateDirectory(runsDirectory);
@@ -693,7 +724,7 @@ public sealed class RunCommandTests
                     UpstreamRequestRef = ResolveUpstreamRequestRef(executionUnit, entryKind),
                     Provider = "ReviewBot",
                     Model = "gpt-5.4-mini",
-                    SessionId = "pid:226",
+                    SessionId = sessionId,
                     RunStatus = runStatus,
                     RawLogRef = $".intent-cli/runs/{executionUnit}.provider.jsonl",
                     PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
@@ -724,6 +755,49 @@ public sealed class RunCommandTests
         File.WriteAllText(
             Path.Combine(runsDirectory, $"{executionUnit}.provider.jsonl"),
             string.Join(Environment.NewLine, providerEvents.Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+    }
+
+    private static void WriteDirectRunRequest(
+        string repoRoot,
+        string executionUnit,
+        string entryKind,
+        string providerSessionId)
+    {
+        var runsDirectory = Path.Combine(repoRoot, ".intent-cli", "runs");
+        Directory.CreateDirectory(runsDirectory);
+
+        File.WriteAllText(
+            Path.Combine(runsDirectory, $"{executionUnit}.request.json"),
+            DirectRunRequestArtifactJson.Serialize(
+                new DirectRunRequestArtifact
+                {
+                    SchemaVersion = "1",
+                    ExecutionUnit = executionUnit,
+                    EntryKind = entryKind,
+                    UpstreamRequestRef = ResolveUpstreamRequestRef(executionUnit, entryKind),
+                    Provider = "ReviewBot",
+                    Model = "gpt-5.4-mini",
+                    Transport = "responses",
+                    LaunchedAt = "2026-04-10T12:00:00.0000000+00:00",
+                    ProviderSessionId = providerSessionId,
+                    TransportSummary = "launched"
+                }));
+    }
+
+    private static DirectRunLaunchResult CreateDirectRunLaunchResult(string executionUnit, string providerSessionId)
+    {
+        return new DirectRunLaunchResult
+        {
+            RequestArtifactPath = $".intent-cli/runs/{executionUnit}.request.json",
+            ProviderEventLogPath = $".intent-cli/runs/{executionUnit}.provider.jsonl",
+            ResultArtifactPath = $".intent-cli/runs/{executionUnit}.result.json",
+            Provider = "ReviewBot",
+            Model = "gpt-5.4-mini",
+            Transport = "responses",
+            ProviderSessionId = providerSessionId,
+            TransportSummary = "launched",
+            RunStatus = "running"
+        };
     }
 
     private static string ResolveUpstreamRequestRef(string executionUnit, string entryKind)

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -690,6 +690,7 @@ public sealed class RunCommandTests
                     SchemaVersion = "1",
                     ExecutionUnit = executionUnit,
                     EntryKind = entryKind,
+                    UpstreamRequestRef = ResolveUpstreamRequestRef(executionUnit, entryKind),
                     Provider = "ReviewBot",
                     Model = "gpt-5.4-mini",
                     SessionId = "pid:226",
@@ -723,6 +724,17 @@ public sealed class RunCommandTests
         File.WriteAllText(
             Path.Combine(runsDirectory, $"{executionUnit}.provider.jsonl"),
             string.Join(Environment.NewLine, providerEvents.Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+    }
+
+    private static string ResolveUpstreamRequestRef(string executionUnit, string entryKind)
+    {
+        return entryKind switch
+        {
+            "implement" => $".intent-cli/implement/{executionUnit}.request.md",
+            "fix" => $".intent-cli/fix/{executionUnit}.request.md",
+            "review" => $".intent-cli/reviews/{executionUnit}.request.json",
+            _ => throw new InvalidOperationException($"Unsupported entry kind '{entryKind}'.")
+        };
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -508,6 +508,51 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenLegacyReviewResultWithoutUpstreamRequestRef_WaitsForCurrentBoundary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:current");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs", "G226.result.json"),
+            """
+            {
+              "schema_version": "1",
+              "execution_unit": "G226",
+              "entry_kind": "review",
+              "provider": "ReviewBot",
+              "model": "gpt-5.4-mini",
+              "session_id": "pid:current",
+              "run_status": "accepted",
+              "raw_log_ref": ".intent-cli/runs/G226.provider.jsonl",
+              "packet_ref": ".intent-cli/issues/G226/packet.yaml",
+              "review_context_ref": ".intent-cli/issues/G226/review-context.md",
+              "linked_pr": {
+                "repo": "J-Tech-Japan/intent-system",
+                "number": 226,
+                "url": "https://github.com/J-Tech-Japan/intent-system/pull/226"
+              },
+              "worktree": {
+                "path": "/repo/.intent-cli/worktrees/G226"
+              }
+            }
+            """);
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("no-actionable-item", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("does not match the current launched request boundary", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ExecuteCore_GivenClarifyBlockedItem_StopsWithClarificationRequired()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -90,6 +90,7 @@ public sealed class RunFixCommandTests
             var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
             Assert.Equal("G20", resultArtifact.ExecutionUnit);
             Assert.Equal("fix", resultArtifact.EntryKind);
+            Assert.Equal(".intent-cli/fix/G20.request.md", resultArtifact.UpstreamRequestRef);
             Assert.Equal("Claude", resultArtifact.Provider);
             Assert.Equal("default", resultArtifact.Model);
             Assert.Equal("pid:8765", resultArtifact.SessionId);

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -84,6 +84,7 @@ public sealed class RunImplementCommandTests
             var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
             Assert.Equal("G19", resultArtifact.ExecutionUnit);
             Assert.Equal("implement", resultArtifact.EntryKind);
+            Assert.Equal(".intent-cli/implement/G19.request.md", resultArtifact.UpstreamRequestRef);
             Assert.Equal("Claude", resultArtifact.Provider);
             Assert.Equal("default", resultArtifact.Model);
             Assert.Equal("pid:4321", resultArtifact.SessionId);


### PR DESCRIPTION
## Summary
- include `upstream_request_ref` in normalized direct-run result artifacts
- persist the same launched upstream request ref when synthesizing implement, fix, and review results
- add regression coverage so review normalized results stay aligned with the launched review request

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~ReviewRunCommandTests|FullyQualifiedName~RunImplementCommandTests|FullyQualifiedName~RunFixCommandTests|FullyQualifiedName~DirectRunResultArtifactJsonTests|FullyQualifiedName~RunCommandTests"`
- `dotnet test IntentSystem.sln`

Refs #237
