### PR TITLE
Capture review backend exit in provider log

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -74,6 +74,13 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                     transport,
                     command));
             },
+            exitCode => eventWriter.Append(CreateBackendExitEvent(
+                DateTimeOffset.UtcNow,
+                executionUnit,
+                entryKind,
+                provider,
+                providerSessionId,
+                exitCode)),
             raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)),
             raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)));
 
@@ -167,6 +174,30 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             SessionId = providerSessionId,
             Kind = "provider-event",
             Payload = ParsePayload(raw)
+        };
+    }
+
+    private static DirectRunProviderEvent CreateBackendExitEvent(
+        DateTimeOffset timestamp,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        int exitCode)
+    {
+        return new DirectRunProviderEvent
+        {
+            Timestamp = timestamp.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = provider,
+            EntryKind = entryKind,
+            SessionId = providerSessionId,
+            Kind = "provider-event",
+            Payload = JsonSerializer.SerializeToElement(new
+            {
+                type = "backend-exit",
+                exit_code = exitCode
+            })
         };
     }
 

--- a/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
@@ -11,6 +11,7 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
         IReadOnlyList<string> arguments,
         TimeSpan earlyExitWindow,
         Action<int> onStarted,
+        Action<int> onExited,
         Action<string> onStdOutLine,
         Action<string> onStdErrLine)
     {
@@ -18,6 +19,7 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
         ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
         ArgumentNullException.ThrowIfNull(arguments);
         ArgumentNullException.ThrowIfNull(onStarted);
+        ArgumentNullException.ThrowIfNull(onExited);
         ArgumentNullException.ThrowIfNull(onStdOutLine);
         ArgumentNullException.ThrowIfNull(onStdErrLine);
 
@@ -43,6 +45,20 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
 
             onStarted(process.Id);
 
+            var exitReported = 0;
+            process.EnableRaisingEvents = true;
+            process.Exited += (_, _) =>
+            {
+                if (System.Threading.Interlocked.Exchange(ref exitReported, 1) != 0)
+                {
+                    return;
+                }
+
+                process.WaitForExit();
+                onExited(process.ExitCode);
+                process.Dispose();
+            };
+
             process.OutputDataReceived += (_, eventArgs) =>
             {
                 if (!string.IsNullOrEmpty(eventArgs.Data))
@@ -66,8 +82,12 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
 
             if (exitedEarly)
             {
-                process.WaitForExit();
-                process.Dispose();
+                if (System.Threading.Interlocked.Exchange(ref exitReported, 1) == 0)
+                {
+                    process.WaitForExit();
+                    onExited(exitCode);
+                    process.Dispose();
+                }
             }
 
             return new DirectRunProcessLaunchResult

--- a/src/IntentSystem.Cli/Commands/IDirectRunProcessRunner.cs
+++ b/src/IntentSystem.Cli/Commands/IDirectRunProcessRunner.cs
@@ -8,6 +8,7 @@ internal interface IDirectRunProcessRunner
         IReadOnlyList<string> arguments,
         TimeSpan earlyExitWindow,
         Action<int> onStarted,
+        Action<int> onExited,
         Action<string> onStdOutLine,
         Action<string> onStdErrLine);
 }

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -98,6 +98,51 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public void Launch_GivenProcessExit_AppendsBackendExitProviderEvent()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G9.provider.jsonl");
+        var runner = new FakeDirectRunProcessRunner
+        {
+            ExitCodeEvent = 0,
+            Result = new DirectRunProcessLaunchResult
+            {
+                ProcessId = 4321,
+                ExitedEarly = false,
+                ExitCode = 0
+            }
+        };
+        var launcher = new DirectRunLauncher(runner);
+
+        launcher.Launch(
+            "G9",
+            "review",
+            ".intent-cli/runs/G9.request.json",
+            ".intent-cli/runs/G9.provider.jsonl",
+            "Codex",
+            "gpt-5.4-mini",
+            "responses",
+            "codex",
+            ["exec", "{prompt}"],
+            DateTimeOffset.Parse("2026-04-09T10:35:00Z"),
+            "/repo",
+            "/repo/.intent-cli/reviews/G9.request.json",
+            providerEventLogPath);
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        var backendExitEvent = Assert.Single(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+        Assert.Equal("G9", backendExitEvent.ExecutionUnit);
+        Assert.Equal("Codex", backendExitEvent.Provider);
+        Assert.Equal("review", backendExitEvent.EntryKind);
+        Assert.Equal("pid:4321", backendExitEvent.SessionId);
+        Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+    }
+
+    [Fact]
     public void Launch_GivenUpstreamRequestArtifactPlaceholder_ExpandsAlias()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -179,6 +224,8 @@ public sealed class DirectRunLauncherTests
 
         public IReadOnlyList<string> StdErrLines { get; init; } = [];
 
+        public int? ExitCodeEvent { get; init; }
+
         public DirectRunProcessLaunchResult Result { get; set; } = new()
         {
             ProcessId = 1,
@@ -192,6 +239,7 @@ public sealed class DirectRunLauncherTests
             IReadOnlyList<string> arguments,
             TimeSpan earlyExitWindow,
             Action<int> onStarted,
+            Action<int> onExited,
             Action<string> onStdOutLine,
             Action<string> onStdErrLine)
         {
@@ -207,6 +255,11 @@ public sealed class DirectRunLauncherTests
             foreach (var line in StdErrLines)
             {
                 onStdErrLine(line);
+            }
+
+            if (ExitCodeEvent is { } exitCode)
+            {
+                onExited(exitCode);
             }
 
             return Result;


### PR DESCRIPTION
## Summary
- append a `backend-exit` provider event when the direct-run process exits so real Codex review runs persist the backend exit into the raw provider log
- extend the process-runner contract with an exit callback and wire the launcher to use it
- add launcher coverage that verifies the raw provider log records the backend exit event

Closes #243

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~DirectRunLauncherTests"
- dotnet test IntentSystem.sln