### PR TITLE
Fix direct review launch stdin handling for Codex

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
@@ -1,0 +1,313 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class DirectRunDetachedCaptureCommand
+{
+    internal const string CommandName = "__direct-run-detached-capture";
+    private static readonly TimeSpan StartupSuccessWindow = TimeSpan.FromMilliseconds(500);
+
+    public static bool TryExecute(string[] args, out int exitCode)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        exitCode = 0;
+        if (args.Length == 0 || !string.Equals(args[0], CommandName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!TryParseArguments(args, out var options))
+        {
+            Console.Error.WriteLine(
+                $"Usage: {CommandName} <provider_log_path> <execution_unit> <entry_kind> <provider> <model> <transport> <launched_at> <working_directory> <command> [args...]");
+            exitCode = 1;
+            return true;
+        }
+
+        exitCode = Execute(options);
+        return true;
+    }
+
+    public static ProcessStartInfo CreateStartInfo(
+        string providerEventLogPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string model,
+        string transport,
+        DateTimeOffset launchedAt,
+        string workingDirectory,
+        string command,
+        IReadOnlyList<string> arguments)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerEventLogPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(model);
+        ArgumentException.ThrowIfNullOrWhiteSpace(transport);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var executablePath = DirectRunHelperHostResolver.ResolveExecutablePath();
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executablePath,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardInput = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        if (string.Equals(Path.GetFileNameWithoutExtension(executablePath), "dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            startInfo.ArgumentList.Add(Assembly.GetExecutingAssembly().Location);
+        }
+
+        startInfo.ArgumentList.Add(CommandName);
+        startInfo.ArgumentList.Add(providerEventLogPath);
+        startInfo.ArgumentList.Add(executionUnit);
+        startInfo.ArgumentList.Add(entryKind);
+        startInfo.ArgumentList.Add(provider);
+        startInfo.ArgumentList.Add(model);
+        startInfo.ArgumentList.Add(transport);
+        startInfo.ArgumentList.Add(launchedAt.ToString("O"));
+        startInfo.ArgumentList.Add(workingDirectory);
+        startInfo.ArgumentList.Add(command);
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        return startInfo;
+    }
+
+    private static int Execute(DirectRunDetachedCaptureOptions options)
+    {
+        var writer = new DirectRunProviderEventWriter(options.ProviderEventLogPath);
+        try
+        {
+            var startInfo = CreateProviderStartInfo(options);
+
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException($"Failed to start detached direct run process '{options.Command}'.");
+            var providerSessionId = $"pid:{Environment.ProcessId}";
+            writer.Append(DirectRunProviderEventFactory.CreateSessionMetadataEvent(
+                options.LaunchedAt,
+                options.ExecutionUnit,
+                options.EntryKind,
+                options.Provider,
+                providerSessionId,
+                options.Model,
+                options.Transport,
+                options.Command));
+
+            process.OutputDataReceived += (_, eventArgs) =>
+            {
+                if (!string.IsNullOrEmpty(eventArgs.Data))
+                {
+                    writer.Append(DirectRunProviderEventFactory.CreateProviderEvent(
+                        DateTimeOffset.UtcNow,
+                        options.ExecutionUnit,
+                        options.EntryKind,
+                        options.Provider,
+                        providerSessionId,
+                        NormalizeCapturedLine(eventArgs.Data)));
+                }
+            };
+            process.ErrorDataReceived += (_, eventArgs) =>
+            {
+                if (!string.IsNullOrEmpty(eventArgs.Data))
+                {
+                    writer.Append(DirectRunProviderEventFactory.CreateProviderEvent(
+                        DateTimeOffset.UtcNow,
+                        options.ExecutionUnit,
+                        options.EntryKind,
+                        options.Provider,
+                        providerSessionId,
+                        NormalizeCapturedLine(eventArgs.Data)));
+                }
+            };
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            Console.Out.WriteLine(providerSessionId);
+            Console.Out.Flush();
+
+            var exitedEarly = process.WaitForExit((int)StartupSuccessWindow.TotalMilliseconds);
+            process.WaitForExit();
+            AppendBackendExitIfMissing(writer, options, providerSessionId, process.ExitCode);
+
+            return exitedEarly && process.ExitCode != 0
+                ? process.ExitCode
+                : 0;
+        }
+        catch (Win32Exception exception)
+        {
+            TryWriteStartupError(exception.Message);
+            return 1;
+        }
+        catch (InvalidOperationException exception)
+        {
+            TryWriteStartupError(exception.Message);
+            return 1;
+        }
+    }
+
+    private static void AppendBackendExitIfMissing(
+        DirectRunProviderEventWriter writer,
+        DirectRunDetachedCaptureOptions options,
+        string providerSessionId,
+        int exitCode)
+    {
+        if (DirectRunSessionBoundary.HasBackendExitEvent(options.ProviderEventLogPath, providerSessionId, options.LaunchedAt))
+        {
+            return;
+        }
+
+        writer.Append(DirectRunProviderEventFactory.CreateBackendExitEvent(
+            DateTimeOffset.UtcNow,
+            options.ExecutionUnit,
+            options.EntryKind,
+            options.Provider,
+            providerSessionId,
+            exitCode));
+    }
+
+    private static void TryWriteStartupError(string message)
+    {
+        try
+        {
+            Console.Out.WriteLine($"error:{message}");
+            Console.Out.Flush();
+        }
+        catch
+        {
+        }
+    }
+
+    private static ProcessStartInfo CreateProviderStartInfo(DirectRunDetachedCaptureOptions options)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            WorkingDirectory = options.WorkingDirectory,
+            UseShellExecute = false,
+            RedirectStandardInput = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        if (ShouldWrapWithPseudoTerminal(options.Provider, options.Command))
+        {
+            startInfo.FileName = "/usr/bin/script";
+            startInfo.ArgumentList.Add("-q");
+            startInfo.ArgumentList.Add("/dev/null");
+            startInfo.ArgumentList.Add(options.Command);
+        }
+        else
+        {
+            startInfo.FileName = options.Command;
+        }
+
+        foreach (var argument in options.Arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        return startInfo;
+    }
+
+    private static bool ShouldWrapWithPseudoTerminal(string provider, string command)
+    {
+        if (OperatingSystem.IsWindows() || !File.Exists("/usr/bin/script"))
+        {
+            return false;
+        }
+
+        return string.Equals(provider, "codex", StringComparison.OrdinalIgnoreCase)
+            || IsCodexLikeCommand(command);
+    }
+
+    private static bool IsCodexLikeCommand(string command)
+    {
+        var fileName = Path.GetFileName(command.Trim());
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return false;
+        }
+
+        var commandStem = Path.GetFileNameWithoutExtension(fileName);
+        return commandStem.StartsWith("codex", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeCapturedLine(string line)
+    {
+        var builder = new StringBuilder(line.Length);
+        foreach (var character in line)
+        {
+            if (character == '\t' || character >= ' ')
+            {
+                builder.Append(character);
+            }
+        }
+
+        var normalized = builder.ToString();
+        while (normalized.StartsWith("^D", StringComparison.Ordinal))
+        {
+            normalized = normalized[2..];
+        }
+
+        return normalized;
+    }
+
+    private static bool TryParseArguments(string[] args, out DirectRunDetachedCaptureOptions options)
+    {
+        options = null!;
+        if (args.Length < 10
+            || string.IsNullOrWhiteSpace(args[1])
+            || string.IsNullOrWhiteSpace(args[2])
+            || string.IsNullOrWhiteSpace(args[3])
+            || string.IsNullOrWhiteSpace(args[4])
+            || string.IsNullOrWhiteSpace(args[5])
+            || string.IsNullOrWhiteSpace(args[6])
+            || string.IsNullOrWhiteSpace(args[7])
+            || string.IsNullOrWhiteSpace(args[8])
+            || string.IsNullOrWhiteSpace(args[9])
+            || !DateTimeOffset.TryParse(args[7], CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var launchedAt))
+        {
+            return false;
+        }
+
+        options = new DirectRunDetachedCaptureOptions(
+            args[1],
+            args[2],
+            args[3],
+            args[4],
+            args[5],
+            args[6],
+            launchedAt,
+            args[8],
+            args[9],
+            args.Length == 10 ? [] : args[10..]);
+        return true;
+    }
+
+    private sealed record DirectRunDetachedCaptureOptions(
+        string ProviderEventLogPath,
+        string ExecutionUnit,
+        string EntryKind,
+        string Provider,
+        string Model,
+        string Transport,
+        DateTimeOffset LaunchedAt,
+        string WorkingDirectory,
+        string Command,
+        IReadOnlyList<string> Arguments);
+}

--- a/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
@@ -92,13 +92,17 @@ internal static class DirectRunDetachedCaptureCommand
     private static int Execute(DirectRunDetachedCaptureOptions options)
     {
         var writer = new DirectRunProviderEventWriter(options.ProviderEventLogPath);
+
         try
         {
             var startInfo = CreateProviderStartInfo(options);
 
             using var process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException($"Failed to start detached direct run process '{options.Command}'.");
-            var providerSessionId = $"pid:{Environment.ProcessId}";
+            var providerSessionId = $"pid:{process.Id}";
+            TryWriteSessionId(providerSessionId);
+            Console.SetOut(TextWriter.Null);
+            Console.SetError(TextWriter.Null);
             writer.Append(DirectRunProviderEventFactory.CreateSessionMetadataEvent(
                 options.LaunchedAt,
                 options.ExecutionUnit,
@@ -138,9 +142,6 @@ internal static class DirectRunDetachedCaptureCommand
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
-            Console.Out.WriteLine(providerSessionId);
-            Console.Out.Flush();
-
             var exitedEarly = process.WaitForExit((int)StartupSuccessWindow.TotalMilliseconds);
             process.WaitForExit();
             AppendBackendExitIfMissing(writer, options, providerSessionId, process.ExitCode);
@@ -149,14 +150,12 @@ internal static class DirectRunDetachedCaptureCommand
                 ? process.ExitCode
                 : 0;
         }
-        catch (Win32Exception exception)
+        catch (Win32Exception)
         {
-            TryWriteStartupError(exception.Message);
             return 1;
         }
-        catch (InvalidOperationException exception)
+        catch (InvalidOperationException)
         {
-            TryWriteStartupError(exception.Message);
             return 1;
         }
     }
@@ -181,11 +180,11 @@ internal static class DirectRunDetachedCaptureCommand
             exitCode));
     }
 
