### PR TITLE
Persist explicit review outcomes for direct review runs

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -276,6 +276,49 @@ internal static class DirectRunCommandSupport
         var sessionId = ResolveSessionId(currentProviderEvents, launchResult.ProviderSessionId);
         var provider = ResolveProvider(currentProviderEvents, launchResult.Provider);
         var runStatus = ResolveRunStatus(currentProviderEvents);
+        string? reviewOutcome = null;
+        string? reviewCommentBodyPath = null;
+        if (string.Equals(entryKind, "review", StringComparison.Ordinal)
+            && DirectRunReviewOutcomeSupport.TryResolveCanonicalReviewOutcome(
+                runStatus,
+                existingReviewOutcome: null,
+                currentProviderEvents,
+                out var resolvedReviewOutcome))
+        {
+            reviewOutcome = resolvedReviewOutcome;
+            if (DirectRunReviewOutcomeSupport.IsCommentOutcome(reviewOutcome))
+            {
+                if (!DirectRunReviewOutcomeSupport.TryResolveReviewCommentBodyPath(
+                        context,
+                        executionUnit,
+                        currentProviderEvents,
+                        out var resolvedCommentBodyPath))
+                {
+                    throw new InvalidOperationException(
+                        $"Review direct run for '{executionUnit}' requested comment but no deterministic comment body was found.");
+                }
+
+                reviewCommentBodyPath = resolvedCommentBodyPath;
+            }
+
+            var outcomeEvent = DirectRunReviewOutcomeSupport.CreateCanonicalReviewOutcomeEventIfNeeded(
+                currentProviderEvents,
+                DateTimeOffset.UtcNow,
+                executionUnit,
+                entryKind,
+                provider,
+                sessionId,
+                reviewOutcome,
+                reviewCommentBodyPath);
+            if (outcomeEvent is not null)
+            {
+                var writer = new DirectRunProviderEventWriter(providerEventLogPath);
+                writer.Append(outcomeEvent);
+                providerEvents = [.. providerEvents, outcomeEvent];
+                currentProviderEvents = [.. currentProviderEvents, outcomeEvent];
+            }
+        }
+
         var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
         var resultArtifactPath = ResolveResultArtifactPath(context, executionUnit);
         var absoluteResultArtifactPath = Path.GetFullPath(Path.Combine(
@@ -292,6 +335,8 @@ internal static class DirectRunCommandSupport
             Model = model,
             SessionId = sessionId,
             RunStatus = runStatus,
+            ReviewOutcome = reviewOutcome,
+            ReviewCommentBodyPath = reviewCommentBodyPath,
             RawLogRef = launchResult.ProviderEventLogPath,
             PacketRef = queueItem.PacketPaths.Yaml,
             ReviewContextRef = queueItem.PacketPaths.ReviewContext,

--- a/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
@@ -29,6 +29,12 @@ internal sealed record DirectRunResultArtifact
     [JsonPropertyName("run_status")]
     public required string RunStatus { get; init; }
 
+    [JsonPropertyName("review_outcome")]
+    public string? ReviewOutcome { get; init; }
+
+    [JsonPropertyName("review_comment_body_path")]
+    public string? ReviewCommentBodyPath { get; init; }
+
     [JsonPropertyName("raw_log_ref")]
     public required string RawLogRef { get; init; }
 

--- a/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
@@ -37,12 +37,6 @@ internal static class DirectRunReviewOutcomeSupport
             return true;
         }
 
-        if (string.Equals(runStatus, "succeeded", StringComparison.Ordinal))
-        {
-            reviewOutcome = "accepted";
-            return true;
-        }
-
         if (IsAcceptOutcome(runStatus) || IsCommentOutcome(runStatus))
         {
             reviewOutcome = runStatus;

--- a/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
@@ -1,0 +1,292 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class DirectRunReviewOutcomeSupport
+{
+    public static bool IsAcceptOutcome(string outcome)
+    {
+        return string.Equals(outcome, "accepted", StringComparison.Ordinal)
+            || string.Equals(outcome, "approved", StringComparison.Ordinal);
+    }
+
+    public static bool IsCommentOutcome(string outcome)
+    {
+        return string.Equals(outcome, "comment", StringComparison.Ordinal)
+            || string.Equals(outcome, "commented", StringComparison.Ordinal)
+            || string.Equals(outcome, "fix-requested", StringComparison.Ordinal)
+            || string.Equals(outcome, "changes-requested", StringComparison.Ordinal);
+    }
+
+    public static bool TryResolveCanonicalReviewOutcome(
+        string runStatus,
+        string? existingReviewOutcome,
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        out string reviewOutcome)
+    {
+        reviewOutcome = string.Empty;
+
+        if (!string.IsNullOrWhiteSpace(existingReviewOutcome))
+        {
+            reviewOutcome = NormalizeRunStatus(existingReviewOutcome);
+            return true;
+        }
+
+        if (TryResolveExplicitReviewOutcome(providerEvents, out reviewOutcome))
+        {
+            return true;
+        }
+
+        if (string.Equals(runStatus, "succeeded", StringComparison.Ordinal))
+        {
+            reviewOutcome = "accepted";
+            return true;
+        }
+
+        if (IsAcceptOutcome(runStatus) || IsCommentOutcome(runStatus))
+        {
+            reviewOutcome = runStatus;
+            return true;
+        }
+
+        return false;
+    }
+
+    public static bool TryResolveExplicitReviewOutcome(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        out string explicitReviewOutcome)
+    {
+        explicitReviewOutcome = string.Empty;
+
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            if (TryResolveRunStatus(providerEvents[index].Payload, out var runStatus)
+                && !string.Equals(runStatus, "succeeded", StringComparison.Ordinal)
+                && !string.Equals(runStatus, "failed", StringComparison.Ordinal)
+                && !string.Equals(runStatus, "running", StringComparison.Ordinal))
+            {
+                explicitReviewOutcome = runStatus;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static bool TryResolveReviewCommentBodyPath(
+        CliContext context,
+        string executionUnit,
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        out string commentBodyPath)
+    {
+        commentBodyPath = string.Empty;
+
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            if (!TryResolveCommentBody(providerEvents[index].Payload, out var bodyOrPath, out var isPath))
+            {
+                continue;
+            }
+
+            if (isPath)
+            {
+                commentBodyPath = bodyOrPath;
+                return true;
+            }
+
+            var relativePath = $".intent-cli/reviews/{executionUnit}.comment.md";
+            var absolutePath = Path.GetFullPath(Path.Combine(
+                context.RepoRoot,
+                relativePath.Replace('/', Path.DirectorySeparatorChar)));
+            var directoryPath = Path.GetDirectoryName(absolutePath)
+                ?? throw new InvalidOperationException("Review comment body path did not contain a directory.");
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(absolutePath, bodyOrPath);
+            commentBodyPath = relativePath;
+            return true;
+        }
+
+        return false;
+    }
+
+    public static DirectRunProviderEvent? CreateCanonicalReviewOutcomeEventIfNeeded(
+        IReadOnlyList<DirectRunProviderEvent> currentProviderEvents,
+        DateTimeOffset timestamp,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        string reviewOutcome,
+        string? reviewCommentBodyPath)
+    {
+        if (HasCanonicalReviewOutcomeEvent(currentProviderEvents, reviewOutcome, reviewCommentBodyPath))
+        {
+            return null;
+        }
+
+        object payload = reviewCommentBodyPath is null
+            ? new
+            {
+                disposition = reviewOutcome
+            }
+            : new
+            {
+                disposition = reviewOutcome,
+                body_path = reviewCommentBodyPath
+            };
+
+        return new DirectRunProviderEvent
+        {
+            Timestamp = timestamp.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = provider,
+            EntryKind = entryKind,
+            SessionId = providerSessionId,
+            Kind = "provider-event",
+            Payload = JsonSerializer.SerializeToElement(payload)
+        };
+    }
+
+    private static bool HasCanonicalReviewOutcomeEvent(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string reviewOutcome,
+        string? reviewCommentBodyPath)
+    {
+        foreach (var providerEvent in providerEvents)
+        {
+            if (!TryResolveRunStatus(providerEvent.Payload, out var resolvedOutcome)
+                || !string.Equals(resolvedOutcome, reviewOutcome, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (reviewCommentBodyPath is null)
+            {
+                return true;
+            }
+
+            if (TryResolveCommentBody(providerEvent.Payload, out var bodyOrPath, out var isPath)
+                && isPath
+                && string.Equals(bodyOrPath, reviewCommentBodyPath, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveCommentBody(JsonElement payload, out string bodyOrPath, out bool isPath)
+    {
+        bodyOrPath = string.Empty;
+        isPath = false;
+
+        if (payload.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (TryReadString(payload, "body_path", out var bodyPath))
+        {
+            bodyOrPath = bodyPath;
+            isPath = true;
+            return true;
+        }
+
+        if (TryReadString(payload, "comment_body", out var commentBody)
+            || TryReadString(payload, "body", out commentBody)
+            || TryReadString(payload, "markdown", out commentBody))
+        {
+            bodyOrPath = commentBody;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveRunStatus(JsonElement payload, out string runStatus)
+    {
+        runStatus = string.Empty;
+
+        if (payload.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (TryReadString(payload, "run_status", out var payloadRunStatus))
+        {
+            runStatus = NormalizeRunStatus(payloadRunStatus);
+            return true;
+        }
+
+        if (TryReadString(payload, "status", out var status))
+        {
+            runStatus = NormalizeRunStatus(status);
+            return true;
+        }
+
+        if (TryReadString(payload, "disposition", out var disposition))
+        {
+            runStatus = NormalizeRunStatus(disposition);
+            return true;
+        }
+
+        if (TryReadInt32(payload, "exit_code", out var exitCode)
+            || TryReadInt32(payload, "exitCode", out exitCode))
+        {
+            runStatus = exitCode == 0 ? "succeeded" : "failed";
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadString(JsonElement payload, string propertyName, out string value)
+    {
+        value = string.Empty;
+
+        if (!payload.TryGetProperty(propertyName, out var element)
+            || element.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        value = element.GetString() ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static bool TryReadInt32(JsonElement payload, string propertyName, out int value)
+    {
+        value = default;
+
+        if (!payload.TryGetProperty(propertyName, out var element))
+        {
+            return false;
+        }
+
+        if (element.ValueKind == JsonValueKind.Number)
+        {
+            return element.TryGetInt32(out value);
+        }
+
+        if (element.ValueKind == JsonValueKind.String)
+        {
+            var raw = element.GetString();
+            return !string.IsNullOrWhiteSpace(raw)
+                && int.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out value);
+        }
+
+        return false;
+    }
+
+    private static string NormalizeRunStatus(string status)
+    {
+        return status.Trim().ToLowerInvariant() switch
+        {
+            "success" or "completed" => "succeeded",
+            "error" => "failed",
+            var normalized when !string.IsNullOrWhiteSpace(normalized) => normalized,
+            _ => "running"
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -549,13 +549,11 @@ internal static class RunCommand
         var runStatus = ResolveEffectiveRunStatus(resultArtifact.RunStatus, providerEvents);
         if (!string.Equals(runStatus, resultArtifact.RunStatus, StringComparison.Ordinal))
         {
-            PersistDirectRunResultArtifact(
-                context,
-                executionUnit,
-                resultArtifact with
-                {
-                    RunStatus = runStatus
-                });
+            resultArtifact = resultArtifact with
+            {
+                RunStatus = runStatus
+            };
+            PersistDirectRunResultArtifact(context, executionUnit, resultArtifact);
         }
 
         if (string.Equals(runStatus, "failed", StringComparison.Ordinal))
@@ -565,6 +563,62 @@ internal static class RunCommand
                 Kind = RunReviewDecisionKind.Failure,
                 Detail = $"Review direct run failed for '{executionUnit}'."
             };
+        }
+
+        string? reviewOutcome = null;
+        string? reviewCommentBodyPath = null;
+        if (DirectRunReviewOutcomeSupport.TryResolveCanonicalReviewOutcome(
+                runStatus,
+                resultArtifact.ReviewOutcome,
+                providerEvents,
+                out var resolvedReviewOutcome))
+        {
+            reviewOutcome = resolvedReviewOutcome;
+            if (DirectRunReviewOutcomeSupport.IsCommentOutcome(reviewOutcome))
+            {
+                if (!string.IsNullOrWhiteSpace(resultArtifact.ReviewCommentBodyPath))
+                {
+                    reviewCommentBodyPath = resultArtifact.ReviewCommentBodyPath;
+                }
+                else if (DirectRunReviewOutcomeSupport.TryResolveReviewCommentBodyPath(
+                             context,
+                             executionUnit,
+                             providerEvents,
+                             out var resolvedCommentBodyPath))
+                {
+                    reviewCommentBodyPath = resolvedCommentBodyPath;
+                }
+            }
+
+            if (!string.Equals(resultArtifact.ReviewOutcome, reviewOutcome, StringComparison.Ordinal)
+                || !string.Equals(resultArtifact.ReviewCommentBodyPath, reviewCommentBodyPath, StringComparison.Ordinal))
+            {
+                resultArtifact = resultArtifact with
+                {
+                    ReviewOutcome = reviewOutcome,
+                    ReviewCommentBodyPath = reviewCommentBodyPath
+                };
+                PersistDirectRunResultArtifact(context, executionUnit, resultArtifact);
+            }
+
+            var outcomeEvent = DirectRunReviewOutcomeSupport.CreateCanonicalReviewOutcomeEventIfNeeded(
+                providerEvents,
+                DateTimeOffset.UtcNow,
+                executionUnit,
+                requestArtifact.EntryKind,
+                requestArtifact.Provider,
+                requestArtifact.ProviderSessionId,
+                reviewOutcome,
+                reviewCommentBodyPath);
+            if (outcomeEvent is not null)
+            {
+                var providerLogPath = Path.GetFullPath(Path.Combine(
+                    context.RepoRoot,
+                    resultArtifact.RawLogRef.Replace('/', Path.DirectorySeparatorChar)));
+                var writer = new DirectRunProviderEventWriter(providerLogPath);
+                writer.Append(outcomeEvent);
+                providerEvents = [.. providerEvents, outcomeEvent];
+            }
         }
 
         if (string.Equals(runStatus, "accepted", StringComparison.Ordinal)
@@ -579,10 +633,9 @@ internal static class RunCommand
 
         if (string.Equals(runStatus, "succeeded", StringComparison.Ordinal))
         {
-            if (TryResolveExplicitReviewOutcome(providerEvents, out var explicitReviewOutcome))
+            if (!string.IsNullOrWhiteSpace(reviewOutcome))
             {
-                if (string.Equals(explicitReviewOutcome, "accepted", StringComparison.Ordinal)
-                    || string.Equals(explicitReviewOutcome, "approved", StringComparison.Ordinal))
+                if (DirectRunReviewOutcomeSupport.IsAcceptOutcome(reviewOutcome))
                 {
                     return new RunReviewDecision
                     {
@@ -591,17 +644,14 @@ internal static class RunCommand
                     };
                 }
 
-                if (string.Equals(explicitReviewOutcome, "comment", StringComparison.Ordinal)
-                    || string.Equals(explicitReviewOutcome, "commented", StringComparison.Ordinal)
-                    || string.Equals(explicitReviewOutcome, "fix-requested", StringComparison.Ordinal)
-                    || string.Equals(explicitReviewOutcome, "changes-requested", StringComparison.Ordinal))
+                if (DirectRunReviewOutcomeSupport.IsCommentOutcome(reviewOutcome))
                 {
-                    if (TryResolveReviewCommentBodyPath(context, executionUnit, providerEvents, out var commentBodyPath))
+                    if (!string.IsNullOrWhiteSpace(reviewCommentBodyPath))
                     {
                         return new RunReviewDecision
                         {
                             Kind = RunReviewDecisionKind.Comment,
-                            CommentBodyPath = commentBodyPath,
+                            CommentBodyPath = reviewCommentBodyPath,
                             Detail = $"Review decision for '{executionUnit}' resolved to comment."
                         };
                     }
@@ -620,12 +670,12 @@ internal static class RunCommand
             || string.Equals(runStatus, "fix-requested", StringComparison.Ordinal)
             || string.Equals(runStatus, "changes-requested", StringComparison.Ordinal))
         {
-            if (TryResolveReviewCommentBodyPath(context, executionUnit, providerEvents, out var commentBodyPath))
+            if (!string.IsNullOrWhiteSpace(reviewCommentBodyPath))
             {
                 return new RunReviewDecision
                 {
                     Kind = RunReviewDecisionKind.Comment,
-                    CommentBodyPath = commentBodyPath,
+                    CommentBodyPath = reviewCommentBodyPath,
                     Detail = $"Review decision for '{executionUnit}' resolved to comment."
                 };
             }
@@ -745,27 +795,6 @@ internal static class RunCommand
             && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal);
     }
 
-    private static bool TryResolveExplicitReviewOutcome(
-        IReadOnlyList<DirectRunProviderEvent> providerEvents,
-        out string explicitReviewOutcome)
-    {
-        explicitReviewOutcome = string.Empty;
-
-        for (var index = providerEvents.Count - 1; index >= 0; index--)
-        {
-            if (TryResolveRunStatus(providerEvents[index].Payload, out var runStatus)
-                && !string.Equals(runStatus, "succeeded", StringComparison.Ordinal)
-                && !string.Equals(runStatus, "failed", StringComparison.Ordinal)
-                && !string.Equals(runStatus, "running", StringComparison.Ordinal))
-            {
-                explicitReviewOutcome = runStatus;
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     private static IReadOnlyList<DirectRunProviderEvent> SelectCurrentSessionEvents(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string launchedSessionId,
@@ -797,69 +826,6 @@ internal static class RunCommand
             && string.Equals(resultArtifact.SessionId, requestArtifact.ProviderSessionId, StringComparison.Ordinal);
     }
 
-    private static bool TryResolveReviewCommentBodyPath(
-        CliContext context,
-        string executionUnit,
-        IReadOnlyList<DirectRunProviderEvent> providerEvents,
-        out string commentBodyPath)
-    {
-        commentBodyPath = string.Empty;
-
-        for (var index = providerEvents.Count - 1; index >= 0; index--)
-        {
-            if (!TryResolveCommentBody(providerEvents[index].Payload, out var bodyOrPath, out var isPath))
-            {
-                continue;
-            }
-
-            if (isPath)
-            {
-                commentBodyPath = bodyOrPath;
-                return true;
-            }
-
-            var relativePath = $".intent-cli/reviews/{executionUnit}.comment.md";
-            var absolutePath = Path.GetFullPath(Path.Combine(
-                context.RepoRoot,
-                relativePath.Replace('/', Path.DirectorySeparatorChar)));
-            var directoryPath = Path.GetDirectoryName(absolutePath)
-                ?? throw new InvalidOperationException("Review comment body path did not contain a directory.");
-            Directory.CreateDirectory(directoryPath);
-            File.WriteAllText(absolutePath, bodyOrPath);
-            commentBodyPath = relativePath;
-            return true;
-        }
-
-        return false;
-    }
-
-    private static bool TryResolveCommentBody(JsonElement payload, out string bodyOrPath, out bool isPath)
-    {
-        bodyOrPath = string.Empty;
-        isPath = false;
-
-        if (payload.ValueKind != JsonValueKind.Object)
-        {
-            return false;
-        }
-
-        if (TryReadString(payload, "body_path", out var bodyPath))
-        {
-            bodyOrPath = bodyPath;
-            isPath = true;
-            return true;
-        }
-
-        if (TryReadString(payload, "comment_body", out var commentBody)
-            || TryReadString(payload, "body", out commentBody)
-            || TryReadString(payload, "markdown", out commentBody))
-        {
-            bodyOrPath = commentBody;
-            return true;
-        }
-
-        return false;
-    }
 
     private static bool TryResolveRunStatus(JsonElement payload, out string runStatus)
     {

--- a/tests/IntentSystem.Cli.Tests/DirectRunResultArtifactJsonTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunResultArtifactJsonTests.cs
@@ -17,6 +17,8 @@ public sealed class DirectRunResultArtifactJsonTests
             Model = "default",
             SessionId = "pid:4321",
             RunStatus = "running",
+            ReviewOutcome = "fix-requested",
+            ReviewCommentBodyPath = ".intent-cli/reviews/G19.comment.md",
             RawLogRef = ".intent-cli/runs/G19.provider.jsonl",
             PacketRef = ".intent-cli/issues/G19/packet.yaml",
             ReviewContextRef = ".intent-cli/issues/G19/review-context.md",
@@ -48,6 +50,8 @@ public sealed class DirectRunResultArtifactJsonTests
         Assert.Equal("default", roundTripped.Model);
         Assert.Equal("pid:4321", roundTripped.SessionId);
         Assert.Equal("running", roundTripped.RunStatus);
+        Assert.Equal("fix-requested", roundTripped.ReviewOutcome);
+        Assert.Equal(".intent-cli/reviews/G19.comment.md", roundTripped.ReviewCommentBodyPath);
         Assert.Equal(".intent-cli/runs/G19.provider.jsonl", roundTripped.RawLogRef);
         Assert.Equal(".intent-cli/issues/G19/packet.yaml", roundTripped.PacketRef);
         Assert.Equal(".intent-cli/issues/G19/review-context.md", roundTripped.ReviewContextRef);
@@ -87,5 +91,7 @@ public sealed class DirectRunResultArtifactJsonTests
         Assert.Equal("review", artifact.EntryKind);
         Assert.Equal(string.Empty, artifact.UpstreamRequestRef);
         Assert.Equal("pid:legacy", artifact.SessionId);
+        Assert.Null(artifact.ReviewOutcome);
+        Assert.Null(artifact.ReviewCommentBodyPath);
     }
 }

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -334,10 +334,83 @@ public sealed class ReviewRunCommandTests
             var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
                 Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
             Assert.Equal("succeeded", resultArtifact.RunStatus);
+            Assert.Equal("accepted", resultArtifact.ReviewOutcome);
+            Assert.Null(resultArtifact.ReviewCommentBodyPath);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && string.Equals(providerEvent.SessionId, "pid:9999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
+                && string.Equals(dispositionElement.GetString(), "accepted", StringComparison.Ordinal));
 
             var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
             var lifecycleEvent = Assert.Single(runEvents, runEvent => runEvent.Event == "provider-lifecycle");
             Assert.Equal("succeeded", lifecycleEvent.RunStatus);
+        }
+        finally
+        {
+            ReviewRunCommand.TimestampFactory = originalTimestampFactory;
+            ReviewRunCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenCommentOutcomeEvent_PersistsDeterministicCommentBodyRef()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = ReviewRunCommand.TimestampFactory;
+        var originalLauncherFactory = ReviewRunCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            ReviewRunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:35:00Z");
+            ReviewRunCommand.DirectRunLauncherFactory = () => new CommentOutcomeFakeDirectRunLauncher(
+                "pid:9999",
+                "ReviewBot",
+                "gpt-5.4-mini",
+                "grpc",
+                "reviewbot",
+                ["launch", "--model", "{model}", "--artifact", "{request_artifact_path}"],
+                "grpc transport launched via 'reviewbot' in '/repo' for provider 'ReviewBot'.",
+                "fix-requested",
+                "Please cover the deterministic submit path.");
+
+            var exitCode = ReviewRunCommand.Execute(CreateContext(repoRoot), ["G9"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run status: succeeded", writer.ToString(), StringComparison.Ordinal);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
+            Assert.Equal("succeeded", resultArtifact.RunStatus);
+            Assert.Equal("fix-requested", resultArtifact.ReviewOutcome);
+            Assert.Equal(".intent-cli/reviews/G9.comment.md", resultArtifact.ReviewCommentBodyPath);
+            Assert.Equal(
+                "Please cover the deterministic submit path.",
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "reviews", "G9.comment.md")));
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && string.Equals(providerEvent.SessionId, "pid:9999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("body_path", out var bodyPathElement)
+                && string.Equals(bodyPathElement.GetString(), ".intent-cli/reviews/G9.comment.md", StringComparison.Ordinal));
         }
         finally
         {
@@ -1024,6 +1097,111 @@ public sealed class ReviewRunCommandTests
                                              {
                                                  type = "backend-exit",
                                                  exit_code = exitCode
+                                             })
+                                         })
+                                     }) + Environment.NewLine;
+            File.WriteAllText(absoluteProviderEventLogPath, providerEvents);
+
+            return new DirectRunLaunchResult
+            {
+                RequestArtifactPath = ".intent-cli/runtime-runs/G9.request.json",
+                ProviderEventLogPath = ".intent-cli/runtime-runs/G9.provider.jsonl",
+                Provider = providerArg,
+                Model = modelArg,
+                Transport = transportArg,
+                ProviderSessionId = providerSessionId,
+                TransportSummary = transportSummary
+            };
+        }
+    }
+
+    private sealed class CommentOutcomeFakeDirectRunLauncher(
+        string providerSessionId,
+        string provider,
+        string model,
+        string transport,
+        string command,
+        IReadOnlyList<string> argsTemplate,
+        string transportSummary,
+        string reviewOutcome,
+        string commentBody) : IDirectRunLauncher
+    {
+        public DirectRunLaunchResult Launch(
+            string executionUnit,
+            string entryKind,
+            string requestArtifactPath,
+            string providerEventLogPath,
+            string providerArg,
+            string modelArg,
+            string transportArg,
+            string commandArg,
+            IReadOnlyList<string> argsTemplateArg,
+            DateTimeOffset launchedAt,
+            string workingDirectory,
+            string absoluteRequestArtifactPath,
+            string absoluteProviderEventLogPath)
+        {
+            Assert.Equal("G9", executionUnit);
+            Assert.Equal("review", entryKind);
+            Assert.Equal(".intent-cli/runtime-runs/G9.request.json", requestArtifactPath);
+            Assert.Equal(".intent-cli/runtime-runs/G9.provider.jsonl", providerEventLogPath);
+            Assert.Equal(provider, providerArg);
+            Assert.Equal(model, modelArg);
+            Assert.Equal(transport, transportArg);
+            Assert.Equal(command, commandArg);
+            Assert.Equal(argsTemplate, argsTemplateArg);
+            Assert.EndsWith("/repo", workingDirectory, StringComparison.Ordinal);
+            Assert.EndsWith("/.intent-cli/reviews/G9.request.json", absoluteRequestArtifactPath, StringComparison.Ordinal);
+            Assert.EndsWith("/.intent-cli/runtime-runs/G9.provider.jsonl", absoluteProviderEventLogPath, StringComparison.Ordinal);
+
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(absoluteProviderEventLogPath)
+                ?? throw new InvalidOperationException("Provider event log path did not contain a directory."));
+            var providerEvents = string.Join(
+                                     Environment.NewLine,
+                                     new[]
+                                     {
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "session-metadata",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 model = modelArg,
+                                                 transport = transportArg,
+                                                 command
+                                             })
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(1).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 disposition = reviewOutcome,
+                                                 comment_body = commentBody
+                                             })
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(2).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 type = "backend-exit",
+                                                 exit_code = 0
                                              })
                                          })
                                      }) + Environment.NewLine;

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -334,17 +334,16 @@ public sealed class ReviewRunCommandTests
             var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
                 Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
             Assert.Equal("succeeded", resultArtifact.RunStatus);
-            Assert.Equal("accepted", resultArtifact.ReviewOutcome);
+            Assert.Null(resultArtifact.ReviewOutcome);
             Assert.Null(resultArtifact.ReviewCommentBodyPath);
 
             var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
                 Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl")));
-            Assert.Contains(providerEvents, providerEvent =>
+            Assert.DoesNotContain(providerEvents, providerEvent =>
                 providerEvent.Kind == "provider-event"
                 && string.Equals(providerEvent.SessionId, "pid:9999", StringComparison.Ordinal)
                 && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
-                && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
-                && string.Equals(dispositionElement.GetString(), "accepted", StringComparison.Ordinal));
+                && providerEvent.Payload.TryGetProperty("disposition", out _));
 
             var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
             var lifecycleEvent = Assert.Single(runEvents, runEvent => runEvent.Event == "provider-lifecycle");

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -411,7 +411,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenSucceededReviewDecisionWithoutExplicitOutcome_Waits()
+    public void ExecuteCore_GivenSucceededReviewDecisionWithoutExplicitOutcome_SynthesizesAcceptedOutcomeAndReusesReviewAcceptBoundary()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -422,14 +422,65 @@ public sealed class RunCommandTests
             Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
             "{}");
         WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
-        WriteDirectRunResult(repoRoot, "G226", "review", "succeeded");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "review",
+            "succeeded",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "ReviewBot",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 0
+                    })
+                }
+            ]);
+        var originalReviewAcceptExecutor = RunCommand.ReviewAcceptExecutor;
 
-        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+        try
+        {
+            RunCommand.ReviewAcceptExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Completed
+                    });
 
