### PR TITLE
Persist real Codex review outcomes after direct runs

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -595,6 +595,10 @@ internal static class DirectRunCommandSupport
             }
         }
 
+        runStatus = string.Equals(entryKind, "review", StringComparison.Ordinal)
+            ? DirectRunReviewOutcomeSupport.ResolveEffectiveReviewRunStatus(runStatus, reviewOutcome)
+            : runStatus;
+
         var worktreePath = RunStartCommand.ResolveWorktreePath(context, executionUnit);
         var resultArtifactPath = ResolveResultArtifactPath(context, executionUnit);
         var absoluteResultArtifactPath = Path.GetFullPath(Path.Combine(

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -288,6 +288,16 @@ internal static class DirectRunCommandSupport
         }
 
         var currentProviderEvents = SelectCurrentSessionEvents(providerEvents, providerSessionId, launchedAt);
+        if (DirectRunReviewOutcomeSupport.TryResolveExplicitReviewOutcome(currentProviderEvents, out _)
+            || DirectRunReviewOutcomeSupport.TryReadReviewOutcomeFromCapturedMessagePath(
+                capturedMessagePath,
+                out _,
+                out _,
+                out _))
+        {
+            return true;
+        }
+
         if (!TryResolveBackendExitCode(currentProviderEvents, out _))
         {
             return false;
@@ -481,7 +491,7 @@ internal static class DirectRunCommandSupport
     {
         return provider.Trim().ToLowerInvariant() switch
         {
-            "codex" when entryKind == DirectRunEntryKind.Review => ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+            "codex" when entryKind == DirectRunEntryKind.Review => ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
             "codex" => ["exec", "--model", "{model}", "{prompt}"],
             "claude" => ["--print", "--model", "{model}", "--output-format", "json", "{prompt}"],
             _ => ["{prompt}"]

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -469,12 +469,16 @@ internal static class DirectRunCommandSupport
                   ]
                 },
                 "comment_body": {
-                  "type": "string",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "minLength": 1
                 }
               },
               "required": [
-                "disposition"
+                "disposition",
+                "comment_body"
               ]
             }
             """);

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -48,12 +48,20 @@ internal static class DirectRunCommandSupport
         var entryKindValue = FormatEntryKind(entryKind);
         var relativeArtifactPath = ResolveArtifactPath(context, executionUnit);
         var relativeProviderEventLogPath = ResolveProviderEventLogPath(context, executionUnit);
+        var relativeCapturedMessagePath = ResolveCapturedMessagePath(context, executionUnit);
         var absoluteArtifactPath = Path.GetFullPath(
             Path.Combine(context.RepoRoot, relativeArtifactPath.Replace('/', Path.DirectorySeparatorChar)));
         var absoluteProviderEventLogPath = Path.GetFullPath(
             Path.Combine(context.RepoRoot, relativeProviderEventLogPath.Replace('/', Path.DirectorySeparatorChar)));
+        var absoluteCapturedMessagePath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, relativeCapturedMessagePath.Replace('/', Path.DirectorySeparatorChar)));
         var absoluteUpstreamRequestPath = Path.GetFullPath(
             Path.Combine(context.RepoRoot, upstreamRequestRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (entryKind == DirectRunEntryKind.Review && File.Exists(absoluteCapturedMessagePath))
+        {
+            File.Delete(absoluteCapturedMessagePath);
+        }
+
         var launchResult = launcher.Launch(
             executionUnit,
             entryKindValue,
@@ -136,7 +144,7 @@ internal static class DirectRunCommandSupport
         var argsTemplate = FirstNonEmptyList(
             entryConfig.Args,
             directRun.Args,
-            ResolveDefaultArgsTemplate(provider));
+            ResolveDefaultArgsTemplate(provider, entryKind));
 
         return new DirectRunResolvedPolicy
         {
@@ -175,6 +183,12 @@ internal static class DirectRunCommandSupport
     {
         var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
         return $"{root}/{executionUnit.Trim()}.result.json";
+    }
+
+    internal static string ResolveCapturedMessagePath(CliContext context, string executionUnit)
+    {
+        var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
+        return $"{root}/{executionUnit.Trim()}.last-message.json";
     }
 
     private static string FormatEntryKind(DirectRunEntryKind entryKind)
@@ -224,10 +238,11 @@ internal static class DirectRunCommandSupport
         };
     }
 
-    private static IReadOnlyList<string> ResolveDefaultArgsTemplate(string provider)
+    private static IReadOnlyList<string> ResolveDefaultArgsTemplate(string provider, DirectRunEntryKind entryKind)
     {
         return provider.Trim().ToLowerInvariant() switch
         {
+            "codex" when entryKind == DirectRunEntryKind.Review => ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
             "codex" => ["exec", "--model", "{model}", "{prompt}"],
             "claude" => ["--print", "--model", "{model}", "--output-format", "json", "{prompt}"],
             _ => ["{prompt}"]
@@ -276,6 +291,28 @@ internal static class DirectRunCommandSupport
         var sessionId = ResolveSessionId(currentProviderEvents, launchResult.ProviderSessionId);
         var provider = ResolveProvider(currentProviderEvents, launchResult.Provider);
         var runStatus = ResolveRunStatus(currentProviderEvents);
+        if (string.Equals(entryKind, "review", StringComparison.Ordinal))
+        {
+            var capturedMessagePath = Path.GetFullPath(Path.Combine(
+                context.RepoRoot,
+                ResolveCapturedMessagePath(context, executionUnit).Replace('/', Path.DirectorySeparatorChar)));
+            var capturedOutcomeEvent = DirectRunReviewOutcomeSupport.TryCreateReviewOutcomeEventFromCapturedMessage(
+                currentProviderEvents,
+                capturedMessagePath,
+                DateTimeOffset.UtcNow,
+                executionUnit,
+                entryKind,
+                provider,
+                sessionId);
+            if (capturedOutcomeEvent is not null)
+            {
+                var writer = new DirectRunProviderEventWriter(providerEventLogPath);
+                writer.Append(capturedOutcomeEvent);
+                providerEvents = [.. providerEvents, capturedOutcomeEvent];
+                currentProviderEvents = [.. currentProviderEvents, capturedOutcomeEvent];
+            }
+        }
+
         string? reviewOutcome = null;
         string? reviewCommentBodyPath = null;
         if (string.Equals(entryKind, "review", StringComparison.Ordinal)

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -54,17 +54,25 @@ internal static class DirectRunCommandSupport
         var relativeArtifactPath = ResolveArtifactPath(context, executionUnit);
         var relativeProviderEventLogPath = ResolveProviderEventLogPath(context, executionUnit);
         var relativeCapturedMessagePath = ResolveCapturedMessagePath(context, executionUnit, launchedAt);
+        var relativeReviewOutputSchemaPath = ResolveReviewOutputSchemaPath(context, executionUnit, launchedAt);
         var absoluteArtifactPath = Path.GetFullPath(
             Path.Combine(context.RepoRoot, relativeArtifactPath.Replace('/', Path.DirectorySeparatorChar)));
         var absoluteProviderEventLogPath = Path.GetFullPath(
             Path.Combine(context.RepoRoot, relativeProviderEventLogPath.Replace('/', Path.DirectorySeparatorChar)));
         var absoluteCapturedMessagePath = Path.GetFullPath(
             Path.Combine(context.RepoRoot, relativeCapturedMessagePath.Replace('/', Path.DirectorySeparatorChar)));
+        var absoluteReviewOutputSchemaPath = Path.GetFullPath(
+            Path.Combine(context.RepoRoot, relativeReviewOutputSchemaPath.Replace('/', Path.DirectorySeparatorChar)));
         var absoluteUpstreamRequestPath = Path.GetFullPath(
             Path.Combine(context.RepoRoot, upstreamRequestRef.Replace('/', Path.DirectorySeparatorChar)));
         if (entryKind == DirectRunEntryKind.Review && File.Exists(absoluteCapturedMessagePath))
         {
             File.Delete(absoluteCapturedMessagePath);
+        }
+
+        if (entryKind == DirectRunEntryKind.Review)
+        {
+            PersistReviewOutputSchema(absoluteReviewOutputSchemaPath);
         }
 
         var launchResult = launcher.Launch(
@@ -423,9 +431,53 @@ internal static class DirectRunCommandSupport
         return $"{root}/{executionUnit.Trim()}.{CreateCapturedMessageSuffix(launchedAt)}.last-message.json";
     }
 
+    internal static string ResolveReviewOutputSchemaPath(
+        CliContext context,
+        string executionUnit,
+        DateTimeOffset launchedAt)
+    {
+        var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
+        return $"{root}/{executionUnit.Trim()}.{CreateCapturedMessageSuffix(launchedAt)}.review-output-schema.json";
+    }
+
     internal static string CreateCapturedMessageSuffix(DateTimeOffset launchedAt)
     {
         return launchedAt.ToUniversalTime().Ticks.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static void PersistReviewOutputSchema(string absoluteReviewOutputSchemaPath)
+    {
+        var directoryPath = Path.GetDirectoryName(absoluteReviewOutputSchemaPath)
+            ?? throw new InvalidOperationException("Review output schema path did not contain a directory.");
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(
+            absoluteReviewOutputSchemaPath,
+            """
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "disposition": {
+                  "type": "string",
+                  "enum": [
+                    "accepted",
+                    "approved",
+                    "comment",
+                    "commented",
+                    "fix-requested",
+                    "changes-requested"
+                  ]
+                },
+                "comment_body": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "disposition"
+              ]
+            }
+            """);
     }
 
     private static string FormatEntryKind(DirectRunEntryKind entryKind)
@@ -491,7 +543,7 @@ internal static class DirectRunCommandSupport
     {
         return provider.Trim().ToLowerInvariant() switch
         {
-            "codex" when entryKind == DirectRunEntryKind.Review => ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+            "codex" when entryKind == DirectRunEntryKind.Review => ["exec", "--json", "--model", "{model}", "--output-schema", "{output_schema_path}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
             "codex" => ["exec", "--model", "{model}", "{prompt}"],
             "claude" => ["--print", "--model", "{model}", "--output-format", "json", "{prompt}"],
             _ => ["{prompt}"]

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -1,6 +1,7 @@
 using IntentSystem.Review;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
+using System.Diagnostics;
 using System.Text.Json;
 
 namespace IntentSystem.Cli.Commands;
@@ -29,7 +30,8 @@ internal static class DirectRunCommandSupport
 {
     private const string LifecycleEventActor = "intent-cli";
     private const string LifecycleEventName = "provider-lifecycle";
-    private static readonly TimeSpan ReviewCompletionWaitWindow = TimeSpan.FromSeconds(30);
+    private const string ReviewCompletionWaitWindowEnvVar = "INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS";
+    private static readonly TimeSpan DefaultReviewCompletionWaitWindow = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan ReviewCompletionPollInterval = TimeSpan.FromMilliseconds(250);
 
     public static DirectRunLaunchResult CreateAndLaunch(
@@ -99,13 +101,19 @@ internal static class DirectRunCommandSupport
         Directory.CreateDirectory(directoryPath);
         File.WriteAllText(absoluteArtifactPath, DirectRunRequestArtifactJson.Serialize(artifact));
 
-        if (ShouldAwaitRealReviewCompletion(entryKind, launcher, policy.Command))
-        {
-            WaitForReviewCompletionBoundary(
+        if (ShouldAwaitRealReviewCompletion(entryKind, launcher, policy.Command)
+            && !WaitForReviewCompletionBoundary(
                 absoluteProviderEventLogPath,
                 absoluteCapturedMessagePath,
                 launchResult.ProviderSessionId,
-                launchedAt);
+                launchedAt))
+        {
+            ClassifyMissingReviewCompletionBoundary(
+                absoluteProviderEventLogPath,
+                executionUnit,
+                entryKindValue,
+                launchResult.Provider,
+                launchResult.ProviderSessionId);
         }
 
         var synthesis = SynthesizeAndPersistResult(
@@ -135,13 +143,13 @@ internal static class DirectRunCommandSupport
             && IsCodexLikeCommand(command);
     }
 
-    private static void WaitForReviewCompletionBoundary(
+    private static bool WaitForReviewCompletionBoundary(
         string providerEventLogPath,
         string capturedMessagePath,
         string providerSessionId,
         DateTimeOffset launchedAt)
     {
-        var deadline = DateTimeOffset.UtcNow + ReviewCompletionWaitWindow;
+        var deadline = DateTimeOffset.UtcNow + ResolveReviewCompletionWaitWindow();
         while (DateTimeOffset.UtcNow < deadline)
         {
             if (HasTerminalReviewBoundary(
@@ -150,11 +158,108 @@ internal static class DirectRunCommandSupport
                     providerSessionId,
                     launchedAt))
             {
-                return;
+                return true;
             }
 
             Thread.Sleep(ReviewCompletionPollInterval);
         }
+
+        return false;
+    }
+
+    private static TimeSpan ResolveReviewCompletionWaitWindow()
+    {
+        var raw = Environment.GetEnvironmentVariable(ReviewCompletionWaitWindowEnvVar);
+        if (!string.IsNullOrWhiteSpace(raw)
+            && int.TryParse(
+                raw,
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var milliseconds)
+            && milliseconds > 0)
+        {
+            return TimeSpan.FromMilliseconds(milliseconds);
+        }
+
+        return DefaultReviewCompletionWaitWindow;
+    }
+
+    private static void ClassifyMissingReviewCompletionBoundary(
+        string providerEventLogPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId)
+    {
+        TryTerminateProviderSession(providerSessionId);
+
+        var timestamp = DateTimeOffset.UtcNow;
+        var writer = new DirectRunProviderEventWriter(providerEventLogPath);
+        writer.Append(new DirectRunProviderEvent
+        {
+            Timestamp = timestamp.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = provider,
+            EntryKind = entryKind,
+            SessionId = providerSessionId,
+            Kind = "provider-event",
+            Payload = JsonSerializer.SerializeToElement(new
+            {
+                type = "contract-gap",
+                run_status = "failed",
+                reason = "review-completion-boundary-timeout"
+            })
+        });
+        writer.Append(DirectRunProviderEventFactory.CreateBackendExitEvent(
+            timestamp,
+            executionUnit,
+            entryKind,
+            provider,
+            providerSessionId,
+            1));
+    }
+
+    private static void TryTerminateProviderSession(string providerSessionId)
+    {
+        if (!TryParseSessionProcessId(providerSessionId, out var processId))
+        {
+            return;
+        }
+
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            if (process.HasExited)
+            {
+                return;
+            }
+
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit((int)TimeSpan.FromSeconds(2).TotalMilliseconds);
+        }
+        catch (Exception exception) when (
+            exception is ArgumentException
+            or InvalidOperationException
+            or NotSupportedException)
+        {
+        }
+    }
+
+    private static bool TryParseSessionProcessId(string providerSessionId, out int processId)
+    {
+        processId = default;
+
+        const string prefix = "pid:";
+        if (!providerSessionId.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return int.TryParse(
+            providerSessionId[prefix.Length..],
+            System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out processId);
     }
 
     private static bool HasTerminalReviewBoundary(

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -31,7 +31,9 @@ internal static class DirectRunCommandSupport
     private const string LifecycleEventActor = "intent-cli";
     private const string LifecycleEventName = "provider-lifecycle";
     private const string ReviewCompletionWaitWindowEnvVar = "INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS";
+    private const string ReviewSessionMaxWaitWindowEnvVar = "INTENT_DIRECT_RUN_REVIEW_SESSION_MAX_WAIT_MS";
     private static readonly TimeSpan DefaultReviewCompletionWaitWindow = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan DefaultReviewSessionMaxWaitWindow = TimeSpan.FromMinutes(10);
     private static readonly TimeSpan ReviewCompletionPollInterval = TimeSpan.FromMilliseconds(250);
 
     public static DirectRunLaunchResult CreateAndLaunch(
@@ -157,16 +159,25 @@ internal static class DirectRunCommandSupport
         string providerSessionId,
         DateTimeOffset launchedAt)
     {
-        var deadline = DateTimeOffset.UtcNow + ResolveReviewCompletionWaitWindow();
-        while (DateTimeOffset.UtcNow < deadline)
+        var sessionDeadline = DateTimeOffset.UtcNow + ResolveReviewSessionMaxWaitWindow();
+        while (DateTimeOffset.UtcNow < sessionDeadline)
         {
-            if (HasTerminalReviewBoundary(
+            if (HasExplicitReviewOutcome(
                     providerEventLogPath,
                     capturedMessagePath,
                     providerSessionId,
                     launchedAt))
             {
                 return true;
+            }
+
+            if (HasReviewSessionTerminated(providerEventLogPath, providerSessionId, launchedAt))
+            {
+                return WaitForReviewOutcomeAfterSessionTermination(
+                    providerEventLogPath,
+                    capturedMessagePath,
+                    providerSessionId,
+                    launchedAt);
             }
 
             Thread.Sleep(ReviewCompletionPollInterval);
@@ -177,7 +188,23 @@ internal static class DirectRunCommandSupport
 
     private static TimeSpan ResolveReviewCompletionWaitWindow()
     {
-        var raw = Environment.GetEnvironmentVariable(ReviewCompletionWaitWindowEnvVar);
+        return ResolvePositiveWaitWindow(
+            ReviewCompletionWaitWindowEnvVar,
+            DefaultReviewCompletionWaitWindow);
+    }
+
+    private static TimeSpan ResolveReviewSessionMaxWaitWindow()
+    {
+        return ResolvePositiveWaitWindow(
+            ReviewSessionMaxWaitWindowEnvVar,
+            DefaultReviewSessionMaxWaitWindow);
+    }
+
+    private static TimeSpan ResolvePositiveWaitWindow(string environmentVariableName, TimeSpan defaultValue)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(environmentVariableName);
+
+        var raw = Environment.GetEnvironmentVariable(environmentVariableName);
         if (!string.IsNullOrWhiteSpace(raw)
             && int.TryParse(
                 raw,
@@ -189,7 +216,7 @@ internal static class DirectRunCommandSupport
             return TimeSpan.FromMilliseconds(milliseconds);
         }
 
-        return DefaultReviewCompletionWaitWindow;
+        return defaultValue;
     }
 
     private static void ClassifyMissingReviewCompletionBoundary(
@@ -270,21 +297,92 @@ internal static class DirectRunCommandSupport
             out processId);
     }
 
-    private static bool HasTerminalReviewBoundary(
+    private static bool WaitForReviewOutcomeAfterSessionTermination(
         string providerEventLogPath,
         string capturedMessagePath,
         string providerSessionId,
         DateTimeOffset launchedAt)
     {
+        var deadline = DateTimeOffset.UtcNow + ResolveReviewCompletionWaitWindow();
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (HasExplicitReviewOutcome(
+                    providerEventLogPath,
+                    capturedMessagePath,
+                    providerSessionId,
+                    launchedAt))
+            {
+                return true;
+            }
+
+            Thread.Sleep(ReviewCompletionPollInterval);
+        }
+
+        return HasExplicitReviewOutcome(
+            providerEventLogPath,
+            capturedMessagePath,
+            providerSessionId,
+            launchedAt);
+    }
+
+    private static bool HasExplicitReviewOutcome(
+        string providerEventLogPath,
+        string capturedMessagePath,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        if (!TryReadCurrentProviderEvents(
+                providerEventLogPath,
+                providerSessionId,
+                launchedAt,
+                out var currentProviderEvents))
+        {
+            return false;
+        }
+
+        return DirectRunReviewOutcomeSupport.TryResolveExplicitReviewOutcome(currentProviderEvents, out _)
+            || DirectRunReviewOutcomeSupport.TryReadReviewOutcomeFromCapturedMessagePath(
+                capturedMessagePath,
+                out _,
+                out _,
+                out _);
+    }
+
+    private static bool HasReviewSessionTerminated(
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        if (TryReadCurrentProviderEvents(
+                providerEventLogPath,
+                providerSessionId,
+                launchedAt,
+                out var currentProviderEvents)
+            && TryResolveBackendExitCode(currentProviderEvents, out _))
+        {
+            return true;
+        }
+
+        return !IsProviderSessionAlive(providerSessionId);
+    }
+
+    private static bool TryReadCurrentProviderEvents(
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset launchedAt,
+        out IReadOnlyList<DirectRunProviderEvent> currentProviderEvents)
+    {
+        currentProviderEvents = [];
         if (!File.Exists(providerEventLogPath))
         {
             return false;
         }
 
-        IReadOnlyList<DirectRunProviderEvent> providerEvents;
         try
         {
-            providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            currentProviderEvents = SelectCurrentSessionEvents(providerEvents, providerSessionId, launchedAt);
+            return true;
         }
         catch (Exception exception) when (
             exception is IOException
@@ -294,24 +392,28 @@ internal static class DirectRunCommandSupport
         {
             return false;
         }
+    }
 
-        var currentProviderEvents = SelectCurrentSessionEvents(providerEvents, providerSessionId, launchedAt);
-        if (DirectRunReviewOutcomeSupport.TryResolveExplicitReviewOutcome(currentProviderEvents, out _)
-            || DirectRunReviewOutcomeSupport.TryReadReviewOutcomeFromCapturedMessagePath(
-                capturedMessagePath,
-                out _,
-                out _,
-                out _))
-        {
-            return true;
-        }
-
-        if (!TryResolveBackendExitCode(currentProviderEvents, out _))
+    private static bool IsProviderSessionAlive(string providerSessionId)
+    {
+        if (!TryParseSessionProcessId(providerSessionId, out var processId))
         {
             return false;
         }
 
-        return true;
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            process.Refresh();
+            return !process.HasExited;
+        }
+        catch (Exception exception) when (
+            exception is ArgumentException
+            or InvalidOperationException
+            or NotSupportedException)
+        {
+            return false;
+        }
     }
 
     private static bool TryResolveBackendExitCode(

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -48,7 +48,7 @@ internal static class DirectRunCommandSupport
         var entryKindValue = FormatEntryKind(entryKind);
         var relativeArtifactPath = ResolveArtifactPath(context, executionUnit);
         var relativeProviderEventLogPath = ResolveProviderEventLogPath(context, executionUnit);
-        var relativeCapturedMessagePath = ResolveCapturedMessagePath(context, executionUnit);
+        var relativeCapturedMessagePath = ResolveCapturedMessagePath(context, executionUnit, launchedAt);
         var absoluteArtifactPath = Path.GetFullPath(
             Path.Combine(context.RepoRoot, relativeArtifactPath.Replace('/', Path.DirectorySeparatorChar)));
         var absoluteProviderEventLogPath = Path.GetFullPath(
@@ -185,10 +185,18 @@ internal static class DirectRunCommandSupport
         return $"{root}/{executionUnit.Trim()}.result.json";
     }
 
-    internal static string ResolveCapturedMessagePath(CliContext context, string executionUnit)
+    internal static string ResolveCapturedMessagePath(
+        CliContext context,
+        string executionUnit,
+        DateTimeOffset launchedAt)
     {
         var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
-        return $"{root}/{executionUnit.Trim()}.last-message.json";
+        return $"{root}/{executionUnit.Trim()}.{CreateCapturedMessageSuffix(launchedAt)}.last-message.json";
+    }
+
+    internal static string CreateCapturedMessageSuffix(DateTimeOffset launchedAt)
+    {
+        return launchedAt.ToUniversalTime().Ticks.ToString(System.Globalization.CultureInfo.InvariantCulture);
     }
 
     private static string FormatEntryKind(DirectRunEntryKind entryKind)
@@ -295,7 +303,7 @@ internal static class DirectRunCommandSupport
         {
             var capturedMessagePath = Path.GetFullPath(Path.Combine(
                 context.RepoRoot,
-                ResolveCapturedMessagePath(context, executionUnit).Replace('/', Path.DirectorySeparatorChar)));
+                ResolveCapturedMessagePath(context, executionUnit, launchedAt).Replace('/', Path.DirectorySeparatorChar)));
             var capturedOutcomeEvent = DirectRunReviewOutcomeSupport.TryCreateReviewOutcomeEventFromCapturedMessage(
                 currentProviderEvents,
                 capturedMessagePath,

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -1,6 +1,7 @@
 using IntentSystem.Review;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
+using System.Text.Json;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -28,6 +29,8 @@ internal static class DirectRunCommandSupport
 {
     private const string LifecycleEventActor = "intent-cli";
     private const string LifecycleEventName = "provider-lifecycle";
+    private static readonly TimeSpan ReviewCompletionWaitWindow = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan ReviewCompletionPollInterval = TimeSpan.FromMilliseconds(250);
 
     public static DirectRunLaunchResult CreateAndLaunch(
         CliContext context,
@@ -96,6 +99,15 @@ internal static class DirectRunCommandSupport
         Directory.CreateDirectory(directoryPath);
         File.WriteAllText(absoluteArtifactPath, DirectRunRequestArtifactJson.Serialize(artifact));
 
+        if (ShouldAwaitRealReviewCompletion(entryKind, launcher, policy.Command))
+        {
+            WaitForReviewCompletionBoundary(
+                absoluteProviderEventLogPath,
+                absoluteCapturedMessagePath,
+                launchResult.ProviderSessionId,
+                launchedAt);
+        }
+
         var synthesis = SynthesizeAndPersistResult(
             context,
             executionUnit,
@@ -109,6 +121,108 @@ internal static class DirectRunCommandSupport
             ResultArtifactPath = synthesis.ResultArtifactPath,
             RunStatus = synthesis.RunStatus
         };
+    }
+
+    private static bool ShouldAwaitRealReviewCompletion(
+        DirectRunEntryKind entryKind,
+        IDirectRunLauncher launcher,
+        string command)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+
+        return entryKind == DirectRunEntryKind.Review
+            && launcher is DirectRunLauncher
+            && IsCodexLikeCommand(command);
+    }
+
+    private static void WaitForReviewCompletionBoundary(
+        string providerEventLogPath,
+        string capturedMessagePath,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        var deadline = DateTimeOffset.UtcNow + ReviewCompletionWaitWindow;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (HasTerminalReviewBoundary(
+                    providerEventLogPath,
+                    capturedMessagePath,
+                    providerSessionId,
+                    launchedAt))
+            {
+                return;
+            }
+
+            Thread.Sleep(ReviewCompletionPollInterval);
+        }
+    }
+
+    private static bool HasTerminalReviewBoundary(
+        string providerEventLogPath,
+        string capturedMessagePath,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        if (!File.Exists(providerEventLogPath))
+        {
+            return false;
+        }
+
+        IReadOnlyList<DirectRunProviderEvent> providerEvents;
+        try
+        {
+            providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or InvalidOperationException
+            or ArgumentException
+            or JsonException)
+        {
+            return false;
+        }
+
+        var currentProviderEvents = SelectCurrentSessionEvents(providerEvents, providerSessionId, launchedAt);
+        if (!TryResolveBackendExitCode(currentProviderEvents, out _))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryResolveBackendExitCode(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        out int exitCode)
+    {
+        exitCode = default;
+
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            var providerEvent = providerEvents[index];
+            if (!HasBackendExitType(providerEvent))
+            {
+                continue;
+            }
+
+            if (TryReadInt32(providerEvent.Payload, "exit_code", out exitCode)
+                || TryReadInt32(providerEvent.Payload, "exitCode", out exitCode))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasBackendExitType(DirectRunProviderEvent providerEvent)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvent);
+
+        return providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal);
     }
 
     private static DirectRunResolvedPolicy ResolvePolicy(
@@ -244,6 +358,18 @@ internal static class DirectRunCommandSupport
             "claude" => "claude",
             _ => provider
         };
+    }
+
+    private static bool IsCodexLikeCommand(string command)
+    {
+        var fileName = Path.GetFileName(command.Trim());
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return false;
+        }
+
+        var commandStem = Path.GetFileNameWithoutExtension(fileName);
+        return commandStem.StartsWith("codex", StringComparison.OrdinalIgnoreCase);
     }
 
     private static IReadOnlyList<string> ResolveDefaultArgsTemplate(string provider, DirectRunEntryKind entryKind)

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -297,6 +297,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 .Replace("{request_artifact_path}", absoluteRequestArtifactPath, StringComparison.Ordinal)
                 .Replace("{upstream_request_artifact_path}", absoluteRequestArtifactPath, StringComparison.Ordinal)
                 .Replace("{direct_run_artifact_path}", requestArtifactPath, StringComparison.Ordinal)
+                .Replace("{output_schema_path}", ResolveOutputSchemaPath(requestArtifactPath, executionUnit, launchedAt), StringComparison.Ordinal)
                 .Replace("{output_last_message_path}", outputLastMessagePath, StringComparison.Ordinal)
                 .Replace("{prompt}", prompt, StringComparison.Ordinal))
             .ToArray();
@@ -332,6 +333,19 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             ?.TrimEnd('/')
             ?? ".";
         return $"{directory}/{executionUnit.Trim()}.{DirectRunCommandSupport.CreateCapturedMessageSuffix(launchedAt)}.last-message.json";
+    }
+
+    private static string ResolveOutputSchemaPath(
+        string requestArtifactPath,
+        string executionUnit,
+        DateTimeOffset launchedAt)
+    {
+        var normalizedPath = requestArtifactPath.Replace('\\', '/');
+        var directory = Path.GetDirectoryName(normalizedPath.Replace('/', Path.DirectorySeparatorChar))
+            ?.Replace(Path.DirectorySeparatorChar, '/')
+            ?.TrimEnd('/')
+            ?? ".";
+        return $"{directory}/{executionUnit.Trim()}.{DirectRunCommandSupport.CreateCapturedMessageSuffix(launchedAt)}.review-output-schema.json";
     }
 
     private static ResolvedProcessInvocation ResolveProcessInvocation(

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -314,11 +314,12 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
 
         return prompt
             + " Your final response must be a single JSON object with a required string field 'disposition'"
-            + " and an optional string field 'comment_body'."
+            + " and a required field 'comment_body' that must be a string when a review comment is required or null when no comment is required."
             + " Use 'accepted' or 'approved' only when no review comment is required."
             + " Use 'comment', 'commented', 'fix-requested', or 'changes-requested' only when a deterministic review comment is required."
             + " Do not return wrapper fields such as 'stop_reason', 'actions', or execution envelopes instead of 'disposition'."
             + " If you detect a deterministic contract gap or need follow-up work, still return 'disposition':'fix-requested' with an actionable 'comment_body'."
+            + " For accepted or approved outcomes, return 'comment_body': null."
             + " Do not wrap the JSON in markdown fences.";
     }
 

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -54,6 +54,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             provider,
             model,
             transport,
+            launchedAt,
             absoluteRequestArtifactPath,
             argsTemplate);
         var processInvocation = ResolveProcessInvocation(
@@ -279,11 +280,12 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         string provider,
         string model,
         string transport,
+        DateTimeOffset launchedAt,
         string absoluteRequestArtifactPath,
         IReadOnlyList<string> argsTemplate)
     {
         var prompt = CreatePrompt(entryKind, absoluteRequestArtifactPath);
-        var outputLastMessagePath = ResolveOutputLastMessagePath(requestArtifactPath, executionUnit);
+        var outputLastMessagePath = ResolveOutputLastMessagePath(requestArtifactPath, executionUnit, launchedAt);
 
         return argsTemplate
             .Select(argument => argument
@@ -317,14 +319,17 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             + " Do not wrap the JSON in markdown fences.";
     }
 
-    private static string ResolveOutputLastMessagePath(string requestArtifactPath, string executionUnit)
+    private static string ResolveOutputLastMessagePath(
+        string requestArtifactPath,
+        string executionUnit,
+        DateTimeOffset launchedAt)
     {
         var normalizedPath = requestArtifactPath.Replace('\\', '/');
         var directory = Path.GetDirectoryName(normalizedPath.Replace('/', Path.DirectorySeparatorChar))
             ?.Replace(Path.DirectorySeparatorChar, '/')
             ?.TrimEnd('/')
             ?? ".";
-        return $"{directory}/{executionUnit.Trim()}.last-message.json";
+        return $"{directory}/{executionUnit.Trim()}.{DirectRunCommandSupport.CreateCapturedMessageSuffix(launchedAt)}.last-message.json";
     }
 
     private static ResolvedProcessInvocation ResolveProcessInvocation(

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -282,8 +282,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         string absoluteRequestArtifactPath,
         IReadOnlyList<string> argsTemplate)
     {
-        var prompt =
-            $"Use the request artifact at '{absoluteRequestArtifactPath}' as the bounded source of truth for this direct run.";
+        var prompt = CreatePrompt(entryKind, absoluteRequestArtifactPath);
+        var outputLastMessagePath = ResolveOutputLastMessagePath(requestArtifactPath, executionUnit);
 
         return argsTemplate
             .Select(argument => argument
@@ -295,8 +295,36 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 .Replace("{request_artifact_path}", absoluteRequestArtifactPath, StringComparison.Ordinal)
                 .Replace("{upstream_request_artifact_path}", absoluteRequestArtifactPath, StringComparison.Ordinal)
                 .Replace("{direct_run_artifact_path}", requestArtifactPath, StringComparison.Ordinal)
+                .Replace("{output_last_message_path}", outputLastMessagePath, StringComparison.Ordinal)
                 .Replace("{prompt}", prompt, StringComparison.Ordinal))
             .ToArray();
+    }
+
+    private static string CreatePrompt(string entryKind, string absoluteRequestArtifactPath)
+    {
+        var prompt =
+            $"Use the request artifact at '{absoluteRequestArtifactPath}' as the bounded source of truth for this direct run.";
+        if (!string.Equals(entryKind, "review", StringComparison.Ordinal))
+        {
+            return prompt;
+        }
+
+        return prompt
+            + " Your final response must be a single JSON object with a required string field 'disposition'"
+            + " and an optional string field 'comment_body'."
+            + " Use 'accepted' or 'approved' only when no review comment is required."
+            + " Use 'comment', 'commented', 'fix-requested', or 'changes-requested' only when a deterministic review comment is required."
+            + " Do not wrap the JSON in markdown fences.";
+    }
+
+    private static string ResolveOutputLastMessagePath(string requestArtifactPath, string executionUnit)
+    {
+        var normalizedPath = requestArtifactPath.Replace('\\', '/');
+        var directory = Path.GetDirectoryName(normalizedPath.Replace('/', Path.DirectorySeparatorChar))
+            ?.Replace(Path.DirectorySeparatorChar, '/')
+            ?.TrimEnd('/')
+            ?? ".";
+        return $"{directory}/{executionUnit.Trim()}.last-message.json";
     }
 
     private static ResolvedProcessInvocation ResolveProcessInvocation(

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -316,6 +316,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             + " and an optional string field 'comment_body'."
             + " Use 'accepted' or 'approved' only when no review comment is required."
             + " Use 'comment', 'commented', 'fix-requested', or 'changes-requested' only when a deterministic review comment is required."
+            + " Do not return wrapper fields such as 'stop_reason', 'actions', or execution envelopes instead of 'disposition'."
+            + " If you detect a deterministic contract gap or need follow-up work, still return 'disposition':'fix-requested' with an actionable 'comment_body'."
             + " Do not wrap the JSON in markdown fences.";
     }
 

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -370,7 +370,9 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             command,
             arguments);
 
-        if (detachHelperFromLauncherSession && !OperatingSystem.IsWindows())
+        if (detachHelperFromLauncherSession
+            && !OperatingSystem.IsWindows()
+            && !string.Equals(entryKind, "review", StringComparison.Ordinal))
         {
             var detachedLauncherStartInfo = CreateDetachedHelperLauncherStartInfo(helperStartInfo);
             return new ResolvedProcessInvocation

--- a/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
@@ -254,7 +254,10 @@ internal static class DirectRunReviewOutcomeSupport
                 && !TryReadString(source, "status", out disposition)
                 && !TryReadString(source, "run_status", out disposition))
             {
-                return false;
+                if (!TryResolveFallbackReviewDisposition(source, out disposition))
+                {
+                    return false;
+                }
             }
 
             reviewOutcome = NormalizeRunStatus(disposition);
@@ -276,14 +279,39 @@ internal static class DirectRunReviewOutcomeSupport
             }
             else if (TryReadString(source, "comment_body", out var commentBody)
                      || TryReadString(source, "body", out commentBody)
-                     || TryReadString(source, "markdown", out commentBody))
+                     || TryReadString(source, "markdown", out commentBody)
+                     || TryReadString(source, "detail", out commentBody)
+                     || TryReadString(source, "message", out commentBody)
+                     || TryReadString(source, "summary", out commentBody))
             {
                 normalizedPayload["comment_body"] = commentBody;
+            }
+            else if (IsCommentOutcome(reviewOutcome))
+            {
+                normalizedPayload["comment_body"] = "Deterministic review follow-up is required.";
             }
 
             payload = JsonSerializer.SerializeToElement(normalizedPayload);
             return true;
         }
+    }
+
+    private static bool TryResolveFallbackReviewDisposition(JsonElement source, out string disposition)
+    {
+        disposition = string.Empty;
+
+        if (!TryReadString(source, "stop_reason", out var stopReason))
+        {
+            return false;
+        }
+
+        if (string.Equals(stopReason, "deterministic-contract-gap", StringComparison.Ordinal))
+        {
+            disposition = "fix-requested";
+            return true;
+        }
+
+        return false;
     }
 
     private static string StripMarkdownCodeFence(string capturedMessage)

--- a/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
@@ -141,6 +141,46 @@ internal static class DirectRunReviewOutcomeSupport
         };
     }
 
+    public static DirectRunProviderEvent? TryCreateReviewOutcomeEventFromCapturedMessage(
+        IReadOnlyList<DirectRunProviderEvent> currentProviderEvents,
+        string capturedMessagePath,
+        DateTimeOffset timestamp,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId)
+    {
+        ArgumentNullException.ThrowIfNull(currentProviderEvents);
+        ArgumentException.ThrowIfNullOrWhiteSpace(capturedMessagePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+
+        if (TryResolveExplicitReviewOutcome(currentProviderEvents, out _)
+            || !File.Exists(capturedMessagePath)
+            || !TryParseCapturedReviewOutcomePayload(
+                File.ReadAllText(capturedMessagePath),
+                out var payload,
+                out var reviewOutcome,
+                out var reviewCommentBodyPath)
+            || HasCanonicalReviewOutcomeEvent(currentProviderEvents, reviewOutcome, reviewCommentBodyPath))
+        {
+            return null;
+        }
+
+        return new DirectRunProviderEvent
+        {
+            Timestamp = timestamp.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = provider,
+            EntryKind = entryKind,
+            SessionId = providerSessionId,
+            Kind = "provider-event",
+            Payload = payload
+        };
+    }
+
     private static bool HasCanonicalReviewOutcomeEvent(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string reviewOutcome,
@@ -168,6 +208,106 @@ internal static class DirectRunReviewOutcomeSupport
         }
 
         return false;
+    }
+
+    private static bool TryParseCapturedReviewOutcomePayload(
+        string capturedMessage,
+        out JsonElement payload,
+        out string reviewOutcome,
+        out string? reviewCommentBodyPath)
+    {
+        payload = default;
+        reviewOutcome = string.Empty;
+        reviewCommentBodyPath = null;
+
+        if (string.IsNullOrWhiteSpace(capturedMessage))
+        {
+            return false;
+        }
+
+        var normalizedMessage = StripMarkdownCodeFence(capturedMessage);
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(normalizedMessage);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        using (document)
+        {
+            var source = document.RootElement;
+            if (source.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            if (source.TryGetProperty("review_result", out var reviewResult)
+                && reviewResult.ValueKind == JsonValueKind.Object)
+            {
+                source = reviewResult;
+            }
+
+            if (!TryReadString(source, "disposition", out var disposition)
+                && !TryReadString(source, "status", out disposition)
+                && !TryReadString(source, "run_status", out disposition))
+            {
+                return false;
+            }
+
+            reviewOutcome = NormalizeRunStatus(disposition);
+            if (!IsAcceptOutcome(reviewOutcome) && !IsCommentOutcome(reviewOutcome))
+            {
+                return false;
+            }
+
+            var normalizedPayload = new Dictionary<string, object?>
+            {
+                ["disposition"] = reviewOutcome
+            };
+
+            if (TryReadString(source, "body_path", out var bodyPath)
+                || TryReadString(source, "review_comment_body_path", out bodyPath))
+            {
+                normalizedPayload["body_path"] = bodyPath;
+                reviewCommentBodyPath = bodyPath;
+            }
+            else if (TryReadString(source, "comment_body", out var commentBody)
+                     || TryReadString(source, "body", out commentBody)
+                     || TryReadString(source, "markdown", out commentBody))
+            {
+                normalizedPayload["comment_body"] = commentBody;
+            }
+
+            payload = JsonSerializer.SerializeToElement(normalizedPayload);
+            return true;
+        }
+    }
+
+    private static string StripMarkdownCodeFence(string capturedMessage)
+    {
+        var normalized = capturedMessage.Trim();
+        if (!normalized.StartsWith("```", StringComparison.Ordinal))
+        {
+            return normalized;
+        }
+
+        var firstLineBreak = normalized.IndexOf('\n');
+        if (firstLineBreak < 0)
+        {
+            return normalized;
+        }
+
+        normalized = normalized[(firstLineBreak + 1)..];
+        var closingFence = normalized.LastIndexOf("```", StringComparison.Ordinal);
+        if (closingFence >= 0)
+        {
+            normalized = normalized[..closingFence];
+        }
+
+        return normalized.Trim();
     }
 
     private static bool TryResolveCommentBody(JsonElement payload, out string bodyOrPath, out bool isPath)

--- a/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
@@ -54,10 +54,7 @@ internal static class DirectRunReviewOutcomeSupport
 
         for (var index = providerEvents.Count - 1; index >= 0; index--)
         {
-            if (TryResolveRunStatus(providerEvents[index].Payload, out var runStatus)
-                && !string.Equals(runStatus, "succeeded", StringComparison.Ordinal)
-                && !string.Equals(runStatus, "failed", StringComparison.Ordinal)
-                && !string.Equals(runStatus, "running", StringComparison.Ordinal))
+            if (TryResolveReviewOutcomeFromPayload(providerEvents[index].Payload, out var runStatus))
             {
                 explicitReviewOutcome = runStatus;
                 return true;
@@ -65,6 +62,17 @@ internal static class DirectRunReviewOutcomeSupport
         }
 
         return false;
+    }
+
+    public static string ResolveEffectiveReviewRunStatus(string runStatus, string? reviewOutcome)
+    {
+        if (!string.IsNullOrWhiteSpace(reviewOutcome)
+            && (IsAcceptOutcome(reviewOutcome) || IsCommentOutcome(reviewOutcome)))
+        {
+            return "succeeded";
+        }
+
+        return runStatus;
     }
 
     public static bool TryResolveReviewCommentBodyPath(
@@ -250,18 +258,7 @@ internal static class DirectRunReviewOutcomeSupport
                 source = reviewResult;
             }
 
-            if (!TryReadString(source, "disposition", out var disposition)
-                && !TryReadString(source, "status", out disposition)
-                && !TryReadString(source, "run_status", out disposition))
-            {
-                if (!TryResolveFallbackReviewDisposition(source, out disposition))
-                {
-                    return false;
-                }
-            }
-
-            reviewOutcome = NormalizeRunStatus(disposition);
-            if (!IsAcceptOutcome(reviewOutcome) && !IsCommentOutcome(reviewOutcome))
+            if (!TryResolveReviewOutcomeFromPayload(source, out reviewOutcome))
             {
                 return false;
             }
@@ -311,7 +308,34 @@ internal static class DirectRunReviewOutcomeSupport
             return true;
         }
 
+        if (string.Equals(stopReason, "no-actionable-item", StringComparison.Ordinal))
+        {
+            disposition = "accepted";
+            return true;
+        }
+
         return false;
+    }
+
+    private static bool TryResolveReviewOutcomeFromPayload(JsonElement payload, out string reviewOutcome)
+    {
+        reviewOutcome = string.Empty;
+
+        if (payload.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (!TryReadString(payload, "disposition", out var disposition)
+            && !TryReadString(payload, "status", out disposition)
+            && !TryReadString(payload, "run_status", out disposition)
+            && !TryResolveFallbackReviewDisposition(payload, out disposition))
+        {
+            return false;
+        }
+
+        reviewOutcome = NormalizeRunStatus(disposition);
+        return IsAcceptOutcome(reviewOutcome) || IsCommentOutcome(reviewOutcome);
     }
 
     private static string StripMarkdownCodeFence(string capturedMessage)
@@ -357,7 +381,10 @@ internal static class DirectRunReviewOutcomeSupport
 
         if (TryReadString(payload, "comment_body", out var commentBody)
             || TryReadString(payload, "body", out commentBody)
-            || TryReadString(payload, "markdown", out commentBody))
+            || TryReadString(payload, "markdown", out commentBody)
+            || TryReadString(payload, "detail", out commentBody)
+            || TryReadString(payload, "message", out commentBody)
+            || TryReadString(payload, "summary", out commentBody))
         {
             bodyOrPath = commentBody;
             return true;

--- a/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
@@ -166,9 +166,8 @@ internal static class DirectRunReviewOutcomeSupport
         ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
 
         if (TryResolveExplicitReviewOutcome(currentProviderEvents, out _)
-            || !File.Exists(capturedMessagePath)
-            || !TryParseCapturedReviewOutcomePayload(
-                File.ReadAllText(capturedMessagePath),
+            || !TryReadReviewOutcomeFromCapturedMessagePath(
+                capturedMessagePath,
                 out var payload,
                 out var reviewOutcome,
                 out var reviewCommentBodyPath)
@@ -187,6 +186,29 @@ internal static class DirectRunReviewOutcomeSupport
             Kind = "provider-event",
             Payload = payload
         };
+    }
+
+    public static bool TryReadReviewOutcomeFromCapturedMessagePath(
+        string capturedMessagePath,
+        out JsonElement payload,
+        out string reviewOutcome,
+        out string? reviewCommentBodyPath)
+    {
+        payload = default;
+        reviewOutcome = string.Empty;
+        reviewCommentBodyPath = null;
+
+        if (!File.Exists(capturedMessagePath)
+            || !TryParseCapturedReviewOutcomePayload(
+                File.ReadAllText(capturedMessagePath),
+                out payload,
+                out reviewOutcome,
+                out reviewCommentBodyPath))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     private static bool HasCanonicalReviewOutcomeEvent(
@@ -246,16 +268,9 @@ internal static class DirectRunReviewOutcomeSupport
 
         using (document)
         {
-            var source = document.RootElement;
-            if (source.ValueKind != JsonValueKind.Object)
+            if (!TryResolveReviewPayloadSource(document.RootElement, out var source))
             {
                 return false;
-            }
-
-            if (source.TryGetProperty("review_result", out var reviewResult)
-                && reviewResult.ValueKind == JsonValueKind.Object)
-            {
-                source = reviewResult;
             }
 
             if (!TryResolveReviewOutcomeFromPayload(source, out reviewOutcome))
@@ -317,19 +332,69 @@ internal static class DirectRunReviewOutcomeSupport
         return false;
     }
 
-    private static bool TryResolveReviewOutcomeFromPayload(JsonElement payload, out string reviewOutcome)
+    private static bool TryResolveReviewPayloadSource(JsonElement payload, out JsonElement source)
     {
-        reviewOutcome = string.Empty;
+        source = default;
 
         if (payload.ValueKind != JsonValueKind.Object)
         {
             return false;
         }
 
-        if (!TryReadString(payload, "disposition", out var disposition)
-            && !TryReadString(payload, "status", out disposition)
-            && !TryReadString(payload, "run_status", out disposition)
-            && !TryResolveFallbackReviewDisposition(payload, out disposition))
+        source = payload;
+        if (payload.TryGetProperty("review_result", out var reviewResult)
+            && reviewResult.ValueKind == JsonValueKind.Object)
+        {
+            source = reviewResult;
+            return true;
+        }
+
+        if (payload.TryGetProperty("type", out var typeElement)
+            && typeElement.ValueKind == JsonValueKind.String
+            && string.Equals(typeElement.GetString(), "item.completed", StringComparison.Ordinal)
+            && payload.TryGetProperty("item", out var itemElement)
+            && itemElement.ValueKind == JsonValueKind.Object
+            && TryReadString(itemElement, "text", out var itemText))
+        {
+            try
+            {
+                using var itemDocument = JsonDocument.Parse(StripMarkdownCodeFence(itemText));
+                if (itemDocument.RootElement.ValueKind != JsonValueKind.Object)
+                {
+                    return false;
+                }
+
+                source = itemDocument.RootElement.Clone();
+                if (source.TryGetProperty("review_result", out var nestedReviewResult)
+                    && nestedReviewResult.ValueKind == JsonValueKind.Object)
+                {
+                    source = nestedReviewResult;
+                }
+
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryResolveReviewOutcomeFromPayload(JsonElement payload, out string reviewOutcome)
+    {
+        reviewOutcome = string.Empty;
+
+        if (!TryResolveReviewPayloadSource(payload, out var source))
+        {
+            return false;
+        }
+
+        if (!TryReadString(source, "disposition", out var disposition)
+            && !TryReadString(source, "status", out disposition)
+            && !TryReadString(source, "run_status", out disposition)
+            && !TryResolveFallbackReviewDisposition(source, out disposition))
         {
             return false;
         }
@@ -367,24 +432,24 @@ internal static class DirectRunReviewOutcomeSupport
         bodyOrPath = string.Empty;
         isPath = false;
 
-        if (payload.ValueKind != JsonValueKind.Object)
+        if (!TryResolveReviewPayloadSource(payload, out var source))
         {
             return false;
         }
 
-        if (TryReadString(payload, "body_path", out var bodyPath))
+        if (TryReadString(source, "body_path", out var bodyPath))
         {
             bodyOrPath = bodyPath;
             isPath = true;
             return true;
         }
 
-        if (TryReadString(payload, "comment_body", out var commentBody)
-            || TryReadString(payload, "body", out commentBody)
-            || TryReadString(payload, "markdown", out commentBody)
-            || TryReadString(payload, "detail", out commentBody)
-            || TryReadString(payload, "message", out commentBody)
-            || TryReadString(payload, "summary", out commentBody))
+        if (TryReadString(source, "comment_body", out var commentBody)
+            || TryReadString(source, "body", out commentBody)
+            || TryReadString(source, "markdown", out commentBody)
+            || TryReadString(source, "detail", out commentBody)
+            || TryReadString(source, "message", out commentBody)
+            || TryReadString(source, "summary", out commentBody))
         {
             bodyOrPath = commentBody;
             return true;
@@ -397,31 +462,31 @@ internal static class DirectRunReviewOutcomeSupport
     {
         runStatus = string.Empty;
 
-        if (payload.ValueKind != JsonValueKind.Object)
+        if (!TryResolveReviewPayloadSource(payload, out var source))
         {
             return false;
         }
 
-        if (TryReadString(payload, "run_status", out var payloadRunStatus))
+        if (TryReadString(source, "run_status", out var payloadRunStatus))
         {
             runStatus = NormalizeRunStatus(payloadRunStatus);
             return true;
         }
 
-        if (TryReadString(payload, "status", out var status))
+        if (TryReadString(source, "status", out var status))
         {
             runStatus = NormalizeRunStatus(status);
             return true;
         }
 
-        if (TryReadString(payload, "disposition", out var disposition))
+        if (TryReadString(source, "disposition", out var disposition))
         {
             runStatus = NormalizeRunStatus(disposition);
             return true;
         }
 
-        if (TryReadInt32(payload, "exit_code", out var exitCode)
-            || TryReadInt32(payload, "exitCode", out exitCode))
+        if (TryReadInt32(source, "exit_code", out var exitCode)
+            || TryReadInt32(source, "exitCode", out exitCode))
         {
             runStatus = exitCode == 0 ? "succeeded" : "failed";
             return true;

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -560,7 +560,16 @@ internal static class RunCommand
             providerEvents,
             Path.GetFullPath(Path.Combine(
                 context.RepoRoot,
-                DirectRunCommandSupport.ResolveCapturedMessagePath(context, executionUnit).Replace('/', Path.DirectorySeparatorChar))),
+                DirectRunCommandSupport.ResolveCapturedMessagePath(
+                    context,
+                    executionUnit,
+                    DirectRunSessionBoundary.TryParseLaunchedAt(requestArtifact.LaunchedAt, out var capturedLaunchedAt)
+                        ? capturedLaunchedAt
+                        : DateTimeOffset.Parse(
+                            requestArtifact.LaunchedAt,
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            System.Globalization.DateTimeStyles.RoundtripKind))
+                .Replace('/', Path.DirectorySeparatorChar))),
             DateTimeOffset.UtcNow,
             executionUnit,
             requestArtifact.EntryKind,

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -556,6 +556,26 @@ internal static class RunCommand
             PersistDirectRunResultArtifact(context, executionUnit, resultArtifact);
         }
 
+        var capturedOutcomeEvent = DirectRunReviewOutcomeSupport.TryCreateReviewOutcomeEventFromCapturedMessage(
+            providerEvents,
+            Path.GetFullPath(Path.Combine(
+                context.RepoRoot,
+                DirectRunCommandSupport.ResolveCapturedMessagePath(context, executionUnit).Replace('/', Path.DirectorySeparatorChar))),
+            DateTimeOffset.UtcNow,
+            executionUnit,
+            requestArtifact.EntryKind,
+            requestArtifact.Provider,
+            requestArtifact.ProviderSessionId);
+        if (capturedOutcomeEvent is not null)
+        {
+            var providerLogPath = Path.GetFullPath(Path.Combine(
+                context.RepoRoot,
+                resultArtifact.RawLogRef.Replace('/', Path.DirectorySeparatorChar)));
+            var writer = new DirectRunProviderEventWriter(providerLogPath);
+            writer.Append(capturedOutcomeEvent);
+            providerEvents = [.. providerEvents, capturedOutcomeEvent];
+        }
+
         if (string.Equals(runStatus, "failed", StringComparison.Ordinal))
         {
             return new RunReviewDecision

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -585,15 +585,6 @@ internal static class RunCommand
             providerEvents = [.. providerEvents, capturedOutcomeEvent];
         }
 
-        if (string.Equals(runStatus, "failed", StringComparison.Ordinal))
-        {
-            return new RunReviewDecision
-            {
-                Kind = RunReviewDecisionKind.Failure,
-                Detail = $"Review direct run failed for '{executionUnit}'."
-            };
-        }
-
         string? reviewOutcome = null;
         string? reviewCommentBodyPath = null;
         if (DirectRunReviewOutcomeSupport.TryResolveCanonicalReviewOutcome(
@@ -648,6 +639,30 @@ internal static class RunCommand
                 writer.Append(outcomeEvent);
                 providerEvents = [.. providerEvents, outcomeEvent];
             }
+        }
+
+        var effectiveRunStatus = DirectRunReviewOutcomeSupport.ResolveEffectiveReviewRunStatus(runStatus, reviewOutcome);
+        if (!string.Equals(effectiveRunStatus, runStatus, StringComparison.Ordinal))
+        {
+            runStatus = effectiveRunStatus;
+        }
+
+        if (!string.Equals(runStatus, resultArtifact.RunStatus, StringComparison.Ordinal))
+        {
+            resultArtifact = resultArtifact with
+            {
+                RunStatus = runStatus
+            };
+            PersistDirectRunResultArtifact(context, executionUnit, resultArtifact);
+        }
+
+        if (string.Equals(runStatus, "failed", StringComparison.Ordinal))
+        {
+            return new RunReviewDecision
+            {
+                Kind = RunReviewDecisionKind.Failure,
+                Detail = $"Review direct run failed for '{executionUnit}'."
+            };
         }
 
         if (string.Equals(runStatus, "accepted", StringComparison.Ordinal)

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -100,6 +100,56 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public void Launch_GivenReviewOutputSchemaPlaceholder_ExpandsSchemaPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var runner = new FakeDirectRunProcessRunner
+        {
+            Result = new DirectRunProcessLaunchResult
+            {
+                ProcessId = 4321,
+                ExitedEarly = false,
+                ExitCode = 0
+            }
+        };
+        var launcher = new DirectRunLauncher(runner);
+        var launchedAt = DateTimeOffset.Parse("2026-04-09T10:15:00Z");
+        var suffix = DirectRunCommandSupport.CreateCapturedMessageSuffix(launchedAt);
+
+        var result = launcher.Launch(
+            "G19",
+            "review",
+            ".intent-cli/runs/G19.request.json",
+            ".intent-cli/runs/G19.provider.jsonl",
+            "Codex",
+            "gpt-5.4-mini",
+            "responses",
+            "codex",
+            [
+                "exec",
+                "--json",
+                "--model",
+                "{model}",
+                "--output-schema",
+                "{output_schema_path}",
+                "--output-last-message",
+                "{output_last_message_path}",
+                "{prompt}"
+            ],
+            launchedAt,
+            "/repo/.intent-cli/worktrees/G19",
+            "/repo/.intent-cli/reviews/G19.request.json",
+            tempDirectory.GetPath(".intent-cli/runs/G19.provider.jsonl"));
+
+        Assert.Equal("pid:4321", result.ProviderSessionId);
+        Assert.Contains(DirectRunDetachedCaptureCommand.CommandName, runner.Arguments);
+        Assert.Contains("--output-schema", runner.Arguments);
+        Assert.Contains($".intent-cli/runs/G19.{suffix}.review-output-schema.json", runner.Arguments);
+        Assert.Contains("--output-last-message", runner.Arguments);
+        Assert.Contains($".intent-cli/runs/G19.{suffix}.last-message.json", runner.Arguments);
+    }
+
+    [Fact]
     public void Launch_GivenProcessExit_AppendsBackendExitProviderEvent()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -1448,7 +1448,7 @@ public sealed class ReviewRunCommandTests
                 workingDirectory,
                 ".intent-cli",
                 "runtime-runs",
-                $"{executionUnit}.last-message.json");
+                $"{executionUnit}.{DirectRunCommandSupport.CreateCapturedMessageSuffix(launchedAt)}.last-message.json");
             Directory.CreateDirectory(
                 Path.GetDirectoryName(capturedMessagePath)
                 ?? throw new InvalidOperationException("Captured last message path did not contain a directory."));

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -969,6 +969,87 @@ public sealed class ReviewRunCommandTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenCapturedDeterministicContractGapLastMessage_PersistsCommentOutcome()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = ReviewRunCommand.TimestampFactory;
+        var originalLauncherFactory = ReviewRunCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            ReviewRunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:35:00Z");
+            ReviewRunCommand.DirectRunLauncherFactory = () => new CapturedLastMessageFakeDirectRunLauncher(
+                "pid:9999",
+                "Codex",
+                CliRuntimeContracts.DefaultCodexDirectRunModel,
+                "stdio",
+                "/opt/homebrew/bin/codex",
+                ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
+                """{"stop_reason":"deterministic-contract-gap","detail":"Please cover the deterministic submit path."}""");
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Claude",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        ArtifactRoot = ".intent-cli/runtime-runs",
+                        Review = new DirectRunEntryConfig
+                        {
+                            Command = "/opt/homebrew/bin/codex"
+                        }
+                    }
+                }
+            };
+
+            var exitCode = ReviewRunCommand.Execute(context, ["G9"], writer);
+
+            Assert.Equal(0, exitCode);
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
+            Assert.Equal("succeeded", resultArtifact.RunStatus);
+            Assert.Equal("fix-requested", resultArtifact.ReviewOutcome);
+            Assert.Equal(".intent-cli/reviews/G9.comment.md", resultArtifact.ReviewCommentBodyPath);
+            Assert.Equal(
+                "Please cover the deterministic submit path.",
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "reviews", "G9.comment.md")));
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && string.Equals(providerEvent.SessionId, "pid:9999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
+                && string.Equals(dispositionElement.GetString(), "fix-requested", StringComparison.Ordinal));
+        }
+        finally
+        {
+            ReviewRunCommand.TimestampFactory = originalTimestampFactory;
+            ReviewRunCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -666,6 +666,87 @@ public sealed class ReviewRunCommandTests
     }
 
     [Fact]
+    public void Execute_GivenRealCodexStyleReviewTimeout_ClassifiesMissingBoundaryAsFailed()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var codexPath = tempDirectory.CreateExecutableFile(
+            Path.Combine("bin", "codex-experimental"),
+            """
+            #!/bin/sh
+            printf '%s\n' '{"type":"ready"}'
+            sleep 2
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "config.toml"),
+            $$"""
+            default_domain = "intent-system"
+            artifact_root = ".intent-cli"
+            worktree_root = ".intent-cli/worktrees"
+
+            [direct_backend]
+            artifact_root = ".intent-cli/runtime-runs"
+
+            [direct_backend.review]
+            provider = "Codex"
+            model = "gpt-5.4-mini"
+            transport = "responses"
+            command = "{{codexPath.Replace("\\", "\\\\", StringComparison.Ordinal)}}"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "packet.yaml"),
+            "execution_unit: G9" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+
+        var originalWaitWindow = Environment.GetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS");
+        try
+        {
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS", "100");
+
+            var process = StartCliProcess(repoRoot, "review run G9");
+            Assert.True(process.WaitForExit(120000), "CLI process did not exit within the timeout.");
+            Assert.Equal(0, process.ExitCode);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
+            Assert.Equal("failed", resultArtifact.RunStatus);
+            Assert.Null(resultArtifact.ReviewOutcome);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "contract-gap", StringComparison.Ordinal));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                && providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
+                && exitCodeElement.GetInt32() == 1);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS", originalWaitWindow);
+        }
+    }
+
+    [Fact]
     public void Execute_GivenCodexReviewCommandWithoutModelOverride_UsesRunnableCodexDefaultModel()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -79,6 +79,14 @@ public sealed class ReviewRunCommandTests
             Assert.Equal("grpc", directRunArtifact.Transport);
             Assert.Equal("pid:9999", directRunArtifact.ProviderSessionId);
 
+            var reviewOutputSchemaPath = Path.Combine(
+                repoRoot,
+                ".intent-cli",
+                "runtime-runs",
+                $"G9.{DirectRunCommandSupport.CreateCapturedMessageSuffix(DateTimeOffset.Parse("2026-04-09T10:35:00Z"))}.review-output-schema.json");
+            Assert.True(File.Exists(reviewOutputSchemaPath));
+            Assert.Contains("\"disposition\"", File.ReadAllText(reviewOutputSchemaPath), StringComparison.Ordinal);
+
             var resultArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json");
             Assert.True(File.Exists(resultArtifactPath));
             var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
@@ -656,11 +664,6 @@ public sealed class ReviewRunCommandTests
         Assert.Contains(providerEvents, providerEvent =>
             providerEvent.Kind == "provider-event"
             && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
-            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
-            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
-        Assert.Contains(providerEvents, providerEvent =>
-            providerEvent.Kind == "provider-event"
-            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
             && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
             && string.Equals(dispositionElement.GetString(), "accepted", StringComparison.Ordinal));
     }
@@ -851,7 +854,7 @@ public sealed class ReviewRunCommandTests
                 CliRuntimeContracts.DefaultCodexDirectRunModel,
                 "stdio",
                 "/opt/homebrew/bin/codex",
-                ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                ["exec", "--json", "--model", "{model}", "--output-schema", "{output_schema_path}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.");
 
             var context = CreateContext(repoRoot) with
@@ -920,7 +923,7 @@ public sealed class ReviewRunCommandTests
                 CliRuntimeContracts.DefaultCodexDirectRunModel,
                 "stdio",
                 "/opt/homebrew/bin/codex",
-                ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                ["exec", "--json", "--model", "{model}", "--output-schema", "{output_schema_path}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
                 """{"disposition":"accepted"}""");
 
@@ -999,7 +1002,7 @@ public sealed class ReviewRunCommandTests
                 CliRuntimeContracts.DefaultCodexDirectRunModel,
                 "stdio",
                 "/opt/homebrew/bin/codex",
-                ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                ["exec", "--json", "--model", "{model}", "--output-schema", "{output_schema_path}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
                 """{"disposition":"fix-requested","comment_body":"Please cover the deterministic submit path."}""");
 
@@ -1071,7 +1074,7 @@ public sealed class ReviewRunCommandTests
                 CliRuntimeContracts.DefaultCodexDirectRunModel,
                 "stdio",
                 "/opt/homebrew/bin/codex",
-                ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                ["exec", "--json", "--model", "{model}", "--output-schema", "{output_schema_path}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
                 """{"stop_reason":"deterministic-contract-gap","detail":"Please cover the deterministic submit path."}""");
 
@@ -1152,7 +1155,7 @@ public sealed class ReviewRunCommandTests
                 CliRuntimeContracts.DefaultCodexDirectRunModel,
                 "stdio",
                 "/opt/homebrew/bin/codex",
-                ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                ["exec", "--json", "--model", "{model}", "--output-schema", "{output_schema_path}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
                 """{"stop_reason":"deterministic-contract-gap","detail":"Please cover the deterministic submit path."}""",
                 137);
@@ -1234,7 +1237,7 @@ public sealed class ReviewRunCommandTests
                 CliRuntimeContracts.DefaultCodexDirectRunModel,
                 "stdio",
                 "/opt/homebrew/bin/codex",
-                ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                ["exec", "--json", "--model", "{model}", "--output-schema", "{output_schema_path}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
                 """{"stop_reason":"no-actionable-item"}""",
                 137);

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -1050,6 +1050,167 @@ public sealed class ReviewRunCommandTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenRawDeterministicContractGapProviderEvent_PersistsCommentOutcomeDespiteFailedBackendExit()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = ReviewRunCommand.TimestampFactory;
+        var originalLauncherFactory = ReviewRunCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            ReviewRunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:35:00Z");
+            ReviewRunCommand.DirectRunLauncherFactory = () => new RawReviewOutcomeFakeDirectRunLauncher(
+                "pid:9999",
+                "Codex",
+                CliRuntimeContracts.DefaultCodexDirectRunModel,
+                "stdio",
+                "/opt/homebrew/bin/codex",
+                ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
+                """{"stop_reason":"deterministic-contract-gap","detail":"Please cover the deterministic submit path."}""",
+                137);
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Claude",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        ArtifactRoot = ".intent-cli/runtime-runs",
+                        Review = new DirectRunEntryConfig
+                        {
+                            Command = "/opt/homebrew/bin/codex"
+                        }
+                    }
+                }
+            };
+
+            var exitCode = ReviewRunCommand.Execute(context, ["G9"], writer);
+
+            Assert.Equal(0, exitCode);
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
+            Assert.Equal("succeeded", resultArtifact.RunStatus);
+            Assert.Equal("fix-requested", resultArtifact.ReviewOutcome);
+            Assert.Equal(".intent-cli/reviews/G9.comment.md", resultArtifact.ReviewCommentBodyPath);
+            Assert.Equal(
+                "Please cover the deterministic submit path.",
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "reviews", "G9.comment.md")));
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && string.Equals(providerEvent.SessionId, "pid:9999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
+                && string.Equals(dispositionElement.GetString(), "fix-requested", StringComparison.Ordinal));
+        }
+        finally
+        {
+            ReviewRunCommand.TimestampFactory = originalTimestampFactory;
+            ReviewRunCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenRawNoActionableItemProviderEvent_PersistsAcceptedOutcomeDespiteFailedBackendExit()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = ReviewRunCommand.TimestampFactory;
+        var originalLauncherFactory = ReviewRunCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            ReviewRunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:35:00Z");
+            ReviewRunCommand.DirectRunLauncherFactory = () => new RawReviewOutcomeFakeDirectRunLauncher(
+                "pid:9999",
+                "Codex",
+                CliRuntimeContracts.DefaultCodexDirectRunModel,
+                "stdio",
+                "/opt/homebrew/bin/codex",
+                ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
+                """{"stop_reason":"no-actionable-item"}""",
+                137);
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Claude",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        ArtifactRoot = ".intent-cli/runtime-runs",
+                        Review = new DirectRunEntryConfig
+                        {
+                            Command = "/opt/homebrew/bin/codex"
+                        }
+                    }
+                }
+            };
+
+            var exitCode = ReviewRunCommand.Execute(context, ["G9"], writer);
+
+            Assert.Equal(0, exitCode);
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
+            Assert.Equal("succeeded", resultArtifact.RunStatus);
+            Assert.Equal("accepted", resultArtifact.ReviewOutcome);
+            Assert.Null(resultArtifact.ReviewCommentBodyPath);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && string.Equals(providerEvent.SessionId, "pid:9999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
+                && string.Equals(dispositionElement.GetString(), "accepted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            ReviewRunCommand.TimestampFactory = originalTimestampFactory;
+            ReviewRunCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext
@@ -1697,6 +1858,104 @@ public sealed class ReviewRunCommandTests
                 Path.GetDirectoryName(capturedMessagePath)
                 ?? throw new InvalidOperationException("Captured last message path did not contain a directory."));
             File.WriteAllText(capturedMessagePath, capturedLastMessage);
+
+            return new DirectRunLaunchResult
+            {
+                RequestArtifactPath = ".intent-cli/runtime-runs/G9.request.json",
+                ProviderEventLogPath = ".intent-cli/runtime-runs/G9.provider.jsonl",
+                Provider = providerArg,
+                Model = modelArg,
+                Transport = transportArg,
+                ProviderSessionId = providerSessionId,
+                TransportSummary = transportSummary
+            };
+        }
+    }
+
+    private sealed class RawReviewOutcomeFakeDirectRunLauncher(
+        string providerSessionId,
+        string provider,
+        string model,
+        string transport,
+        string command,
+        IReadOnlyList<string> argsTemplate,
+        string transportSummary,
+        string providerPayload,
+        int exitCode) : IDirectRunLauncher
+    {
+        public DirectRunLaunchResult Launch(
+            string executionUnit,
+            string entryKind,
+            string requestArtifactPath,
+            string providerEventLogPath,
+            string providerArg,
+            string modelArg,
+            string transportArg,
+            string commandArg,
+            IReadOnlyList<string> argsTemplateArg,
+            DateTimeOffset launchedAt,
+            string workingDirectory,
+            string absoluteRequestArtifactPath,
+            string absoluteProviderEventLogPath)
+        {
+            Assert.Equal("G9", executionUnit);
+            Assert.Equal("review", entryKind);
+            Assert.Equal(".intent-cli/runtime-runs/G9.request.json", requestArtifactPath);
+            Assert.Equal(".intent-cli/runtime-runs/G9.provider.jsonl", providerEventLogPath);
+            Assert.Equal(provider, providerArg);
+            Assert.Equal(model, modelArg);
+            Assert.Equal(transport, transportArg);
+            Assert.Equal(command, commandArg);
+            Assert.Equal(argsTemplate, argsTemplateArg);
+
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(absoluteProviderEventLogPath)
+                ?? throw new InvalidOperationException("Provider event log path did not contain a directory."));
+            var providerEvents = string.Join(
+                                     Environment.NewLine,
+                                     new[]
+                                     {
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "session-metadata",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 model = modelArg,
+                                                 transport = transportArg,
+                                                 command
+                                             })
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(1).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "provider-event",
+                                             Payload = DirectRunProviderEventFactory.ParsePayload(providerPayload)
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(2).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 type = "backend-exit",
+                                                 exit_code = exitCode
+                                             })
+                                         })
+                                     }) + Environment.NewLine;
+            File.WriteAllText(absoluteProviderEventLogPath, providerEvents);
 
             return new DirectRunLaunchResult
             {

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -666,6 +666,81 @@ public sealed class ReviewRunCommandTests
     }
 
     [Fact]
+    public void Execute_GivenRealCodexJsonOutcomeBeforeBackendExit_PersistsAcceptedOutcome()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var codexPath = tempDirectory.CreateExecutableFile(
+            Path.Combine("bin", "codex-experimental"),
+            """
+            #!/bin/sh
+            printf '%s\n' '{"type":"thread.started","thread_id":"thread-1"}'
+            printf '%s\n' '{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"{\"disposition\":\"accepted\"}"}}'
+            sleep 2
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "config.toml"),
+            $$"""
+            default_domain = "intent-system"
+            artifact_root = ".intent-cli"
+            worktree_root = ".intent-cli/worktrees"
+
+            [direct_backend]
+            artifact_root = ".intent-cli/runtime-runs"
+
+            [direct_backend.review]
+            provider = "Codex"
+            model = "gpt-5.4-mini"
+            transport = "responses"
+            command = "{{codexPath.Replace("\\", "\\\\", StringComparison.Ordinal)}}"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "packet.yaml"),
+            "execution_unit: G9" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+
+        var originalWaitWindow = Environment.GetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS");
+        try
+        {
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS", "300");
+
+            var process = StartCliProcess(repoRoot, "review run G9");
+            Assert.True(process.WaitForExit(120000), "CLI process did not exit within the timeout.");
+            Assert.Equal(0, process.ExitCode);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
+            Assert.Equal("succeeded", resultArtifact.RunStatus);
+            Assert.Equal("accepted", resultArtifact.ReviewOutcome);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "item.completed", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS", originalWaitWindow);
+        }
+    }
+
+    [Fact]
     public void Execute_GivenRealCodexStyleReviewTimeout_ClassifiesMissingBoundaryAsFailed()
     {
         if (OperatingSystem.IsWindows())
@@ -776,7 +851,7 @@ public sealed class ReviewRunCommandTests
                 CliRuntimeContracts.DefaultCodexDirectRunModel,
                 "stdio",
                 "/opt/homebrew/bin/codex",
-                ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.");
 
             var context = CreateContext(repoRoot) with
@@ -845,7 +920,7 @@ public sealed class ReviewRunCommandTests
                 CliRuntimeContracts.DefaultCodexDirectRunModel,
                 "stdio",
                 "/opt/homebrew/bin/codex",
-                ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
                 """{"disposition":"accepted"}""");
 
@@ -924,7 +999,7 @@ public sealed class ReviewRunCommandTests
                 CliRuntimeContracts.DefaultCodexDirectRunModel,
                 "stdio",
                 "/opt/homebrew/bin/codex",
-                ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
                 """{"disposition":"fix-requested","comment_body":"Please cover the deterministic submit path."}""");
 
@@ -996,7 +1071,7 @@ public sealed class ReviewRunCommandTests
                 CliRuntimeContracts.DefaultCodexDirectRunModel,
                 "stdio",
                 "/opt/homebrew/bin/codex",
-                ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
                 """{"stop_reason":"deterministic-contract-gap","detail":"Please cover the deterministic submit path."}""");
 
@@ -1077,7 +1152,7 @@ public sealed class ReviewRunCommandTests
                 CliRuntimeContracts.DefaultCodexDirectRunModel,
                 "stdio",
                 "/opt/homebrew/bin/codex",
-                ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
                 """{"stop_reason":"deterministic-contract-gap","detail":"Please cover the deterministic submit path."}""",
                 137);
@@ -1159,7 +1234,7 @@ public sealed class ReviewRunCommandTests
                 CliRuntimeContracts.DefaultCodexDirectRunModel,
                 "stdio",
                 "/opt/homebrew/bin/codex",
-                ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                ["exec", "--json", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
                 """{"stop_reason":"no-actionable-item"}""",
                 137);

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -584,6 +584,88 @@ public sealed class ReviewRunCommandTests
     }
 
     [Fact]
+    public void Execute_GivenRealCodexStyleReviewCommand_WaitsForCurrentSessionOutcomeBeforeReturning()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var codexPath = tempDirectory.CreateExecutableFile(
+            Path.Combine("bin", "codex-experimental"),
+            """
+            #!/bin/sh
+            output_last_message=""
+            while [ $# -gt 0 ]; do
+              if [ "$1" = "--output-last-message" ]; then
+                output_last_message="$2"
+                shift 2
+                continue
+              fi
+              shift
+            done
+            printf '%s\n' '{"type":"ready"}'
+            sleep 2
+            if [ -n "$output_last_message" ]; then
+              mkdir -p "$(dirname "$output_last_message")"
+              printf '%s\n' '{"disposition":"accepted"}' > "$output_last_message"
+            fi
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "config.toml"),
+            $$"""
+            default_domain = "intent-system"
+            artifact_root = ".intent-cli"
+            worktree_root = ".intent-cli/worktrees"
+
+            [direct_backend]
+            artifact_root = ".intent-cli/runtime-runs"
+
+            [direct_backend.review]
+            provider = "Codex"
+            model = "gpt-5.4-mini"
+            transport = "responses"
+            command = "{{codexPath.Replace("\\", "\\\\", StringComparison.Ordinal)}}"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "packet.yaml"),
+            "execution_unit: G9" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+
+        var process = StartCliProcess(repoRoot, "review run G9");
+        Assert.True(process.WaitForExit(120000), "CLI process did not exit within the timeout.");
+        Assert.Equal(0, process.ExitCode);
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
+        Assert.Equal("succeeded", resultArtifact.RunStatus);
+        Assert.Equal("accepted", resultArtifact.ReviewOutcome);
+
+        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl")));
+        Assert.Contains(providerEvents, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+        Assert.Contains(providerEvents, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
+            && string.Equals(dispositionElement.GetString(), "accepted", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Execute_GivenCodexReviewCommandWithoutModelOverride_UsesRunnableCodexDefaultModel()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -487,9 +487,22 @@ public sealed class ReviewRunCommandTests
             Path.Combine("repo", ".intent-cli", "runs.jsonl"),
             CreateRunLog());
 
-        var process = StartCliProcess(repoRoot, "review run G9");
-        Assert.True(process.WaitForExit(120000), "CLI process did not exit within the timeout.");
-        Assert.Equal(0, process.ExitCode);
+        var originalWaitWindow = Environment.GetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS");
+        var originalSessionMaxWaitWindow = Environment.GetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_SESSION_MAX_WAIT_MS");
+        try
+        {
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS", "100");
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_SESSION_MAX_WAIT_MS", "5000");
+
+            var process = StartCliProcess(repoRoot, "review run G9");
+            Assert.True(process.WaitForExit(120000), "CLI process did not exit within the timeout.");
+            Assert.Equal(0, process.ExitCode);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS", originalWaitWindow);
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_SESSION_MAX_WAIT_MS", originalSessionMaxWaitWindow);
+        }
 
         var providerEventLogPath = Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl");
         TemporaryDirectory.WaitForCondition(
@@ -557,9 +570,22 @@ public sealed class ReviewRunCommandTests
             Path.Combine("repo", ".intent-cli", "runs.jsonl"),
             CreateRunLog());
 
-        var process = StartCliProcess(repoRoot, "review run G9");
-        Assert.True(process.WaitForExit(120000), "CLI process did not exit within the timeout.");
-        Assert.Equal(0, process.ExitCode);
+        var originalWaitWindow = Environment.GetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS");
+        var originalSessionMaxWaitWindow = Environment.GetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_SESSION_MAX_WAIT_MS");
+        try
+        {
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS", "100");
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_SESSION_MAX_WAIT_MS", "5000");
+
+            var process = StartCliProcess(repoRoot, "review run G9");
+            Assert.True(process.WaitForExit(120000), "CLI process did not exit within the timeout.");
+            Assert.Equal(0, process.ExitCode);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS", originalWaitWindow);
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_SESSION_MAX_WAIT_MS", originalSessionMaxWaitWindow);
+        }
 
         var requestArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.request.json");
         TemporaryDirectory.WaitForCondition(
@@ -606,7 +632,7 @@ public sealed class ReviewRunCommandTests
     }
 
     [Fact]
-    public void Execute_GivenRealCodexStyleReviewCommand_WaitsForCurrentSessionOutcomeBeforeReturning()
+    public void Execute_GivenRealCodexStyleReviewCommand_DoesNotForceTimeoutWhileCurrentSessionIsStillRunning()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -664,22 +690,40 @@ public sealed class ReviewRunCommandTests
             Path.Combine("repo", ".intent-cli", "runs.jsonl"),
             CreateRunLog());
 
-        var process = StartCliProcess(repoRoot, "review run G9");
-        Assert.True(process.WaitForExit(120000), "CLI process did not exit within the timeout.");
-        Assert.Equal(0, process.ExitCode);
+        var originalWaitWindow = Environment.GetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS");
+        var originalSessionMaxWaitWindow = Environment.GetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_SESSION_MAX_WAIT_MS");
+        try
+        {
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS", "100");
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_SESSION_MAX_WAIT_MS", "5000");
 
-        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
-            Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
-        Assert.Equal("succeeded", resultArtifact.RunStatus);
-        Assert.Equal("accepted", resultArtifact.ReviewOutcome);
+            var process = StartCliProcess(repoRoot, "review run G9");
+            Assert.True(process.WaitForExit(120000), "CLI process did not exit within the timeout.");
+            Assert.Equal(0, process.ExitCode);
 
-        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
-            Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl")));
-        Assert.Contains(providerEvents, providerEvent =>
-            providerEvent.Kind == "provider-event"
-            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
-            && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
-            && string.Equals(dispositionElement.GetString(), "accepted", StringComparison.Ordinal));
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
+            Assert.Equal("succeeded", resultArtifact.RunStatus);
+            Assert.Equal("accepted", resultArtifact.ReviewOutcome);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
+                && string.Equals(dispositionElement.GetString(), "accepted", StringComparison.Ordinal));
+            Assert.DoesNotContain(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "contract-gap", StringComparison.Ordinal));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS", originalWaitWindow);
+            Environment.SetEnvironmentVariable("INTENT_DIRECT_RUN_REVIEW_SESSION_MAX_WAIT_MS", originalSessionMaxWaitWindow);
+        }
     }
 
     [Fact]
@@ -758,7 +802,7 @@ public sealed class ReviewRunCommandTests
     }
 
     [Fact]
-    public void Execute_GivenRealCodexStyleReviewTimeout_ClassifiesMissingBoundaryAsFailed()
+    public void Execute_GivenRealCodexStyleReviewCompletesWithoutOutcome_ClassifiesMissingBoundaryAsFailed()
     {
         if (OperatingSystem.IsWindows())
         {

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -85,7 +85,21 @@ public sealed class ReviewRunCommandTests
                 "runtime-runs",
                 $"G9.{DirectRunCommandSupport.CreateCapturedMessageSuffix(DateTimeOffset.Parse("2026-04-09T10:35:00Z"))}.review-output-schema.json");
             Assert.True(File.Exists(reviewOutputSchemaPath));
-            Assert.Contains("\"disposition\"", File.ReadAllText(reviewOutputSchemaPath), StringComparison.Ordinal);
+            using var reviewOutputSchemaDocument = System.Text.Json.JsonDocument.Parse(File.ReadAllText(reviewOutputSchemaPath));
+            var reviewOutputSchema = reviewOutputSchemaDocument.RootElement;
+            Assert.Equal("object", reviewOutputSchema.GetProperty("type").GetString());
+            var required = reviewOutputSchema.GetProperty("required").EnumerateArray().Select(element => element.GetString()).ToArray();
+            Assert.Contains("disposition", required);
+            Assert.Contains("comment_body", required);
+            var commentBodyTypes = reviewOutputSchema
+                .GetProperty("properties")
+                .GetProperty("comment_body")
+                .GetProperty("type")
+                .EnumerateArray()
+                .Select(element => element.GetString())
+                .ToArray();
+            Assert.Contains("string", commentBodyTypes);
+            Assert.Contains("null", commentBodyTypes);
 
             var resultArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json");
             Assert.True(File.Exists(resultArtifactPath));
@@ -618,7 +632,7 @@ public sealed class ReviewRunCommandTests
             sleep 2
             if [ -n "$output_last_message" ]; then
               mkdir -p "$(dirname "$output_last_message")"
-              printf '%s\n' '{"disposition":"accepted"}' > "$output_last_message"
+              printf '%s\n' '{"disposition":"accepted","comment_body":null}' > "$output_last_message"
             fi
             """);
         tempDirectory.CreateFile(
@@ -925,7 +939,7 @@ public sealed class ReviewRunCommandTests
                 "/opt/homebrew/bin/codex",
                 ["exec", "--json", "--model", "{model}", "--output-schema", "{output_schema_path}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
-                """{"disposition":"accepted"}""");
+                """{"disposition":"accepted","comment_body":null}""");
 
             var context = CreateContext(repoRoot) with
             {

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -613,7 +613,7 @@ public sealed class ReviewRunCommandTests
                 CliRuntimeContracts.DefaultCodexDirectRunModel,
                 "stdio",
                 "/opt/homebrew/bin/codex",
-                ["exec", "--model", "{model}", "{prompt}"],
+                ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
                 "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.");
 
             var context = CreateContext(repoRoot) with
