### PR TITLE
Fix Codex direct-run default model resolution

### DIFF
--- a/src/IntentSystem.Cli/CliRuntimeContracts.cs
+++ b/src/IntentSystem.Cli/CliRuntimeContracts.cs
@@ -39,6 +39,7 @@ internal static class CliRuntimeContracts
     public const string DefaultInterviewRole = "Claude";
     public const string DefaultClarifyRole = "Codex";
     public const string DefaultDirectRunModel = "default";
+    public const string DefaultCodexDirectRunModel = "gpt-5.4-mini";
     public const string DefaultDirectRunTransport = "stdio";
 
     public static string GetIntentCliDirectoryPath(string repoRoot)

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -125,7 +125,9 @@ internal static class DirectRunCommandSupport
         };
 
         var provider = FirstNonEmpty(entryConfig.Provider, directRun.Provider, fallbackProvider);
-        var model = FirstNonEmpty(entryConfig.Model, directRun.Model, CliRuntimeContracts.DefaultDirectRunModel);
+        var model = ResolveModel(
+            provider,
+            FirstNonEmpty(entryConfig.Model, directRun.Model, CliRuntimeContracts.DefaultDirectRunModel));
         var transport = FirstNonEmpty(
             entryConfig.Transport,
             directRun.Transport,
@@ -144,6 +146,17 @@ internal static class DirectRunCommandSupport
             Command = command,
             ArgsTemplate = argsTemplate
         };
+    }
+
+    private static string ResolveModel(string provider, string configuredModel)
+    {
+        if (string.Equals(provider.Trim(), "codex", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(configuredModel.Trim(), CliRuntimeContracts.DefaultDirectRunModel, StringComparison.OrdinalIgnoreCase))
+        {
+            return CliRuntimeContracts.DefaultCodexDirectRunModel;
+        }
+
+        return configuredModel;
     }
 
     private static string ResolveArtifactPath(CliContext context, string executionUnit)

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -420,6 +420,78 @@ public sealed class ReviewRunCommandTests
             && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void Execute_GivenCodexReviewCommandWithoutModelOverride_UsesRunnableCodexDefaultModel()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "packet.yaml"),
