### PR TITLE
Fix fresh-session dead fix supervision recovery

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -114,8 +114,15 @@ internal static class RunSuperviseCommand
         if (session is null)
         {
             var createdSession = CreateSession(supervisionContext, now, retryBudget);
-            PersistSession(sessionArtifactPath, createdSession);
-            return CreateResult(sessionArtifactRef, createdSession);
+            return FinalizeSessionInitialization(
+                context,
+                queueState,
+                executionUnit,
+                sessionArtifactPath,
+                sessionArtifactRef,
+                runLogPath,
+                createdSession,
+                now);
         }
 
         if (session.WorkerEntry != supervisionContext.WorkerEntry)
@@ -124,8 +131,15 @@ internal static class RunSuperviseCommand
             {
                 CreatedAt = session.CreatedAt
             };
-            PersistSession(sessionArtifactPath, realignedSession);
-            return CreateResult(sessionArtifactRef, realignedSession);
+            return FinalizeSessionInitialization(
+                context,
+                queueState,
+                executionUnit,
+                sessionArtifactPath,
+                sessionArtifactRef,
+                runLogPath,
+                realignedSession,
+                now);
         }
 
         session = session with
@@ -260,6 +274,58 @@ internal static class RunSuperviseCommand
         };
         PersistSession(sessionArtifactPath, monitoringSession);
         return CreateResult(sessionArtifactRef, monitoringSession);