@@ -647,6 +647,157 @@ public sealed class ReviewRunCommandTests
                 Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.request.json")));
             Assert.Equal(CliRuntimeContracts.DefaultCodexDirectRunModel, directRunArtifact.Model);
             Assert.Equal("Codex", directRunArtifact.Provider);
+        }
+        finally
+        {
+            ReviewRunCommand.TimestampFactory = originalTimestampFactory;
+            ReviewRunCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenCapturedAcceptedLastMessage_PersistsReviewOutcome()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = ReviewRunCommand.TimestampFactory;
+        var originalLauncherFactory = ReviewRunCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            ReviewRunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:35:00Z");
+            ReviewRunCommand.DirectRunLauncherFactory = () => new CapturedLastMessageFakeDirectRunLauncher(
+                "pid:9999",
+                "Codex",
+                CliRuntimeContracts.DefaultCodexDirectRunModel,
+                "stdio",
+                "/opt/homebrew/bin/codex",
+                ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
+                """{"disposition":"accepted"}""");
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Claude",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        ArtifactRoot = ".intent-cli/runtime-runs",
+                        Review = new DirectRunEntryConfig
+                        {
+                            Command = "/opt/homebrew/bin/codex"
+                        }
+                    }
+                }
+            };
+
+            var exitCode = ReviewRunCommand.Execute(context, ["G9"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run status: succeeded", writer.ToString(), StringComparison.Ordinal);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
+            Assert.Equal("succeeded", resultArtifact.RunStatus);
+            Assert.Equal("accepted", resultArtifact.ReviewOutcome);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && string.Equals(providerEvent.SessionId, "pid:9999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("disposition", out var dispositionElement)
+                && string.Equals(dispositionElement.GetString(), "accepted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            ReviewRunCommand.TimestampFactory = originalTimestampFactory;
+            ReviewRunCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenCapturedCommentLastMessage_PersistsDeterministicCommentBodyRef()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G9", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = ReviewRunCommand.TimestampFactory;
+        var originalLauncherFactory = ReviewRunCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            ReviewRunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:35:00Z");
+            ReviewRunCommand.DirectRunLauncherFactory = () => new CapturedLastMessageFakeDirectRunLauncher(
+                "pid:9999",
+                "Codex",
+                CliRuntimeContracts.DefaultCodexDirectRunModel,
+                "stdio",
+                "/opt/homebrew/bin/codex",
+                ["exec", "--model", "{model}", "--output-last-message", "{output_last_message_path}", "{prompt}"],
+                "stdio transport launched via '/opt/homebrew/bin/codex' in '/repo' for provider 'Codex'.",
+                """{"disposition":"fix-requested","comment_body":"Please cover the deterministic submit path."}""");
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Claude",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        ArtifactRoot = ".intent-cli/runtime-runs",
+                        Review = new DirectRunEntryConfig
+                        {
+                            Command = "/opt/homebrew/bin/codex"
+                        }
+                    }
+                }
+            };
+
+            var exitCode = ReviewRunCommand.Execute(context, ["G9"], writer);
+
+            Assert.Equal(0, exitCode);
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runtime-runs", "G9.result.json")));
+            Assert.Equal("succeeded", resultArtifact.RunStatus);
+            Assert.Equal("fix-requested", resultArtifact.ReviewOutcome);
+            Assert.Equal(".intent-cli/reviews/G9.comment.md", resultArtifact.ReviewCommentBodyPath);
+            Assert.Equal(
+                "Please cover the deterministic submit path.",
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "reviews", "G9.comment.md")));
         }
         finally
         {
@@ -1205,6 +1356,103 @@ public sealed class ReviewRunCommandTests
                                          })
                                      }) + Environment.NewLine;
             File.WriteAllText(absoluteProviderEventLogPath, providerEvents);
