### PR TITLE
Fix review backend raw exit capture

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -265,7 +265,7 @@ internal static class DirectRunCommandSupport
                 $"Provider raw event log at {providerEventLogPath} did not contain any events.");
         }
 
-        var currentProviderEvents = SelectCurrentSessionEvents(providerEvents, launchResult.ProviderSessionId);
+        var currentProviderEvents = SelectCurrentSessionEvents(providerEvents, launchResult.ProviderSessionId, launchedAt);
 
         var runLogPath = context.GetRunLogPath();
         var existingRunEvents = File.Exists(runLogPath)
@@ -349,22 +349,10 @@ internal static class DirectRunCommandSupport
 
     private static IReadOnlyList<DirectRunProviderEvent> SelectCurrentSessionEvents(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
-        string launchedSessionId)
+        string launchedSessionId,
+        DateTimeOffset launchedAt)
     {
-        ArgumentNullException.ThrowIfNull(providerEvents);
-
-        if (string.IsNullOrWhiteSpace(launchedSessionId))
-        {
-            return providerEvents;
-        }
-
-        var matchedEvents = providerEvents
-            .Where(providerEvent => string.Equals(providerEvent.SessionId, launchedSessionId, StringComparison.Ordinal))
-            .ToArray();
-
-        return matchedEvents.Length > 0
-            ? matchedEvents
-            : providerEvents;
+        return DirectRunSessionBoundary.SelectEvents(providerEvents, launchedSessionId, launchedAt);
     }
 
     private static string ResolveProvider(

--- a/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
@@ -59,15 +59,21 @@ internal static class DirectRunExitMonitorCommand
             throw new InvalidOperationException("Could not resolve the IntentSystem CLI assembly path for the exit monitor.");
         }
 
+        var executablePath = ResolveMonitorExecutablePath(assemblyPath);
         var startInfo = new ProcessStartInfo
         {
-            FileName = "dotnet",
+            FileName = executablePath,
             UseShellExecute = false,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true
         };
-        startInfo.ArgumentList.Add(assemblyPath);
+
+        if (string.Equals(Path.GetFileNameWithoutExtension(executablePath), "dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            startInfo.ArgumentList.Add(assemblyPath);
+        }
+
         startInfo.ArgumentList.Add(CommandName);
         startInfo.ArgumentList.Add(processId.ToString(CultureInfo.InvariantCulture));
         startInfo.ArgumentList.Add(providerEventLogPath);
@@ -75,6 +81,7 @@ internal static class DirectRunExitMonitorCommand
         startInfo.ArgumentList.Add(entryKind);
         startInfo.ArgumentList.Add(provider);
         startInfo.ArgumentList.Add(providerSessionId);
+
         return startInfo;
     }
 
@@ -226,6 +233,52 @@ internal static class DirectRunExitMonitorCommand
             args[5],
             args[6]);
         return true;