-    private static void TryWriteStartupError(string message)
+    private static void TryWriteSessionId(string providerSessionId)
     {
         try
         {
-            Console.Out.WriteLine($"error:{message}");
+            Console.Out.WriteLine(providerSessionId);
             Console.Out.Flush();
         }
         catch
@@ -204,17 +203,7 @@ internal static class DirectRunDetachedCaptureCommand
             RedirectStandardError = true
         };
 
-        if (ShouldWrapWithPseudoTerminal(options.Provider, options.Command))
-        {
-            startInfo.FileName = "/usr/bin/script";
-            startInfo.ArgumentList.Add("-q");
-            startInfo.ArgumentList.Add("/dev/null");
-            startInfo.ArgumentList.Add(options.Command);
-        }
-        else
-        {
-            startInfo.FileName = options.Command;
-        }
+        startInfo.FileName = options.Command;
 
         foreach (var argument in options.Arguments)
         {
@@ -222,29 +211,6 @@ internal static class DirectRunDetachedCaptureCommand
         }
 
         return startInfo;
-    }
-
-    private static bool ShouldWrapWithPseudoTerminal(string provider, string command)
-    {
-        if (OperatingSystem.IsWindows() || !File.Exists("/usr/bin/script"))
-        {
-            return false;
-        }
-
-        return string.Equals(provider, "codex", StringComparison.OrdinalIgnoreCase)
-            || IsCodexLikeCommand(command);
-    }
-
-    private static bool IsCodexLikeCommand(string command)
-    {
-        var fileName = Path.GetFileName(command.Trim());
-        if (string.IsNullOrWhiteSpace(fileName))
-        {
-            return false;
-        }
-
-        var commandStem = Path.GetFileNameWithoutExtension(fileName);
-        return commandStem.StartsWith("codex", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string NormalizeCapturedLine(string line)

--- a/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
@@ -10,6 +10,9 @@ internal static class DirectRunDetachedCaptureCommand
 {
     internal const string CommandName = "__direct-run-detached-capture";
     private static readonly TimeSpan StartupSuccessWindow = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan ExitPollInterval = TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan OutputDrainGracePeriod = TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan ExitCodeResolutionGracePeriod = TimeSpan.FromSeconds(3);
 
     public static bool TryExecute(string[] args, out int exitCode)
     {
@@ -92,14 +95,19 @@ internal static class DirectRunDetachedCaptureCommand
     private static int Execute(DirectRunDetachedCaptureOptions options)
     {
         var writer = new DirectRunProviderEventWriter(options.ProviderEventLogPath);
+        Process? process = null;
+        Task? stdoutPump = null;
+        Task? stderrPump = null;
+        var providerSessionId = string.Empty;
+        var exitedEarly = false;
 
         try
         {
             var startInfo = CreateProviderStartInfo(options);
 
-            using var process = Process.Start(startInfo)
+            process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException($"Failed to start detached direct run process '{options.Command}'.");
-            var providerSessionId = $"pid:{process.Id}";
+            providerSessionId = $"pid:{process.Id}";
             TryWriteSessionId(providerSessionId);
             Console.SetOut(TextWriter.Null);
             Console.SetError(TextWriter.Null);
@@ -112,42 +120,34 @@ internal static class DirectRunDetachedCaptureCommand
                 options.Model,
                 options.Transport,
                 options.Command));
+            StartProviderExitMonitorIfPossible(
+                process.Id,
+                options.ProviderEventLogPath,
+                options.ExecutionUnit,
+                options.EntryKind,
+                options.Provider,
+                providerSessionId,
+                options.LaunchedAt);
 
-            process.OutputDataReceived += (_, eventArgs) =>
-            {
-                if (!string.IsNullOrEmpty(eventArgs.Data))
-                {
-                    writer.Append(DirectRunProviderEventFactory.CreateProviderEvent(
-                        DateTimeOffset.UtcNow,
-                        options.ExecutionUnit,
-                        options.EntryKind,
-                        options.Provider,
-                        providerSessionId,
-                        NormalizeCapturedLine(eventArgs.Data)));
-                }
-            };
-            process.ErrorDataReceived += (_, eventArgs) =>
-            {
-                if (!string.IsNullOrEmpty(eventArgs.Data))
-                {
-                    writer.Append(DirectRunProviderEventFactory.CreateProviderEvent(
-                        DateTimeOffset.UtcNow,
-                        options.ExecutionUnit,
-                        options.EntryKind,
-                        options.Provider,
-                        providerSessionId,
-                        NormalizeCapturedLine(eventArgs.Data)));
-                }
-            };
-            process.BeginOutputReadLine();
-            process.BeginErrorReadLine();
+            stdoutPump = StartOutputPump(
+                process.StandardOutput,
+                writer,
+                options,
+                providerSessionId);
+            stderrPump = StartOutputPump(
+                process.StandardError,
+                writer,
+                options,
+                providerSessionId);
 
-            var exitedEarly = process.WaitForExit((int)StartupSuccessWindow.TotalMilliseconds);
-            process.WaitForExit();
-            AppendBackendExitIfMissing(writer, options, providerSessionId, process.ExitCode);
+            exitedEarly = process.WaitForExit((int)StartupSuccessWindow.TotalMilliseconds);
+            WaitForProcessExit(process);
+            var exitCode = ResolveExitCode(process, exitedEarly);
+            AppendBackendExitIfMissing(writer, options, providerSessionId, exitCode);
+            TryCompleteOutputPumps(stdoutPump, stderrPump);
 
-            return exitedEarly && process.ExitCode != 0
-                ? process.ExitCode
+            return exitedEarly && exitCode != 0
+                ? exitCode
                 : 0;
         }
         catch (Win32Exception)
@@ -157,6 +157,33 @@ internal static class DirectRunDetachedCaptureCommand
         catch (InvalidOperationException)
         {
             return 1;
+        }
+        finally
+        {
+            if (process is not null)
+            {
+                try
+                {
+                    if (!string.IsNullOrWhiteSpace(providerSessionId))
+                    {
+                        AppendBackendExitIfMissing(
+                            writer,
+                            options,
+                            providerSessionId,
+                            ResolveExitCode(process, exitedEarly));
+                    }
+                }
+                catch (InvalidOperationException)
+                {
+                }
+
+                if (stdoutPump is not null && stderrPump is not null)
+                {
+                    TryCompleteOutputPumps(stdoutPump, stderrPump);
+                }
+
+                process.Dispose();
+            }
         }
     }
 
@@ -178,6 +205,202 @@ internal static class DirectRunDetachedCaptureCommand
             options.Provider,
             providerSessionId,
             exitCode));