-        Assert.Equal("no-actionable-item", result.StopReason);
-        Assert.Equal("G226", result.ExecutionUnit);
-        Assert.Empty(result.Actions);
-        Assert.Contains("Review direct run for 'G226' is 'succeeded'.", result.Detail, StringComparison.Ordinal);
+                return new ReviewAcceptResult
+                {
+                    ExecutionUnit = executionUnit,
+                    MergedPrRef = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                    ClosedIssueRef = "https://github.com/J-Tech-Japan/intent-system/issues/226"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Null(result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review accept", action.Name);
+            Assert.Equal("G226", action.ExecutionUnit);
+
+            var artifact = DirectRunResultArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("accepted", artifact.ReviewOutcome);
+        }
+        finally
+        {
+            RunCommand.ReviewAcceptExecutor = originalReviewAcceptExecutor;
+        }
     }
 
     [Fact]
@@ -515,7 +566,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenSucceededReviewDecisionWithOnlyStaleAcceptedOutcome_Waits()
+    public void ExecuteCore_GivenSucceededReviewDecisionWithOnlyStaleAcceptedOutcome_SynthesizesCurrentSessionAcceptedOutcome()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -561,13 +612,47 @@ public sealed class RunCommandTests
                     })
                 }
             ]);
+        var originalReviewAcceptExecutor = RunCommand.ReviewAcceptExecutor;
 
