### PR TITLE
Fix G25 dead fix-session supervision handling

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -2,6 +2,8 @@ using IntentSystem.Review;
 using IntentSystem.Supervisor;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
+using System.Diagnostics;
+using System.Text.Json;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -138,6 +140,44 @@ internal static class RunSuperviseCommand
             HandoffArtifactRef = supervisionContext.HandoffArtifactRef,
             RetryBudget = retryBudget
         };
+
+        if (session.WorkerEntry == RunSupervisionWorkerEntry.Fix
+            && TryCaptureDeadWorkerSessionFailure(
+                context,
+                executionUnit,
+                session.WorkerEntry,
+                out var deadWorkerReason))
+        {
+            if (session.RetryCount >= session.RetryBudget)
+            {
+                return ExhaustRetryBudget(
+                    context,
+                    queueState,
+                    executionUnit,
+                    sessionArtifactPath,
+                    sessionArtifactRef,
+                    runLogPath,
+                    session,
+                    now,
+                    deadWorkerReason);
+            }
+
+            var interruptedSession = session with
+            {
+                UpdatedAt = now,
+                LastInterruptionReason = deadWorkerReason
+            };
+
+            return AttemptAutoResume(
+                context,
+                queueState,
+                executionUnit,
+                sessionArtifactPath,
+                sessionArtifactRef,
+                runLogPath,
+                interruptedSession,
+                now);
+        }
 
         if (session.Status == RunSupervisionSessionStatus.RetryScheduled)
         {
@@ -536,6 +576,160 @@ internal static class RunSuperviseCommand
     private static string ResolveArtifactPath(string repoRoot, string artifactRef)
     {
         return Path.GetFullPath(Path.Combine(repoRoot, artifactRef.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static bool TryCaptureDeadWorkerSessionFailure(
+        CliContext context,
+        string executionUnit,
+        RunSupervisionWorkerEntry workerEntry,
+        out string reason)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        reason = string.Empty;
+        var expectedEntryKind = ResolveDirectRunEntryKind(workerEntry);
+        var requestArtifactPath = ResolveDirectRunRequestArtifactPath(context, executionUnit);
+        var resultArtifactPath = ResolveDirectRunResultArtifactPath(context, executionUnit);
+        if (!File.Exists(requestArtifactPath) || !File.Exists(resultArtifactPath))
+        {
+            return false;
+        }
+
+        var requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        if (!string.Equals(requestArtifact.EntryKind, expectedEntryKind, StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.EntryKind, expectedEntryKind, StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.SessionId, requestArtifact.ProviderSessionId, StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.RunStatus, "running", StringComparison.Ordinal)
+            || !TryParseSessionProcessId(requestArtifact.ProviderSessionId, out var processId)
+            || IsProcessAlive(processId))
+        {
+            return false;
+        }
+
+        var providerLogPath = ResolveDirectRunProviderLogPath(context, executionUnit);
+        if (!File.Exists(providerLogPath))
+        {
+            return false;
+        }
+
+        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerLogPath));
+        var currentProviderEvents = SelectCurrentSessionEvents(providerEvents, requestArtifact.ProviderSessionId, requestArtifact.LaunchedAt);
+        if (currentProviderEvents.Any(HasBackendExitType))
+        {
+            return false;
+        }
+
+        var backendExitEvent = DirectRunProviderEventFactory.CreateBackendExitEvent(
+            DateTimeOffset.UtcNow,
+            executionUnit,
+            expectedEntryKind,
+            requestArtifact.Provider,
+            requestArtifact.ProviderSessionId,
+            exitCode: 1);
+        new DirectRunProviderEventWriter(providerLogPath).Append(backendExitEvent);
+
+        File.WriteAllText(
+            resultArtifactPath,
+            DirectRunResultArtifactJson.Serialize(resultArtifact with
+            {
+                RunStatus = "failed"
+            }));
+
+        reason =
+            $"Worker session '{requestArtifact.ProviderSessionId}' for '{executionUnit}' is no longer alive and no terminal provider event was captured.";
+        return true;
+    }
+
+    private static string ResolveDirectRunRequestArtifactPath(CliContext context, string executionUnit)
+    {
+        var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
+        return ResolveArtifactPath(context.RepoRoot, $"{root}/{executionUnit.Trim()}.request.json");
+    }
+
+    private static string ResolveDirectRunResultArtifactPath(CliContext context, string executionUnit)
+    {
+        var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
+        return ResolveArtifactPath(context.RepoRoot, $"{root}/{executionUnit.Trim()}.result.json");
+    }
+
+    private static string ResolveDirectRunProviderLogPath(CliContext context, string executionUnit)
+    {
+        var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
+        return ResolveArtifactPath(context.RepoRoot, $"{root}/{executionUnit.Trim()}.provider.jsonl");
+    }
+
+    private static string ResolveDirectRunEntryKind(RunSupervisionWorkerEntry workerEntry)
+    {
+        return workerEntry switch
+        {
+            RunSupervisionWorkerEntry.Implement => "implement",
+            RunSupervisionWorkerEntry.Fix => "fix",
+            _ => throw new InvalidOperationException($"Unsupported worker entry '{workerEntry}'.")
+        };
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> SelectCurrentSessionEvents(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string launchedSessionId,
+        string launchedAt)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+        if (!DirectRunSessionBoundary.TryParseLaunchedAt(launchedAt, out var parsedLaunchedAt))
+        {
+            parsedLaunchedAt = default;
+        }
+
+        return DirectRunSessionBoundary.SelectEvents(
+            providerEvents,
+            launchedSessionId,
+            parsedLaunchedAt == default ? null : parsedLaunchedAt);
+    }
+
+    private static bool TryParseSessionProcessId(string providerSessionId, out int processId)
+    {
+        processId = default;
+
+        const string prefix = "pid:";
+        if (!providerSessionId.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return int.TryParse(
+            providerSessionId[prefix.Length..],
+            System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out processId);
+    }
+
+    private static bool IsProcessAlive(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            process.Refresh();
+            return !process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private static bool HasBackendExitType(DirectRunProviderEvent providerEvent)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvent);
+
+        return providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal);
     }
 
     private static void PersistQueueState(CliContext context, QueueState queueState)

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -1404,6 +1404,182 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenDeadFixWorkerSession_DoesNotRemainUnderSupervision()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 0,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Claude",
+                    EntryKind = "fix",
+                    SessionId = "pid:999999",
+                    Kind = "session-metadata",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        model = "sonnet",
+                        transport = "sdk",
+                        command = "claude"
+                    })
+                }
+            ],
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var originalRunFixExecutor = RunSuperviseCommand.RunFixExecutor;
+
+        try
+        {
+            RunSuperviseCommand.RunFixExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunRequest(repoRoot, executionUnit, "fix", "pid:4242", provider: "Claude");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "fix",
+                    "running",
+                    providerEvents:
+                    [
+                        new DirectRunProviderEvent
+                        {
+                            Timestamp = "2026-04-10T12:01:00.0000000+00:00",
+                            ExecutionUnit = executionUnit,
+                            Provider = "Claude",
+                            EntryKind = "fix",
+                            SessionId = "pid:4242",
+                            Kind = "session-metadata",
+                            Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                            {
+                                model = "sonnet",
+                                transport = "sdk",
+                                command = "claude"
+                            })
+                        }
+                    ],
+                    sessionId: "pid:4242",
+                    provider: "Claude");
+
+                return new RunFixResult
+                {
+                    Request = new RunFixRequest
+                    {
+                        ExecutionUnit = executionUnit,
+                        State = "fixing",
+                        ImplementRole = "Codex",
+                        QueueWorkerRole = "coder",
+                        QueueReviewRole = "reviewer",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = $"issue-226-{executionUnit.ToLowerInvariant()}",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        LatestLinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                        LatestCommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                        PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                        ReviewCommentArtifactRef = $".intent-cli/reviews/{executionUnit}.comment.json",
+                        ReviewRequestRef = $".intent-cli/reviews/{executionUnit}.request.json",
+                        ReviewCommentBodyPath = $".intent-cli/reviews/{executionUnit}.comment.md",
+                        IssueTitle = "[G226] Root Run Orchestration Command",
+                        Goal = "Coordinate the root run loop.",
+                        TargetPart = "run command",
+                        TargetRepo = "submodules/intent-system",
+                        TargetPath = ".",
+                        InScope = [],
+                        OutOfScope = [],
+                        AcceptanceCriteria = [],
+                        DeterministicReviewChecks = [],
+                        ExpectedEvidence = []
+                    },
+                    ArtifactPath = $".intent-cli/fix/{executionUnit}.request.md"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("run supervise", action.Name);
+            Assert.DoesNotContain("Worker remains under supervision.", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("auto-resumed", result.Detail, StringComparison.OrdinalIgnoreCase);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+        }
+        finally
+        {
+            RunSuperviseCommand.RunFixExecutor = originalRunFixExecutor;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenClarifyBlockedItem_StopsWithClarificationRequired()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -2,6 +2,7 @@ using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
+using System.Text.Json;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -313,6 +314,114 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenDeadFixWorkerSession_CapturesFailureAndAutoResumesFixLoop()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateFixingRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G25.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession(workerEntry: RunSupervisionWorkerEntry.Fix)));
+        WriteDeadFixDirectRunArtifacts(repoRoot, "pid:999999");
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalRunFixExecutor = RunSuperviseCommand.RunFixExecutor;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+            RunSuperviseCommand.RunFixExecutor = (_, executionUnit) =>
+            {
+                WriteLiveFixDirectRunArtifacts(repoRoot, executionUnit, "pid:4242");
+
+                return new RunFixResult
+                {
+                    Request = new RunFixRequest
+                    {
+                        ExecutionUnit = executionUnit,
+                        State = "fixing",
+                        ImplementRole = "Claude",
+                        QueueWorkerRole = "coder",
+                        QueueReviewRole = "reviewer",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = "issue-178-g25",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/178",
+                        LatestLinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/180",
+                        LatestCommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1",
+                        PacketRef = ".intent-cli/issues/G25/packet.yaml",
+                        ReviewContextRef = ".intent-cli/issues/G25/review-context.md",
+                        ReviewCommentArtifactRef = ".intent-cli/reviews/G25.comment.json",
+                        ReviewRequestRef = ".intent-cli/reviews/G25.request.json",
+                        ReviewCommentBodyPath = ".intent-cli/reviews/G25.comment.md",
+                        IssueTitle = "[G25] Run Supervise Command",
+                        Goal = "Supervise retryable run interruptions.",
+                        TargetPart = "cli run supervise command",
+                        TargetRepo = "submodules/intent-system",
+                        TargetPath = ".",
+                        InScope = [],
+                        OutOfScope = [],
+                        AcceptanceCriteria = [],
+                        DeterministicReviewChecks = [],
+                        ExpectedEvidence = []
+                    },
+                    ArtifactPath = ".intent-cli/fix/G25.request.md"
+                };
+            };
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionWorkerEntry.Fix, session.WorkerEntry);
+            Assert.Equal(RunSupervisionSessionStatus.Monitoring, session.Status);
+            Assert.Equal(1, session.RetryCount);
+            Assert.Null(session.NextRetryAt);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                && providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
+                && exitCodeElement.GetInt32() == 1);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.result.json")));
+            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("retry-attempted", runEvents[^2].Event);
+            Assert.Equal("auto-resumed", runEvents[^1].Event);
+            Assert.Contains("no longer alive", runEvents[^2].Reason, StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.RunFixExecutor = originalRunFixExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenNonRetryableAutoResumeFailure_BlocksSelectedItemAndAppendsTerminalEvents()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -454,21 +563,28 @@ public sealed class RunSuperviseCommandTests
         };
     }
 