+    }
+
+    private static void StartProviderExitMonitorIfPossible(
+        int processId,
+        string providerEventLogPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var monitorStartInfo = DirectRunExitMonitorCommand.CreateDetachedStartInfo(
+            processId,
+            providerEventLogPath,
+            executionUnit,
+            entryKind,
+            provider,
+            providerSessionId,
+            launchedAt);
+
+        var launcherStartInfo = new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false
+        };
+        launcherStartInfo.ArgumentList.Add("-c");
+        launcherStartInfo.ArgumentList.Add(
+            """
+            if command -v nohup >/dev/null 2>&1; then
+                nohup "$@" >/dev/null 2>&1 </dev/null &
+            else
+                "$@" >/dev/null 2>&1 </dev/null &
+            fi
+            """);
+        launcherStartInfo.ArgumentList.Add("direct-run-exit-monitor-launcher");
+        launcherStartInfo.ArgumentList.Add(monitorStartInfo.FileName);
+        foreach (var argument in monitorStartInfo.ArgumentList)
+        {
+            launcherStartInfo.ArgumentList.Add(argument);
+        }
+
+        using var launcher = Process.Start(launcherStartInfo);
+    }
+
+    private static void WaitForProcessExit(Process process)
+    {
+        while (IsProcessAlive(process))
+        {
+            Thread.Sleep(ExitPollInterval);
+        }
+    }
+
+    private static int ResolveExitCode(Process process, bool exitedEarly)
+    {
+        try
+        {
+            process.WaitForExit((int)ExitCodeResolutionGracePeriod.TotalMilliseconds);
+            process.Refresh();
+            return process.ExitCode;
+        }
+        catch (InvalidOperationException)
+        {
+            return exitedEarly ? 1 : 0;
+        }
+    }
+
+    private static Task StartOutputPump(
+        StreamReader reader,
+        DirectRunProviderEventWriter writer,
+        DirectRunDetachedCaptureOptions options,
+        string providerSessionId)
+    {
+        return Task.Run(() =>
+        {
+            while (true)
+            {
+                string? line;
+                try
+                {
+                    line = reader.ReadLine();
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+                catch (InvalidOperationException)
+                {
+                    break;
+                }
+
+                if (line is null)
+                {
+                    break;
+                }
+
+                var normalizedLine = NormalizeCapturedLine(line);
+                if (string.IsNullOrEmpty(normalizedLine))
+                {
+                    continue;
+                }
+
+                writer.Append(DirectRunProviderEventFactory.CreateProviderEvent(
+                    DateTimeOffset.UtcNow,
+                    options.ExecutionUnit,
+                    options.EntryKind,
+                    options.Provider,
+                    providerSessionId,
+                    normalizedLine));
+            }
+        });
+    }
+
+    private static void TryCompleteOutputPumps(params Task[] pumps)
+    {
+        try
+        {
+            Task.WaitAll(pumps, OutputDrainGracePeriod);
+        }
+        catch (AggregateException)
+        {
+        }
+    }
+
+    private static bool IsProcessAlive(Process process)
+    {
+        try
+        {
+            process.Refresh();
+            if (process.HasExited)
+            {
+                return false;
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            return true;
+        }
+
+        var processState = TryReadUnixProcessState(process.Id);
+        if (string.IsNullOrWhiteSpace(processState))
+        {
+            return false;
+        }
+
+        return processState.IndexOf('Z') < 0;
+    }
+
+    private static string? TryReadUnixProcessState(int processId)
+    {
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "/bin/ps",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList =
+                {
+                    "-o",
+                    "stat=",
+                    "-p",
+                    processId.ToString(CultureInfo.InvariantCulture)
+                }
+            });
+
+            if (process is null)
+            {
+                return null;
+            }
+
+            using (process)
+            {
+                var output = process.StandardOutput.ReadToEnd();
+                process.WaitForExit();
+                return output.Trim();
+            }
+        }
+        catch (Exception exception) when (
+            exception is Win32Exception
+            or InvalidOperationException)
+        {
+            return null;
+        }
     }
 
     private static void TryWriteSessionId(string providerSessionId)

--- a/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
-using System.Reflection;
 using System.Text.Json;
 
 namespace IntentSystem.Cli.Commands;
@@ -54,13 +53,7 @@ internal static class DirectRunExitMonitorCommand
         ArgumentException.ThrowIfNullOrWhiteSpace(provider);
         ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
 
-        var assemblyPath = Assembly.GetExecutingAssembly().Location;
-        if (string.IsNullOrWhiteSpace(assemblyPath) || !File.Exists(assemblyPath))
-        {
-            throw new InvalidOperationException("Could not resolve the IntentSystem CLI assembly path for the exit monitor.");
-        }
-
-        var executablePath = ResolveMonitorExecutablePath(assemblyPath);
+        var executablePath = DirectRunHelperHostResolver.ResolveExecutablePath();
         var startInfo = new ProcessStartInfo
         {
             FileName = executablePath,
@@ -72,7 +65,7 @@ internal static class DirectRunExitMonitorCommand
 
         if (string.Equals(Path.GetFileNameWithoutExtension(executablePath), "dotnet", StringComparison.OrdinalIgnoreCase))
         {
-            startInfo.ArgumentList.Add(assemblyPath);
+            startInfo.ArgumentList.Add(System.Reflection.Assembly.GetExecutingAssembly().Location);
         }
 
         startInfo.ArgumentList.Add(CommandName);
@@ -217,52 +210,6 @@ internal static class DirectRunExitMonitorCommand
             args[6],
             launchedAt);
         return true;