+
+            return new DirectRunLaunchResult
+            {
+                RequestArtifactPath = ".intent-cli/runtime-runs/G9.request.json",
+                ProviderEventLogPath = ".intent-cli/runtime-runs/G9.provider.jsonl",
+                Provider = providerArg,
+                Model = modelArg,
+                Transport = transportArg,
+                ProviderSessionId = providerSessionId,
+                TransportSummary = transportSummary
+            };
+        }
+    }
+
+    private sealed class CapturedLastMessageFakeDirectRunLauncher(
+        string providerSessionId,
+        string provider,
+        string model,
+        string transport,
+        string command,
+        IReadOnlyList<string> argsTemplate,
+        string transportSummary,
+        string capturedLastMessage) : IDirectRunLauncher
+    {
+        public DirectRunLaunchResult Launch(
+            string executionUnit,
+            string entryKind,
+            string requestArtifactPath,
+            string providerEventLogPath,
+            string providerArg,
+            string modelArg,
+            string transportArg,
+            string commandArg,
+            IReadOnlyList<string> argsTemplateArg,
+            DateTimeOffset launchedAt,
+            string workingDirectory,
+            string absoluteRequestArtifactPath,
+            string absoluteProviderEventLogPath)
+        {
+            Assert.Equal("G9", executionUnit);
+            Assert.Equal("review", entryKind);
+            Assert.Equal(".intent-cli/runtime-runs/G9.request.json", requestArtifactPath);
+            Assert.Equal(".intent-cli/runtime-runs/G9.provider.jsonl", providerEventLogPath);
+            Assert.Equal(provider, providerArg);
+            Assert.Equal(model, modelArg);
+            Assert.Equal(transport, transportArg);
+            Assert.Equal(command, commandArg);
+            Assert.Equal(argsTemplate, argsTemplateArg);
+
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(absoluteProviderEventLogPath)
+                ?? throw new InvalidOperationException("Provider event log path did not contain a directory."));
+            var providerEvents = string.Join(
+                                     Environment.NewLine,
+                                     new[]
+                                     {
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "session-metadata",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 model = modelArg,
+                                                 transport = transportArg,
+                                                 command
+                                             })
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(1).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = providerSessionId,
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 type = "backend-exit",
+                                                 exit_code = 0
+                                             })
+                                         })
+                                     }) + Environment.NewLine;
+            File.WriteAllText(absoluteProviderEventLogPath, providerEvents);
+
+            var capturedMessagePath = Path.Combine(
+                workingDirectory,
+                ".intent-cli",
+                "runtime-runs",
+                $"{executionUnit}.last-message.json");
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(capturedMessagePath)
+                ?? throw new InvalidOperationException("Captured last message path did not contain a directory."));
+            File.WriteAllText(capturedMessagePath, capturedLastMessage);
 
             return new DirectRunLaunchResult
             {

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -796,6 +796,7 @@ public sealed class RunCommandTests
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
+        var launchedAt = DateTimeOffset.Parse("2026-04-10T12:00:00.0000000+00:00");
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "queue-state.json"),
             QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