-        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+        try
+        {
+            RunCommand.ReviewAcceptExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Completed
+                    });
 
-        Assert.Equal("no-actionable-item", result.StopReason);
-        Assert.Equal("G226", result.ExecutionUnit);
-        Assert.Empty(result.Actions);
-        Assert.Contains("Review direct run for 'G226' is 'succeeded'.", result.Detail, StringComparison.Ordinal);
+                return new ReviewAcceptResult
+                {
+                    ExecutionUnit = executionUnit,
+                    MergedPrRef = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                    ClosedIssueRef = "https://github.com/J-Tech-Japan/intent-system/issues/226"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Null(result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review accept", action.Name);
+            Assert.Equal("G226", action.ExecutionUnit);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                string.Equals(providerEvent.SessionId, "pid:226", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
+                && string.Equals(dispositionElement.GetString(), "accepted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunCommand.ReviewAcceptExecutor = originalReviewAcceptExecutor;
+        }
     }
 
     [Fact]
@@ -618,7 +703,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenRunningReviewDecisionWithExitedCurrentSession_AppendsBackendExitAndAdvancesBoundary()
+    public void ExecuteCore_GivenRunningReviewDecisionWithExitedCurrentSession_AppendsBackendExitAndSynthesizesAcceptedOutcome()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -652,24 +737,138 @@ public sealed class RunCommandTests
             ],
             sessionId: "pid:999999",
             provider: "Codex");
