### PR TITLE
[codex] Repair codex-like review backend exit logging

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -55,12 +55,9 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             absoluteRequestArtifactPath,
             argsTemplate);
         var processInvocation = ResolveProcessInvocation(
-            executionUnit,
-            entryKind,
             provider,
             command,
-            arguments,
-            absoluteProviderEventLogPath);
+            arguments);
         var eventWriter = new DirectRunProviderEventWriter(absoluteProviderEventLogPath);
         var providerSessionId = string.Empty;
         var process = processRunner.Start(
@@ -89,8 +86,22 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                     provider,
                     providerSessionId,
                     exitCode),
-            raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)),
-            raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)));
+            raw => AppendProviderOutput(
+                eventWriter,
+                absoluteProviderEventLogPath,
+                executionUnit,
+                entryKind,
+                provider,
+                providerSessionId,
+                raw),
+            raw => AppendProviderOutput(
+                eventWriter,
+                absoluteProviderEventLogPath,
+                executionUnit,
+                entryKind,
+                provider,
+                providerSessionId,
+                raw));
 
         if (process.ExitedEarly && process.ExitCode != 0)
         {
@@ -139,12 +150,9 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
     }
 
     private static ResolvedProcessInvocation ResolveProcessInvocation(
-        string executionUnit,
-        string entryKind,
         string provider,
         string command,
-        IReadOnlyList<string> arguments,
-        string absoluteProviderEventLogPath)
+        IReadOnlyList<string> arguments)
     {
         if (!ShouldShellWrapForPersistentExitLogging(provider, command))
         {
@@ -162,23 +170,12 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             [
                 "-c",
                 """
-                provider_log_path=$1
-                execution_unit=$2
-                entry_kind=$3
-                provider=$4
-                shift 4
-                session_id="pid:$$"
                 "$@"
                 exit_code=$?
-                timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-                printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":$exit_code}}" >> "$provider_log_path"
+                printf '%s\n' "{\"type\":\"backend-exit\",\"exit_code\":$exit_code}"
                 exit "$exit_code"
                 """,
                 "direct-run-wrapper",
-                absoluteProviderEventLogPath,
-                executionUnit,
-                entryKind,
-                provider,
                 command,
                 .. arguments
             ]
@@ -234,6 +231,40 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             exitCode));
     }
 