@@ -803,7 +804,7 @@ public sealed class RunCommandTests
             Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
             "{}");
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "runs", "G226.last-message.json"),
+            Path.Combine("repo", ".intent-cli", "runs", CreateCapturedLastMessageFileName("G226", launchedAt)),
             """{"disposition":"accepted"}""");
         WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226", provider: "Codex");
         WriteDirectRunResult(
@@ -872,6 +873,7 @@ public sealed class RunCommandTests
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
+        var launchedAt = DateTimeOffset.Parse("2026-04-10T12:00:00.0000000+00:00");
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "queue-state.json"),
             QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
@@ -879,7 +881,7 @@ public sealed class RunCommandTests
             Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
             "{}");
         tempDirectory.CreateFile(
-            Path.Combine("repo", ".intent-cli", "runs", "G226.last-message.json"),
+            Path.Combine("repo", ".intent-cli", "runs", CreateCapturedLastMessageFileName("G226", launchedAt)),
             """{"disposition":"fix-requested","comment_body":"Please cover the deterministic submit path."}""");
         WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226", provider: "Codex");
         WriteDirectRunResult(
@@ -942,6 +944,58 @@ public sealed class RunCommandTests
         {
             RunCommand.ReviewCommentExecutor = originalReviewCommentExecutor;
         }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenSucceededReviewDecisionWithOnlyStaleCapturedAcceptedLastMessage_Waits()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var staleLaunchedAt = DateTimeOffset.Parse("2026-04-10T11:59:00.0000000+00:00");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs", CreateCapturedLastMessageFileName("G226", staleLaunchedAt)),
+            """{"disposition":"accepted"}""");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226", provider: "Codex");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "review",
+            "succeeded",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 0
+                    })
+                }
+            ],
+            provider: "Codex");
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("no-actionable-item", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("Review direct run for 'G226' is 'succeeded'.", result.Detail, StringComparison.Ordinal);
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+        Assert.Null(resultArtifact.ReviewOutcome);
     }
 
     [Fact]