-    }
-
-    private static string ResolveMonitorExecutablePath(string assemblyPath)
-    {
-        var appHostPath = Path.Combine(
-            Path.GetDirectoryName(assemblyPath)
-                ?? throw new InvalidOperationException("IntentSystem CLI assembly path did not contain a directory."),
-            Path.GetFileNameWithoutExtension(assemblyPath) + (OperatingSystem.IsWindows() ? ".exe" : string.Empty));
-
-        if (File.Exists(appHostPath))
-        {
-            return appHostPath;
-        }
-
-        var processPath = Environment.ProcessPath;
-        if (!string.IsNullOrWhiteSpace(processPath)
-            && Path.IsPathRooted(processPath)
-            && File.Exists(processPath)
-            && string.Equals(Path.GetFileNameWithoutExtension(processPath), "dotnet", StringComparison.OrdinalIgnoreCase))
-        {
-            return processPath;
-        }
-
-        var dotnetHostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
-        if (!string.IsNullOrWhiteSpace(dotnetHostPath)
-            && Path.IsPathRooted(dotnetHostPath)
-            && File.Exists(dotnetHostPath)
-            && string.Equals(Path.GetFileNameWithoutExtension(dotnetHostPath), "dotnet", StringComparison.OrdinalIgnoreCase))
-        {
-            return dotnetHostPath;
-        }
-
-        var pathValue = Environment.GetEnvironmentVariable("PATH");
-        if (!string.IsNullOrWhiteSpace(pathValue))
-        {
-            foreach (var directory in pathValue.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            {
-                var candidate = Path.Combine(directory, OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
-                if (Path.IsPathRooted(candidate) && File.Exists(candidate))
-                {
-                    return candidate;
-                }
-            }
-        }
-
-        throw new InvalidOperationException("Could not resolve an executable host for the detached exit monitor.");
     }
 
     private static DirectRunProviderEvent CreateBackendExitEvent(

--- a/src/IntentSystem.Cli/Commands/DirectRunHelperHostResolver.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunHelperHostResolver.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class DirectRunHelperHostResolver
+{
+    public static string ResolveExecutablePath()
+    {
+        var assemblyPath = Assembly.GetExecutingAssembly().Location;
+        if (string.IsNullOrWhiteSpace(assemblyPath) || !File.Exists(assemblyPath))
+        {
+            throw new InvalidOperationException("Could not resolve the IntentSystem CLI assembly path for the direct run helper.");
+        }
+
+        var appHostPath = Path.Combine(
+            Path.GetDirectoryName(assemblyPath)
+                ?? throw new InvalidOperationException("IntentSystem CLI assembly path did not contain a directory."),
+            Path.GetFileNameWithoutExtension(assemblyPath) + (OperatingSystem.IsWindows() ? ".exe" : string.Empty));
+
+        if (File.Exists(appHostPath))
+        {
+            return appHostPath;
+        }
+
+        var processPath = Environment.ProcessPath;
+        if (!string.IsNullOrWhiteSpace(processPath)
+            && Path.IsPathRooted(processPath)
+            && File.Exists(processPath)
+            && string.Equals(Path.GetFileNameWithoutExtension(processPath), "dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            return processPath;
+        }
+
+        var dotnetHostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+        if (!string.IsNullOrWhiteSpace(dotnetHostPath)
+            && Path.IsPathRooted(dotnetHostPath)
+            && File.Exists(dotnetHostPath)
+            && string.Equals(Path.GetFileNameWithoutExtension(dotnetHostPath), "dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            return dotnetHostPath;
+        }
+
+        var pathValue = Environment.GetEnvironmentVariable("PATH");
+        if (!string.IsNullOrWhiteSpace(pathValue))
+        {
+            foreach (var directory in pathValue.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var candidate = Path.Combine(directory, OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
+                if (Path.IsPathRooted(candidate) && File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        throw new InvalidOperationException("Could not resolve a runnable host for the IntentSystem CLI direct run helper.");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -6,6 +6,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
 {
     private static readonly TimeSpan DefaultEarlyExitWindow = TimeSpan.FromMilliseconds(500);
     private static readonly TimeSpan PersistentExitObservationWindow = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan DetachedCaptureSessionIdWaitWindow = TimeSpan.FromSeconds(10);
     private readonly IDirectRunProcessRunner processRunner;
 
     public DirectRunLauncher()
@@ -65,7 +66,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             arguments,
             launchedAt,
             workingDirectory,
-            absoluteProviderEventLogPath);
+            absoluteProviderEventLogPath,
+            processRunner is DirectRunProcessRunner);
         var eventWriter = new DirectRunProviderEventWriter(absoluteProviderEventLogPath);
         var providerSessionId = string.Empty;
         string? detachedLaunchError = null;
@@ -77,9 +79,13 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             DefaultEarlyExitWindow,
             processId =>
             {
-                if (processInvocation.UsesDetachedCaptureHelper)
+                if (processInvocation.UsesDetachedCaptureHelper && processInvocation.StartedProcessCarriesProviderSession)
                 {
                     providerSessionId = $"pid:{processId}";
+                    return;
+                }
+                if (processInvocation.UsesDetachedCaptureHelper)
+                {
                     return;
                 }
 
@@ -167,6 +173,14 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             providerSessionId,
             launchedAt);
 
+        if (processInvocation.UsesDetachedCaptureHelper)
+        {
+            providerSessionId = ResolveDetachedProviderSessionId(
+                absoluteProviderEventLogPath,
+                launchedAt,
+                providerSessionId);
+        }
+
         if (process.ExitedEarly && process.ExitCode != 0)
         {
             if (processInvocation.UsesDetachedCaptureHelper && !string.IsNullOrWhiteSpace(detachedLaunchError))
@@ -196,6 +210,66 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             TransportSummary =
                 $"{transport} transport launched via '{command}' in '{workingDirectory}' for provider '{provider}'."
         };
+    }
+
+    private static string ResolveDetachedProviderSessionId(
+        string providerEventLogPath,
+        DateTimeOffset launchedAt,
+        string fallbackSessionId)
+    {
+        var deadline = DateTimeOffset.UtcNow + DetachedCaptureSessionIdWaitWindow;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var resolvedSessionId = TryReadDetachedProviderSessionId(providerEventLogPath, launchedAt);
+            if (!string.IsNullOrWhiteSpace(resolvedSessionId))
+            {
+                return resolvedSessionId;
+            }
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(100));
+        }
+
+        return fallbackSessionId;
+    }
+
+    private static string? TryReadDetachedProviderSessionId(string providerEventLogPath, DateTimeOffset launchedAt)
+    {
+        if (!File.Exists(providerEventLogPath))
+        {
+            return null;
+        }
+
+        string? resolvedSessionId = null;
+        foreach (var line in File.ReadLines(providerEventLogPath))
+        {
+            DirectRunProviderEvent providerEvent;
+            try
+            {
+                providerEvent = DirectRunProviderEventJsonl.DeserializeLine(line);
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or ArgumentException
+                or System.Text.Json.JsonException)
+            {
+                continue;
+            }
+
+            if (!string.Equals(providerEvent.Kind, "session-metadata", StringComparison.Ordinal)
+                || !DateTimeOffset.TryParse(
+                    providerEvent.Timestamp,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.RoundtripKind,
+                    out var providerEventTimestamp)
+                || providerEventTimestamp < launchedAt)
+            {
+                continue;
+            }
+
+            resolvedSessionId = providerEvent.SessionId;
+        }
+
+        return resolvedSessionId;
     }
 
     private static IReadOnlyList<string> ResolveArguments(
@@ -235,7 +309,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         IReadOnlyList<string> arguments,
         DateTimeOffset launchedAt,
         string workingDirectory,
-        string absoluteProviderEventLogPath)
+        string absoluteProviderEventLogPath,
+        bool detachHelperFromLauncherSession)
     {
         if (!ShouldShellWrapForPersistentExitLogging(provider, command))
         {
@@ -245,7 +320,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 Arguments = arguments,
                 RequiresPersistentExitMonitor = false,
                 InheritStandardInput = false,
-                UsesDetachedCaptureHelper = false
+                UsesDetachedCaptureHelper = false,
+                StartedProcessCarriesProviderSession = true
             };
         }
 
@@ -261,14 +337,58 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             command,
             arguments);
 
+        if (detachHelperFromLauncherSession && !OperatingSystem.IsWindows())
+        {
+            var detachedLauncherStartInfo = CreateDetachedHelperLauncherStartInfo(helperStartInfo);
+            return new ResolvedProcessInvocation
+            {
+                FileName = detachedLauncherStartInfo.FileName,
+                Arguments = detachedLauncherStartInfo.ArgumentList.ToArray(),
+                RequiresPersistentExitMonitor = false,
+                InheritStandardInput = false,
+                UsesDetachedCaptureHelper = true,
+                StartedProcessCarriesProviderSession = false
+            };
+        }
+
         return new ResolvedProcessInvocation
         {
             FileName = helperStartInfo.FileName,
             Arguments = helperStartInfo.ArgumentList.ToArray(),
             RequiresPersistentExitMonitor = false,
-            InheritStandardInput = true,
-            UsesDetachedCaptureHelper = true
+            InheritStandardInput = false,
+            UsesDetachedCaptureHelper = true,
+            StartedProcessCarriesProviderSession = true
         };
+    }
+
+    private static ProcessStartInfo CreateDetachedHelperLauncherStartInfo(ProcessStartInfo helperStartInfo)
+    {
+        var launcherStartInfo = new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        launcherStartInfo.ArgumentList.Add("-c");
+        launcherStartInfo.ArgumentList.Add(
+            """
+            if command -v nohup >/dev/null 2>&1; then
+                nohup "$@" >/dev/null 2>&1 </dev/null &
+            else
+                "$@" >/dev/null 2>&1 </dev/null &
+            fi
+            """);
+        launcherStartInfo.ArgumentList.Add("direct-run-detached-capture-launcher");
+        launcherStartInfo.ArgumentList.Add(helperStartInfo.FileName);
+        foreach (var argument in helperStartInfo.ArgumentList)
+        {
+            launcherStartInfo.ArgumentList.Add(argument);
+        }
+
+        return launcherStartInfo;
     }
 
     private static bool ShouldShellWrapForPersistentExitLogging(string provider, string command)
@@ -450,11 +570,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
     {
         if (raw.StartsWith("pid:", StringComparison.Ordinal))
         {
-            if (string.IsNullOrWhiteSpace(providerSessionId))
-            {
-                providerSessionId = raw;
-            }
-
+            providerSessionId = raw;
             return true;
         }
 
@@ -478,5 +594,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         public required bool InheritStandardInput { get; init; }
 
         public required bool UsesDetachedCaptureHelper { get; init; }
+
+        public required bool StartedProcessCarriesProviderSession { get; init; }
     }
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -69,6 +69,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             workingDirectory,
             processInvocation.FileName,
             processInvocation.Arguments,
+            processInvocation.InheritStandardInput,
             DefaultEarlyExitWindow,
             processId =>
             {
@@ -175,7 +176,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             {
                 FileName = command,
                 Arguments = arguments,
-                RequiresPersistentExitMonitor = false
+                RequiresPersistentExitMonitor = false,
+                InheritStandardInput = false
             };
         }
 
@@ -197,7 +199,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 command,
                 .. arguments
             ],
-            RequiresPersistentExitMonitor = true
+            RequiresPersistentExitMonitor = true,
+            InheritStandardInput = true
         };
     }
 
@@ -456,5 +459,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         public required IReadOnlyList<string> Arguments { get; init; }
 
         public required bool RequiresPersistentExitMonitor { get; init; }
+
+        public required bool InheritStandardInput { get; init; }
     }
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Text.Json;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -60,11 +59,16 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             executionUnit,
             entryKind,
             provider,