+    }
+
+    private static string ResolveMonitorExecutablePath(string assemblyPath)
+    {
+        var appHostPath = Path.Combine(
+            Path.GetDirectoryName(assemblyPath)
+                ?? throw new InvalidOperationException("IntentSystem CLI assembly path did not contain a directory."),
+            Path.GetFileNameWithoutExtension(assemblyPath) + (OperatingSystem.IsWindows() ? ".exe" : string.Empty));
+
+        if (File.Exists(appHostPath))
+        {
+            return appHostPath;
+        }
+
+        var processPath = Environment.ProcessPath;
+        if (!string.IsNullOrWhiteSpace(processPath)
+            && Path.IsPathRooted(processPath)
+            && File.Exists(processPath)
+            && string.Equals(Path.GetFileNameWithoutExtension(processPath), "dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            return processPath;
+        }
+
+        var dotnetHostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+        if (!string.IsNullOrWhiteSpace(dotnetHostPath)
+            && Path.IsPathRooted(dotnetHostPath)
+            && File.Exists(dotnetHostPath)
+            && string.Equals(Path.GetFileNameWithoutExtension(dotnetHostPath), "dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            return dotnetHostPath;
+        }
+
+        var pathValue = Environment.GetEnvironmentVariable("PATH");
+        if (!string.IsNullOrWhiteSpace(pathValue))
+        {
+            foreach (var directory in pathValue.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var candidate = Path.Combine(directory, OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
+                if (Path.IsPathRooted(candidate) && File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        throw new InvalidOperationException("Could not resolve an executable host for the detached exit monitor.");
     }
 
     private static DirectRunProviderEvent CreateBackendExitEvent(

--- a/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
@@ -1,0 +1,262 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class DirectRunExitMonitorCommand
+{
+    private const string CommandName = "__direct-run-exit-monitor";
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan ExitGracePeriod = TimeSpan.FromMilliseconds(250);
+
+    public static bool TryExecute(string[] args, out int exitCode)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        exitCode = 0;
+        if (args.Length == 0 || !string.Equals(args[0], CommandName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!TryParseArguments(args, out var options))
+        {
+            Console.Error.WriteLine(
+                $"Usage: {CommandName} <pid> <provider_log_path> <execution_unit> <entry_kind> <provider> <session_id>");
+            exitCode = 1;
+            return true;
+        }
+
+        exitCode = Execute(options);
+        return true;
+    }
+
+    public static ProcessStartInfo CreateDetachedStartInfo(
+        int processId,
+        string providerEventLogPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId)
+    {
+        if (processId <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(processId));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerEventLogPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+
+        var assemblyPath = Assembly.GetExecutingAssembly().Location;
+        if (string.IsNullOrWhiteSpace(assemblyPath) || !File.Exists(assemblyPath))
+        {
+            throw new InvalidOperationException("Could not resolve the IntentSystem CLI assembly path for the exit monitor.");
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            UseShellExecute = false,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        startInfo.ArgumentList.Add(assemblyPath);
+        startInfo.ArgumentList.Add(CommandName);
+        startInfo.ArgumentList.Add(processId.ToString(CultureInfo.InvariantCulture));
+        startInfo.ArgumentList.Add(providerEventLogPath);
+        startInfo.ArgumentList.Add(executionUnit);
+        startInfo.ArgumentList.Add(entryKind);
+        startInfo.ArgumentList.Add(provider);
+        startInfo.ArgumentList.Add(providerSessionId);
+        return startInfo;
+    }
+
+    private static int Execute(DirectRunExitMonitorOptions options)
+    {
+        WaitForProcessExit(options.ProcessId);
+        Thread.Sleep(ExitGracePeriod);
+
+        if (HasBackendExitEvent(options.ProviderEventLogPath, options.ProviderSessionId))
+        {
+            return 0;
+        }
+
+        var eventWriter = new DirectRunProviderEventWriter(options.ProviderEventLogPath);
+        eventWriter.Append(CreateBackendExitEvent(
+            DateTimeOffset.UtcNow,
+            options.ExecutionUnit,
+            options.EntryKind,
+            options.Provider,
+            options.ProviderSessionId,
+            1));
+
+        return 0;
+    }
+
+    private static void WaitForProcessExit(int processId)
+    {
+        while (IsProcessAlive(processId))
+        {
+            Thread.Sleep(PollInterval);
+        }
+    }
+
+    private static bool IsProcessAlive(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            if (process.HasExited)
+            {
+                return false;
+            }
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            return true;
+        }
+
+        var processState = TryReadUnixProcessState(processId);
+        if (string.IsNullOrWhiteSpace(processState))
+        {
+            return false;
+        }
+
+        return processState.IndexOf('Z') < 0;
+    }
+
+    private static string? TryReadUnixProcessState(int processId)
+    {
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "/bin/ps",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList =
+                {
+                    "-o",
+                    "stat=",
+                    "-p",
+                    processId.ToString(CultureInfo.InvariantCulture)
+                }
+            });
+
+            if (process is null)
+            {
+                return null;
+            }
+
+            using (process)
+            {
+                var output = process.StandardOutput.ReadToEnd();
+                process.WaitForExit();
+                return output.Trim();
+            }
+        }
+        catch (Exception exception) when (
+            exception is Win32Exception
+            or InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private static bool HasBackendExitEvent(string providerEventLogPath, string providerSessionId)
+    {
+        if (!File.Exists(providerEventLogPath))
+        {
+            return false;
+        }
+
+        foreach (var line in File.ReadLines(providerEventLogPath))
+        {
+            if (line.Contains($"\"session_id\":\"{providerSessionId}\"", StringComparison.Ordinal)
+                && line.Contains("\"kind\":\"provider-event\"", StringComparison.Ordinal)
+                && line.Contains("\"type\":\"backend-exit\"", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryParseArguments(string[] args, out DirectRunExitMonitorOptions options)
+    {
+        options = null!;
+        if (args.Length != 7 || !int.TryParse(args[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var processId))
+        {
+            return false;
+        }
+
+        if (processId <= 0
+            || string.IsNullOrWhiteSpace(args[2])
+            || string.IsNullOrWhiteSpace(args[3])
+            || string.IsNullOrWhiteSpace(args[4])
+            || string.IsNullOrWhiteSpace(args[5])
+            || string.IsNullOrWhiteSpace(args[6]))
+        {
+            return false;
+        }
+
+        options = new DirectRunExitMonitorOptions(
+            processId,
+            args[2],
+            args[3],
+            args[4],
+            args[5],
+            args[6]);
+        return true;
+    }
+
+    private static DirectRunProviderEvent CreateBackendExitEvent(
+        DateTimeOffset timestamp,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        int exitCode)
+    {
+        return new DirectRunProviderEvent
+        {
+            Timestamp = timestamp.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = provider,
+            EntryKind = entryKind,
+            SessionId = providerSessionId,
+            Kind = "provider-event",
+            Payload = JsonSerializer.SerializeToElement(new
+            {
+                type = "backend-exit",
+                exit_code = exitCode
+            })
+        };
+    }
+
+    private sealed record DirectRunExitMonitorOptions(
+        int ProcessId,
+        string ProviderEventLogPath,
+        string ExecutionUnit,
+        string EntryKind,
+        string Provider,
+        string ProviderSessionId);
+}

--- a/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
@@ -25,7 +25,7 @@ internal static class DirectRunExitMonitorCommand
         if (!TryParseArguments(args, out var options))
         {
             Console.Error.WriteLine(
-                $"Usage: {CommandName} <pid> <provider_log_path> <execution_unit> <entry_kind> <provider> <session_id>");
+                $"Usage: {CommandName} <pid> <provider_log_path> <execution_unit> <entry_kind> <provider> <session_id> <launched_at>");
             exitCode = 1;
             return true;
         }
@@ -40,7 +40,8 @@ internal static class DirectRunExitMonitorCommand
         string executionUnit,
         string entryKind,
         string provider,
-        string providerSessionId)
+        string providerSessionId,
+        DateTimeOffset launchedAt)
     {
         if (processId <= 0)
         {
@@ -81,6 +82,7 @@ internal static class DirectRunExitMonitorCommand
         startInfo.ArgumentList.Add(entryKind);
         startInfo.ArgumentList.Add(provider);
         startInfo.ArgumentList.Add(providerSessionId);
+        startInfo.ArgumentList.Add(launchedAt.ToString("O"));
 
         return startInfo;
     }
@@ -90,7 +92,7 @@ internal static class DirectRunExitMonitorCommand
         WaitForProcessExit(options.ProcessId);
         Thread.Sleep(ExitGracePeriod);
 
-        if (HasBackendExitEvent(options.ProviderEventLogPath, options.ProviderSessionId))
+        if (DirectRunSessionBoundary.HasBackendExitEvent(options.ProviderEventLogPath, options.ProviderSessionId, options.LaunchedAt))
         {
             return 0;
         }
@@ -187,30 +189,10 @@ internal static class DirectRunExitMonitorCommand
         }
     }
 
-    private static bool HasBackendExitEvent(string providerEventLogPath, string providerSessionId)
-    {
-        if (!File.Exists(providerEventLogPath))
-        {
-            return false;
-        }
-
-        foreach (var line in File.ReadLines(providerEventLogPath))
-        {
-            if (line.Contains($"\"session_id\":\"{providerSessionId}\"", StringComparison.Ordinal)
-                && line.Contains("\"kind\":\"provider-event\"", StringComparison.Ordinal)
-                && line.Contains("\"type\":\"backend-exit\"", StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     private static bool TryParseArguments(string[] args, out DirectRunExitMonitorOptions options)
     {
         options = null!;
-        if (args.Length != 7 || !int.TryParse(args[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var processId))
+        if (args.Length != 8 || !int.TryParse(args[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var processId))
         {
             return false;
         }
@@ -220,7 +202,8 @@ internal static class DirectRunExitMonitorCommand
             || string.IsNullOrWhiteSpace(args[3])
             || string.IsNullOrWhiteSpace(args[4])
             || string.IsNullOrWhiteSpace(args[5])
-            || string.IsNullOrWhiteSpace(args[6]))
+            || string.IsNullOrWhiteSpace(args[6])
+            || !DirectRunSessionBoundary.TryParseLaunchedAt(args[7], out var launchedAt))
         {
             return false;
         }
@@ -231,7 +214,8 @@ internal static class DirectRunExitMonitorCommand
             args[3],
             args[4],
             args[5],
-            args[6]);
+            args[6],
+            launchedAt);
         return true;
     }
 
@@ -311,5 +295,6 @@ internal static class DirectRunExitMonitorCommand
         string ExecutionUnit,
         string EntryKind,
         string Provider,
-        string ProviderSessionId);
+        string ProviderSessionId,
+        DateTimeOffset LaunchedAt);
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -89,7 +89,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                     executionUnit,
                     entryKind,
                     provider,
-                    providerSessionId);
+                    providerSessionId,
+                    launchedAt);
             },
             exitCode => AppendBackendExitEventIfMissing(
                     eventWriter,
@@ -98,7 +99,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                     entryKind,
                     provider,
                     providerSessionId,
-                    exitCode),
+                    exitCode,
+                    launchedAt),
             raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)),
             raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)));
 
@@ -110,7 +112,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             executionUnit,
             entryKind,
             provider,