@@ -1394,6 +1448,11 @@ public sealed class RunCommandTests
             "review" => $".intent-cli/reviews/{executionUnit}.request.json",
             _ => throw new InvalidOperationException($"Unsupported entry kind '{entryKind}'.")
         };
+    }
+
+    private static string CreateCapturedLastMessageFileName(string executionUnit, DateTimeOffset launchedAt)
+    {
+        return $"{executionUnit}.{DirectRunCommandSupport.CreateCapturedMessageSuffix(launchedAt)}.last-message.json";
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -947,6 +947,187 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFailedReviewResultWithRawNoActionableItem_Accepts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226", provider: "Codex");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "review",
+            "failed",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        stop_reason = "no-actionable-item"
+                    })
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:02.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 137
+                    })
+                }
+            ],
+            provider: "Codex");
+        var originalReviewAcceptExecutor = RunCommand.ReviewAcceptExecutor;
+
+        try
+        {
+            RunCommand.ReviewAcceptExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Completed
+                    });
+
+                return new ReviewAcceptResult
+                {
+                    ExecutionUnit = executionUnit,
+                    MergedPrRef = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                    ClosedIssueRef = "https://github.com/J-Tech-Japan/intent-system/issues/226"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Null(result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review accept", action.Name);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("succeeded", resultArtifact.RunStatus);
+            Assert.Equal("accepted", resultArtifact.ReviewOutcome);
+        }
+        finally
+        {
+            RunCommand.ReviewAcceptExecutor = originalReviewAcceptExecutor;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenFailedReviewResultWithRawDeterministicContractGap_Comments()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226", provider: "Codex");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "review",
+            "failed",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        stop_reason = "deterministic-contract-gap",
+                        detail = "Please cover the deterministic submit path."
+                    })
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:02.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 137
+                    })
+                }
+            ],
+            provider: "Codex");
+        var originalReviewCommentExecutor = RunCommand.ReviewCommentExecutor;
+
+        try
+        {
+            RunCommand.ReviewCommentExecutor = (context, executionUnit, bodyPath) =>
+            {
+                Assert.Equal(".intent-cli/reviews/G226.comment.md", bodyPath);
+                Assert.Equal(
+                    "Please cover the deterministic submit path.",
+                    File.ReadAllText(Path.Combine(context.RepoRoot, bodyPath.Replace('/', Path.DirectorySeparatorChar))));
+
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Fixing
+                    });
+
+                return new ReviewCommentResult
+                {
+                    ExecutionUnit = executionUnit,
+                    ArtifactPath = ".intent-cli/reviews/G226.comment.json",
+                    CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("deterministic-contract-gap", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review comment", action.Name);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("succeeded", resultArtifact.RunStatus);
+            Assert.Equal("fix-requested", resultArtifact.ReviewOutcome);
+            Assert.Equal(".intent-cli/reviews/G226.comment.md", resultArtifact.ReviewCommentBodyPath);
+        }
+        finally
+        {
+            RunCommand.ReviewCommentExecutor = originalReviewCommentExecutor;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenSucceededReviewDecisionWithOnlyStaleCapturedAcceptedLastMessage_Waits()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -792,6 +792,159 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenSucceededReviewDecisionWithCapturedAcceptedLastMessage_ReusesReviewAcceptBoundary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs", "G226.last-message.json"),
+            """{"disposition":"accepted"}""");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226", provider: "Codex");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "review",
+            "succeeded",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 0
+                    })
+                }
+            ],
+            provider: "Codex");
+        var originalReviewAcceptExecutor = RunCommand.ReviewAcceptExecutor;
+
+        try
+        {
+            RunCommand.ReviewAcceptExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Completed
+                    });
+
+                return new ReviewAcceptResult
+                {
+                    ExecutionUnit = executionUnit,
+                    MergedPrRef = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                    ClosedIssueRef = "https://github.com/J-Tech-Japan/intent-system/issues/226"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Null(result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review accept", action.Name);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("accepted", resultArtifact.ReviewOutcome);
+        }
+        finally
+        {
+            RunCommand.ReviewAcceptExecutor = originalReviewAcceptExecutor;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenSucceededReviewDecisionWithCapturedCommentLastMessage_ReusesReviewCommentBoundary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs", "G226.last-message.json"),
+            """{"disposition":"fix-requested","comment_body":"Please cover the deterministic submit path."}""");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226", provider: "Codex");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "review",
+            "succeeded",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 0
+                    })
+                }
+            ],
+            provider: "Codex");
+        var originalReviewCommentExecutor = RunCommand.ReviewCommentExecutor;
+
+        try
+        {
+            RunCommand.ReviewCommentExecutor = (context, executionUnit, bodyPath) =>
+            {
+                Assert.Equal(".intent-cli/reviews/G226.comment.md", bodyPath);
+                Assert.Equal(
+                    "Please cover the deterministic submit path.",
+                    File.ReadAllText(Path.Combine(context.RepoRoot, bodyPath.Replace('/', Path.DirectorySeparatorChar))));
+
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => queueItem with
+                    {
+                        State = QueueItemState.Fixing
+                    });
+
+                return new ReviewCommentResult
+                {
+                    ExecutionUnit = executionUnit,
+                    ArtifactPath = ".intent-cli/reviews/G226.comment.json",
+                    CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("deterministic-contract-gap", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review comment", action.Name);
+        }
+        finally
+        {
+            RunCommand.ReviewCommentExecutor = originalReviewCommentExecutor;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenCommentReviewDecisionWithCommentBody_ReusesReviewCommentBoundary()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- add a deterministic captured-last-message path for Codex review direct runs and require a structured review outcome response
- ingest captured Codex review outcomes into current-session provider events and normalized results without fabricating accepted-by-success
- reuse captured accepted/comment outcomes during subsequent run orchestration

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~ReviewRunCommandTests|FullyQualifiedName~RunCommandTests|FullyQualifiedName~DirectRunLauncherTests"
- dotnet test IntentSystem.sln

Closes #258