+        var originalReviewAcceptExecutor = RunCommand.ReviewAcceptExecutor;
 
-        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+        try
+        {
+            RunCommand.ReviewAcceptExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Completed
+                    });
 
-        Assert.Equal("no-actionable-item", result.StopReason);
-        Assert.Equal("G226", result.ExecutionUnit);
-        Assert.Contains("Review direct run for 'G226' is 'succeeded'.", result.Detail, StringComparison.Ordinal);
+                return new ReviewAcceptResult
+                {
+                    ExecutionUnit = executionUnit,
+                    MergedPrRef = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                    ClosedIssueRef = "https://github.com/J-Tech-Japan/intent-system/issues/226"
+                };
+            };
 
-        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
-            Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl")));
-        Assert.Contains(events, providerEvent =>
-            providerEvent.Kind == "provider-event"
-            && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
-            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
-            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
-            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
-        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
-            Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
-        Assert.Equal("succeeded", resultArtifact.RunStatus);
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Null(result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review accept", action.Name);
+            Assert.Equal("G226", action.ExecutionUnit);
+
+            var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl")));
+            Assert.Contains(events, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+            Assert.Contains(events, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
+                && string.Equals(dispositionElement.GetString(), "accepted", StringComparison.Ordinal));
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("succeeded", resultArtifact.RunStatus);
+            Assert.Equal("accepted", resultArtifact.ReviewOutcome);
+        }
+        finally
+        {
+            RunCommand.ReviewAcceptExecutor = originalReviewAcceptExecutor;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenSucceededReviewDecisionWithPersistedCommentOutcome_ReusesReviewCommentBoundary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.md"),
+            "Please cover the deterministic submit path.");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "review",
+            "succeeded",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "ReviewBot",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 0
+                    })
+                }
+            ],
+            reviewOutcome: "fix-requested",
+            reviewCommentBodyPath: ".intent-cli/reviews/G226.comment.md");
+        var originalReviewCommentExecutor = RunCommand.ReviewCommentExecutor;
+
+        try
+        {
+            RunCommand.ReviewCommentExecutor = (context, executionUnit, bodyPath) =>
+            {
+                Assert.Equal(".intent-cli/reviews/G226.comment.md", bodyPath);
+                Assert.Equal(
+                    "Please cover the deterministic submit path.",
+                    File.ReadAllText(Path.Combine(context.RepoRoot, bodyPath.Replace('/', Path.DirectorySeparatorChar))));
+
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Fixing
+                    });
+
+                return new ReviewCommentResult
+                {
+                    ExecutionUnit = executionUnit,
+                    ArtifactPath = ".intent-cli/reviews/G226.comment.json",
+                    CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("deterministic-contract-gap", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review comment", action.Name);
+            Assert.Equal("G226", action.ExecutionUnit);
+            Assert.Contains("requires .intent-cli/reviews/G226.comment.json", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunCommand.ReviewCommentExecutor = originalReviewCommentExecutor;
+        }
     }
 
     [Fact]
@@ -1016,7 +1215,9 @@ public sealed class RunCommandTests
         string runStatus,
         IReadOnlyList<DirectRunProviderEvent>? providerEvents = null,
         string sessionId = "pid:226",
-        string provider = "ReviewBot")
+        string provider = "ReviewBot",
+        string? reviewOutcome = null,
+        string? reviewCommentBodyPath = null)
     {
         var runsDirectory = Path.Combine(repoRoot, ".intent-cli", "runs");
         Directory.CreateDirectory(runsDirectory);
@@ -1034,6 +1235,8 @@ public sealed class RunCommandTests
                     Model = "gpt-5.4-mini",
                     SessionId = sessionId,
                     RunStatus = runStatus,
+                    ReviewOutcome = reviewOutcome,
+                    ReviewCommentBodyPath = reviewCommentBodyPath,
                     RawLogRef = $".intent-cli/runs/{executionUnit}.provider.jsonl",
                     PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
                     ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -411,7 +411,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenSucceededReviewDecisionWithoutExplicitOutcome_SynthesizesAcceptedOutcomeAndReusesReviewAcceptBoundary()
+    public void ExecuteCore_GivenSucceededReviewDecisionWithoutExplicitOutcome_Waits()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -444,43 +444,17 @@ public sealed class RunCommandTests
                     })
                 }
             ]);