-            providerSessionId);
+            providerSessionId,
+            launchedAt);
 
         if (process.ExitedEarly && process.ExitCode != 0)
         {
@@ -228,12 +231,14 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         string entryKind,
         string provider,
         string providerSessionId,
-        int exitCode)
+        int exitCode,
+        DateTimeOffset launchedAt)
     {
         ArgumentNullException.ThrowIfNull(eventWriter);
         ArgumentException.ThrowIfNullOrWhiteSpace(providerEventLogPath);
 
-        if (string.IsNullOrWhiteSpace(providerSessionId) || HasBackendExitEvent(providerEventLogPath, providerSessionId))
+        if (string.IsNullOrWhiteSpace(providerSessionId)
+            || DirectRunSessionBoundary.HasBackendExitEvent(providerEventLogPath, providerSessionId, launchedAt))
         {
             return;
         }
@@ -254,7 +259,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         string executionUnit,
         string entryKind,
         string provider,
-        string providerSessionId)
+        string providerSessionId,
+        DateTimeOffset launchedAt)
     {
         if (!requiresPersistentExitMonitor || OperatingSystem.IsWindows())
         {
@@ -267,7 +273,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             executionUnit,
             entryKind,
             provider,
-            providerSessionId);
+            providerSessionId,
+            launchedAt);
 
         var launcherStartInfo = new ProcessStartInfo
         {
@@ -303,13 +310,14 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         string executionUnit,
         string entryKind,
         string provider,
-        string providerSessionId)
+        string providerSessionId,
+        DateTimeOffset launchedAt)
     {
         if (!requiresPersistentExitMonitor
             || OperatingSystem.IsWindows()
             || processId <= 0
             || string.IsNullOrWhiteSpace(providerSessionId)
-            || HasBackendExitEvent(providerEventLogPath, providerSessionId))
+            || DirectRunSessionBoundary.HasBackendExitEvent(providerEventLogPath, providerSessionId, launchedAt))
         {
             return;
         }
@@ -317,7 +325,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         var deadline = DateTimeOffset.UtcNow + PersistentExitObservationWindow;
         while (DateTimeOffset.UtcNow < deadline)
         {
-            if (HasBackendExitEvent(providerEventLogPath, providerSessionId))
+            if (DirectRunSessionBoundary.HasBackendExitEvent(providerEventLogPath, providerSessionId, launchedAt))
             {
                 return;
             }
@@ -331,7 +339,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                     entryKind,
                     provider,
                     providerSessionId,
-                    1);
+                    1,
+                    launchedAt);
                 return;
             }
 
@@ -354,26 +363,6 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         {
             return false;
         }