+            model,
+            transport,
             command,
             arguments,
+            launchedAt,
+            workingDirectory,
             absoluteProviderEventLogPath);
         var eventWriter = new DirectRunProviderEventWriter(absoluteProviderEventLogPath);
         var providerSessionId = string.Empty;
+        string? detachedLaunchError = null;
         var process = processRunner.Start(
             workingDirectory,
             processInvocation.FileName,
@@ -73,8 +77,14 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             DefaultEarlyExitWindow,
             processId =>
             {
+                if (processInvocation.UsesDetachedCaptureHelper)
+                {
+                    providerSessionId = $"pid:{processId}";
+                    return;
+                }
+
                 providerSessionId = $"pid:{processId}";
-                eventWriter.Append(CreateSessionMetadataEvent(
+                eventWriter.Append(DirectRunProviderEventFactory.CreateSessionMetadataEvent(
                     launchedAt,
                     executionUnit,
                     entryKind,
@@ -102,8 +112,49 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                     providerSessionId,
                     exitCode,
                     launchedAt),
-            raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)),
-            raw => eventWriter.Append(CreateProviderEvent(DateTimeOffset.UtcNow, executionUnit, entryKind, provider, providerSessionId, raw)));
+            raw =>
+            {
+                if (processInvocation.UsesDetachedCaptureHelper
+                    && TryHandleDetachedCaptureHandshake(
+                        raw,
+                        eventWriter,
+                        launchedAt,
+                        executionUnit,
+                        entryKind,
+                        provider,
+                        model,
+                        transport,
+                        command,
+                        ref providerSessionId,
+                        ref detachedLaunchError))
+                {
+                    return;
+                }
+
+                eventWriter.Append(DirectRunProviderEventFactory.CreateProviderEvent(
+                    DateTimeOffset.UtcNow,
+                    executionUnit,
+                    entryKind,
+                    provider,
+                    providerSessionId,
+                    raw));
+            },
+            raw =>
+            {
+                if (processInvocation.UsesDetachedCaptureHelper && detachedLaunchError is null)
+                {
+                    detachedLaunchError = raw;
+                    return;
+                }
+
+                eventWriter.Append(DirectRunProviderEventFactory.CreateProviderEvent(
+                    DateTimeOffset.UtcNow,
+                    executionUnit,
+                    entryKind,
+                    provider,
+                    providerSessionId,
+                    raw));
+            });
 
         BestEffortAppendBackendExitIfProcessExitedSoon(
             processInvocation.RequiresPersistentExitMonitor,
@@ -118,8 +169,20 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
 
         if (process.ExitedEarly && process.ExitCode != 0)
         {
+            if (processInvocation.UsesDetachedCaptureHelper && !string.IsNullOrWhiteSpace(detachedLaunchError))
+            {
+                throw new InvalidOperationException(
+                    $"Direct run launch failed for provider '{provider}' using command '{command}': {detachedLaunchError}");
+            }
+
             throw new InvalidOperationException(
                 $"Direct run launch failed for provider '{provider}' using command '{command}' with exit code {process.ExitCode}.");
+        }
+
+        if (processInvocation.UsesDetachedCaptureHelper && string.IsNullOrWhiteSpace(providerSessionId))
+        {
+            throw new InvalidOperationException(
+                $"Direct run launch failed for provider '{provider}' using command '{command}': detached capture helper did not report a provider session.");
         }
 
         return new DirectRunLaunchResult
@@ -166,8 +229,12 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         string executionUnit,
         string entryKind,
         string provider,
+        string model,
+        string transport,
         string command,
         IReadOnlyList<string> arguments,
+        DateTimeOffset launchedAt,
+        string workingDirectory,
         string absoluteProviderEventLogPath)
     {
         if (!ShouldShellWrapForPersistentExitLogging(provider, command))
@@ -177,30 +244,30 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 FileName = command,
                 Arguments = arguments,
                 RequiresPersistentExitMonitor = false,
-                InheritStandardInput = false
+                InheritStandardInput = false,
+                UsesDetachedCaptureHelper = false
             };
         }
 
+        var helperStartInfo = DirectRunDetachedCaptureCommand.CreateStartInfo(
+            absoluteProviderEventLogPath,
+            executionUnit,
+            entryKind,
+            provider,
+            model,
+            transport,
+            launchedAt,
+            workingDirectory,
+            command,
+            arguments);
+
         return new ResolvedProcessInvocation
         {
-            FileName = "/bin/sh",
-            Arguments =
-            [
-                "-c",
-                """
-                shift 4
-                exec "$@"
-                """,
-                "direct-run-wrapper",
-                absoluteProviderEventLogPath,
-                executionUnit,
-                entryKind,
-                provider,
-                command,
-                .. arguments
-            ],
-            RequiresPersistentExitMonitor = true,
-            InheritStandardInput = true
+            FileName = helperStartInfo.FileName,
+            Arguments = helperStartInfo.ArgumentList.ToArray(),
+            RequiresPersistentExitMonitor = false,
+            InheritStandardInput = true,
+            UsesDetachedCaptureHelper = true
         };
     }
 
@@ -246,7 +313,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             return;
         }
 
-        eventWriter.Append(CreateBackendExitEvent(
+        eventWriter.Append(DirectRunProviderEventFactory.CreateBackendExitEvent(
             DateTimeOffset.UtcNow,
             executionUnit,
             entryKind,
@@ -368,88 +435,36 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         }
     }
 
-    private static DirectRunProviderEvent CreateSessionMetadataEvent(
+    private static bool TryHandleDetachedCaptureHandshake(
+        string raw,
+        DirectRunProviderEventWriter eventWriter,
         DateTimeOffset launchedAt,
         string executionUnit,
         string entryKind,
         string provider,
-        string providerSessionId,
         string model,
         string transport,
-        string command)
+        string command,
+        ref string providerSessionId,
+        ref string? detachedLaunchError)
     {
-        return new DirectRunProviderEvent
+        if (raw.StartsWith("pid:", StringComparison.Ordinal))
         {
-            Timestamp = launchedAt.ToString("O"),
-            ExecutionUnit = executionUnit,
-            Provider = provider,
-            EntryKind = entryKind,
-            SessionId = providerSessionId,
-            Kind = "session-metadata",
-            Payload = JsonSerializer.SerializeToElement(new
+            if (string.IsNullOrWhiteSpace(providerSessionId))
             {
-                model,
-                transport,
-                command
-            })
-        };
-    }
+                providerSessionId = raw;
+            }
 
-    private static DirectRunProviderEvent CreateProviderEvent(
-        DateTimeOffset timestamp,
-        string executionUnit,
-        string entryKind,
-        string provider,
-        string providerSessionId,
-        string raw)
-    {
-        return new DirectRunProviderEvent
-        {
-            Timestamp = timestamp.ToString("O"),
-            ExecutionUnit = executionUnit,
-            Provider = provider,
-            EntryKind = entryKind,
-            SessionId = providerSessionId,
-            Kind = "provider-event",
-            Payload = ParsePayload(raw)
-        };
-    }
-
-    private static DirectRunProviderEvent CreateBackendExitEvent(
-        DateTimeOffset timestamp,
-        string executionUnit,
-        string entryKind,
-        string provider,
-        string providerSessionId,
-        int exitCode)
-    {
-        return new DirectRunProviderEvent
-        {
-            Timestamp = timestamp.ToString("O"),
-            ExecutionUnit = executionUnit,
-            Provider = provider,
-            EntryKind = entryKind,
-            SessionId = providerSessionId,
-            Kind = "provider-event",
-            Payload = JsonSerializer.SerializeToElement(new
-            {
-                type = "backend-exit",
-                exit_code = exitCode
-            })
-        };
-    }
-
-    private static JsonElement ParsePayload(string raw)
-    {
-        try
-        {
-            using var document = JsonDocument.Parse(raw);
-            return document.RootElement.Clone();
+            return true;
         }
-        catch (JsonException)
+
+        if (raw.StartsWith("error:", StringComparison.Ordinal))
         {
-            return JsonSerializer.SerializeToElement(raw);
+            detachedLaunchError = raw["error:".Length..].Trim();
+            return true;
         }
+
+        return false;
     }
 
     private sealed record ResolvedProcessInvocation
@@ -461,5 +476,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         public required bool RequiresPersistentExitMonitor { get; init; }
 
         public required bool InheritStandardInput { get; init; }
+
+        public required bool UsesDetachedCaptureHelper { get; init; }
     }
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
@@ -87,9 +87,9 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
-            var exitedEarly = process.WaitForExit((int)earlyExitWindow.TotalMilliseconds);
-            var exitCode = exitedEarly ? process.ExitCode : 0;
             var processId = process.Id;