-    private static RunSupervisionSession CreateMonitoringSession()
+    private static RunSupervisionSession CreateMonitoringSession(
+        RunSupervisionWorkerEntry workerEntry = RunSupervisionWorkerEntry.Implement)
     {
         return new RunSupervisionSession
         {
             ExecutionUnit = "G25",
-            WorkerEntry = RunSupervisionWorkerEntry.Implement,
+            WorkerEntry = workerEntry,
             Status = RunSupervisionSessionStatus.Monitoring,
-            QueueState = "active",
+            QueueState = workerEntry == RunSupervisionWorkerEntry.Fix ? "fixing" : "active",
             WorktreePath = "/repo/.intent-cli/worktrees/G25",
             ChildRepoPath = "/repo/submodules/intent-system",
             Branch = "issue-178-g25",
             LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/178",
-            LinkedPr = null,
-            CommentRef = null,
-            HandoffArtifactRef = ".intent-cli/implement/G25.request.md",
+            LinkedPr = workerEntry == RunSupervisionWorkerEntry.Fix
+                ? "https://github.com/J-Tech-Japan/intent-system/pull/180"
+                : null,
+            CommentRef = workerEntry == RunSupervisionWorkerEntry.Fix
+                ? "https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"
+                : null,
+            HandoffArtifactRef = workerEntry == RunSupervisionWorkerEntry.Fix
+                ? ".intent-cli/fix/G25.request.md"
+                : ".intent-cli/implement/G25.request.md",
             RetryCount = 0,
             RetryBudget = 3,
             CreatedAt = DateTimeOffset.Parse("2026-04-08T09:00:00Z"),
@@ -541,6 +657,120 @@ public sealed class RunSuperviseCommandTests
         {"ts":"2026-04-08T10:10:00Z","execution_unit":"G25","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/180"}
         {"ts":"2026-04-08T10:15:00Z","execution_unit":"G25","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1","reason":"contract mismatch"}
         """ + Environment.NewLine;
+    }
+
+    private static void WriteDeadFixDirectRunArtifacts(string repoRoot, string sessionId)
+    {
+        var requestArtifact = new DirectRunRequestArtifact
+        {
+            SchemaVersion = "1",
+            ExecutionUnit = "G25",
+            EntryKind = "fix",
+            UpstreamRequestRef = ".intent-cli/fix/G25.request.md",
+            Provider = "Claude",
+            Model = "sonnet",
+            Transport = "sdk",
+            LaunchedAt = "2026-04-08T10:20:00.0000000+00:00",
+            ProviderSessionId = sessionId,
+            TransportSummary = "sdk transport"
+        };
+        var resultArtifact = new DirectRunResultArtifact
+        {
+            SchemaVersion = "1",
+            ExecutionUnit = "G25",
+            EntryKind = "fix",
+            UpstreamRequestRef = ".intent-cli/fix/G25.request.md",
+            Provider = "Claude",
+            Model = "sonnet",
+            SessionId = sessionId,
+            RunStatus = "running",
+            RawLogRef = ".intent-cli/runs/G25.provider.jsonl",
+            PacketRef = ".intent-cli/issues/G25/packet.yaml",
+            ReviewContextRef = ".intent-cli/issues/G25/review-context.md",
+            Worktree = new DirectRunWorktreeContext
+            {
+                Path = "/repo/.intent-cli/worktrees/G25"
+            }
+        };
+        var providerEvents = new[]
+        {
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.0000000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "session-metadata",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    model = "sonnet",
+                    transport = "sdk",
+                    command = "claude"
+                })
+            })
+        };
+
+        var runsPath = Path.Combine(repoRoot, ".intent-cli", "runs");
+        Directory.CreateDirectory(runsPath);
+        File.WriteAllText(Path.Combine(runsPath, "G25.request.json"), DirectRunRequestArtifactJson.Serialize(requestArtifact));
+        File.WriteAllText(Path.Combine(runsPath, "G25.result.json"), DirectRunResultArtifactJson.Serialize(resultArtifact));
+        File.WriteAllText(Path.Combine(runsPath, "G25.provider.jsonl"), string.Join(Environment.NewLine, providerEvents) + Environment.NewLine);
+    }
+
+    private static void WriteLiveFixDirectRunArtifacts(string repoRoot, string executionUnit, string sessionId)
+    {
+        var requestArtifact = new DirectRunRequestArtifact
+        {
+            SchemaVersion = "1",
+            ExecutionUnit = executionUnit,
+            EntryKind = "fix",
+            UpstreamRequestRef = $".intent-cli/fix/{executionUnit}.request.md",
+            Provider = "Claude",
+            Model = "sonnet",
+            Transport = "sdk",
+            LaunchedAt = "2026-04-08T10:30:00.0000000+00:00",
+            ProviderSessionId = sessionId,
+            TransportSummary = "sdk transport"
+        };
+        var resultArtifact = new DirectRunResultArtifact
+        {
+            SchemaVersion = "1",
+            ExecutionUnit = executionUnit,
+            EntryKind = "fix",
+            UpstreamRequestRef = $".intent-cli/fix/{executionUnit}.request.md",
+            Provider = "Claude",
+            Model = "sonnet",
+            SessionId = sessionId,
+            RunStatus = "running",
+            RawLogRef = $".intent-cli/runs/{executionUnit}.provider.jsonl",
+            PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+            ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+            Worktree = new DirectRunWorktreeContext
+            {
+                Path = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit)
+            }
+        };
+        var providerLogPath = Path.Combine(repoRoot, ".intent-cli", "runs", $"{executionUnit}.provider.jsonl");
+        File.AppendAllText(
+            providerLogPath,
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:30:00.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "session-metadata",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    model = "sonnet",
+                    transport = "sdk",
+                    command = "claude"
+                })
+            }) + Environment.NewLine);
+        File.WriteAllText(Path.Combine(repoRoot, ".intent-cli", "runs", $"{executionUnit}.request.json"), DirectRunRequestArtifactJson.Serialize(requestArtifact));
+        File.WriteAllText(Path.Combine(repoRoot, ".intent-cli", "runs", $"{executionUnit}.result.json"), DirectRunResultArtifactJson.Serialize(resultArtifact));
     }
 
     private sealed class TemporaryDirectory : IDisposable


### PR DESCRIPTION
## Summary
- detect dead current fix worker sessions during `run supervise` instead of leaving monitoring state indefinitely
- append a terminal backend-exit for the dead session and close its stale `running` result boundary
- immediately auto-resume the same fix loop through existing supervision retry behavior, with regression coverage in both supervise and root run flows

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunSuperviseCommandTests.Execute_GivenDeadFixWorkerSession_CapturesFailureAndAutoResumesFixLoop|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenDeadFixWorkerSession_DoesNotRemainUnderSupervision" --logger "console;verbosity=normal"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --logger "console;verbosity=minimal"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~ReviewRunCommandTests.Execute_GivenRealCodexStyleReviewCommand_DoesNotForceTimeoutWhileCurrentSessionIsStillRunning" --logger "console;verbosity=normal"
- dotnet test IntentSystem.sln

## Notes
- This uses hermetic regression coverage for the dead-session case rather than a local `toy-calc-sample` rerun.
