### PR TITLE
Persist Codex backend exit from wrapped run

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -163,7 +163,21 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             Arguments =
             [
                 "-c",
-                "provider_log_path=$1; execution_unit=$2; entry_kind=$3; provider=$4; shift 4; \"$@\"; exit_code=$?; timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ'); printf '{\"ts\":\"%s\",\"execution_unit\":\"%s\",\"provider\":\"%s\",\"entry_kind\":\"%s\",\"session_id\":\"pid:%s\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":%s}}\\n' \"$timestamp\" \"$execution_unit\" \"$provider\" \"$entry_kind\" \"$$\" \"$exit_code\" >> \"$provider_log_path\"; exit \"$exit_code\"",
+                """
+                provider_log_path=$1
+                execution_unit=$2
+                entry_kind=$3
+                provider=$4
+                shift 4
+                session_id="pid:$$"
+                append_backend_exit() {
+                  exit_code=$?
+                  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+                  printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":$exit_code}}" >> "$provider_log_path"
+                }
+                trap append_backend_exit EXIT
+                "$@"
+                """,
                 "direct-run-wrapper",
                 absoluteProviderEventLogPath,
                 executionUnit,

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -81,15 +81,14 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                     transport,
                     command));
             },
-            processInvocation.SelfReportsBackendExit
-                ? static _ => { }
-                : exitCode => eventWriter.Append(CreateBackendExitEvent(
-                    DateTimeOffset.UtcNow,
+            exitCode => AppendBackendExitEventIfMissing(
+                    eventWriter,
+                    absoluteProviderEventLogPath,
                     executionUnit,
                     entryKind,
                     provider,
                     providerSessionId,
-                    exitCode)),
+                    exitCode),
             raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)),
             raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)));
 
@@ -152,8 +151,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             return new ResolvedProcessInvocation
             {
                 FileName = command,
-                Arguments = arguments,
-                SelfReportsBackendExit = false
+                Arguments = arguments
             };
         }
 
@@ -185,8 +183,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 provider,
                 command,
                 .. arguments
-            ],
-            SelfReportsBackendExit = true
+            ]
         };
     }
 