+            var exitedEarly = process.WaitForExit((int)earlyExitWindow.TotalMilliseconds);
+            var exitCode = exitedEarly ? TryGetExitCode(process) : 0;
 
             if (exitedEarly)
             {
@@ -120,5 +120,17 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
     {
         ActiveProcesses.TryRemove(process.Id, out _);
         process.Dispose();
+    }
+
+    private static int TryGetExitCode(Process process)
+    {
+        try
+        {
+            return process.ExitCode;
+        }
+        catch (InvalidOperationException)
+        {
+            return 0;
+        }
     }
 }

--- a/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
@@ -12,6 +12,7 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
         string workingDirectory,
         string fileName,
         IReadOnlyList<string> arguments,
+        bool inheritStandardInput,
         TimeSpan earlyExitWindow,
         Action<int> onStarted,
         Action<int> onExited,
@@ -33,7 +34,7 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
                 FileName = fileName,
                 WorkingDirectory = workingDirectory,
                 UseShellExecute = false,
-                RedirectStandardInput = true,
+                RedirectStandardInput = !inheritStandardInput,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
@@ -45,7 +46,12 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
 
             var process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException($"Failed to start direct run process '{fileName}'.");
-            process.StandardInput.Close();
+
+            if (!inheritStandardInput)
+            {
+                process.StandardInput.Close();
+            }
+
             ActiveProcesses[process.Id] = process;
 
             onStarted(process.Id);

--- a/src/IntentSystem.Cli/Commands/DirectRunProviderEventFactory.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProviderEventFactory.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class DirectRunProviderEventFactory
+{
+    public static DirectRunProviderEvent CreateSessionMetadataEvent(
+        DateTimeOffset launchedAt,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        string model,
+        string transport,
+        string command)
+    {
+        return new DirectRunProviderEvent
+        {
+            Timestamp = launchedAt.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = provider,
+            EntryKind = entryKind,
+            SessionId = providerSessionId,
+            Kind = "session-metadata",
+            Payload = JsonSerializer.SerializeToElement(new
+            {
+                model,
+                transport,
+                command
+            })
+        };
+    }
+
+    public static DirectRunProviderEvent CreateProviderEvent(
+        DateTimeOffset timestamp,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        string raw)
+    {
+        return new DirectRunProviderEvent
+        {
+            Timestamp = timestamp.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = provider,
+            EntryKind = entryKind,
+            SessionId = providerSessionId,
+            Kind = "provider-event",
+            Payload = ParsePayload(raw)
+        };
+    }
+
+    public static DirectRunProviderEvent CreateBackendExitEvent(
+        DateTimeOffset timestamp,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        int exitCode)
+    {
+        return new DirectRunProviderEvent
+        {
+            Timestamp = timestamp.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = provider,
+            EntryKind = entryKind,
+            SessionId = providerSessionId,
+            Kind = "provider-event",
+            Payload = JsonSerializer.SerializeToElement(new
+            {
+                type = "backend-exit",
+                exit_code = exitCode
+            })
+        };
+    }
+
+    public static JsonElement ParsePayload(string raw)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(raw);
+            return document.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return JsonSerializer.SerializeToElement(raw);
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IDirectRunProcessRunner.cs
+++ b/src/IntentSystem.Cli/Commands/IDirectRunProcessRunner.cs
@@ -6,6 +6,7 @@ internal interface IDirectRunProcessRunner
         string workingDirectory,
         string fileName,
         IReadOnlyList<string> arguments,
+        bool inheritStandardInput,
         TimeSpan earlyExitWindow,
         Action<int> onStarted,
         Action<int> onExited,

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -664,26 +664,7 @@ internal static class RunCommand
             return providerEvents;
         }
 
-        var providerEventLogPath = Path.Combine(
-            context.RepoRoot,
-            ResolveDirectRunProviderLogRef(context, executionUnit).Replace('/', Path.DirectorySeparatorChar));
-        var writer = new DirectRunProviderEventWriter(providerEventLogPath);
-        writer.Append(new DirectRunProviderEvent
-        {
-            Timestamp = DateTimeOffset.UtcNow.ToString("O"),
-            ExecutionUnit = executionUnit,
-            Provider = requestArtifact.Provider,
-            EntryKind = requestArtifact.EntryKind,
-            SessionId = requestArtifact.ProviderSessionId,
-            Kind = "provider-event",
-            Payload = JsonSerializer.SerializeToElement(new
-            {
-                type = "backend-exit",
-                exit_code = 1
-            })
-        });
-
-        return TryReadDirectRunProviderEvents(context, executionUnit);
+        return providerEvents;
     }
 
     private static string ResolveEffectiveRunStatus(

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -664,7 +664,21 @@ internal static class RunCommand
             return providerEvents;
         }
 