-        var originalReviewAcceptExecutor = RunCommand.ReviewAcceptExecutor;
 
-        try
-        {
-            RunCommand.ReviewAcceptExecutor = (context, executionUnit) =>
-            {
-                PersistQueueState(
-                    context.RepoRoot,
-                    queueItem => queueItem with
-                    {
-                        State = QueueItemState.Completed
-                    });
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-                return new ReviewAcceptResult
-                {
-                    ExecutionUnit = executionUnit,
-                    MergedPrRef = "https://github.com/J-Tech-Japan/intent-system/pull/226",
-                    ClosedIssueRef = "https://github.com/J-Tech-Japan/intent-system/issues/226"
-                };
-            };
+        Assert.Equal("no-actionable-item", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("Review direct run for 'G226' is 'succeeded'.", result.Detail, StringComparison.Ordinal);
 
-            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
-
-            Assert.Equal("no-actionable-item", result.StopReason);
-            Assert.Null(result.ExecutionUnit);
-            var action = Assert.Single(result.Actions);
-            Assert.Equal("review accept", action.Name);
-            Assert.Equal("G226", action.ExecutionUnit);
-
-            var artifact = DirectRunResultArtifactJson.Deserialize(
-                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
-            Assert.Equal("accepted", artifact.ReviewOutcome);
-        }
-        finally
-        {
-            RunCommand.ReviewAcceptExecutor = originalReviewAcceptExecutor;
-        }
+        var artifact = DirectRunResultArtifactJson.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+        Assert.Null(artifact.ReviewOutcome);
     }
 
     [Fact]
@@ -566,7 +540,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenSucceededReviewDecisionWithOnlyStaleAcceptedOutcome_SynthesizesCurrentSessionAcceptedOutcome()
+    public void ExecuteCore_GivenSucceededReviewDecisionWithOnlyStaleAcceptedOutcome_Waits()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -612,47 +586,20 @@ public sealed class RunCommandTests
                     })
                 }
             ]);
