### PR TITLE
Ingest review backend exit status

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -447,6 +447,12 @@ internal static class DirectRunCommandSupport
             return NormalizeRunStatus(disposition);
         }
 
+        if (TryReadInt32(payload, "exit_code", out var exitCode)
+            || TryReadInt32(payload, "exitCode", out exitCode))
+        {
+            return exitCode == 0 ? "succeeded" : "failed";
+        }
+
         return null;
     }
 
@@ -465,6 +471,35 @@ internal static class DirectRunCommandSupport
 
         value = element.GetString() ?? string.Empty;
         return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static bool TryReadInt32(
+        System.Text.Json.JsonElement payload,
+        string propertyName,
+        out int value)
+    {
+        value = 0;
+
+        if (!payload.TryGetProperty(propertyName, out var element))
+        {
+            return false;
+        }
+
+        if (element.ValueKind == System.Text.Json.JsonValueKind.Number)
+        {
+            return element.TryGetInt32(out value);
+        }
+
+        if (element.ValueKind == System.Text.Json.JsonValueKind.String)
+        {
+            return int.TryParse(
+                element.GetString(),
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out value);
+        }
+
+        return false;
     }
 
     private static string NormalizeRunStatus(string status)

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -539,6 +539,9 @@ internal static class RunCommand
             };
         }
 