+    private static void AppendProviderOutput(
+        DirectRunProviderEventWriter eventWriter,
+        string providerEventLogPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        string raw)
+    {
+        ArgumentNullException.ThrowIfNull(eventWriter);
+        ArgumentException.ThrowIfNullOrWhiteSpace(raw);
+
+        if (TryParseBackendExitPayload(raw, out var exitCode))
+        {
+            AppendBackendExitEventIfMissing(
+                eventWriter,
+                providerEventLogPath,
+                executionUnit,
+                entryKind,
+                provider,
+                providerSessionId,
+                exitCode);
+            return;
+        }
+
+        eventWriter.Append(CreateProviderEvent(
+            DateTimeOffset.UtcNow,
+            executionUnit,
+            entryKind,
+            provider,
+            providerSessionId,
+            raw));
+    }
+
     private static bool HasBackendExitEvent(string providerEventLogPath, string providerSessionId)
     {
         if (!File.Exists(providerEventLogPath))
@@ -249,6 +280,66 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             {
                 return true;
             }
+        }
+
+        return false;
+    }
+
+    private static bool TryParseBackendExitPayload(string raw, out int exitCode)
+    {
+        exitCode = 0;
+
+        try
+        {
+            using var document = JsonDocument.Parse(raw);
+            var payload = document.RootElement;
+            return payload.ValueKind == JsonValueKind.Object
+                && TryReadString(payload, "type", out var eventType)
+                && string.Equals(eventType, "backend-exit", StringComparison.Ordinal)
+                && (TryReadInt32(payload, "exit_code", out exitCode)
+                    || TryReadInt32(payload, "exitCode", out exitCode));
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryReadString(JsonElement payload, string propertyName, out string value)
+    {
+        value = string.Empty;
+
+        if (!payload.TryGetProperty(propertyName, out var element)
+            || element.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        value = element.GetString() ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static bool TryReadInt32(JsonElement payload, string propertyName, out int value)
+    {
+        value = 0;
+
+        if (!payload.TryGetProperty(propertyName, out var element))
+        {
+            return false;
+        }
+
+        if (element.ValueKind == JsonValueKind.Number)
+        {
+            return element.TryGetInt32(out value);
+        }
+
+        if (element.ValueKind == JsonValueKind.String)
+        {
+            return int.TryParse(
+                element.GetString(),
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out value);
         }
 
         return false;

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -168,10 +168,60 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 provider=$4
                 shift 4
                 session_id="pid:$$"
-                "$@"
+                result_artifact_path="${provider_log_path%.provider.jsonl}.result.json"
+                child_pid=""
+                exit_code=0
+                backend_exit_written=0
+                update_result_artifact() {
+                    if [ ! -f "$result_artifact_path" ]; then
+                        attempts=0
+                        while [ "$attempts" -lt 50 ] && [ ! -f "$result_artifact_path" ]; do
+                            sleep 0.1
+                            attempts=$((attempts + 1))
+                        done
+                    fi
+                    if [ ! -f "$result_artifact_path" ]; then
+                        return
+                    fi
+                    run_status="failed"
+                    if [ "$exit_code" -eq 0 ]; then
+                        run_status="succeeded"
+                    fi
+                    temp_result_path="${result_artifact_path}.tmp.$$"
+                    if sed "s/\"run_status\": \"[^\"]*\"/\"run_status\": \"$run_status\"/" "$result_artifact_path" > "$temp_result_path"; then
+                        mv "$temp_result_path" "$result_artifact_path"
+                    else
+                        rm -f "$temp_result_path"
+                    fi
+                }
+                append_backend_exit() {
+                    if [ "$backend_exit_written" -ne 0 ]; then
+                        return
+                    fi
+                    backend_exit_written=1
+                    timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+                    printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":$exit_code}}" >> "$provider_log_path"
+                    update_result_artifact
+                }
+                handle_signal() {
+                    signal_name=$1
+                    if [ -n "$child_pid" ] && kill -0 "$child_pid" 2>/dev/null; then
+                        kill -s "$signal_name" "$child_pid" 2>/dev/null || true
+                        wait "$child_pid"
+                        exit_code=$?
+                    fi
+                    append_backend_exit
+                    trap - EXIT HUP INT TERM
+                    exit "$exit_code"
+                }
+                trap 'append_backend_exit' EXIT
+                trap 'handle_signal HUP' HUP
+                trap 'handle_signal INT' INT
+                trap 'handle_signal TERM' TERM
+                "$@" &
+                child_pid=$!
+                wait "$child_pid"
                 exit_code=$?
-                timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-                printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":$exit_code}}" >> "$provider_log_path"
                 exit "$exit_code"
                 """,
                 "direct-run-wrapper",

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -63,7 +63,6 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             arguments,
             absoluteProviderEventLogPath);
         var eventWriter = new DirectRunProviderEventWriter(absoluteProviderEventLogPath);
-        var absoluteResultArtifactPath = ResolveResultArtifactPath(absoluteProviderEventLogPath);
         var providerSessionId = string.Empty;
         var process = processRunner.Start(
             workingDirectory,
@@ -86,7 +85,6 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                     processInvocation.RequiresPersistentExitMonitor,
                     processId,
                     absoluteProviderEventLogPath,
-                    absoluteResultArtifactPath,
                     executionUnit,
                     entryKind,
                     provider,
@@ -180,32 +178,9 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 provider=$4
                 shift 4
                 session_id="pid:$$"
-                result_artifact_path="${provider_log_path%.provider.jsonl}.result.json"
                 child_pid=""
                 exit_code=0
                 backend_exit_written=0
-                update_result_artifact() {
-                    if [ ! -f "$result_artifact_path" ]; then
-                        attempts=0
-                        while [ "$attempts" -lt 50 ] && [ ! -f "$result_artifact_path" ]; do
-                            sleep 0.1
-                            attempts=$((attempts + 1))
-                        done
-                    fi
-                    if [ ! -f "$result_artifact_path" ]; then
-                        return
-                    fi
-                    run_status="failed"
-                    if [ "$exit_code" -eq 0 ]; then
-                        run_status="succeeded"
-                    fi
-                    temp_result_path="${result_artifact_path}.tmp.$$"
-                    if sed "s/\"run_status\": \"[^\"]*\"/\"run_status\": \"$run_status\"/" "$result_artifact_path" > "$temp_result_path"; then
-                        mv "$temp_result_path" "$result_artifact_path"
-                    else
-                        rm -f "$temp_result_path"
-                    fi
-                }
                 append_backend_exit() {
                     if [ "$backend_exit_written" -ne 0 ]; then
                         return
@@ -213,7 +188,6 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                     backend_exit_written=1
                     timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
                     printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":$exit_code}}" >> "$provider_log_path"
-                    update_result_artifact
                 }
                 handle_signal() {
                     signal_name=$1
@@ -246,17 +220,6 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             ],
             RequiresPersistentExitMonitor = true
         };
-    }
-
-    private static string ResolveResultArtifactPath(string providerEventLogPath)
-    {
-        const string providerSuffix = ".provider.jsonl";
-        if (!providerEventLogPath.EndsWith(providerSuffix, StringComparison.Ordinal))
-        {
-            return providerEventLogPath + ".result.json";
-        }
-
-        return providerEventLogPath[..^providerSuffix.Length] + ".result.json";
     }
 
     private static bool ShouldShellWrapForPersistentExitLogging(string provider, string command)
@@ -312,7 +275,6 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         bool requiresPersistentExitMonitor,
         int processId,
         string providerEventLogPath,
-        string resultArtifactPath,
         string executionUnit,
         string entryKind,
         string provider,
@@ -335,11 +297,10 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             """
             pid=$1
             provider_log_path=$2
-            result_artifact_path=$3
-            execution_unit=$4
-            entry_kind=$5
-            provider=$6
-            session_id=$7
+            execution_unit=$3
+            entry_kind=$4
+            provider=$5
+            session_id=$6
             while kill -0 "$pid" 2>/dev/null; do
                 sleep 1
             done
@@ -348,19 +309,10 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             fi
             timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
             printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":1}}" >> "$provider_log_path"
-            if [ -f "$result_artifact_path" ]; then
-                temp_result_path="${result_artifact_path}.tmp.$$"
-                if sed "s/\"run_status\": \"[^\"]*\"/\"run_status\": \"failed\"/" "$result_artifact_path" > "$temp_result_path"; then
-                    mv "$temp_result_path" "$result_artifact_path"
-                else
-                    rm -f "$temp_result_path"
-                fi
-            fi
             """);
         startInfo.ArgumentList.Add("direct-run-exit-monitor");
         startInfo.ArgumentList.Add(processId.ToString());
         startInfo.ArgumentList.Add(providerEventLogPath);
-        startInfo.ArgumentList.Add(resultArtifactPath);
         startInfo.ArgumentList.Add(executionUnit);
         startInfo.ArgumentList.Add(entryKind);
         startInfo.ArgumentList.Add(provider);

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 
 namespace IntentSystem.Cli.Commands;
@@ -62,6 +63,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             arguments,
             absoluteProviderEventLogPath);
         var eventWriter = new DirectRunProviderEventWriter(absoluteProviderEventLogPath);
+        var absoluteResultArtifactPath = ResolveResultArtifactPath(absoluteProviderEventLogPath);
         var providerSessionId = string.Empty;
         var process = processRunner.Start(
             workingDirectory,
@@ -80,6 +82,15 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                     model,
                     transport,
                     command));
+                StartPersistentExitMonitorIfNeeded(
+                    processInvocation.RequiresPersistentExitMonitor,
+                    processId,
+                    absoluteProviderEventLogPath,
+                    absoluteResultArtifactPath,
+                    executionUnit,
+                    entryKind,
+                    provider,
+                    providerSessionId);
             },
             exitCode => AppendBackendExitEventIfMissing(
                     eventWriter,
@@ -151,7 +162,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             return new ResolvedProcessInvocation
             {
                 FileName = command,
-                Arguments = arguments
+                Arguments = arguments,
+                RequiresPersistentExitMonitor = false
             };
         }
 
@@ -231,8 +243,20 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 provider,
                 command,
                 .. arguments
-            ]
+            ],
+            RequiresPersistentExitMonitor = true
         };
+    }
+
+    private static string ResolveResultArtifactPath(string providerEventLogPath)
+    {
+        const string providerSuffix = ".provider.jsonl";
+        if (!providerEventLogPath.EndsWith(providerSuffix, StringComparison.Ordinal))
+        {
+            return providerEventLogPath + ".result.json";
+        }
+
+        return providerEventLogPath[..^providerSuffix.Length] + ".result.json";
     }
 
     private static bool ShouldShellWrapForPersistentExitLogging(string provider, string command)
@@ -282,6 +306,68 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             provider,
             providerSessionId,
             exitCode));
+    }
+
+    private static void StartPersistentExitMonitorIfNeeded(
+        bool requiresPersistentExitMonitor,
+        int processId,
+        string providerEventLogPath,
+        string resultArtifactPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId)
+    {
+        if (!requiresPersistentExitMonitor || OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false
+        };
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add(
+            """
+            pid=$1
+            provider_log_path=$2
+            result_artifact_path=$3
+            execution_unit=$4
+            entry_kind=$5
+            provider=$6
+            session_id=$7
+            while kill -0 "$pid" 2>/dev/null; do
+                sleep 1
+            done
+            if [ -f "$provider_log_path" ] && grep -F "\"session_id\":\"$session_id\"" "$provider_log_path" | grep -F "\"type\":\"backend-exit\"" >/dev/null 2>&1; then
+                exit 0
+            fi
+            timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+            printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":1}}" >> "$provider_log_path"
+            if [ -f "$result_artifact_path" ]; then
+                temp_result_path="${result_artifact_path}.tmp.$$"
+                if sed "s/\"run_status\": \"[^\"]*\"/\"run_status\": \"failed\"/" "$result_artifact_path" > "$temp_result_path"; then
+                    mv "$temp_result_path" "$result_artifact_path"
+                else
+                    rm -f "$temp_result_path"
+                fi
+            fi
+            """);
+        startInfo.ArgumentList.Add("direct-run-exit-monitor");
+        startInfo.ArgumentList.Add(processId.ToString());
+        startInfo.ArgumentList.Add(providerEventLogPath);
+        startInfo.ArgumentList.Add(resultArtifactPath);
+        startInfo.ArgumentList.Add(executionUnit);
+        startInfo.ArgumentList.Add(entryKind);
+        startInfo.ArgumentList.Add(provider);
+        startInfo.ArgumentList.Add(providerSessionId);
+
+        var monitor = Process.Start(startInfo);
+        monitor?.Dispose();
     }
 
     private static bool HasBackendExitEvent(string providerEventLogPath, string providerSessionId)
@@ -393,5 +479,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         public required string FileName { get; init; }
 
         public required IReadOnlyList<string> Arguments { get; init; }
+
+        public required bool RequiresPersistentExitMonitor { get; init; }
     }
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -55,9 +55,12 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             absoluteRequestArtifactPath,
             argsTemplate);
         var processInvocation = ResolveProcessInvocation(
+            executionUnit,
+            entryKind,
             provider,
             command,
-            arguments);
+            arguments,
+            absoluteProviderEventLogPath);
         var eventWriter = new DirectRunProviderEventWriter(absoluteProviderEventLogPath);
         var providerSessionId = string.Empty;
         var process = processRunner.Start(
@@ -86,22 +89,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                     provider,
                     providerSessionId,
                     exitCode),
-            raw => AppendProviderOutput(
-                eventWriter,
-                absoluteProviderEventLogPath,
-                executionUnit,
-                entryKind,
-                provider,
-                providerSessionId,
-                raw),
-            raw => AppendProviderOutput(
-                eventWriter,
-                absoluteProviderEventLogPath,
-                executionUnit,
-                entryKind,
-                provider,
-                providerSessionId,
-                raw));
+            raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)),
+            raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)));
 
         if (process.ExitedEarly && process.ExitCode != 0)
         {
@@ -150,9 +139,12 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
     }
 
     private static ResolvedProcessInvocation ResolveProcessInvocation(
+        string executionUnit,
+        string entryKind,
         string provider,
         string command,
-        IReadOnlyList<string> arguments)
+        IReadOnlyList<string> arguments,
+        string absoluteProviderEventLogPath)
     {
         if (!ShouldShellWrapForPersistentExitLogging(provider, command))
         {
@@ -170,12 +162,23 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             [
                 "-c",
                 """
+                provider_log_path=$1
+                execution_unit=$2
+                entry_kind=$3
+                provider=$4
+                shift 4
+                session_id="pid:$$"
                 "$@"
                 exit_code=$?
-                printf '%s\n' "{\"type\":\"backend-exit\",\"exit_code\":$exit_code}"
+                timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+                printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":$exit_code}}" >> "$provider_log_path"
                 exit "$exit_code"
                 """,
                 "direct-run-wrapper",
+                absoluteProviderEventLogPath,
+                executionUnit,
+                entryKind,
+                provider,
                 command,
                 .. arguments
             ]
@@ -231,40 +234,6 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             exitCode));
     }
 
-    private static void AppendProviderOutput(
-        DirectRunProviderEventWriter eventWriter,
-        string providerEventLogPath,
-        string executionUnit,
-        string entryKind,
-        string provider,
-        string providerSessionId,
-        string raw)
-    {
-        ArgumentNullException.ThrowIfNull(eventWriter);
-        ArgumentException.ThrowIfNullOrWhiteSpace(raw);
-
-        if (TryParseBackendExitPayload(raw, out var exitCode))
-        {
-            AppendBackendExitEventIfMissing(
-                eventWriter,
-                providerEventLogPath,
-                executionUnit,
-                entryKind,
-                provider,
-                providerSessionId,
-                exitCode);
-            return;
-        }
-
-        eventWriter.Append(CreateProviderEvent(
-            DateTimeOffset.UtcNow,
-            executionUnit,
-            entryKind,
-            provider,
-            providerSessionId,
-            raw));
-    }
-
     private static bool HasBackendExitEvent(string providerEventLogPath, string providerSessionId)
     {
         if (!File.Exists(providerEventLogPath))
@@ -280,66 +249,6 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             {
                 return true;
             }
-        }
-
-        return false;
-    }
-
-    private static bool TryParseBackendExitPayload(string raw, out int exitCode)
-    {
-        exitCode = 0;
-
-        try
-        {
-            using var document = JsonDocument.Parse(raw);
-            var payload = document.RootElement;
-            return payload.ValueKind == JsonValueKind.Object
-                && TryReadString(payload, "type", out var eventType)
-                && string.Equals(eventType, "backend-exit", StringComparison.Ordinal)
-                && (TryReadInt32(payload, "exit_code", out exitCode)
-                    || TryReadInt32(payload, "exitCode", out exitCode));
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
-    }
-
-    private static bool TryReadString(JsonElement payload, string propertyName, out string value)
-    {
-        value = string.Empty;
-
-        if (!payload.TryGetProperty(propertyName, out var element)
-            || element.ValueKind != JsonValueKind.String)
-        {
-            return false;
-        }
-
-        value = element.GetString() ?? string.Empty;
-        return !string.IsNullOrWhiteSpace(value);
-    }
-
-    private static bool TryReadInt32(JsonElement payload, string propertyName, out int value)
-    {
-        value = 0;
-
-        if (!payload.TryGetProperty(propertyName, out var element))
-        {
-            return false;
-        }
-
-        if (element.ValueKind == JsonValueKind.Number)
-        {
-            return element.TryGetInt32(out value);
-        }
-
-        if (element.ValueKind == JsonValueKind.String)
-        {
-            return int.TryParse(
-                element.GetString(),
-                System.Globalization.NumberStyles.Integer,
-                System.Globalization.CultureInfo.InvariantCulture,
-                out value);
         }
 
         return false;

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -187,9 +187,25 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
 
     private static bool ShouldShellWrapForPersistentExitLogging(string provider, string command)
     {
-        return !OperatingSystem.IsWindows()
-            && (string.Equals(provider, "codex", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(command, "codex", StringComparison.OrdinalIgnoreCase));
+        if (OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        return string.Equals(provider, "codex", StringComparison.OrdinalIgnoreCase)
+            || IsCodexLikeCommand(command);
+    }
+
+    private static bool IsCodexLikeCommand(string command)
+    {
+        var fileName = Path.GetFileName(command.Trim());
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return false;
+        }
+
+        var commandStem = Path.GetFileNameWithoutExtension(fileName);
+        return commandStem.StartsWith("codex", StringComparison.OrdinalIgnoreCase);
     }
 
     private static void AppendBackendExitEventIfMissing(

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -295,6 +295,13 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         startInfo.ArgumentList.Add("-c");
         startInfo.ArgumentList.Add(
             """
+            monitor_script=$1
+            shift
+            nohup /bin/sh -c "$monitor_script" direct-run-exit-monitor "$@" >/dev/null 2>&1 </dev/null &
+            """);
+        startInfo.ArgumentList.Add("direct-run-exit-monitor-launcher");
+        startInfo.ArgumentList.Add(
+            """
             pid=$1
             provider_log_path=$2
             execution_unit=$3
@@ -310,7 +317,6 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
             printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":1}}" >> "$provider_log_path"
             """);
-        startInfo.ArgumentList.Add("direct-run-exit-monitor");
         startInfo.ArgumentList.Add(processId.ToString());
         startInfo.ArgumentList.Add(providerEventLogPath);
         startInfo.ArgumentList.Add(executionUnit);

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -296,6 +296,88 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public async Task Launch_GivenWrappedCodexProcessEndsWithoutExitCallback_MonitorAppendsBackendExitProviderEvent()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var externalProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-c", "sleep 1" }
+        });
+        Assert.NotNull(externalProcess);
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14.provider.jsonl");
+        var resultArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14.result.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(resultArtifactPath)!);
+        File.WriteAllText(
+            resultArtifactPath,
+            DirectRunResultArtifactJson.Serialize(CreateResultArtifact("G14", "review", ".intent-cli/runs/G14.provider.jsonl", "running")));
+        var runner = new FakeDirectRunProcessRunner
+        {
+            Result = new DirectRunProcessLaunchResult
+            {
+                ProcessId = externalProcess!.Id,
+                ExitedEarly = false,
+                ExitCode = 0
+            }
+        };
+        var launcher = new DirectRunLauncher(runner);
+
+        var result = launcher.Launch(
+            "G14",
+            "review",
+            ".intent-cli/runs/G14.request.json",
+            ".intent-cli/runs/G14.provider.jsonl",
+            "OpenAI",
+            "gpt-5.4-mini",
+            "responses",
+            "/opt/homebrew/bin/codex",
+            ["exec", "test prompt"],
+            DateTimeOffset.Parse("2026-04-09T11:15:00Z"),
+            "/repo",
+            "/repo/.intent-cli/reviews/G14.request.json",
+            providerEventLogPath);
+
+        await TemporaryDirectory.WaitForConditionAsync(
+            () =>
+            {
+                if (!File.Exists(providerEventLogPath))
+                {
+                    return false;
+                }
+
+                var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                return events.Any(providerEvent =>
+                    providerEvent.Kind == "provider-event"
+                    && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                    && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                    && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                    && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+            },
+            TimeSpan.FromSeconds(5));
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        var backendExitEvent = Assert.Single(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.Equal(1, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        Assert.Equal("failed", resultArtifact.RunStatus);
+    }
+
+    [Fact]
     public void Launch_GivenWrappedCodexProcessReceivesTerminationSignal_AppendsBackendExitProviderEvent()
     {
         if (OperatingSystem.IsWindows())
@@ -322,7 +404,7 @@ public sealed class DirectRunLauncherTests
             {
                 Task.Run(async () =>
                 {
-                    await Task.Delay(TimeSpan.FromMilliseconds(200));
+                    await Task.Delay(TimeSpan.FromMilliseconds(800));
                     SignalProcess(processId, "TERM");
                 });
             }

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -221,13 +221,8 @@ public sealed class DirectRunLauncherTests
 
         using var tempDirectory = new TemporaryDirectory();
         var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G12.provider.jsonl");
-        var resultArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G12.result.json");
         var worktreePath = tempDirectory.GetPath("repo");
         Directory.CreateDirectory(worktreePath);
-        Directory.CreateDirectory(Path.GetDirectoryName(resultArtifactPath)!);
-        File.WriteAllText(
-            resultArtifactPath,
-            DirectRunResultArtifactJson.Serialize(CreateResultArtifact("G12", "review", ".intent-cli/runs/G12.provider.jsonl", "running")));
         var codexPath = tempDirectory.CreateExecutableFile(
             "repo/codex-experimental",
             """
@@ -290,9 +285,6 @@ public sealed class DirectRunLauncherTests
             && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
             && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
         Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
-
-        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
-        Assert.Equal("succeeded", resultArtifact.RunStatus);
     }
 
     [Fact]
@@ -315,11 +307,6 @@ public sealed class DirectRunLauncherTests
 
         using var tempDirectory = new TemporaryDirectory();
         var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14.provider.jsonl");
-        var resultArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14.result.json");
-        Directory.CreateDirectory(Path.GetDirectoryName(resultArtifactPath)!);
-        File.WriteAllText(
-            resultArtifactPath,
-            DirectRunResultArtifactJson.Serialize(CreateResultArtifact("G14", "review", ".intent-cli/runs/G14.provider.jsonl", "running")));
         var runner = new FakeDirectRunProcessRunner
         {
             Result = new DirectRunProcessLaunchResult
@@ -372,9 +359,6 @@ public sealed class DirectRunLauncherTests
             && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
             && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
         Assert.Equal(1, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
-
-        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
-        Assert.Equal("failed", resultArtifact.RunStatus);
     }
 
     [Fact]
@@ -527,39 +511,6 @@ public sealed class DirectRunLauncherTests
         });
 
         signalProcess?.WaitForExit();
-    }
-
-    private static DirectRunResultArtifact CreateResultArtifact(
-        string executionUnit,
-        string entryKind,
-        string rawLogRef,
-        string runStatus)
-    {
-        return new DirectRunResultArtifact
-        {
-            SchemaVersion = "1",
-            ExecutionUnit = executionUnit,
-            EntryKind = entryKind,
-            UpstreamRequestRef = $".intent-cli/{entryKind}s/{executionUnit}.request.json",
-            Provider = "OpenAI",
-            Model = "gpt-5.4-mini",
-            SessionId = "pid:placeholder",
-            RunStatus = runStatus,
-            RawLogRef = rawLogRef,
-            PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
-            ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
-            LinkedIssue = null,
-            LinkedPr = new DirectRunLinkedPullRequestContext
-            {
-                Repo = "J-Tech-Japan/intent-system",
-                Number = 248,
-                Url = "https://github.com/J-Tech-Japan/intent-system/pull/248"
-            },
-            Worktree = new DirectRunWorktreeContext
-            {
-                Path = $"/repo/.intent-cli/worktrees/{executionUnit}"
-            }
-        };
     }
 
     private sealed class FakeDirectRunProcessRunner : IDirectRunProcessRunner

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using IntentSystem.Cli.Commands;
 
 namespace IntentSystem.Cli.Tests;
@@ -220,8 +221,13 @@ public sealed class DirectRunLauncherTests
 
         using var tempDirectory = new TemporaryDirectory();
         var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G12.provider.jsonl");
+        var resultArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G12.result.json");
         var worktreePath = tempDirectory.GetPath("repo");
         Directory.CreateDirectory(worktreePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(resultArtifactPath)!);
+        File.WriteAllText(
+            resultArtifactPath,
+            DirectRunResultArtifactJson.Serialize(CreateResultArtifact("G12", "review", ".intent-cli/runs/G12.provider.jsonl", "running")));
         var codexPath = tempDirectory.CreateExecutableFile(
             "repo/codex-experimental",
             """
@@ -284,6 +290,73 @@ public sealed class DirectRunLauncherTests
             && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
             && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
         Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        Assert.Equal("succeeded", resultArtifact.RunStatus);
+    }
+
+    [Fact]
+    public void Launch_GivenWrappedCodexProcessReceivesTerminationSignal_AppendsBackendExitProviderEvent()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G13.provider.jsonl");
+        var worktreePath = tempDirectory.GetPath("repo");
+        Directory.CreateDirectory(worktreePath);
+        var codexPath = tempDirectory.CreateExecutableFile(
+            "repo/codex-experimental",
+            """
+            #!/bin/sh
+            trap 'exit 0' TERM HUP INT
+            printf '%s\n' '{"type":"ready"}'
+            sleep 10
+            """);
+        var runner = new FakeDirectRunProcessRunner
+        {
+            ExecuteReceivedProcess = true,
+            OnStartedProcess = processId =>
+            {
+                Task.Run(async () =>
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(200));
+                    SignalProcess(processId, "TERM");
+                });
+            }
+        };
+        var launcher = new DirectRunLauncher(runner);
+
+        var result = launcher.Launch(
+            "G13",
+            "review",
+            ".intent-cli/runs/G13.request.json",
+            ".intent-cli/runs/G13.provider.jsonl",
+            "OpenAI",
+            "gpt-5.4-mini",
+            "responses",
+            codexPath,
+            ["exec", "test prompt"],
+            DateTimeOffset.Parse("2026-04-09T11:10:00Z"),
+            worktreePath,
+            tempDirectory.GetPath(".intent-cli/reviews/G13.request.json"),
+            providerEventLogPath);
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "ready", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
     }
 
     [Fact]
@@ -356,6 +429,57 @@ public sealed class DirectRunLauncherTests
         Assert.Contains("exit code 17", exception.Message, StringComparison.Ordinal);
     }
 
+    private static void SignalProcess(int processId, string signalName)
+    {
+        using var signalProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList =
+            {
+                "-c",
+                $"kill -s {signalName} {processId}"
+            }
+        });
+
+        signalProcess?.WaitForExit();
+    }
+
+    private static DirectRunResultArtifact CreateResultArtifact(
+        string executionUnit,
+        string entryKind,
+        string rawLogRef,
+        string runStatus)
+    {
+        return new DirectRunResultArtifact
+        {
+            SchemaVersion = "1",
+            ExecutionUnit = executionUnit,
+            EntryKind = entryKind,
+            UpstreamRequestRef = $".intent-cli/{entryKind}s/{executionUnit}.request.json",
+            Provider = "OpenAI",
+            Model = "gpt-5.4-mini",
+            SessionId = "pid:placeholder",
+            RunStatus = runStatus,
+            RawLogRef = rawLogRef,
+            PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+            ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+            LinkedIssue = null,
+            LinkedPr = new DirectRunLinkedPullRequestContext
+            {
+                Repo = "J-Tech-Japan/intent-system",
+                Number = 248,
+                Url = "https://github.com/J-Tech-Japan/intent-system/pull/248"
+            },
+            Worktree = new DirectRunWorktreeContext
+            {
+                Path = $"/repo/.intent-cli/worktrees/{executionUnit}"
+            }
+        };
+    }
+
     private sealed class FakeDirectRunProcessRunner : IDirectRunProcessRunner
     {
         public string WorkingDirectory { get; private set; } = string.Empty;
@@ -371,6 +495,8 @@ public sealed class DirectRunLauncherTests
         public int? ExitCodeEvent { get; init; }
 
         public bool ExecuteReceivedProcess { get; init; }
+
+        public Action<int>? OnStartedProcess { get; init; }
 
         public DirectRunProcessLaunchResult Result { get; set; } = new()
         {
@@ -412,6 +538,7 @@ public sealed class DirectRunLauncherTests
                 var process = System.Diagnostics.Process.Start(startInfo)
                     ?? throw new InvalidOperationException("Failed to start wrapper process.");
                 onStarted(process.Id);
+                OnStartedProcess?.Invoke(process.Id);
 
                 using (process)
                 {

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -184,10 +184,10 @@ public sealed class DirectRunLauncherTests
             "review",
             ".intent-cli/runs/G10.request.json",
             ".intent-cli/runs/G10.provider.jsonl",
-            "Codex",
+            "OpenAI",
             "gpt-5.4-mini",
             "responses",
-            "/tmp/fake-codex",
+            "/tmp/codex-experimental",
             ["exec", "test prompt"],
             DateTimeOffset.Parse("2026-04-09T10:45:00Z"),
             "/repo",
@@ -204,7 +204,7 @@ public sealed class DirectRunLauncherTests
             && providerEvent.Payload.TryGetProperty("type", out var typeElement)
             && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
         Assert.Equal("G10", backendExitEvent.ExecutionUnit);
-        Assert.Equal("Codex", backendExitEvent.Provider);
+        Assert.Equal("OpenAI", backendExitEvent.Provider);
         Assert.Equal("review", backendExitEvent.EntryKind);
         Assert.Equal("pid:2468", backendExitEvent.SessionId);
         Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
@@ -223,7 +223,7 @@ public sealed class DirectRunLauncherTests
         var worktreePath = tempDirectory.GetPath("repo");
         Directory.CreateDirectory(worktreePath);
         var codexPath = tempDirectory.CreateExecutableFile(
-            "repo/codex",
+            "repo/codex-experimental",
             """
             #!/bin/sh
             sleep 1
@@ -240,7 +240,7 @@ public sealed class DirectRunLauncherTests
             "review",
             ".intent-cli/runs/G11.request.json",
             ".intent-cli/runs/G11.provider.jsonl",
-            "Codex",
+            "OpenAI",
             "gpt-5.4-mini",
             "responses",
             codexPath,

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -211,7 +211,7 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
-    public async Task Launch_GivenWrappedCodexProcessThatEndsAfterLaunch_AppendsBackendExitProviderEvent()
+    public async Task Launch_GivenRealProcessRunnerAndAbsoluteCodexCommand_AppendsBackendExitProviderEvent()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -219,39 +219,35 @@ public sealed class DirectRunLauncherTests
         }
 
         using var tempDirectory = new TemporaryDirectory();
-        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G11.provider.jsonl");
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G12.provider.jsonl");
         var worktreePath = tempDirectory.GetPath("repo");
         Directory.CreateDirectory(worktreePath);
         var codexPath = tempDirectory.CreateExecutableFile(
             "repo/codex-experimental",
             """
             #!/bin/sh
+            printf '%s\n' '{"type":"ready"}'
             sleep 1
             """);
-        var runner = new FakeDirectRunProcessRunner
-        {
-            ExecuteReceivedProcess = true,
-            ReturnBeforeExitCallback = true
-        };
-        var launcher = new DirectRunLauncher(runner);
+        var launcher = new DirectRunLauncher();
 
         var result = launcher.Launch(
-            "G11",
+            "G12",
             "review",
-            ".intent-cli/runs/G11.request.json",
-            ".intent-cli/runs/G11.provider.jsonl",
+            ".intent-cli/runs/G12.request.json",
+            ".intent-cli/runs/G12.provider.jsonl",
             "OpenAI",
             "gpt-5.4-mini",
             "responses",
             codexPath,
             ["exec", "test prompt"],
-            DateTimeOffset.Parse("2026-04-09T10:55:00Z"),
+            DateTimeOffset.Parse("2026-04-09T11:05:00Z"),
             worktreePath,
-            tempDirectory.GetPath(".intent-cli/reviews/G11.request.json"),
+            tempDirectory.GetPath(".intent-cli/reviews/G12.request.json"),
             providerEventLogPath);
 
         var initialEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
-        Assert.Single(initialEvents, providerEvent =>
+        Assert.Contains(initialEvents, providerEvent =>
             providerEvent.Kind == "session-metadata"
             && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
         Assert.DoesNotContain(initialEvents, providerEvent =>
@@ -275,6 +271,12 @@ public sealed class DirectRunLauncherTests
             TimeSpan.FromSeconds(5));
 
         var finalEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.Contains(finalEvents, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "ready", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
         var backendExitEvent = Assert.Single(finalEvents, providerEvent =>
             providerEvent.Kind == "provider-event"
             && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
@@ -370,8 +372,6 @@ public sealed class DirectRunLauncherTests
 
         public bool ExecuteReceivedProcess { get; init; }
 
-        public bool ReturnBeforeExitCallback { get; init; }
-
         public DirectRunProcessLaunchResult Result { get; set; } = new()
         {
             ProcessId = 1,
@@ -412,18 +412,6 @@ public sealed class DirectRunLauncherTests
                 var process = System.Diagnostics.Process.Start(startInfo)
                     ?? throw new InvalidOperationException("Failed to start wrapper process.");
                 onStarted(process.Id);
-
-                if (ReturnBeforeExitCallback)
-                {
-                    process.EnableRaisingEvents = true;
-                    process.Exited += (_, _) => process.Dispose();
-                    return new DirectRunProcessLaunchResult
-                    {
-                        ProcessId = process.Id,
-                        ExitedEarly = false,
-                        ExitCode = 0
-                    };
-                }
 
                 using (process)
                 {

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
@@ -345,6 +346,80 @@ public sealed class ReviewRunCommandTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenCliProcessExitsBeforeAbsoluteCodexReviewCompletes_PersistsBackendExitToRawLog()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var codexPath = tempDirectory.CreateExecutableFile(
+            Path.Combine("bin", "codex-experimental"),
+            """
+            #!/bin/sh
+            printf '%s\n' '{"type":"ready"}'
+            sleep 1
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "config.toml"),
+            $$"""
+            default_domain = "intent-system"
+            artifact_root = ".intent-cli"
+            worktree_root = ".intent-cli/worktrees"
+
+            [direct_backend]
+            artifact_root = ".intent-cli/runtime-runs"
+
+            [direct_backend.review]
+            provider = "OpenAI"
+            model = "gpt-5.4-mini"
+            transport = "responses"
+            command = "{{codexPath.Replace("\\", "\\\\", StringComparison.Ordinal)}}"
+            args = ["exec", "{prompt}"]
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "packet.yaml"),
+            "execution_unit: G9" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+
+        var process = StartCliProcess(repoRoot, "review run G9");
+        Assert.True(process.WaitForExit(120000), "CLI process did not exit within the timeout.");
+        Assert.Equal(0, process.ExitCode);
+
+        var providerEventLogPath = Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl");
+        TemporaryDirectory.WaitForCondition(
+            () => File.Exists(providerEventLogPath)
+                && DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath)).Any(providerEvent =>
+                    providerEvent.Kind == "provider-event"
+                    && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                    && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                    && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)),
+            TimeSpan.FromSeconds(5));
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "ready", StringComparison.Ordinal));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext
@@ -443,6 +518,34 @@ public sealed class ReviewRunCommandTests
         """ + Environment.NewLine;
     }
 
+    private static Process StartCliProcess(string workingDirectory, string arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "/bin/zsh",
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        startInfo.ArgumentList.Add("-lc");
+        startInfo.ArgumentList.Add(
+            $"dotnet run --project {QuoteForShell(Path.Combine(GetSolutionRoot(), "src", "IntentSystem.Cli", "IntentSystem.Cli.csproj"))} -- {arguments}");
+
+        return Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start CLI process.");
+    }
+
+    private static string GetSolutionRoot()
+    {
+        return Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+    }
+
+    private static string QuoteForShell(string value)
+    {
+        return $"'{value.Replace("'", "'\"'\"'")}'";
+    }
+
     private sealed class TemporaryDirectory : IDisposable
     {
         private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-review-run-tests-").FullName;
@@ -463,6 +566,42 @@ public sealed class ReviewRunCommandTests
             Directory.CreateDirectory(directoryPath);
             File.WriteAllText(fullPath, contents);
             return fullPath;
+        }
+
+        public string CreateExecutableFile(string relativePath, string contents)
+        {
+            var fullPath = CreateFile(relativePath, contents);
+
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(
+                    fullPath,
+                    UnixFileMode.UserRead
+                    | UnixFileMode.UserWrite
+                    | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead
+                    | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead
+                    | UnixFileMode.OtherExecute);
+            }
+
+            return fullPath;
+        }
+
+        public static void WaitForCondition(Func<bool> predicate, TimeSpan timeout)
+        {
+            var startedAt = DateTimeOffset.UtcNow;
+            while (DateTimeOffset.UtcNow - startedAt < timeout)
+            {
+                if (predicate())
+                {
+                    return;
+                }
+
+                Thread.Sleep(TimeSpan.FromMilliseconds(100));
+            }
+
+            Assert.True(predicate(), $"Condition was not satisfied within {timeout}.");
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- treat codex-like command basenames such as absolute `codex` paths and `codex-experimental` as wrapped review-run targets
- keep wrapped backend-exit logging on the shell boundary for those commands
- add regression coverage for non-`Codex` providers that still execute through codex-like commands

Closes #247

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~DirectRunLauncherTests"
- dotnet test IntentSystem.sln