-        var originalReviewAcceptExecutor = RunCommand.ReviewAcceptExecutor;
 
-        try
-        {
-            RunCommand.ReviewAcceptExecutor = (context, executionUnit) =>
-            {
-                PersistQueueState(
-                    context.RepoRoot,
-                    queueItem => queueItem with
-                    {
-                        State = QueueItemState.Completed
-                    });
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-                return new ReviewAcceptResult
-                {
-                    ExecutionUnit = executionUnit,
-                    MergedPrRef = "https://github.com/J-Tech-Japan/intent-system/pull/226",
-                    ClosedIssueRef = "https://github.com/J-Tech-Japan/intent-system/issues/226"
-                };
-            };
+        Assert.Equal("no-actionable-item", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("Review direct run for 'G226' is 'succeeded'.", result.Detail, StringComparison.Ordinal);
 
-            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
-
-            Assert.Equal("no-actionable-item", result.StopReason);
-            Assert.Null(result.ExecutionUnit);
-            var action = Assert.Single(result.Actions);
-            Assert.Equal("review accept", action.Name);
-            Assert.Equal("G226", action.ExecutionUnit);
-
-            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
-                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl")));
-            Assert.Contains(providerEvents, providerEvent =>
-                string.Equals(providerEvent.SessionId, "pid:226", StringComparison.Ordinal)
-                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
-                && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
-                && string.Equals(dispositionElement.GetString(), "accepted", StringComparison.Ordinal));
-        }
-        finally
-        {
-            RunCommand.ReviewAcceptExecutor = originalReviewAcceptExecutor;
-        }
+        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl")));
+        Assert.DoesNotContain(providerEvents, providerEvent =>
+            string.Equals(providerEvent.SessionId, "pid:226", StringComparison.Ordinal)
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("disposition", out _));
     }
 
     [Fact]