-    }
-
-    private static bool HasBackendExitEvent(string providerEventLogPath, string providerSessionId)
-    {
-        if (!File.Exists(providerEventLogPath))
-        {
-            return false;
-        }
-
-        foreach (var line in File.ReadLines(providerEventLogPath))
-        {
-            if (line.Contains($"\"session_id\":\"{providerSessionId}\"", StringComparison.Ordinal)
-                && line.Contains("\"kind\":\"provider-event\"", StringComparison.Ordinal)
-                && line.Contains("\"type\":\"backend-exit\"", StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static DirectRunProviderEvent CreateSessionMetadataEvent(

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -287,11 +287,12 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
 
         var startInfo = new ProcessStartInfo
         {
-            FileName = "/bin/sh",
+            FileName = ResolveNohupCommand(),
             UseShellExecute = false,
             RedirectStandardOutput = false,
             RedirectStandardError = false
         };
+        startInfo.ArgumentList.Add("/bin/sh");
         startInfo.ArgumentList.Add("-c");
         startInfo.ArgumentList.Add(
             """
@@ -320,6 +321,13 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
 
         var monitor = Process.Start(startInfo);
         monitor?.Dispose();
+    }
+
+    private static string ResolveNohupCommand()
+    {
+        return File.Exists("/usr/bin/nohup")
+            ? "/usr/bin/nohup"
+            : "nohup";
     }
 
     private static bool HasBackendExitEvent(string providerEventLogPath, string providerSessionId)

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -183,43 +183,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             [
                 "-c",
                 """
-                provider_log_path=$1
-                execution_unit=$2
-                entry_kind=$3
-                provider=$4
                 shift 4
-                session_id="pid:$$"
-                child_pid=""
-                exit_code=0
-                backend_exit_written=0
-                append_backend_exit() {
-                    if [ "$backend_exit_written" -ne 0 ]; then
-                        return
-                    fi
-                    backend_exit_written=1
-                    timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-                    printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":$exit_code}}" >> "$provider_log_path"
-                }
-                handle_signal() {
-                    signal_name=$1
-                    if [ -n "$child_pid" ] && kill -0 "$child_pid" 2>/dev/null; then
-                        kill -s "$signal_name" "$child_pid" 2>/dev/null || true
-                        wait "$child_pid"
-                        exit_code=$?
-                    fi
-                    append_backend_exit
-                    trap - EXIT HUP INT TERM
-                    exit "$exit_code"
-                }
-                trap 'append_backend_exit' EXIT
-                trap 'handle_signal HUP' HUP
-                trap 'handle_signal INT' INT
-                trap 'handle_signal TERM' TERM
-                "$@" &
-                child_pid=$!
-                wait "$child_pid"
-                exit_code=$?
-                exit "$exit_code"
+                exec "$@"
                 """,
                 "direct-run-wrapper",
                 absoluteProviderEventLogPath,
@@ -296,69 +261,38 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             return;
         }
 
-        var startInfo = new ProcessStartInfo
+        var monitorStartInfo = DirectRunExitMonitorCommand.CreateDetachedStartInfo(
+            processId,
+            providerEventLogPath,
+            executionUnit,
+            entryKind,
+            provider,
+            providerSessionId);
+
+        var launcherStartInfo = new ProcessStartInfo
         {
             FileName = "/bin/sh",
             UseShellExecute = false,
             RedirectStandardOutput = false,
             RedirectStandardError = false
         };
-        startInfo.ArgumentList.Add("-c");
-        startInfo.ArgumentList.Add(
+        launcherStartInfo.ArgumentList.Add("-c");
+        launcherStartInfo.ArgumentList.Add(
             """
-            monitor_script=$1
-            shift
             if command -v nohup >/dev/null 2>&1; then
-                nohup /bin/sh -c "$monitor_script" direct-run-exit-monitor "$@" >/dev/null 2>&1 </dev/null &
+                nohup "$@" >/dev/null 2>&1 </dev/null &
             else
-                /bin/sh -c "$monitor_script" direct-run-exit-monitor "$@" >/dev/null 2>&1 </dev/null &
+                "$@" >/dev/null 2>&1 </dev/null &
             fi
             """);
-        startInfo.ArgumentList.Add("direct-run-exit-monitor-launcher");
-        startInfo.ArgumentList.Add(
-            """
-            pid=$1
-            provider_log_path=$2
-            execution_unit=$3
-            entry_kind=$4
-            provider=$5
-            session_id=$6
-            is_process_alive() {
-                if ! kill -0 "$pid" 2>/dev/null; then
-                    return 1
-                fi
+        launcherStartInfo.ArgumentList.Add("direct-run-exit-monitor-launcher");
+        launcherStartInfo.ArgumentList.Add(monitorStartInfo.FileName);
+        foreach (var argument in monitorStartInfo.ArgumentList)
+        {
+            launcherStartInfo.ArgumentList.Add(argument);
+        }
 
-                process_state=$(ps -o stat= -p "$pid" 2>/dev/null | tr -d '[:space:]')
-                if [ -z "$process_state" ]; then
-                    return 1
-                fi
-
-                case "$process_state" in
-                    Z*|*Z*)
-                        return 1
-                        ;;
-                esac
-
-                return 0
-            }
-            while is_process_alive; do
-                sleep 1
-            done
-            if [ -f "$provider_log_path" ] && grep -F "\"session_id\":\"$session_id\"" "$provider_log_path" | grep -F "\"type\":\"backend-exit\"" >/dev/null 2>&1; then
-                exit 0
-            fi
-            timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-            printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":1}}" >> "$provider_log_path"
-            """);
-        startInfo.ArgumentList.Add(processId.ToString());
-        startInfo.ArgumentList.Add(providerEventLogPath);
-        startInfo.ArgumentList.Add(executionUnit);
-        startInfo.ArgumentList.Add(entryKind);
-        startInfo.ArgumentList.Add(provider);
-        startInfo.ArgumentList.Add(providerSessionId);
-
-        var monitor = Process.Start(startInfo);
-        monitor?.Dispose();
+        using var launcher = Process.Start(launcherStartInfo);
     }
 
     private static void BestEffortAppendBackendExitIfProcessExitedSoon(

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -287,13 +287,23 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
 
         var startInfo = new ProcessStartInfo
         {
-            FileName = ResolveNohupCommand(),
+            FileName = "/bin/sh",
             UseShellExecute = false,
             RedirectStandardOutput = false,
             RedirectStandardError = false
         };
-        startInfo.ArgumentList.Add("/bin/sh");
         startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add(
+            """
+            monitor_script=$1
+            shift
+            if command -v nohup >/dev/null 2>&1; then
+                nohup /bin/sh -c "$monitor_script" direct-run-exit-monitor "$@" >/dev/null 2>&1 </dev/null &
+            else
+                /bin/sh -c "$monitor_script" direct-run-exit-monitor "$@" >/dev/null 2>&1 </dev/null &
+            fi
+            """);
+        startInfo.ArgumentList.Add("direct-run-exit-monitor-launcher");
         startInfo.ArgumentList.Add(
             """
             pid=$1
@@ -329,7 +339,6 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
             printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":1}}" >> "$provider_log_path"
             """);
-        startInfo.ArgumentList.Add("direct-run-exit-monitor");
         startInfo.ArgumentList.Add(processId.ToString());
         startInfo.ArgumentList.Add(providerEventLogPath);
         startInfo.ArgumentList.Add(executionUnit);
@@ -339,13 +348,6 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
 
         var monitor = Process.Start(startInfo);
         monitor?.Dispose();
-    }
-
-    private static string ResolveNohupCommand()
-    {
-        return File.Exists("/usr/bin/nohup")
-            ? "/usr/bin/nohup"
-            : "nohup";
     }
 
     private static bool HasBackendExitEvent(string providerEventLogPath, string providerSessionId)

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -302,7 +302,25 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             entry_kind=$4
             provider=$5
             session_id=$6
-            while kill -0 "$pid" 2>/dev/null; do
+            is_process_alive() {
+                if ! kill -0 "$pid" 2>/dev/null; then
+                    return 1
+                fi
+
+                process_state=$(ps -o stat= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+                if [ -z "$process_state" ]; then
+                    return 1
+                fi
+
+                case "$process_state" in
+                    Z*|*Z*)
+                        return 1
+                        ;;
+                esac
+
+                return 0
+            }
+            while is_process_alive; do
                 sleep 1
             done
             if [ -f "$provider_log_path" ] && grep -F "\"session_id\":\"$session_id\"" "$provider_log_path" | grep -F "\"type\":\"backend-exit\"" >/dev/null 2>&1; then

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -295,13 +295,6 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         startInfo.ArgumentList.Add("-c");
         startInfo.ArgumentList.Add(
             """
-            monitor_script=$1
-            shift
-            nohup /bin/sh -c "$monitor_script" direct-run-exit-monitor "$@" >/dev/null 2>&1 </dev/null &
-            """);
-        startInfo.ArgumentList.Add("direct-run-exit-monitor-launcher");
-        startInfo.ArgumentList.Add(
-            """
             pid=$1
             provider_log_path=$2
             execution_unit=$3
@@ -317,6 +310,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
             printf '%s\n' "{\"ts\":\"$timestamp\",\"execution_unit\":\"$execution_unit\",\"provider\":\"$provider\",\"entry_kind\":\"$entry_kind\",\"session_id\":\"$session_id\",\"kind\":\"provider-event\",\"payload\":{\"type\":\"backend-exit\",\"exit_code\":1}}" >> "$provider_log_path"
             """);
+        startInfo.ArgumentList.Add("direct-run-exit-monitor");
         startInfo.ArgumentList.Add(processId.ToString());
         startInfo.ArgumentList.Add(providerEventLogPath);
         startInfo.ArgumentList.Add(executionUnit);

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -6,6 +6,7 @@ namespace IntentSystem.Cli.Commands;
 internal sealed class DirectRunLauncher : IDirectRunLauncher
 {
     private static readonly TimeSpan DefaultEarlyExitWindow = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan PersistentExitObservationWindow = TimeSpan.FromSeconds(3);
     private readonly IDirectRunProcessRunner processRunner;
 
     public DirectRunLauncher()
@@ -100,6 +101,16 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                     exitCode),
             raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)),
             raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)));
+
+        BestEffortAppendBackendExitIfProcessExitedSoon(
+            processInvocation.RequiresPersistentExitMonitor,
+            process.ProcessId,
+            eventWriter,
+            absoluteProviderEventLogPath,
+            executionUnit,
+            entryKind,
+            provider,
+            providerSessionId);
 
         if (process.ExitedEarly && process.ExitCode != 0)
         {
@@ -348,6 +359,67 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
 
         var monitor = Process.Start(startInfo);
         monitor?.Dispose();
+    }
+
+    private static void BestEffortAppendBackendExitIfProcessExitedSoon(
+        bool requiresPersistentExitMonitor,
+        int processId,
+        DirectRunProviderEventWriter eventWriter,
+        string providerEventLogPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId)
+    {
+        if (!requiresPersistentExitMonitor
+            || OperatingSystem.IsWindows()
+            || processId <= 0
+            || string.IsNullOrWhiteSpace(providerSessionId)
+            || HasBackendExitEvent(providerEventLogPath, providerSessionId))
+        {
+            return;
+        }
+
+        var deadline = DateTimeOffset.UtcNow + PersistentExitObservationWindow;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (HasBackendExitEvent(providerEventLogPath, providerSessionId))
+            {
+                return;
+            }
+
+            if (!IsProcessAlive(processId))
+            {
+                AppendBackendExitEventIfMissing(
+                    eventWriter,
+                    providerEventLogPath,
+                    executionUnit,
+                    entryKind,
+                    provider,
+                    providerSessionId,
+                    1);
+                return;
+            }
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(100));
+        }
+    }
+
+    private static bool IsProcessAlive(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            return !process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
     }
 
     private static bool HasBackendExitEvent(string providerEventLogPath, string providerSessionId)

--- a/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
@@ -33,7 +33,7 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
                 FileName = fileName,
                 WorkingDirectory = workingDirectory,
                 UseShellExecute = false,
-                RedirectStandardInput = false,
+                RedirectStandardInput = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
@@ -45,6 +45,7 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
 
             var process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException($"Failed to start direct run process '{fileName}'.");
+            process.StandardInput.Close();
             ActiveProcesses[process.Id] = process;
 
             onStarted(process.Id);

--- a/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
@@ -1,10 +1,13 @@
 using System.ComponentModel;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 
 namespace IntentSystem.Cli.Commands;
 
 internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
 {
+    private static readonly ConcurrentDictionary<int, Process> ActiveProcesses = new();
+
     public DirectRunProcessLaunchResult Start(
         string workingDirectory,
         string fileName,
@@ -42,6 +45,7 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
 
             var process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException($"Failed to start direct run process '{fileName}'.");
+            ActiveProcesses[process.Id] = process;
 
             onStarted(process.Id);
 
@@ -56,7 +60,7 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
 
                 process.WaitForExit();
                 onExited(process.ExitCode);
-                process.Dispose();
+                ReleaseProcess(process);
             };
 
             process.OutputDataReceived += (_, eventArgs) =>
@@ -86,7 +90,7 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
                 {
                     process.WaitForExit();
                     onExited(exitCode);
-                    process.Dispose();
+                    ReleaseProcess(process);
                 }
             }
 
@@ -103,5 +107,11 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
                 $"Failed to start direct run process '{fileName}': {exception.Message}",
                 exception);
         }
+    }
+
+    private static void ReleaseProcess(Process process)
+    {
+        ActiveProcesses.TryRemove(process.Id, out _);
+        process.Dispose();
     }
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunSessionBoundary.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunSessionBoundary.cs
@@ -1,0 +1,101 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class DirectRunSessionBoundary
+{
+    public static IReadOnlyList<DirectRunProviderEvent> SelectEvents(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string launchedSessionId,
+        DateTimeOffset? launchedAt)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        if (string.IsNullOrWhiteSpace(launchedSessionId))
+        {
+            return providerEvents;
+        }
+
+        var matchedEvents = providerEvents
+            .Where(providerEvent => IsMatchingSessionEvent(providerEvent, launchedSessionId, launchedAt))
+            .ToArray();
+
+        return matchedEvents.Length > 0
+            ? matchedEvents
+            : providerEvents;
+    }
+
+    public static bool HasBackendExitEvent(
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset? launchedAt)
+    {
+        if (!File.Exists(providerEventLogPath))
+        {
+            return false;
+        }
+
+        foreach (var line in File.ReadLines(providerEventLogPath))
+        {
+            DirectRunProviderEvent providerEvent;
+            try
+            {
+                providerEvent = DirectRunProviderEventJsonl.DeserializeLine(line);
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or ArgumentException
+                or System.Text.Json.JsonException)
+            {
+                continue;
+            }
+
+            if (IsMatchingSessionEvent(providerEvent, providerSessionId, launchedAt)
+                && providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static bool IsMatchingSessionEvent(
+        DirectRunProviderEvent providerEvent,
+        string providerSessionId,
+        DateTimeOffset? launchedAt)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvent);
+
+        if (!string.Equals(providerEvent.SessionId, providerSessionId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (launchedAt is null)
+        {
+            return true;
+        }
+
+        if (!DateTimeOffset.TryParse(
+                providerEvent.Timestamp,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.RoundtripKind,
+                out var providerEventTimestamp))
+        {
+            return true;
+        }
+
+        return providerEventTimestamp >= launchedAt.Value;
+    }
+
+    public static bool TryParseLaunchedAt(string launchedAt, out DateTimeOffset parsed)
+    {
+        return DateTimeOffset.TryParse(
+            launchedAt,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.RoundtripKind,
+            out parsed);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -545,7 +545,7 @@ internal static class RunCommand
             executionUnit,
             requestArtifact,
             TryReadDirectRunProviderEvents(context, executionUnit));
-        providerEvents = SelectCurrentSessionEvents(providerEvents, requestArtifact.ProviderSessionId);
+        providerEvents = SelectCurrentSessionEvents(providerEvents, requestArtifact.ProviderSessionId, requestArtifact.LaunchedAt);
         var runStatus = ResolveEffectiveRunStatus(resultArtifact.RunStatus, providerEvents);
         if (!string.Equals(runStatus, resultArtifact.RunStatus, StringComparison.Ordinal))
         {
@@ -655,7 +655,7 @@ internal static class RunCommand
         ArgumentNullException.ThrowIfNull(requestArtifact);
         ArgumentNullException.ThrowIfNull(providerEvents);
 
-        var currentProviderEvents = SelectCurrentSessionEvents(providerEvents, requestArtifact.ProviderSessionId);
+        var currentProviderEvents = SelectCurrentSessionEvents(providerEvents, requestArtifact.ProviderSessionId, requestArtifact.LaunchedAt);
         if (!string.Equals(requestArtifact.Provider, "Codex", StringComparison.OrdinalIgnoreCase)
             || currentProviderEvents.Any(HasBackendExitType)
             || !TryParseSessionProcessId(requestArtifact.ProviderSessionId, out var processId)
@@ -773,22 +773,19 @@ internal static class RunCommand
 
     private static IReadOnlyList<DirectRunProviderEvent> SelectCurrentSessionEvents(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
-        string launchedSessionId)
+        string launchedSessionId,
+        string launchedAt)
     {
         ArgumentNullException.ThrowIfNull(providerEvents);
-
-        if (string.IsNullOrWhiteSpace(launchedSessionId))
+        if (!DirectRunSessionBoundary.TryParseLaunchedAt(launchedAt, out var parsedLaunchedAt))
         {
-            return providerEvents;
+            parsedLaunchedAt = default;
         }
 
-        var matchedEvents = providerEvents
-            .Where(providerEvent => string.Equals(providerEvent.SessionId, launchedSessionId, StringComparison.Ordinal))
-            .ToArray();
-
-        return matchedEvents.Length > 0
-            ? matchedEvents
-            : providerEvents;
+        return DirectRunSessionBoundary.SelectEvents(
+            providerEvents,
+            launchedSessionId,
+            parsedLaunchedAt == default ? null : parsedLaunchedAt);
     }
 
     private static bool MatchesCurrentReviewRequestBoundary(

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using IntentSystem.Review;
 using IntentSystem.Supervisor;
@@ -539,9 +540,12 @@ internal static class RunCommand
             };
         }
 
-        var providerEvents = SelectCurrentSessionEvents(
-            TryReadDirectRunProviderEvents(context, executionUnit),
-            requestArtifact.ProviderSessionId);
+        var providerEvents = EnsureCurrentSessionTerminalProviderEvent(
+            context,
+            executionUnit,
+            requestArtifact,
+            TryReadDirectRunProviderEvents(context, executionUnit));
+        providerEvents = SelectCurrentSessionEvents(providerEvents, requestArtifact.ProviderSessionId);
         var runStatus = ResolveEffectiveRunStatus(resultArtifact.RunStatus, providerEvents);
         if (!string.Equals(runStatus, resultArtifact.RunStatus, StringComparison.Ordinal))
         {
@@ -640,6 +644,48 @@ internal static class RunCommand
         };
     }
 
+    private static IReadOnlyList<DirectRunProviderEvent> EnsureCurrentSessionTerminalProviderEvent(
+        CliContext context,
+        string executionUnit,
+        DirectRunRequestArtifact requestArtifact,
+        IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(requestArtifact);
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        var currentProviderEvents = SelectCurrentSessionEvents(providerEvents, requestArtifact.ProviderSessionId);
+        if (!string.Equals(requestArtifact.Provider, "Codex", StringComparison.OrdinalIgnoreCase)
+            || currentProviderEvents.Any(HasBackendExitType)
+            || !TryParseSessionProcessId(requestArtifact.ProviderSessionId, out var processId)
+            || IsProcessAlive(processId))
+        {
+            return providerEvents;
+        }
+
+        var providerEventLogPath = Path.Combine(
+            context.RepoRoot,
+            ResolveDirectRunProviderLogRef(context, executionUnit).Replace('/', Path.DirectorySeparatorChar));
+        var writer = new DirectRunProviderEventWriter(providerEventLogPath);
+        writer.Append(new DirectRunProviderEvent
+        {
+            Timestamp = DateTimeOffset.UtcNow.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = requestArtifact.Provider,
+            EntryKind = requestArtifact.EntryKind,
+            SessionId = requestArtifact.ProviderSessionId,
+            Kind = "provider-event",
+            Payload = JsonSerializer.SerializeToElement(new
+            {
+                type = "backend-exit",
+                exit_code = 1
+            })
+        });
+
+        return TryReadDirectRunProviderEvents(context, executionUnit);
+    }
+
     private static string ResolveEffectiveRunStatus(
         string currentRunStatus,
         IReadOnlyList<DirectRunProviderEvent> providerEvents)
@@ -658,6 +704,50 @@ internal static class RunCommand
         }
 
         return currentRunStatus;
+    }
+
+    private static bool TryParseSessionProcessId(string providerSessionId, out int processId)
+    {
+        processId = default;
+
+        const string prefix = "pid:";
+        if (!providerSessionId.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return int.TryParse(
+            providerSessionId[prefix.Length..],
+            System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out processId);
+    }
+
+    private static bool IsProcessAlive(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            return !process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private static bool HasBackendExitType(DirectRunProviderEvent providerEvent)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvent);
+
+        return providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal);
     }
 
     private static bool TryResolveExplicitReviewOutcome(

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -10,6 +10,11 @@ internal static class Program
     {
         try
         {
+            if (DirectRunExitMonitorCommand.TryExecute(args, out var directRunExitMonitorExitCode))
+            {
+                return directRunExitMonitorExitCode;
+            }
+
             var currentDirectory = Directory.GetCurrentDirectory();
             if (IsIntakeInitCommand(args))
             {

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -284,6 +284,74 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public async Task Launch_GivenRepeatedRealWrappedCodexRuns_EachSessionAppendsOwnBackendExitProviderEvent()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var worktreePath = tempDirectory.GetPath("repo");
+        Directory.CreateDirectory(worktreePath);
+        var codexPath = tempDirectory.CreateExecutableFile(
+            "repo/codex-experimental",
+            """
+            #!/bin/sh
+            printf '%s\n' '{"type":"ready"}'
+            sleep 1
+            """);
+        var launcher = new DirectRunLauncher();
+        var observedSessions = new List<string>();
+
+        for (var iteration = 1; iteration <= 5; iteration++)
+        {
+            var executionUnit = $"G12R{iteration}";
+            var providerEventLogPath = tempDirectory.GetPath($".intent-cli/runs/{executionUnit}.provider.jsonl");
+            var result = launcher.Launch(
+                executionUnit,
+                "review",
+                $".intent-cli/runs/{executionUnit}.request.json",
+                $".intent-cli/runs/{executionUnit}.provider.jsonl",
+                "OpenAI",
+                "gpt-5.4-mini",
+                "responses",
+                codexPath,
+                ["exec", "test prompt"],
+                DateTimeOffset.Parse("2026-04-09T11:05:00Z").AddMinutes(iteration),
+                worktreePath,
+                tempDirectory.GetPath($".intent-cli/reviews/{executionUnit}.request.json"),
+                providerEventLogPath);
+
+            observedSessions.Add(result.ProviderSessionId);
+
+            await TemporaryDirectory.WaitForConditionAsync(
+                () =>
+                {
+                    var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                    return events.Any(providerEvent =>
+                        providerEvent.Kind == "provider-event"
+                        && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                        && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                        && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                        && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+                },
+                TimeSpan.FromSeconds(5));
+
+            var finalEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            var backendExitEvent = Assert.Single(finalEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+            Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+        }
+
+        Assert.Equal(observedSessions.Count, observedSessions.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
     public async Task Launch_GivenRealProcessRunnerAndNonWrappedCommand_PreservesExitCallbackAfterGarbageCollection()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -494,6 +494,32 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public void CreateDetachedStartInfo_UsesExecutableHostPath()
+    {
+        var startInfo = DirectRunExitMonitorCommand.CreateDetachedStartInfo(
+            1234,
+            "/tmp/provider.jsonl",
+            "G14c",
+            "review",
+            "Codex",
+            "pid:1234");
+
+        Assert.True(Path.IsPathRooted(startInfo.FileName));
+        Assert.True(File.Exists(startInfo.FileName));
+
+        if (string.Equals(Path.GetFileNameWithoutExtension(startInfo.FileName), "dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            Assert.True(Path.IsPathRooted(startInfo.ArgumentList[0]));
+            Assert.EndsWith("IntentSystem.Cli.dll", startInfo.ArgumentList[0], StringComparison.Ordinal);
+            Assert.Equal("__direct-run-exit-monitor", startInfo.ArgumentList[1]);
+        }
+        else
+        {
+            Assert.Equal("__direct-run-exit-monitor", startInfo.ArgumentList[0]);
+        }
+    }
+
+    [Fact]
     public void Launch_GivenWrappedCodexProcessExitsShortlyAfterLaunch_PersistsBackendExitBeforeReturning()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -251,12 +251,6 @@ public sealed class DirectRunLauncherTests
         Assert.Contains(initialEvents, providerEvent =>
             providerEvent.Kind == "session-metadata"
             && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
-        Assert.DoesNotContain(initialEvents, providerEvent =>
-            providerEvent.Kind == "provider-event"
-            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
-            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
-            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
-            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
 
         await TemporaryDirectory.WaitForConditionAsync(
             () =>
@@ -359,6 +353,61 @@ public sealed class DirectRunLauncherTests
             && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
             && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
         Assert.Equal(1, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+    }
+
+    [Fact]
+    public void Launch_GivenWrappedCodexProcessExitsShortlyAfterLaunch_PersistsBackendExitBeforeReturning()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var externalProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-c", "sleep 1" }
+        });
+        Assert.NotNull(externalProcess);
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14a.provider.jsonl");
+        var runner = new FakeDirectRunProcessRunner
+        {
+            Result = new DirectRunProcessLaunchResult
+            {
+                ProcessId = externalProcess!.Id,
+                ExitedEarly = false,
+                ExitCode = 0
+            }
+        };
+        var launcher = new DirectRunLauncher(runner);
+
+        var result = launcher.Launch(
+            "G14a",
+            "review",
+            ".intent-cli/runs/G14a.request.json",
+            ".intent-cli/runs/G14a.provider.jsonl",
+            "OpenAI",
+            "gpt-5.4-mini",
+            "responses",
+            "/opt/homebrew/bin/codex",
+            ["exec", "test prompt"],
+            DateTimeOffset.Parse("2026-04-09T11:17:00Z"),
+            "/repo",
+            "/repo/.intent-cli/reviews/G14a.request.json",
+            providerEventLogPath);
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -153,11 +153,13 @@ public sealed class DirectRunLauncherTests
             && providerEvent.Payload.TryGetProperty("type", out var typeElement)
             && string.Equals(typeElement.GetString(), "ready", StringComparison.Ordinal)
             && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
-        var backendExitEvent = Assert.Single(events, providerEvent =>
-            providerEvent.Kind == "provider-event"
-            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
-            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
-            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+        var backendExitEvent = events
+            .Where(providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal))
+            .Last();
         Assert.Equal("G9", backendExitEvent.ExecutionUnit);
         Assert.Equal("Codex", backendExitEvent.Provider);
         Assert.Equal("review", backendExitEvent.EntryKind);
@@ -170,6 +172,26 @@ public sealed class DirectRunLauncherTests
     {
         using var tempDirectory = new TemporaryDirectory();
         var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G10.provider.jsonl");
+        Directory.CreateDirectory(Path.GetDirectoryName(providerEventLogPath)!);
+        File.WriteAllText(
+            providerEventLogPath,
+            string.Join(
+                Environment.NewLine,
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-09T10:44:59.0000000+00:00",
+                    ExecutionUnit = "G10",
+                    Provider = "OpenAI",
+                    EntryKind = "review",
+                    SessionId = "pid:2468",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                }),
+                string.Empty));
         var runner = new FakeDirectRunProcessRunner
         {
             ExitCodeEvent = 0,
@@ -201,16 +223,25 @@ public sealed class DirectRunLauncherTests
         Assert.Equal("pid:2468", result.ProviderSessionId);
 
         var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
-        var backendExitEvent = Assert.Single(events, providerEvent =>
-            providerEvent.Kind == "provider-event"
-            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
-            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
-            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+        var backendExitEvent = events
+            .Where(providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal))
+            .Last();
         Assert.Equal("G10", backendExitEvent.ExecutionUnit);
         Assert.Equal("OpenAI", backendExitEvent.Provider);
         Assert.Equal("review", backendExitEvent.EntryKind);
         Assert.Equal("pid:2468", backendExitEvent.SessionId);
         Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+        Assert.Equal(
+            2,
+            events.Count(providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)));
     }
 
     [Fact]
@@ -527,7 +558,8 @@ public sealed class DirectRunLauncherTests
             "G14b",
             "review",
             "OpenAI",
-            providerSessionId));
+            providerSessionId,
+            DateTimeOffset.UtcNow));
         Assert.NotNull(monitor);
         monitor!.StandardInput.Close();
         monitor.StandardOutput.Dispose();
@@ -562,6 +594,76 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public async Task DirectRunExitMonitorCommand_GivenStaleBackendExitForSamePid_AppendsFreshBackendExit()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var externalProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-c", "sleep 1" }
+        });
+        Assert.NotNull(externalProcess);
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14c.provider.jsonl");
+        Directory.CreateDirectory(Path.GetDirectoryName(providerEventLogPath)!);
+        var providerSessionId = $"pid:{externalProcess!.Id}";
+        var launchedAt = DateTimeOffset.UtcNow;
+        File.WriteAllText(
+            providerEventLogPath,
+            string.Join(
+                Environment.NewLine,
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.AddMinutes(-1).ToString("O"),
+                    ExecutionUnit = "G14c",
+                    Provider = "OpenAI",
+                    EntryKind = "review",
+                    SessionId = providerSessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                }),
+                string.Empty));
+
+        using var monitor = Process.Start(DirectRunExitMonitorCommand.CreateDetachedStartInfo(
+            externalProcess.Id,
+            providerEventLogPath,
+            "G14c",
+            "review",
+            "OpenAI",
+            providerSessionId,
+            launchedAt));
+        Assert.NotNull(monitor);
+        monitor!.StandardInput.Close();
+        monitor.StandardOutput.Dispose();
+        monitor.StandardError.Dispose();
+
+        await TemporaryDirectory.WaitForConditionAsync(
+            () =>
+            {
+                var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                return events.Count(providerEvent =>
+                           providerEvent.Kind == "provider-event"
+                           && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                           && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                           && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                           && string.Equals(providerEvent.SessionId, providerSessionId, StringComparison.Ordinal)) == 2;
+            },
+            TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
     public void CreateDetachedStartInfo_UsesExecutableHostPath()
     {
         var startInfo = DirectRunExitMonitorCommand.CreateDetachedStartInfo(
@@ -570,7 +672,8 @@ public sealed class DirectRunLauncherTests
             "G14c",
             "review",
             "Codex",
-            "pid:1234");
+            "pid:1234",
+            DateTimeOffset.Parse("2026-04-09T11:18:00Z"));
 
         Assert.True(Path.IsPathRooted(startInfo.FileName));
         Assert.True(File.Exists(startInfo.FileName));

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -282,6 +282,69 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public async Task Launch_GivenRealProcessRunnerAndNonWrappedCommand_PreservesExitCallbackAfterGarbageCollection()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G12a.provider.jsonl");
+        var worktreePath = tempDirectory.GetPath("repo");
+        Directory.CreateDirectory(worktreePath);
+        var runnerPath = tempDirectory.CreateExecutableFile(
+            "repo/review-runner",
+            """
+            #!/bin/sh
+            printf '%s\n' '{"type":"ready"}'
+            sleep 1
+            """);
+        var launcher = new DirectRunLauncher();
+
+        var result = launcher.Launch(
+            "G12a",
+            "review",
+            ".intent-cli/runs/G12a.request.json",
+            ".intent-cli/runs/G12a.provider.jsonl",
+            "ReviewBot",
+            "gpt-5.4-mini",
+            "responses",
+            runnerPath,
+            ["test prompt"],
+            DateTimeOffset.Parse("2026-04-09T11:06:00Z"),
+            worktreePath,
+            tempDirectory.GetPath(".intent-cli/reviews/G12a.request.json"),
+            providerEventLogPath);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        await TemporaryDirectory.WaitForConditionAsync(
+            () =>
+            {
+                var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                return events.Any(providerEvent =>
+                    providerEvent.Kind == "provider-event"
+                    && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                    && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                    && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                    && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+            },
+            TimeSpan.FromSeconds(5));
+
+        var finalEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        var backendExitEvent = Assert.Single(finalEvents, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+    }
+
+    [Fact]
     public async Task Launch_GivenWrappedCodexProcessEndsWithoutExitCallback_MonitorAppendsBackendExitProviderEvent()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -139,6 +139,8 @@ public sealed class DirectRunLauncherTests
 
         Assert.Equal("pid:", result.ProviderSessionId[..4]);
         Assert.Equal("/bin/sh", runner.FileName);
+        Assert.Equal("-c", runner.Arguments[0]);
+        Assert.Contains("exec \"$@\"", runner.Arguments[1], StringComparison.Ordinal);
         Assert.Contains(codexPath, runner.Arguments, StringComparer.Ordinal);
 
         var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
@@ -415,6 +417,79 @@ public sealed class DirectRunLauncherTests
             && providerEvent.Payload.TryGetProperty("type", out var typeElement)
             && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
             && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.Equal(1, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+    }
+
+    [Fact]
+    public async Task DirectRunExitMonitorCommand_GivenDetachedProcess_AppendsBackendExitForCurrentSession()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var externalProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-c", "sleep 1" }
+        });
+        Assert.NotNull(externalProcess);
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14b.provider.jsonl");
+        var providerSessionId = $"pid:{externalProcess!.Id}";
+        var writer = new DirectRunProviderEventWriter(providerEventLogPath);
+        writer.Append(new DirectRunProviderEvent
+        {
+            Timestamp = DateTimeOffset.UtcNow.ToString("O"),
+            ExecutionUnit = "G14b",
+            Provider = "OpenAI",
+            EntryKind = "review",
+            SessionId = providerSessionId,
+            Kind = "provider-event",
+            Payload = System.Text.Json.JsonSerializer.SerializeToElement(new { type = "ready" })
+        });
+
+        using var monitor = Process.Start(DirectRunExitMonitorCommand.CreateDetachedStartInfo(
+            externalProcess.Id,
+            providerEventLogPath,
+            "G14b",
+            "review",
+            "OpenAI",
+            providerSessionId));
+        Assert.NotNull(monitor);
+        monitor!.StandardInput.Close();
+        monitor.StandardOutput.Dispose();
+        monitor.StandardError.Dispose();
+
+        await TemporaryDirectory.WaitForConditionAsync(
+            () =>
+            {
+                if (!File.Exists(providerEventLogPath))
+                {
+                    return false;
+                }
+
+                var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                return events.Any(providerEvent =>
+                    providerEvent.Kind == "provider-event"
+                    && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                    && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                    && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                    && string.Equals(providerEvent.SessionId, providerSessionId, StringComparison.Ordinal));
+            },
+            TimeSpan.FromSeconds(5));
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        var backendExitEvent = Assert.Single(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, providerSessionId, StringComparison.Ordinal));
         Assert.Equal(1, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
     }
 

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -421,6 +421,85 @@ public sealed class ReviewRunCommandTests
     }
 
     [Fact]
+    public void Execute_GivenCliProcessExitsWithOnlyCodexCommandPath_PersistsCurrentSessionBackendExitToRawLog()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var codexPath = tempDirectory.CreateExecutableFile(
+            Path.Combine("bin", "codex-experimental"),
+            """
+            #!/bin/sh
+            printf '%s\n' '{"type":"ready"}'
+            sleep 1
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "config.toml"),
+            $$"""
+            default_domain = "intent-system"
+            artifact_root = ".intent-cli"
+            worktree_root = ".intent-cli/worktrees"
+
+            [direct_backend]
+            artifact_root = ".intent-cli/runtime-runs"
+
+            [direct_backend.review]
+            command = "{{codexPath.Replace("\\", "\\\\", StringComparison.Ordinal)}}"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "packet.yaml"),
+            "execution_unit: G9" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+
+        var process = StartCliProcess(repoRoot, "review run G9");
+        Assert.True(process.WaitForExit(120000), "CLI process did not exit within the timeout.");
+        Assert.Equal(0, process.ExitCode);
+
+        var requestArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.request.json");
+        TemporaryDirectory.WaitForCondition(
+            () => File.Exists(requestArtifactPath),
+            TimeSpan.FromSeconds(5));
+        var requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+        Assert.Equal("Codex", requestArtifact.Provider);
+        Assert.Equal("gpt-5.4-mini", requestArtifact.Model);
+
+        var providerEventLogPath = Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl");
+        TemporaryDirectory.WaitForCondition(
+            () => File.Exists(providerEventLogPath)
+                && DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath)).Any(providerEvent =>
+                    providerEvent.Kind == "provider-event"
+                    && string.Equals(providerEvent.SessionId, requestArtifact.ProviderSessionId, StringComparison.Ordinal)
+                    && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                    && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                    && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)),
+            TimeSpan.FromSeconds(5));
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "session-metadata"
+            && string.Equals(providerEvent.SessionId, requestArtifact.ProviderSessionId, StringComparison.Ordinal)
+            && string.Equals(providerEvent.Provider, "Codex", StringComparison.Ordinal));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && string.Equals(providerEvent.SessionId, requestArtifact.ProviderSessionId, StringComparison.Ordinal)
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Execute_GivenCodexReviewCommandWithoutModelOverride_UsesRunnableCodexDefaultModel()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -497,6 +497,18 @@ public sealed class ReviewRunCommandTests
             && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
             && providerEvent.Payload.TryGetProperty("type", out var typeElement)
             && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+
+        var rootRunProcess = StartCliProcess(repoRoot, "run");
+        Assert.True(rootRunProcess.WaitForExit(120000), "Root run process did not exit within the timeout.");
+        Assert.Equal(0, rootRunProcess.ExitCode);
+        var rootRunOutput = rootRunProcess.StandardOutput.ReadToEnd();
+        var rootRunError = rootRunProcess.StandardError.ReadToEnd();
+        Assert.DoesNotContain("is 'running'", rootRunOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("is 'running'", rootRunError, StringComparison.Ordinal);
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
+        Assert.NotEqual("running", resultArtifact.RunStatus);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -618,6 +618,58 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenRunningReviewDecisionWithExitedCurrentSession_BackfillsBackendExitAndFails()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:999999", provider: "Codex");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "review",
+            "running",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "review",
+                    SessionId = "pid:999999",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "ready"
+                    })
+                }
+            ],
+            sessionId: "pid:999999",
+            provider: "Codex");
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("non-retryable-failure", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Contains("Review direct run failed for 'G226'.", result.Detail, StringComparison.Ordinal);
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl")));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void ExecuteCore_GivenCommentReviewDecisionWithCommentBody_ReusesReviewCommentBoundary()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -960,7 +1012,8 @@ public sealed class RunCommandTests
         string entryKind,
         string runStatus,
         IReadOnlyList<DirectRunProviderEvent>? providerEvents = null,
-        string sessionId = "pid:226")
+        string sessionId = "pid:226",
+        string provider = "ReviewBot")
     {
         var runsDirectory = Path.Combine(repoRoot, ".intent-cli", "runs");
         Directory.CreateDirectory(runsDirectory);
@@ -974,7 +1027,7 @@ public sealed class RunCommandTests
                     ExecutionUnit = executionUnit,
                     EntryKind = entryKind,
                     UpstreamRequestRef = ResolveUpstreamRequestRef(executionUnit, entryKind),
-                    Provider = "ReviewBot",
+                    Provider = provider,
                     Model = "gpt-5.4-mini",
                     SessionId = sessionId,
                     RunStatus = runStatus,
@@ -1013,7 +1066,8 @@ public sealed class RunCommandTests
         string repoRoot,
         string executionUnit,
         string entryKind,
-        string providerSessionId)
+        string providerSessionId,
+        string provider = "ReviewBot")
     {
         var runsDirectory = Path.Combine(repoRoot, ".intent-cli", "runs");
         Directory.CreateDirectory(runsDirectory);
@@ -1027,7 +1081,7 @@ public sealed class RunCommandTests
                     ExecutionUnit = executionUnit,
                     EntryKind = entryKind,
                     UpstreamRequestRef = ResolveUpstreamRequestRef(executionUnit, entryKind),
-                    Provider = "ReviewBot",
+                    Provider = provider,
                     Model = "gpt-5.4-mini",
                     Transport = "responses",
                     LaunchedAt = "2026-04-10T12:00:00.0000000+00:00",


### PR DESCRIPTION
## Summary
- simplify the detached raw-log exit monitor so it starts directly instead of relying on a nested shell/nohup launcher
- keep current-session `backend-exit` appends inside the G95 raw provider log boundary
- add a hermetic review-run repro using only the Codex command path and assert the launched session receives a terminal raw event

Closes #252