+            "execution_unit: G9" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = ReviewRunCommand.TimestampFactory;
+        var originalLauncherFactory = ReviewRunCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            ReviewRunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:35:00Z");
+            ReviewRunCommand.DirectRunLauncherFactory = () => new FakeDirectRunLauncher(
+                "pid:9999",
+                "Codex",
+                CliRuntimeContracts.DefaultCodexDirectRunModel,
+                "stdio",
+                "/opt/homebrew/bin/codex",
+                ["exec", "--model", "{model}", "{prompt}"],
+                "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.");
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Claude",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        ArtifactRoot = ".intent-cli/runtime-runs",
+                        Review = new DirectRunEntryConfig
+                        {
+                            Command = "/opt/homebrew/bin/codex"
+                        }
+                    }
+                }
+            };
+
+            var exitCode = ReviewRunCommand.Execute(context, ["G9"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains($"Direct model: {CliRuntimeContracts.DefaultCodexDirectRunModel}", writer.ToString(), StringComparison.Ordinal);
+
+            var directRunArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.request.json")));
+            Assert.Equal(CliRuntimeContracts.DefaultCodexDirectRunModel, directRunArtifact.Model);
+            Assert.Equal("Codex", directRunArtifact.Provider);
+        }
+        finally
+        {
+            ReviewRunCommand.TimestampFactory = originalTimestampFactory;
+            ReviewRunCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -147,7 +147,9 @@ public sealed class RunFixCommandTests
         string provider,
         string model,
         string transport,
-        string transportSummary) : IDirectRunLauncher
+        string transportSummary,
+        string expectedCommand = "claude",
+        IReadOnlyList<string>? expectedArgsTemplate = null) : IDirectRunLauncher
     {
         public DirectRunLaunchResult Launch(
             string executionUnit,
@@ -171,8 +173,8 @@ public sealed class RunFixCommandTests
             Assert.Equal(provider, providerArg);
             Assert.Equal(model, modelArg);
             Assert.Equal(transport, transportArg);
-            Assert.Equal("claude", command);
-            Assert.Equal(["--print", "--model", "{model}", "--output-format", "json", "{prompt}"], argsTemplate);
+            Assert.Equal(expectedCommand, command);
+            Assert.Equal(expectedArgsTemplate ?? ["--print", "--model", "{model}", "--output-format", "json", "{prompt}"], argsTemplate);
             Assert.EndsWith("/.intent-cli/worktrees/G20", workingDirectory, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/fix/G20.request.md", absoluteRequestArtifactPath, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/runs/G20.provider.jsonl", absoluteProviderEventLogPath, StringComparison.Ordinal);
@@ -225,6 +227,79 @@ public sealed class RunFixCommandTests
                 ProviderSessionId = providerSessionId,
                 TransportSummary = transportSummary
             };
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenCodexCommandPathWithoutModelOverride_UsesRunnableCodexDefaultModel()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunFixCommand.TimestampFactory;
+        var originalLauncherFactory = RunFixCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            RunFixCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:25:00Z");
+            RunFixCommand.DirectRunLauncherFactory = () => new FakeDirectRunLauncher(
+                "pid:8765",
+                "Codex",
+                CliRuntimeContracts.DefaultCodexDirectRunModel,
+                "stdio",
+                "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo/.intent-cli/worktrees/G20' for provider 'Codex'.",
+                "/opt/homebrew/bin/codex",
+                ["exec", "--model", "{model}", "{prompt}"]);
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Codex",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        Command = "/opt/homebrew/bin/codex"
+                    }
+                }
+            };
+
+            var exitCode = RunFixCommand.Execute(context, ["G20"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains($"Direct model: {CliRuntimeContracts.DefaultCodexDirectRunModel}", writer.ToString(), StringComparison.Ordinal);
+
+            var directRunArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G20.request.json")));
+            Assert.Equal(CliRuntimeContracts.DefaultCodexDirectRunModel, directRunArtifact.Model);
+            Assert.Equal("Codex", directRunArtifact.Provider);
+        }
+        finally
+        {
+            RunFixCommand.TimestampFactory = originalTimestampFactory;
+            RunFixCommand.DirectRunLauncherFactory = originalLauncherFactory;
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -158,7 +158,9 @@ public sealed class RunImplementCommandTests
         string provider,
         string model,
         string transport,
-        string transportSummary) : IDirectRunLauncher
+        string transportSummary,
+        string expectedCommand = "claude",
+        IReadOnlyList<string>? expectedArgsTemplate = null) : IDirectRunLauncher
     {
         public DirectRunLaunchResult Launch(
             string executionUnit,
@@ -182,8 +184,8 @@ public sealed class RunImplementCommandTests
             Assert.Equal(provider, providerArg);
             Assert.Equal(model, modelArg);
             Assert.Equal(transport, transportArg);
-            Assert.Equal("claude", command);
-            Assert.Equal(["--print", "--model", "{model}", "--output-format", "json", "{prompt}"], argsTemplate);
+            Assert.Equal(expectedCommand, command);
+            Assert.Equal(expectedArgsTemplate ?? ["--print", "--model", "{model}", "--output-format", "json", "{prompt}"], argsTemplate);
             Assert.EndsWith("/.intent-cli/worktrees/G19", workingDirectory, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/implement/G19.request.md", absoluteRequestArtifactPath, StringComparison.Ordinal);
             Assert.EndsWith("/.intent-cli/runs/G19.provider.jsonl", absoluteProviderEventLogPath, StringComparison.Ordinal);
@@ -236,6 +238,76 @@ public sealed class RunImplementCommandTests
                 ProviderSessionId = providerSessionId,
                 TransportSummary = transportSummary
             };
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenCodexCommandPathWithoutModelOverride_UsesRunnableCodexDefaultModel()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G19"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunImplementCommand.TimestampFactory;
+        var originalLauncherFactory = RunImplementCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            RunImplementCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:15:00Z");
+            RunImplementCommand.DirectRunLauncherFactory = () => new FakeDirectRunLauncher(
+                "pid:4321",
+                "Codex",
+                CliRuntimeContracts.DefaultCodexDirectRunModel,
+                "stdio",
+                "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo/.intent-cli/worktrees/G19' for provider 'Codex'.",
+                "/opt/homebrew/bin/codex",
+                ["exec", "--model", "{model}", "{prompt}"]);
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Codex",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        Command = "/opt/homebrew/bin/codex"
+                    }
+                }
+            };
+
+            var exitCode = RunImplementCommand.Execute(context, ["G19"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains($"Direct model: {CliRuntimeContracts.DefaultCodexDirectRunModel}", writer.ToString(), StringComparison.Ordinal);
+
+            var directRunArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G19.request.json")));
+            Assert.Equal(CliRuntimeContracts.DefaultCodexDirectRunModel, directRunArtifact.Model);
+            Assert.Equal("Codex", directRunArtifact.Provider);
+        }
+        finally
+        {
+            RunImplementCommand.TimestampFactory = originalTimestampFactory;
+            RunImplementCommand.DirectRunLauncherFactory = originalLauncherFactory;
         }
     }
 


### PR DESCRIPTION
## Summary
- map the Codex direct-backend placeholder model `default` to a runnable baseline during policy resolution
- keep existing config defaults intact while preventing Codex launches from passing the unsupported `default` model
- cover implement, fix, and review direct-run flows where only the Codex command path is configured

Closes #250