@@ -195,6 +192,52 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         return !OperatingSystem.IsWindows()
             && (string.Equals(provider, "codex", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(command, "codex", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static void AppendBackendExitEventIfMissing(
+        DirectRunProviderEventWriter eventWriter,
+        string providerEventLogPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        int exitCode)
+    {
+        ArgumentNullException.ThrowIfNull(eventWriter);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerEventLogPath);
+
+        if (string.IsNullOrWhiteSpace(providerSessionId) || HasBackendExitEvent(providerEventLogPath, providerSessionId))
+        {
+            return;
+        }
+
+        eventWriter.Append(CreateBackendExitEvent(
+            DateTimeOffset.UtcNow,
+            executionUnit,
+            entryKind,
+            provider,
+            providerSessionId,
+            exitCode));
+    }
+
+    private static bool HasBackendExitEvent(string providerEventLogPath, string providerSessionId)
+    {
+        if (!File.Exists(providerEventLogPath))
+        {
+            return false;
+        }
+
+        foreach (var line in File.ReadLines(providerEventLogPath))
+        {
+            if (line.Contains($"\"session_id\":\"{providerSessionId}\"", StringComparison.Ordinal)
+                && line.Contains("\"kind\":\"provider-event\"", StringComparison.Ordinal)
+                && line.Contains("\"type\":\"backend-exit\"", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static DirectRunProviderEvent CreateSessionMetadataEvent(
@@ -286,7 +329,5 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         public required string FileName { get; init; }
 
         public required IReadOnlyList<string> Arguments { get; init; }
-
-        public required bool SelfReportsBackendExit { get; init; }
     }
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -168,13 +168,11 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 provider=$4
                 shift 4
                 session_id="pid:$$"
-                append_backend_exit() {
-                  exit_code=$?
-                  timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-                  printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":$exit_code}}" >> "$provider_log_path"
-                }
-                trap append_backend_exit EXIT
                 "$@"
+                exit_code=$?
+                timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+                printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":$exit_code}}" >> "$provider_log_path"
+                exit "$exit_code"
                 """,
                 "direct-run-wrapper",
                 absoluteProviderEventLogPath,

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -54,12 +54,19 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             transport,
             absoluteRequestArtifactPath,
             argsTemplate);
+        var processInvocation = ResolveProcessInvocation(
+            executionUnit,
+            entryKind,
+            provider,
+            command,
+            arguments,
+            absoluteProviderEventLogPath);
         var eventWriter = new DirectRunProviderEventWriter(absoluteProviderEventLogPath);
         var providerSessionId = string.Empty;
         var process = processRunner.Start(
             workingDirectory,
-            command,
-            arguments,
+            processInvocation.FileName,
+            processInvocation.Arguments,
             DefaultEarlyExitWindow,
             processId =>
             {
@@ -74,13 +81,15 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                     transport,
                     command));
             },
-            exitCode => eventWriter.Append(CreateBackendExitEvent(
-                DateTimeOffset.UtcNow,
-                executionUnit,
-                entryKind,
-                provider,
-                providerSessionId,
-                exitCode)),
+            processInvocation.SelfReportsBackendExit
+                ? static _ => { }
+                : exitCode => eventWriter.Append(CreateBackendExitEvent(
+                    DateTimeOffset.UtcNow,
+                    executionUnit,
+                    entryKind,
+                    provider,
+                    providerSessionId,
+                    exitCode)),
             raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)),
             raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)));
 
@@ -128,6 +137,50 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 .Replace("{direct_run_artifact_path}", requestArtifactPath, StringComparison.Ordinal)
                 .Replace("{prompt}", prompt, StringComparison.Ordinal))
             .ToArray();
+    }
+
+    private static ResolvedProcessInvocation ResolveProcessInvocation(
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string command,
+        IReadOnlyList<string> arguments,
+        string absoluteProviderEventLogPath)
+    {
+        if (!ShouldShellWrapForPersistentExitLogging(provider, command))
+        {
+            return new ResolvedProcessInvocation
+            {
+                FileName = command,
+                Arguments = arguments,
+                SelfReportsBackendExit = false
+            };
+        }
+
+        return new ResolvedProcessInvocation
+        {
+            FileName = "/bin/sh",
+            Arguments =
+            [
+                "-c",
+                "provider_log_path=$1; execution_unit=$2; entry_kind=$3; provider=$4; shift 4; \"$@\"; exit_code=$?; timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ'); printf '{\"ts\":\"%s\",\"execution_unit\":\"%s\",\"provider\":\"%s\",\"entry_kind\":\"%s\",\"session_id\":\"pid:%s\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":%s}}\\n' \"$timestamp\" \"$execution_unit\" \"$provider\" \"$entry_kind\" \"$$\" \"$exit_code\" >> \"$provider_log_path\"; exit \"$exit_code\"",
+                "direct-run-wrapper",
+                absoluteProviderEventLogPath,
+                executionUnit,
+                entryKind,
+                provider,
+                command,
+                .. arguments
+            ],
+            SelfReportsBackendExit = true
+        };
+    }
+
+    private static bool ShouldShellWrapForPersistentExitLogging(string provider, string command)
+    {
+        return !OperatingSystem.IsWindows()
+            && (string.Equals(provider, "codex", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(command, "codex", StringComparison.OrdinalIgnoreCase));
     }
 
     private static DirectRunProviderEvent CreateSessionMetadataEvent(
@@ -212,5 +265,14 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         {
             return JsonSerializer.SerializeToElement(raw);
         }
+    }
+
+    private sealed record ResolvedProcessInvocation
+    {
+        public required string FileName { get; init; }
+
+        public required IReadOnlyList<string> Arguments { get; init; }
+
+        public required bool SelfReportsBackendExit { get; init; }
     }
 }

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -211,6 +211,80 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public async Task Launch_GivenWrappedCodexProcessThatEndsAfterLaunch_AppendsBackendExitProviderEvent()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G11.provider.jsonl");
+        var worktreePath = tempDirectory.GetPath("repo");
+        Directory.CreateDirectory(worktreePath);
+        var codexPath = tempDirectory.CreateExecutableFile(
+            "repo/codex",
+            """
+            #!/bin/sh
+            sleep 1
+            """);
+        var runner = new FakeDirectRunProcessRunner
+        {
+            ExecuteReceivedProcess = true,
+            ReturnBeforeExitCallback = true
+        };
+        var launcher = new DirectRunLauncher(runner);
+
+        var result = launcher.Launch(
+            "G11",
+            "review",
+            ".intent-cli/runs/G11.request.json",
+            ".intent-cli/runs/G11.provider.jsonl",
+            "Codex",
+            "gpt-5.4-mini",
+            "responses",
+            codexPath,
+            ["exec", "test prompt"],
+            DateTimeOffset.Parse("2026-04-09T10:55:00Z"),
+            worktreePath,
+            tempDirectory.GetPath(".intent-cli/reviews/G11.request.json"),
+            providerEventLogPath);
+
+        var initialEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.Single(initialEvents, providerEvent =>
+            providerEvent.Kind == "session-metadata"
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.DoesNotContain(initialEvents, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+
+        await TemporaryDirectory.WaitForConditionAsync(
+            () =>
+            {
+                var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                return events.Any(providerEvent =>
+                    providerEvent.Kind == "provider-event"
+                    && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                    && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                    && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                    && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+            },
+            TimeSpan.FromSeconds(5));
+
+        var finalEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        var backendExitEvent = Assert.Single(finalEvents, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+    }
+
+    [Fact]
     public void Launch_GivenUpstreamRequestArtifactPlaceholder_ExpandsAlias()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -296,6 +370,8 @@ public sealed class DirectRunLauncherTests
 
         public bool ExecuteReceivedProcess { get; init; }
 
+        public bool ReturnBeforeExitCallback { get; init; }
+
         public DirectRunProcessLaunchResult Result { get; set; } = new()
         {
             ProcessId = 1,
@@ -333,30 +409,46 @@ public sealed class DirectRunLauncherTests
                     startInfo.ArgumentList.Add(argument);
                 }
 
-                using var process = System.Diagnostics.Process.Start(startInfo)
+                var process = System.Diagnostics.Process.Start(startInfo)
                     ?? throw new InvalidOperationException("Failed to start wrapper process.");
                 onStarted(process.Id);
-                var stdout = process.StandardOutput.ReadToEnd();
-                var stderr = process.StandardError.ReadToEnd();
-                process.WaitForExit();
 
-                foreach (var line in SplitLines(stdout))
+                if (ReturnBeforeExitCallback)
                 {
-                    onStdOutLine(line);
+                    process.EnableRaisingEvents = true;
+                    process.Exited += (_, _) => process.Dispose();
+                    return new DirectRunProcessLaunchResult
+                    {
+                        ProcessId = process.Id,
+                        ExitedEarly = false,
+                        ExitCode = 0
+                    };
                 }
 
-                foreach (var line in SplitLines(stderr))
+                using (process)
                 {
-                    onStdErrLine(line);
-                }
+                    var stdout = process.StandardOutput.ReadToEnd();
+                    var stderr = process.StandardError.ReadToEnd();
+                    process.WaitForExit();
 
-                onExited(process.ExitCode);
-                return new DirectRunProcessLaunchResult
-                {
-                    ProcessId = process.Id,
-                    ExitedEarly = true,
-                    ExitCode = process.ExitCode
-                };
+                    foreach (var line in SplitLines(stdout))
+                    {
+                        onStdOutLine(line);
+                    }
+
+                    foreach (var line in SplitLines(stderr))
+                    {
+                        onStdErrLine(line);
+                    }
+
+                    onExited(process.ExitCode);
+                    return new DirectRunProcessLaunchResult
+                    {
+                        ProcessId = process.Id,
+                        ExitedEarly = true,
+                        ExitCode = process.ExitCode
+                    };
+                }
             }
 
             onStarted(Result.ProcessId);
@@ -416,6 +508,22 @@ public sealed class DirectRunLauncherTests
             }
 
             return path;
+        }
+
+        public static async Task WaitForConditionAsync(Func<bool> predicate, TimeSpan timeout)
+        {
+            var startedAt = DateTimeOffset.UtcNow;
+            while (DateTimeOffset.UtcNow - startedAt < timeout)
+            {
+                if (predicate())
+                {
+                    return;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+            }
+
+            Assert.True(predicate(), $"Condition was not satisfied within {timeout}.");
         }
 
         public void Dispose()

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -100,20 +100,22 @@ public sealed class DirectRunLauncherTests
     [Fact]
     public void Launch_GivenProcessExit_AppendsBackendExitProviderEvent()
     {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
         using var tempDirectory = new TemporaryDirectory();
         var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G9.provider.jsonl");
+        var worktreePath = tempDirectory.GetPath("repo");
+        Directory.CreateDirectory(worktreePath);
         var runner = new FakeDirectRunProcessRunner
         {
-            Result = new DirectRunProcessLaunchResult
-            {
-                ProcessId = 4321,
-                ExitedEarly = false,
-                ExitCode = 0
-            }
+            ExecuteReceivedProcess = true
         };
         var launcher = new DirectRunLauncher(runner);
 
-        launcher.Launch(
+        var result = launcher.Launch(
             "G9",
             "review",
             ".intent-cli/runs/G9.request.json",
@@ -121,23 +123,25 @@ public sealed class DirectRunLauncherTests
             "Codex",
             "gpt-5.4-mini",
             "responses",
-            "codex",
-            ["exec", "{prompt}"],
+            "/bin/sh",
+            ["-c", "printf '{\"type\":\"ready\"}\\n'"],
             DateTimeOffset.Parse("2026-04-09T10:35:00Z"),
-            "/repo",
-            "/repo/.intent-cli/reviews/G9.request.json",
+            worktreePath,
+            tempDirectory.GetPath(".intent-cli/reviews/G9.request.json"),
             providerEventLogPath);
 
-        Assert.Equal("/bin/sh", runner.FileName);
-        Assert.Equal("-c", runner.Arguments[0]);
-        Assert.Equal("direct-run-wrapper", runner.Arguments[2]);
-        Assert.Equal(providerEventLogPath, runner.Arguments[3]);
-        Assert.Equal("G9", runner.Arguments[4]);
-        Assert.Equal("review", runner.Arguments[5]);
-        Assert.Equal("Codex", runner.Arguments[6]);
-        Assert.Equal("codex", runner.Arguments[7]);
+        Assert.Equal("pid:", result.ProviderSessionId[..4]);
 
         var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "session-metadata"
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "ready", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
         var backendExitEvent = Assert.Single(events, providerEvent =>
             providerEvent.Kind == "provider-event"
             && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
@@ -146,7 +150,7 @@ public sealed class DirectRunLauncherTests
         Assert.Equal("G9", backendExitEvent.ExecutionUnit);
         Assert.Equal("Codex", backendExitEvent.Provider);
         Assert.Equal("review", backendExitEvent.EntryKind);
-        Assert.Equal("pid:4321", backendExitEvent.SessionId);
+        Assert.Equal(result.ProviderSessionId, backendExitEvent.SessionId);
         Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
     }
 
@@ -234,6 +238,8 @@ public sealed class DirectRunLauncherTests
 
         public int? ExitCodeEvent { get; init; }
 
+        public bool ExecuteReceivedProcess { get; init; }
+
         public DirectRunProcessLaunchResult Result { get; set; } = new()
         {
             ProcessId = 1,
@@ -254,6 +260,49 @@ public sealed class DirectRunLauncherTests
             WorkingDirectory = workingDirectory;
             FileName = fileName;
             Arguments = arguments.ToArray();
+
+            if (ExecuteReceivedProcess)
+            {
+                var startInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = fileName,
+                    WorkingDirectory = workingDirectory,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true
+                };
+
+                foreach (var argument in arguments)
+                {
+                    startInfo.ArgumentList.Add(argument);
+                }
+
+                using var process = System.Diagnostics.Process.Start(startInfo)
+                    ?? throw new InvalidOperationException("Failed to start wrapper process.");
+                onStarted(process.Id);
+                var stdout = process.StandardOutput.ReadToEnd();
+                var stderr = process.StandardError.ReadToEnd();
+                process.WaitForExit();
+
+                foreach (var line in SplitLines(stdout))
+                {
+                    onStdOutLine(line);
+                }
+
+                foreach (var line in SplitLines(stderr))
+                {
+                    onStdErrLine(line);
+                }
+
+                onExited(process.ExitCode);
+                return new DirectRunProcessLaunchResult
+                {
+                    ProcessId = process.Id,
+                    ExitedEarly = true,
+                    ExitCode = process.ExitCode
+                };
+            }
+
             onStarted(Result.ProcessId);
             foreach (var line in StdOutLines)
             {
@@ -265,42 +314,20 @@ public sealed class DirectRunLauncherTests
                 onStdErrLine(line);
             }
 
-            if (string.Equals(fileName, "/bin/sh", StringComparison.Ordinal)
-                && arguments.Count >= 8)
-            {
-                var providerEventLogPath = arguments[3];
-                var executionUnit = arguments[4];
-                var entryKind = arguments[5];
-                var provider = arguments[6];
-                var exitCode = Result.ExitedEarly
-                    ? Result.ExitCode
-                    : ExitCodeEvent ?? 0;
-                var directoryPath = Path.GetDirectoryName(providerEventLogPath)
-                    ?? throw new InvalidOperationException("Provider event log path did not contain a directory.");
-                Directory.CreateDirectory(directoryPath);
-                File.AppendAllText(
-                    providerEventLogPath,
-                    DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
-                    {
-                        Timestamp = "2026-04-09T10:35:01Z",
-                        ExecutionUnit = executionUnit,
-                        Provider = provider,
-                        EntryKind = entryKind,
-                        SessionId = $"pid:{Result.ProcessId}",
-                        Kind = "provider-event",
-                        Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
-                        {
-                            type = "backend-exit",
-                            exit_code = exitCode
-                        })
-                    }) + Environment.NewLine);
-            }
-            else if (ExitCodeEvent is { } exitCode)
+            if (ExitCodeEvent is { } exitCode)
             {
                 onExited(exitCode);
             }
 
             return Result;
+        }
+
+        private static IReadOnlyList<string> SplitLines(string content)
+        {
+            return content
+                .Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Replace('\r', '\n')
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries);
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -104,7 +104,6 @@ public sealed class DirectRunLauncherTests
         var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G9.provider.jsonl");
         var runner = new FakeDirectRunProcessRunner
         {
-            ExitCodeEvent = 0,
             Result = new DirectRunProcessLaunchResult
             {
                 ProcessId = 4321,
@@ -128,6 +127,15 @@ public sealed class DirectRunLauncherTests
             "/repo",
             "/repo/.intent-cli/reviews/G9.request.json",
             providerEventLogPath);
+
+        Assert.Equal("/bin/sh", runner.FileName);
+        Assert.Equal("-c", runner.Arguments[0]);
+        Assert.Equal("direct-run-wrapper", runner.Arguments[2]);
+        Assert.Equal(providerEventLogPath, runner.Arguments[3]);
+        Assert.Equal("G9", runner.Arguments[4]);
+        Assert.Equal("review", runner.Arguments[5]);
+        Assert.Equal("Codex", runner.Arguments[6]);
+        Assert.Equal("codex", runner.Arguments[7]);
 
         var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
         var backendExitEvent = Assert.Single(events, providerEvent =>
@@ -257,7 +265,37 @@ public sealed class DirectRunLauncherTests
                 onStdErrLine(line);
             }
 
-            if (ExitCodeEvent is { } exitCode)
+            if (string.Equals(fileName, "/bin/sh", StringComparison.Ordinal)
+                && arguments.Count >= 8)
+            {
+                var providerEventLogPath = arguments[3];
+                var executionUnit = arguments[4];
+                var entryKind = arguments[5];
+                var provider = arguments[6];
+                var exitCode = Result.ExitedEarly
+                    ? Result.ExitCode
+                    : ExitCodeEvent ?? 0;
+                var directoryPath = Path.GetDirectoryName(providerEventLogPath)
+                    ?? throw new InvalidOperationException("Provider event log path did not contain a directory.");
+                Directory.CreateDirectory(directoryPath);
+                File.AppendAllText(
+                    providerEventLogPath,
+                    DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                    {
+                        Timestamp = "2026-04-09T10:35:01Z",
+                        ExecutionUnit = executionUnit,
+                        Provider = provider,
+                        EntryKind = entryKind,
+                        SessionId = $"pid:{Result.ProcessId}",
+                        Kind = "provider-event",
+                        Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                        {
+                            type = "backend-exit",
+                            exit_code = exitCode
+                        })
+                    }) + Environment.NewLine);
+            }
+            else if (ExitCodeEvent is { } exitCode)
             {
                 onExited(exitCode);
             }

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -109,6 +109,12 @@ public sealed class DirectRunLauncherTests
         var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G9.provider.jsonl");
         var worktreePath = tempDirectory.GetPath("repo");
         Directory.CreateDirectory(worktreePath);
+        var codexPath = tempDirectory.CreateExecutableFile(
+            "repo/codex",
+            """
+            #!/bin/sh
+            printf '%s\n' '{"type":"ready"}'
+            """);
         var runner = new FakeDirectRunProcessRunner
         {
             ExecuteReceivedProcess = true
@@ -123,14 +129,16 @@ public sealed class DirectRunLauncherTests
             "Codex",
             "gpt-5.4-mini",
             "responses",
-            "/bin/sh",
-            ["-c", "printf '{\"type\":\"ready\"}\\n'"],
+            codexPath,
+            ["exec", "test prompt"],
             DateTimeOffset.Parse("2026-04-09T10:35:00Z"),
             worktreePath,
             tempDirectory.GetPath(".intent-cli/reviews/G9.request.json"),
             providerEventLogPath);
 
         Assert.Equal("pid:", result.ProviderSessionId[..4]);
+        Assert.Equal("/bin/sh", runner.FileName);
+        Assert.Contains(codexPath, runner.Arguments, StringComparer.Ordinal);
 
         var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
         Assert.Contains(events, providerEvent =>
@@ -151,6 +159,54 @@ public sealed class DirectRunLauncherTests
         Assert.Equal("Codex", backendExitEvent.Provider);
         Assert.Equal("review", backendExitEvent.EntryKind);
         Assert.Equal(result.ProviderSessionId, backendExitEvent.SessionId);
+        Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+    }
+
+    [Fact]
+    public void Launch_GivenWrappedCodexExitWithoutWrapperWrite_AppendsFallbackBackendExitProviderEvent()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G10.provider.jsonl");
+        var runner = new FakeDirectRunProcessRunner
+        {
+            ExitCodeEvent = 0,
+            Result = new DirectRunProcessLaunchResult
+            {
+                ProcessId = 2468,
+                ExitedEarly = false,
+                ExitCode = 0
+            }
+        };
+        var launcher = new DirectRunLauncher(runner);
+
+        var result = launcher.Launch(
+            "G10",
+            "review",
+            ".intent-cli/runs/G10.request.json",
+            ".intent-cli/runs/G10.provider.jsonl",
+            "Codex",
+            "gpt-5.4-mini",
+            "responses",
+            "/tmp/fake-codex",
+            ["exec", "test prompt"],
+            DateTimeOffset.Parse("2026-04-09T10:45:00Z"),
+            "/repo",
+            "/repo/.intent-cli/reviews/G10.request.json",
+            providerEventLogPath);
+
+        Assert.Equal("/bin/sh", runner.FileName);
+        Assert.Equal("pid:2468", result.ProviderSessionId);
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        var backendExitEvent = Assert.Single(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+        Assert.Equal("G10", backendExitEvent.ExecutionUnit);
+        Assert.Equal("Codex", backendExitEvent.Provider);
+        Assert.Equal("review", backendExitEvent.EntryKind);
+        Assert.Equal("pid:2468", backendExitEvent.SessionId);
         Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
     }
 
@@ -338,6 +394,28 @@ public sealed class DirectRunLauncherTests
         public string GetPath(string relativePath)
         {
             return Path.Combine(rootPath, relativePath);
+        }
+
+        public string CreateExecutableFile(string relativePath, string content)
+        {
+            var path = GetPath(relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, content);
+
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(
+                    path,
+                    UnixFileMode.UserRead
+                    | UnixFileMode.UserWrite
+                    | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead
+                    | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead
+                    | UnixFileMode.OtherExecute);
+            }
+
+            return path;
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- wrap Codex direct runs in a shell launcher that appends a `backend-exit` provider event directly into the raw provider log when the backend process exits
- keep the in-process exit callback as the fallback for non-Codex providers while avoiding duplicate backend-exit events for wrapped Codex launches
- extend launcher coverage to prove Codex runs use the wrapper and still persist the backend exit event

Closes #245

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~DirectRunLauncherTests"
- dotnet test IntentSystem.sln