-        return providerEvents;
+        var backendExitEvent = DirectRunProviderEventFactory.CreateBackendExitEvent(
+            DateTimeOffset.UtcNow,
+            executionUnit,
+            requestArtifact.EntryKind,
+            requestArtifact.Provider,
+            requestArtifact.ProviderSessionId,
+            exitCode: 0);
+        var providerLogRef = ResolveDirectRunProviderLogRef(context, executionUnit);
+        var providerLogPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            providerLogRef.Replace('/', Path.DirectorySeparatorChar)));
+        var writer = new DirectRunProviderEventWriter(providerLogPath);
+        writer.Append(backendExitEvent);
+
+        return [.. providerEvents, backendExitEvent];
     }
 
     private static string ResolveEffectiveRunStatus(

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -10,6 +10,11 @@ internal static class Program
     {
         try
         {
+            if (DirectRunDetachedCaptureCommand.TryExecute(args, out var directRunDetachedCaptureExitCode))
+            {
+                return directRunDetachedCaptureExitCode;
+            }
+
             if (DirectRunExitMonitorCommand.TryExecute(args, out var directRunExitMonitorExitCode))
             {
                 return directRunExitMonitorExitCode;

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -41,6 +41,7 @@ public sealed class DirectRunLauncherTests
 
         Assert.Equal("review-runner", runner.FileName);
         Assert.Equal("/repo/.intent-cli/worktrees/G19", runner.WorkingDirectory);
+        Assert.False(runner.InheritStandardInput);
         Assert.Equal(
             [
                 "launch",
@@ -139,6 +140,7 @@ public sealed class DirectRunLauncherTests
 
         Assert.Equal("pid:", result.ProviderSessionId[..4]);
         Assert.Equal("/bin/sh", runner.FileName);
+        Assert.True(runner.InheritStandardInput);
         Assert.Equal("-c", runner.Arguments[0]);
         Assert.Contains("exec \"$@\"", runner.Arguments[1], StringComparison.Ordinal);
         Assert.Contains(codexPath, runner.Arguments, StringComparer.Ordinal);
@@ -220,6 +222,7 @@ public sealed class DirectRunLauncherTests
             providerEventLogPath);
 
         Assert.Equal("/bin/sh", runner.FileName);
+        Assert.True(runner.InheritStandardInput);
         Assert.Equal("pid:2468", result.ProviderSessionId);
 
         var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
@@ -905,6 +908,8 @@ public sealed class DirectRunLauncherTests
 
         public IReadOnlyList<string> Arguments { get; private set; } = [];
 
+        public bool InheritStandardInput { get; private set; }
+
         public IReadOnlyList<string> StdOutLines { get; init; } = [];
 
         public IReadOnlyList<string> StdErrLines { get; init; } = [];
@@ -926,6 +931,7 @@ public sealed class DirectRunLauncherTests
             string workingDirectory,
             string fileName,
             IReadOnlyList<string> arguments,
+            bool inheritStandardInput,
             TimeSpan earlyExitWindow,
             Action<int> onStarted,
             Action<int> onExited,
@@ -935,6 +941,7 @@ public sealed class DirectRunLauncherTests
             WorkingDirectory = workingDirectory;
             FileName = fileName;
             Arguments = arguments.ToArray();
+            InheritStandardInput = inheritStandardInput;
 
             if (ExecuteReceivedProcess)
             {
@@ -943,6 +950,7 @@ public sealed class DirectRunLauncherTests
                     FileName = fileName,
                     WorkingDirectory = workingDirectory,
                     UseShellExecute = false,
+                    RedirectStandardInput = !inheritStandardInput,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true
                 };
@@ -954,6 +962,12 @@ public sealed class DirectRunLauncherTests
 
                 var process = System.Diagnostics.Process.Start(startInfo)
                     ?? throw new InvalidOperationException("Failed to start wrapper process.");
+
+                if (!inheritStandardInput)
+                {
+                    process.StandardInput.Close();
+                }
+
                 onStarted(process.Id);
                 OnStartedProcess?.Invoke(process.Id);
 

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -514,6 +514,103 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public async Task Launch_GivenWrappedCodexProcess_DetachedCaptureClosesProviderStandardInput()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14stdin.provider.jsonl");
+        var worktreePath = tempDirectory.GetPath("repo");
+        Directory.CreateDirectory(worktreePath);
+        var codexPath = tempDirectory.CreateExecutableFile(
+            "repo/codex-experimental",
+            """
+            #!/bin/sh
+            printf '%s\n' '{"type":"ready"}'
+            if IFS= read -r _; then
+                printf '%s\n' '{"type":"stdin-open"}'
+            else
+                printf '%s\n' '{"type":"stdin-eof"}'
+            fi
+            """);
+        var launcher = new DirectRunLauncher();
+
+        var result = launcher.Launch(
+            "G14stdin",
+            "review",
+            ".intent-cli/runs/G14stdin.request.json",
+            ".intent-cli/runs/G14stdin.provider.jsonl",
+            "OpenAI",
+            "gpt-5.4-mini",
+            "responses",
+            codexPath,
+            ["exec", "test prompt"],
+            DateTimeOffset.Parse("2026-04-09T11:16:00Z"),
+            worktreePath,
+            tempDirectory.GetPath(".intent-cli/reviews/G14stdin.request.json"),
+            providerEventLogPath);
+
+        try
+        {
+            await TemporaryDirectory.WaitForConditionAsync(
+                () =>
+                {
+                    if (!File.Exists(providerEventLogPath))
+                    {
+                        return false;
+                    }
+
+                    var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                    return events.Any(providerEvent =>
+                               providerEvent.Kind == "provider-event"
+                               && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                               && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                               && string.Equals(typeElement.GetString(), "stdin-eof", StringComparison.Ordinal)
+                               && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal))
+                           && events.Any(providerEvent =>
+                               providerEvent.Kind == "provider-event"
+                               && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                               && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                               && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                               && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+                },
+                TimeSpan.FromSeconds(5));
+
+            var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            Assert.DoesNotContain(events, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "stdin-open", StringComparison.Ordinal)
+                && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+            Assert.Contains(events, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "stdin-eof", StringComparison.Ordinal)
+                && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+            var backendExitEvent = Assert.Single(events, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+            Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+        }
+        finally
+        {
+            if (TryParseProcessId(result.ProviderSessionId, out var processId) && IsProcessAlive(processId))
+            {
+                SignalProcess(processId, "TERM");
+                TemporaryDirectory.WaitForCondition(() => !IsProcessAlive(processId), TimeSpan.FromSeconds(5));
+            }
+        }
+    }
+
+    [Fact]
     public async Task DirectRunExitMonitorCommand_GivenDetachedProcess_AppendsBackendExitForCurrentSession()
     {
         if (OperatingSystem.IsWindows())
@@ -834,6 +931,31 @@ public sealed class DirectRunLauncherTests
         });
 
         signalProcess?.WaitForExit();
+    }
+
+    private static bool TryParseProcessId(string providerSessionId, out int processId)
+    {
+        processId = default;
+        const string prefix = "pid:";
+        return providerSessionId.StartsWith(prefix, StringComparison.Ordinal)
+            && int.TryParse(providerSessionId[prefix.Length..], out processId);
+    }
+
+    private static bool IsProcessAlive(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            return !process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
     }
 
     private sealed class FakeDirectRunProcessRunner : IDirectRunProcessRunner

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -140,7 +140,7 @@ public sealed class DirectRunLauncherTests
 
         Assert.Equal("pid:", result.ProviderSessionId[..4]);
         Assert.True(Path.IsPathRooted(runner.FileName));
-        Assert.True(runner.InheritStandardInput);
+        Assert.False(runner.InheritStandardInput);
         Assert.Contains(DirectRunDetachedCaptureCommand.CommandName, runner.Arguments);
         Assert.Contains(codexPath, runner.Arguments, StringComparer.Ordinal);
 
@@ -222,7 +222,7 @@ public sealed class DirectRunLauncherTests
             providerEventLogPath);
 
         Assert.True(Path.IsPathRooted(runner.FileName));
-        Assert.True(runner.InheritStandardInput);
+        Assert.False(runner.InheritStandardInput);
         Assert.Contains(DirectRunDetachedCaptureCommand.CommandName, runner.Arguments);
         Assert.Equal("pid:2468", result.ProviderSessionId);
 

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -139,10 +139,9 @@ public sealed class DirectRunLauncherTests
             providerEventLogPath);
 
         Assert.Equal("pid:", result.ProviderSessionId[..4]);
-        Assert.Equal("/bin/sh", runner.FileName);
+        Assert.True(Path.IsPathRooted(runner.FileName));
         Assert.True(runner.InheritStandardInput);
-        Assert.Equal("-c", runner.Arguments[0]);
-        Assert.Contains("exec \"$@\"", runner.Arguments[1], StringComparison.Ordinal);
+        Assert.Contains(DirectRunDetachedCaptureCommand.CommandName, runner.Arguments);
         Assert.Contains(codexPath, runner.Arguments, StringComparer.Ordinal);
 
         var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
@@ -196,6 +195,7 @@ public sealed class DirectRunLauncherTests
                 string.Empty));
         var runner = new FakeDirectRunProcessRunner
         {
+            StdOutLines = ["pid:2468"],
             ExitCodeEvent = 0,
             Result = new DirectRunProcessLaunchResult
             {
@@ -221,8 +221,9 @@ public sealed class DirectRunLauncherTests
             "/repo/.intent-cli/reviews/G10.request.json",
             providerEventLogPath);
 
-        Assert.Equal("/bin/sh", runner.FileName);
+        Assert.True(Path.IsPathRooted(runner.FileName));
         Assert.True(runner.InheritStandardInput);
+        Assert.Contains(DirectRunDetachedCaptureCommand.CommandName, runner.Arguments);
         Assert.Equal("pid:2468", result.ProviderSessionId);
 
         var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
@@ -449,35 +450,25 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
-    public async Task Launch_GivenWrappedCodexProcessEndsWithoutExitCallback_MonitorAppendsBackendExitProviderEvent()
+    public async Task Launch_GivenWrappedCodexProcessEndsAfterCliReturns_DetachedCaptureAppendsBackendExitProviderEvent()
     {
         if (OperatingSystem.IsWindows())
         {
             return;
         }
 
-        using var externalProcess = Process.Start(new ProcessStartInfo
-        {
-            FileName = "/bin/sh",
-            UseShellExecute = false,
-            RedirectStandardOutput = false,
-            RedirectStandardError = false,
-            ArgumentList = { "-c", "sleep 1" }
-        });
-        Assert.NotNull(externalProcess);
-
         using var tempDirectory = new TemporaryDirectory();
         var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14.provider.jsonl");
-        var runner = new FakeDirectRunProcessRunner
-        {
-            Result = new DirectRunProcessLaunchResult
-            {
-                ProcessId = externalProcess!.Id,
-                ExitedEarly = false,
-                ExitCode = 0
-            }
-        };
-        var launcher = new DirectRunLauncher(runner);
+        var worktreePath = tempDirectory.GetPath("repo");
+        Directory.CreateDirectory(worktreePath);
+        var codexPath = tempDirectory.CreateExecutableFile(
+            "repo/codex-experimental",
+            """
+            #!/bin/sh
+            printf '%s\n' '{"type":"ready"}'
+            sleep 1
+            """);
+        var launcher = new DirectRunLauncher();
 
         var result = launcher.Launch(
             "G14",
@@ -487,11 +478,11 @@ public sealed class DirectRunLauncherTests
             "OpenAI",
             "gpt-5.4-mini",
             "responses",
-            "/opt/homebrew/bin/codex",
+            codexPath,
             ["exec", "test prompt"],
             DateTimeOffset.Parse("2026-04-09T11:15:00Z"),
-            "/repo",
-            "/repo/.intent-cli/reviews/G14.request.json",
+            worktreePath,
+            tempDirectory.GetPath(".intent-cli/reviews/G14.request.json"),
             providerEventLogPath);
 
         await TemporaryDirectory.WaitForConditionAsync(
@@ -519,7 +510,7 @@ public sealed class DirectRunLauncherTests
             && providerEvent.Payload.TryGetProperty("type", out var typeElement)
             && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
             && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
-        Assert.Equal(1, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+        Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
     }
 
     [Fact]
@@ -694,62 +685,7 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
-    public void Launch_GivenWrappedCodexProcessExitsShortlyAfterLaunch_PersistsBackendExitBeforeReturning()
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            return;
-        }
-
-        using var externalProcess = Process.Start(new ProcessStartInfo
-        {
-            FileName = "/bin/sh",
-            UseShellExecute = false,
-            RedirectStandardOutput = false,
-            RedirectStandardError = false,
-            ArgumentList = { "-c", "sleep 1" }
-        });
-        Assert.NotNull(externalProcess);
-
-        using var tempDirectory = new TemporaryDirectory();
-        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14a.provider.jsonl");
-        var runner = new FakeDirectRunProcessRunner
-        {
-            Result = new DirectRunProcessLaunchResult
-            {
-                ProcessId = externalProcess!.Id,
-                ExitedEarly = false,
-                ExitCode = 0
-            }
-        };
-        var launcher = new DirectRunLauncher(runner);
-
-        var result = launcher.Launch(
-            "G14a",
-            "review",
-            ".intent-cli/runs/G14a.request.json",
-            ".intent-cli/runs/G14a.provider.jsonl",
-            "OpenAI",
-            "gpt-5.4-mini",
-            "responses",
-            "/opt/homebrew/bin/codex",
-            ["exec", "test prompt"],
-            DateTimeOffset.Parse("2026-04-09T11:17:00Z"),
-            "/repo",
-            "/repo/.intent-cli/reviews/G14a.request.json",
-            providerEventLogPath);
-
-        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
-        Assert.Contains(events, providerEvent =>
-            providerEvent.Kind == "provider-event"
-            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
-            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
-            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
-            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public void Launch_GivenWrappedCodexProcessReceivesTerminationSignal_AppendsBackendExitProviderEvent()
+    public void Launch_GivenWrappedCodexProcessTerminates_AppendsBackendExitProviderEvent()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -764,23 +700,10 @@ public sealed class DirectRunLauncherTests
             "repo/codex-experimental",
             """
             #!/bin/sh
-            trap 'exit 0' TERM HUP INT
             printf '%s\n' '{"type":"ready"}'
-            sleep 10
+            sleep 1
             """);
-        var runner = new FakeDirectRunProcessRunner
-        {
-            ExecuteReceivedProcess = true,
-            OnStartedProcess = processId =>
-            {
-                Task.Run(async () =>
-                {
-                    await Task.Delay(TimeSpan.FromMilliseconds(800));
-                    SignalProcess(processId, "TERM");
-                });
-            }
-        };
-        var launcher = new DirectRunLauncher(runner);
+        var launcher = new DirectRunLauncher();
 
         var result = launcher.Launch(
             "G13",
@@ -796,6 +719,19 @@ public sealed class DirectRunLauncherTests
             worktreePath,
             tempDirectory.GetPath(".intent-cli/reviews/G13.request.json"),
             providerEventLogPath);
+
+        TemporaryDirectory.WaitForCondition(
+            () =>
+            {
+                var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                return events.Any(providerEvent =>
+                    providerEvent.Kind == "provider-event"
+                    && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                    && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                    && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                    && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+            },
+            TimeSpan.FromSeconds(5));
 
         var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
         Assert.Contains(events, providerEvent =>
@@ -1070,6 +1006,11 @@ public sealed class DirectRunLauncherTests
             }
 
             Assert.True(predicate(), $"Condition was not satisfied within {timeout}.");
+        }
+
+        public static void WaitForCondition(Func<bool> predicate, TimeSpan timeout)
+        {
+            WaitForConditionAsync(predicate, timeout).GetAwaiter().GetResult();
         }
 
         public void Dispose()

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -618,7 +618,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenRunningReviewDecisionWithExitedCurrentSession_KeepsWaitingWithoutSynthesizingFailure()
+    public void ExecuteCore_GivenRunningReviewDecisionWithExitedCurrentSession_AppendsBackendExitAndAdvancesBoundary()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -657,16 +657,19 @@ public sealed class RunCommandTests
 
         Assert.Equal("no-actionable-item", result.StopReason);
         Assert.Equal("G226", result.ExecutionUnit);
-        Assert.Contains("Review direct run for 'G226' is 'running'.", result.Detail, StringComparison.Ordinal);
+        Assert.Contains("Review direct run for 'G226' is 'succeeded'.", result.Detail, StringComparison.Ordinal);
 
         var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
             Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl")));
-        Assert.DoesNotContain(events, providerEvent =>
+        Assert.Contains(events, providerEvent =>
             providerEvent.Kind == "provider-event"
             && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
             && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
             && providerEvent.Payload.TryGetProperty("type", out var typeElement)
             && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+        Assert.Equal("succeeded", resultArtifact.RunStatus);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -618,7 +618,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenRunningReviewDecisionWithExitedCurrentSession_BackfillsBackendExitAndFails()
+    public void ExecuteCore_GivenRunningReviewDecisionWithExitedCurrentSession_KeepsWaitingWithoutSynthesizingFailure()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -655,13 +655,13 @@ public sealed class RunCommandTests
 
         var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-        Assert.Equal("non-retryable-failure", result.StopReason);
+        Assert.Equal("no-actionable-item", result.StopReason);
         Assert.Equal("G226", result.ExecutionUnit);
-        Assert.Contains("Review direct run failed for 'G226'.", result.Detail, StringComparison.Ordinal);
+        Assert.Contains("Review direct run for 'G226' is 'running'.", result.Detail, StringComparison.Ordinal);
 
         var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
             Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl")));
-        Assert.Contains(events, providerEvent =>
+        Assert.DoesNotContain(events, providerEvent =>
             providerEvent.Kind == "provider-event"
             && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
             && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object


### PR DESCRIPTION
## Summary
- keep standard input inherited for wrapped Codex direct review launches instead of redirecting and closing it immediately
- thread the stdin policy through the direct run launcher/process runner contract
- cover wrapped vs non-wrapped stdin behavior in direct run launcher tests

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter DirectRunLauncherTests
- dotnet test IntentSystem.sln
- dotnet run --project /Users/tomohisa/.codex/worktrees/3a1f/intent-system/src/IntentSystem.Cli/IntentSystem.Cli.csproj -- review run TOY-CALC-01 (from toy-calc-sample; verified new pid:3619 session emitted real provider activity instead of immediate synthetic backend-exit)

Closes #254