@@ -703,7 +650,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenRunningReviewDecisionWithExitedCurrentSession_AppendsBackendExitAndSynthesizesAcceptedOutcome()
+    public void ExecuteCore_GivenRunningReviewDecisionWithExitedCurrentSession_AppendsBackendExitAndWaits()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -737,58 +684,31 @@ public sealed class RunCommandTests
             ],
             sessionId: "pid:999999",
             provider: "Codex");
-        var originalReviewAcceptExecutor = RunCommand.ReviewAcceptExecutor;
 
-        try
-        {
-            RunCommand.ReviewAcceptExecutor = (context, executionUnit) =>
-            {
-                PersistQueueState(
-                    context.RepoRoot,
-                    queueItem => queueItem with
-                    {
-                        State = QueueItemState.Completed
-                    });
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-                return new ReviewAcceptResult
-                {
-                    ExecutionUnit = executionUnit,
-                    MergedPrRef = "https://github.com/J-Tech-Japan/intent-system/pull/226",
-                    ClosedIssueRef = "https://github.com/J-Tech-Japan/intent-system/issues/226"
-                };
-            };
+        Assert.Equal("no-actionable-item", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("Review direct run for 'G226' is 'succeeded'.", result.Detail, StringComparison.Ordinal);
 
-            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
-
-            Assert.Equal("no-actionable-item", result.StopReason);
-            Assert.Null(result.ExecutionUnit);
-            var action = Assert.Single(result.Actions);
-            Assert.Equal("review accept", action.Name);
-            Assert.Equal("G226", action.ExecutionUnit);
-
-            var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
-                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl")));
-            Assert.Contains(events, providerEvent =>
-                providerEvent.Kind == "provider-event"
-                && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
-                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
-                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
-                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
-            Assert.Contains(events, providerEvent =>
-                providerEvent.Kind == "provider-event"
-                && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
-                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
-                && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
-                && string.Equals(dispositionElement.GetString(), "accepted", StringComparison.Ordinal));
-            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
-                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
-            Assert.Equal("succeeded", resultArtifact.RunStatus);
-            Assert.Equal("accepted", resultArtifact.ReviewOutcome);
-        }
-        finally
-        {
-            RunCommand.ReviewAcceptExecutor = originalReviewAcceptExecutor;
-        }
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl")));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+        Assert.DoesNotContain(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("disposition", out _));
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+        Assert.Equal("succeeded", resultArtifact.RunStatus);
+        Assert.Null(resultArtifact.ReviewOutcome);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- persist explicit review outcomes and deterministic comment body refs into direct review result artifacts
- synthesize canonical current-session review outcome events when a successful review run only reports backend exit
- teach the root run loop to reuse persisted review outcomes for review accept/comment progression

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~DirectRunResultArtifactJsonTests|FullyQualifiedName~ReviewRunCommandTests|FullyQualifiedName~RunCommandTests"
- dotnet test IntentSystem.sln

Closes #256