+    }
+
+    private static RunSuperviseResult FinalizeSessionInitialization(
+        CliContext context,
+        QueueState queueState,
+        string executionUnit,
+        string sessionArtifactPath,
+        string sessionArtifactRef,
+        string runLogPath,
+        RunSupervisionSession session,
+        DateTimeOffset now)
+    {
+        if (session.WorkerEntry == RunSupervisionWorkerEntry.Fix
+            && TryCaptureDeadWorkerSessionFailure(
+                context,
+                executionUnit,
+                session.WorkerEntry,
+                out var deadWorkerReason))
+        {
+            if (session.RetryCount >= session.RetryBudget)
+            {
+                return ExhaustRetryBudget(
+                    context,
+                    queueState,
+                    executionUnit,
+                    sessionArtifactPath,
+                    sessionArtifactRef,
+                    runLogPath,
+                    session,
+                    now,
+                    deadWorkerReason);
+            }
+
+            var interruptedSession = session with
+            {
+                UpdatedAt = now,
+                LastInterruptionReason = deadWorkerReason
+            };
+
+            return AttemptAutoResume(
+                context,
+                queueState,
+                executionUnit,
+                sessionArtifactPath,
+                sessionArtifactRef,
+                runLogPath,
+                interruptedSession,
+                now);
+        }
+
+        PersistSession(sessionArtifactPath, session);
+        return CreateResult(sessionArtifactRef, session);
     }
 
     private static RunSuperviseResult AttemptAutoResume(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -1580,6 +1580,167 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFixingItemWithoutExistingSessionAndDeadFixWorkerSession_DoesNotRemainUnderSupervision()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Claude",
+                    EntryKind = "fix",
+                    SessionId = "pid:999999",
+                    Kind = "session-metadata",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        model = "sonnet",
+                        transport = "sdk",
+                        command = "claude"
+                    })
+                }
+            ],
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var originalRunFixExecutor = RunSuperviseCommand.RunFixExecutor;
+
+        try
+        {
+            RunSuperviseCommand.RunFixExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunRequest(repoRoot, executionUnit, "fix", "pid:4242", provider: "Claude");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "fix",
+                    "running",
+                    providerEvents:
+                    [
+                        new DirectRunProviderEvent
+                        {
+                            Timestamp = "2026-04-10T12:01:00.0000000+00:00",
+                            ExecutionUnit = executionUnit,
+                            Provider = "Claude",
+                            EntryKind = "fix",
+                            SessionId = "pid:4242",
+                            Kind = "session-metadata",
+                            Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                            {
+                                model = "sonnet",
+                                transport = "sdk",
+                                command = "claude"
+                            })
+                        }
+                    ],
+                    sessionId: "pid:4242",
+                    provider: "Claude");
+
+                return new RunFixResult
+                {
+                    Request = new RunFixRequest
+                    {
+                        ExecutionUnit = executionUnit,
+                        State = "fixing",
+                        ImplementRole = "Codex",
+                        QueueWorkerRole = "coder",
+                        QueueReviewRole = "reviewer",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = $"issue-226-{executionUnit.ToLowerInvariant()}",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        LatestLinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                        LatestCommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                        PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                        ReviewCommentArtifactRef = $".intent-cli/reviews/{executionUnit}.comment.json",
+                        ReviewRequestRef = $".intent-cli/reviews/{executionUnit}.request.json",
+                        ReviewCommentBodyPath = $".intent-cli/reviews/{executionUnit}.comment.md",
+                        IssueTitle = "[G226] Root Run Orchestration Command",
+                        Goal = "Coordinate the root run loop.",
+                        TargetPart = "run command",
+                        TargetRepo = "submodules/intent-system",
+                        TargetPath = ".",
+                        InScope = [],
+                        OutOfScope = [],
+                        AcceptanceCriteria = [],
+                        DeterministicReviewChecks = [],
+                        ExpectedEvidence = []
+                    },
+                    ArtifactPath = $".intent-cli/fix/{executionUnit}.request.md"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("run supervise", action.Name);
+            Assert.DoesNotContain("Worker remains under supervision.", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("auto-resumed", result.Detail, StringComparison.OrdinalIgnoreCase);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
+            Assert.Equal(RunSupervisionWorkerEntry.Fix, session.WorkerEntry);
+            Assert.Equal(RunSupervisionSessionStatus.Monitoring, session.Status);
+            Assert.Equal(1, session.RetryCount);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+        }
+        finally
+        {
+            RunSuperviseCommand.RunFixExecutor = originalRunFixExecutor;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenClarifyBlockedItem_StopsWithClarificationRequired()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -422,6 +422,111 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenFixingItemWithoutExistingSessionAndDeadFixWorkerSession_CapturesFailureAndAutoResumesFixLoop()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateFixingRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G25.request.md"),
+            "# Repair Worker Handoff");
+        WriteDeadFixDirectRunArtifacts(repoRoot, "pid:999999");
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalRunFixExecutor = RunSuperviseCommand.RunFixExecutor;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+            RunSuperviseCommand.RunFixExecutor = (_, executionUnit) =>
+            {
+                WriteLiveFixDirectRunArtifacts(repoRoot, executionUnit, "pid:4242");
+
+                return new RunFixResult
+                {
+                    Request = new RunFixRequest
+                    {
+                        ExecutionUnit = executionUnit,
+                        State = "fixing",
+                        ImplementRole = "Claude",
+                        QueueWorkerRole = "coder",
+                        QueueReviewRole = "reviewer",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = "issue-178-g25",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/178",
+                        LatestLinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/180",
+                        LatestCommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1",
+                        PacketRef = ".intent-cli/issues/G25/packet.yaml",
+                        ReviewContextRef = ".intent-cli/issues/G25/review-context.md",
+                        ReviewCommentArtifactRef = ".intent-cli/reviews/G25.comment.json",
+                        ReviewRequestRef = ".intent-cli/reviews/G25.request.json",
+                        ReviewCommentBodyPath = ".intent-cli/reviews/G25.comment.md",
+                        IssueTitle = "[G25] Run Supervise Command",
+                        Goal = "Supervise retryable run interruptions.",
+                        TargetPart = "cli run supervise command",
+                        TargetRepo = "submodules/intent-system",
+                        TargetPath = ".",
+                        InScope = [],
+                        OutOfScope = [],
+                        AcceptanceCriteria = [],
+                        DeterministicReviewChecks = [],
+                        ExpectedEvidence = []
+                    },
+                    ArtifactPath = ".intent-cli/fix/G25.request.md"
+                };
+            };
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionWorkerEntry.Fix, session.WorkerEntry);
+            Assert.Equal(RunSupervisionSessionStatus.Monitoring, session.Status);
+            Assert.Equal(1, session.RetryCount);
+            Assert.Null(session.NextRetryAt);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                && providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
+                && exitCodeElement.GetInt32() == 1);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.result.json")));
+            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("retry-attempted", runEvents[^2].Event);
+            Assert.Equal("auto-resumed", runEvents[^1].Event);
+            Assert.Contains("no longer alive", runEvents[^2].Reason, StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.RunFixExecutor = originalRunFixExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenNonRetryableAutoResumeFailure_BlocksSelectedItemAndAppendsTerminalEvents()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- reconcile dead current fix direct-run boundaries before treating fresh or realigned supervision sessions as clean monitoring starts
- reuse the existing fix retry and auto-resume path during fresh session initialization
- add regression coverage for `run supervise` and root `run` when no supervision session exists but the current fix session is already dead

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "Execute_GivenFixingItemWithoutExistingSessionAndDeadFixWorkerSession_CapturesFailureAndAutoResumesFixLoop|ExecuteCore_GivenFixingItemWithoutExistingSessionAndDeadFixWorkerSession_DoesNotRemainUnderSupervision" --logger "console;verbosity=minimal"
- dotnet test IntentSystem.sln --logger "console;verbosity=minimal"

Closes #264