+        var providerEvents = SelectCurrentSessionEvents(
+            TryReadDirectRunProviderEvents(context, executionUnit),
+            requestArtifact.ProviderSessionId);
         var runStatus = resultArtifact.RunStatus;
         if (string.Equals(runStatus, "failed", StringComparison.Ordinal))
         {
@@ -561,7 +564,6 @@ internal static class RunCommand
 
         if (string.Equals(runStatus, "succeeded", StringComparison.Ordinal))
         {
-            var providerEvents = TryReadDirectRunProviderEvents(context, executionUnit);
             if (TryResolveExplicitReviewOutcome(providerEvents, out var explicitReviewOutcome))
             {
                 if (string.Equals(explicitReviewOutcome, "accepted", StringComparison.Ordinal)
@@ -603,7 +605,6 @@ internal static class RunCommand
             || string.Equals(runStatus, "fix-requested", StringComparison.Ordinal)
             || string.Equals(runStatus, "changes-requested", StringComparison.Ordinal))
         {
-            var providerEvents = TryReadDirectRunProviderEvents(context, executionUnit);
             if (TryResolveReviewCommentBodyPath(context, executionUnit, providerEvents, out var commentBodyPath))
             {
                 return new RunReviewDecision
@@ -647,6 +648,26 @@ internal static class RunCommand
         }
 
         return false;
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> SelectCurrentSessionEvents(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string launchedSessionId)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        if (string.IsNullOrWhiteSpace(launchedSessionId))
+        {
+            return providerEvents;
+        }
+
+        var matchedEvents = providerEvents
+            .Where(providerEvent => string.Equals(providerEvent.SessionId, launchedSessionId, StringComparison.Ordinal))
+            .ToArray();
+
+        return matchedEvents.Length > 0
+            ? matchedEvents
+            : providerEvents;
     }
 
     private static bool MatchesCurrentReviewRequestBoundary(

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -550,14 +550,52 @@ internal static class RunCommand
         }
 
         if (string.Equals(runStatus, "accepted", StringComparison.Ordinal)
-            || string.Equals(runStatus, "approved", StringComparison.Ordinal)
-            || string.Equals(runStatus, "succeeded", StringComparison.Ordinal))
+            || string.Equals(runStatus, "approved", StringComparison.Ordinal))
         {
             return new RunReviewDecision
             {
                 Kind = RunReviewDecisionKind.Accept,
                 Detail = $"Review decision for '{executionUnit}' resolved to accept."
             };
+        }
+
+        if (string.Equals(runStatus, "succeeded", StringComparison.Ordinal))
+        {
+            var providerEvents = TryReadDirectRunProviderEvents(context, executionUnit);
+            if (TryResolveExplicitReviewOutcome(providerEvents, out var explicitReviewOutcome))
+            {
+                if (string.Equals(explicitReviewOutcome, "accepted", StringComparison.Ordinal)
+                    || string.Equals(explicitReviewOutcome, "approved", StringComparison.Ordinal))
+                {
+                    return new RunReviewDecision
+                    {
+                        Kind = RunReviewDecisionKind.Accept,
+                        Detail = $"Review decision for '{executionUnit}' resolved to accept."
+                    };
+                }
+
+                if (string.Equals(explicitReviewOutcome, "comment", StringComparison.Ordinal)
+                    || string.Equals(explicitReviewOutcome, "commented", StringComparison.Ordinal)
+                    || string.Equals(explicitReviewOutcome, "fix-requested", StringComparison.Ordinal)
+                    || string.Equals(explicitReviewOutcome, "changes-requested", StringComparison.Ordinal))
+                {
+                    if (TryResolveReviewCommentBodyPath(context, executionUnit, providerEvents, out var commentBodyPath))
+                    {
+                        return new RunReviewDecision
+                        {
+                            Kind = RunReviewDecisionKind.Comment,
+                            CommentBodyPath = commentBodyPath,
+                            Detail = $"Review decision for '{executionUnit}' resolved to comment."
+                        };
+                    }
+
+                    return new RunReviewDecision
+                    {
+                        Kind = RunReviewDecisionKind.ContractGap,
+                        Detail = $"Review decision for '{executionUnit}' requested comment but no deterministic comment body was found."
+                    };
+                }
+            }
         }
 
         if (string.Equals(runStatus, "comment", StringComparison.Ordinal)
@@ -588,6 +626,27 @@ internal static class RunCommand
             Kind = RunReviewDecisionKind.Waiting,
             Detail = $"Review direct run for '{executionUnit}' is '{runStatus}'."
         };
+    }
+
+    private static bool TryResolveExplicitReviewOutcome(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        out string explicitReviewOutcome)
+    {
+        explicitReviewOutcome = string.Empty;
+
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            if (TryResolveRunStatus(providerEvents[index].Payload, out var runStatus)
+                && !string.Equals(runStatus, "succeeded", StringComparison.Ordinal)
+                && !string.Equals(runStatus, "failed", StringComparison.Ordinal)
+                && !string.Equals(runStatus, "running", StringComparison.Ordinal))
+            {
+                explicitReviewOutcome = runStatus;
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool MatchesCurrentReviewRequestBoundary(
@@ -668,6 +727,36 @@ internal static class RunCommand
         return false;
     }
 
+    private static bool TryResolveRunStatus(JsonElement payload, out string runStatus)
+    {
+        runStatus = string.Empty;
+
+        if (payload.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (TryReadString(payload, "run_status", out var payloadRunStatus))
+        {
+            runStatus = NormalizeRunStatus(payloadRunStatus);
+            return true;
+        }
+
+        if (TryReadString(payload, "status", out var status))
+        {
+            runStatus = NormalizeRunStatus(status);
+            return true;
+        }
+
+        if (TryReadString(payload, "disposition", out var disposition))
+        {
+            runStatus = NormalizeRunStatus(disposition);
+            return true;
+        }
+
+        return false;
+    }
+
     private static bool TryReadString(JsonElement payload, string propertyName, out string value)
     {
         value = string.Empty;
@@ -680,6 +769,17 @@ internal static class RunCommand
 
         value = element.GetString() ?? string.Empty;
         return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static string NormalizeRunStatus(string status)
+    {
+        return status.Trim().ToLowerInvariant() switch
+        {
+            "success" or "completed" => "succeeded",
+            "error" => "failed",
+            var normalized when !string.IsNullOrWhiteSpace(normalized) => normalized,
+            _ => "running"
+        };
     }
 
     private static RunCommandResult CreateStopResult(

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -294,6 +294,57 @@ public sealed class ReviewRunCommandTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenBackendExitEvent_NormalizesSucceededRunStatus()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = ReviewRunCommand.TimestampFactory;
+        var originalLauncherFactory = ReviewRunCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            ReviewRunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:35:00Z");
+            ReviewRunCommand.DirectRunLauncherFactory = () => new ExitCodeFakeDirectRunLauncher(
+                "pid:9999",
+                "ReviewBot",
+                "gpt-5.4-mini",
+                "grpc",
+                "reviewbot",
+                ["launch", "--model", "{model}", "--artifact", "{request_artifact_path}"],
+                "grpc transport launched via 'reviewbot' in '/repo' for provider 'ReviewBot'.",
+                0);
+
+            var exitCode = ReviewRunCommand.Execute(CreateContext(repoRoot), ["G9"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run status: succeeded", writer.ToString(), StringComparison.Ordinal);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
+            Assert.Equal("succeeded", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            var lifecycleEvent = Assert.Single(runEvents, runEvent => runEvent.Event == "provider-lifecycle");
+            Assert.Equal("succeeded", lifecycleEvent.RunStatus);
+        }
+        finally
+        {
+            ReviewRunCommand.TimestampFactory = originalTimestampFactory;
+            ReviewRunCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext
@@ -585,6 +636,96 @@ public sealed class ReviewRunCommandTests
                                          })
                                      }) + Environment.NewLine;
             File.AppendAllText(absoluteProviderEventLogPath, providerEvents);
+
+            return new DirectRunLaunchResult
+            {
+                RequestArtifactPath = ".intent-cli/runtime-runs/G9.request.json",
+                ProviderEventLogPath = ".intent-cli/runtime-runs/G9.provider.jsonl",
+                Provider = providerArg,
+                Model = modelArg,
+                Transport = transportArg,
+                ProviderSessionId = providerSessionId,
+                TransportSummary = transportSummary
+            };
+        }
+    }
+
+    private sealed class ExitCodeFakeDirectRunLauncher(
+        string providerSessionId,
+        string provider,
+        string model,
+        string transport,
+        string command,
+        IReadOnlyList<string> argsTemplate,
+        string transportSummary,
+        int exitCode) : IDirectRunLauncher
+    {
+        public DirectRunLaunchResult Launch(
+            string executionUnit,
+            string entryKind,
+            string requestArtifactPath,
+            string providerEventLogPath,
+            string providerArg,
+            string modelArg,
+            string transportArg,
+            string commandArg,
+            IReadOnlyList<string> argsTemplateArg,
+            DateTimeOffset launchedAt,
+            string workingDirectory,
+            string absoluteRequestArtifactPath,
+            string absoluteProviderEventLogPath)
+        {
+            Assert.Equal("G9", executionUnit);
+            Assert.Equal("review", entryKind);
+            Assert.Equal(".intent-cli/runtime-runs/G9.request.json", requestArtifactPath);
+            Assert.Equal(".intent-cli/runtime-runs/G9.provider.jsonl", providerEventLogPath);
+            Assert.Equal(provider, providerArg);
+            Assert.Equal(model, modelArg);
+            Assert.Equal(transport, transportArg);
+            Assert.Equal(command, commandArg);
+            Assert.Equal(argsTemplate, argsTemplateArg);
+            Assert.EndsWith("/repo", workingDirectory, StringComparison.Ordinal);
+            Assert.EndsWith("/.intent-cli/reviews/G9.request.json", absoluteRequestArtifactPath, StringComparison.Ordinal);
+            Assert.EndsWith("/.intent-cli/runtime-runs/G9.provider.jsonl", absoluteProviderEventLogPath, StringComparison.Ordinal);
+
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(absoluteProviderEventLogPath)
+                ?? throw new InvalidOperationException("Provider event log path did not contain a directory."));
+            var providerEvents = string.Join(
+                                     Environment.NewLine,
+                                     new[]
+                                     {
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "session-metadata",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 model = modelArg,
+                                                 transport = transportArg,
+                                                 command
+                                             })
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(1).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 type = "backend-exit",
+                                                 exit_code = exitCode
+                                             })
+                                         })
+                                     }) + Environment.NewLine;
+            File.WriteAllText(absoluteProviderEventLogPath, providerEvents);
 
             return new DirectRunLaunchResult
             {

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -515,6 +515,62 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenSucceededReviewDecisionWithOnlyStaleAcceptedOutcome_Waits()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "review",
+            "succeeded",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T11:59:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "ReviewBot",
+                    EntryKind = "review",
+                    SessionId = "pid:stale",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        disposition = "accepted"
+                    })
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "ReviewBot",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 0
+                    })
+                }
+            ]);
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("no-actionable-item", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("Review direct run for 'G226' is 'succeeded'.", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ExecuteCore_GivenCommentReviewDecisionWithCommentBody_ReusesReviewCommentBoundary()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -411,7 +411,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenSucceededReviewDecision_ReusesReviewAcceptBoundary()
+    public void ExecuteCore_GivenSucceededReviewDecisionWithoutExplicitOutcome_Waits()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -423,6 +423,62 @@ public sealed class RunCommandTests
             "{}");
         WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
         WriteDirectRunResult(repoRoot, "G226", "review", "succeeded");
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("no-actionable-item", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("Review direct run for 'G226' is 'succeeded'.", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenSucceededReviewDecisionWithExplicitAcceptedOutcome_ReusesReviewAcceptBoundary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "review",
+            "succeeded",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "ReviewBot",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        disposition = "accepted"
+                    })
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "ReviewBot",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 0
+                    })
+                }
+            ]);
         var originalReviewAcceptExecutor = RunCommand.ReviewAcceptExecutor;
 
         try

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -411,6 +411,54 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenSucceededReviewDecision_ReusesReviewAcceptBoundary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
+        WriteDirectRunResult(repoRoot, "G226", "review", "succeeded");
+        var originalReviewAcceptExecutor = RunCommand.ReviewAcceptExecutor;
+
+        try
+        {
+            RunCommand.ReviewAcceptExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Completed
+                    });
+
+                return new ReviewAcceptResult
+                {
+                    ExecutionUnit = executionUnit,
+                    MergedPrRef = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                    ClosedIssueRef = "https://github.com/J-Tech-Japan/intent-system/issues/226"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Null(result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review accept", action.Name);
+            Assert.Equal("G226", action.ExecutionUnit);
+        }
+        finally
+        {
+            RunCommand.ReviewAcceptExecutor = originalReviewAcceptExecutor;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenCommentReviewDecisionWithCommentBody_ReusesReviewCommentBoundary()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- ingest review backend exit payloads that report only exit codes into normalized direct-run status
- add review-run coverage that persists a succeeded status from backend exit events into the result artifact and lifecycle log
- add run-command coverage to confirm a normalized succeeded review result triggers the review accept boundary

Closes #241

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~ReviewRunCommandTests|FullyQualifiedName~RunCommandTests"
- dotnet test IntentSystem.sln