### PR TITLE
Fix review backend exit ingestion into normalized result

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -542,7 +542,18 @@ internal static class RunCommand
         var providerEvents = SelectCurrentSessionEvents(
             TryReadDirectRunProviderEvents(context, executionUnit),
             requestArtifact.ProviderSessionId);
-        var runStatus = resultArtifact.RunStatus;
+        var runStatus = ResolveEffectiveRunStatus(resultArtifact.RunStatus, providerEvents);
+        if (!string.Equals(runStatus, resultArtifact.RunStatus, StringComparison.Ordinal))
+        {
+            PersistDirectRunResultArtifact(
+                context,
+                executionUnit,
+                resultArtifact with
+                {
+                    RunStatus = runStatus
+                });
+        }
+
         if (string.Equals(runStatus, "failed", StringComparison.Ordinal))
         {
             return new RunReviewDecision
@@ -627,6 +638,26 @@ internal static class RunCommand
             Kind = RunReviewDecisionKind.Waiting,
             Detail = $"Review direct run for '{executionUnit}' is '{runStatus}'."
         };
+    }
+
+    private static string ResolveEffectiveRunStatus(
+        string currentRunStatus,
+        IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        if (!string.Equals(currentRunStatus, "running", StringComparison.Ordinal))
+        {
+            return currentRunStatus;
+        }
+
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            if (TryResolveRunStatus(providerEvents[index].Payload, out var runStatus))
+            {
+                return runStatus;
+            }
+        }
+
+        return currentRunStatus;
     }
 
     private static bool TryResolveExplicitReviewOutcome(
@@ -775,6 +806,37 @@ internal static class RunCommand
             return true;
         }
 
+        if (TryReadInt32(payload, "exit_code", out var exitCode)
+            || TryReadInt32(payload, "exitCode", out exitCode))
+        {
+            runStatus = exitCode == 0 ? "succeeded" : "failed";
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadInt32(JsonElement payload, string propertyName, out int value)
+    {
+        value = default;
+
+        if (!payload.TryGetProperty(propertyName, out var element))
+        {
+            return false;
+        }
+
+        if (element.ValueKind == JsonValueKind.Number)
+        {
+            return element.TryGetInt32(out value);
+        }
+
+        if (element.ValueKind == JsonValueKind.String)
+        {
+            var raw = element.GetString();
+            return !string.IsNullOrWhiteSpace(raw)
+                && int.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out value);
+        }
+
         return false;
     }
 
@@ -801,6 +863,23 @@ internal static class RunCommand
             var normalized when !string.IsNullOrWhiteSpace(normalized) => normalized,
             _ => "running"
         };
+    }
+
+    private static void PersistDirectRunResultArtifact(
+        CliContext context,
+        string executionUnit,
+        DirectRunResultArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var resultArtifactPath = Path.Combine(
+            context.RepoRoot,
+            ResolveDirectRunResultArtifactRef(context, executionUnit).Replace('/', Path.DirectorySeparatorChar));
+        var directoryPath = Path.GetDirectoryName(resultArtifactPath)
+            ?? throw new InvalidOperationException("Direct run result artifact path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(resultArtifactPath, DirectRunResultArtifactJson.Serialize(artifact));
     }
 
     private static RunCommandResult CreateStopResult(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -571,6 +571,53 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenRunningReviewDecisionWithBackendExitFailure_FailsAndPersistsNormalizedResult()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "review",
+            "running",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "ReviewBot",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                }
+            ]);
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("non-retryable-failure", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("Review direct run failed for 'G226'.", result.Detail, StringComparison.Ordinal);
+
+        var artifact = DirectRunResultArtifactJson.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+        Assert.Equal("failed", artifact.RunStatus);
+    }
+
+    [Fact]
     public void ExecuteCore_GivenCommentReviewDecisionWithCommentBody_ReusesReviewCommentBoundary()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- ingest current-session review backend exit events when the persisted direct-run result is still running
- normalize `exit_code` and `exitCode` payloads to succeeded/failed for review decision resolution
- persist the corrected direct-run result status and cover the failure case with a regression test

Closes #241