### PR TITLE
Guard child-facing targets from host runtime paths

### DIFF
--- a/src/IntentSystem.Cli/Commands/ChildWorkTargetGuard.cs
+++ b/src/IntentSystem.Cli/Commands/ChildWorkTargetGuard.cs
@@ -6,14 +6,34 @@ internal static class ChildWorkTargetGuard
 
     public static void EnsureTargetAllowed(
         string executionUnit,
+        string hostRepoRootPath,
+        string targetRepo,
         string checkoutRootPath,
         string targetPath,
         string targetPart)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(hostRepoRootPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetRepo);
         ArgumentException.ThrowIfNullOrWhiteSpace(checkoutRootPath);
         ArgumentException.ThrowIfNullOrWhiteSpace(targetPath);
         ArgumentException.ThrowIfNullOrWhiteSpace(targetPart);
+
+        if (ContainsHostRuntimeSegment(targetRepo))
+        {
+            throw new InvalidOperationException(
+                $"Child target repo '{targetRepo}' for '{executionUnit}' points to host runtime-only '.intent-cli/**' content. Parent-side clarification is required before generating or launching child work.");
+        }
+
+        var normalizedHostRepoRoot = Path.GetFullPath(hostRepoRootPath);
+        var resolvedTargetRepo = ResolvePath(normalizedHostRepoRoot, targetRepo);
+        if (IsWithinRoot(
+                ResolvePath(normalizedHostRepoRoot, HostRuntimeSegment),
+                resolvedTargetRepo))
+        {
+            throw new InvalidOperationException(
+                $"Child target repo '{targetRepo}' for '{executionUnit}' resolves into host runtime-only '.intent-cli/**' content. Parent-side clarification is required before generating or launching child work.");
+        }
 
         if (ContainsHostRuntimeSegment(targetPath))
         {

--- a/src/IntentSystem.Cli/Commands/ChildWorkTargetGuard.cs
+++ b/src/IntentSystem.Cli/Commands/ChildWorkTargetGuard.cs
@@ -1,0 +1,83 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class ChildWorkTargetGuard
+{
+    private const string HostRuntimeSegment = ".intent-cli";
+
+    public static void EnsureTargetAllowed(
+        string executionUnit,
+        string checkoutRootPath,
+        string targetPath,
+        string targetPart)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(checkoutRootPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetPart);
+
+        if (ContainsHostRuntimeSegment(targetPath))
+        {
+            throw new InvalidOperationException(
+                $"Child target path '{targetPath}' for '{executionUnit}' points to host runtime-only '.intent-cli/**' content. Parent-side clarification is required before generating or launching child work.");
+        }
+
+        if (ContainsHostRuntimeSegment(targetPart))
+        {
+            throw new InvalidOperationException(
+                $"Child target part '{targetPart}' for '{executionUnit}' points to host runtime-only '.intent-cli/**' content. Parent-side clarification is required before generating or launching child work.");
+        }
+
+        var normalizedCheckoutRoot = Path.GetFullPath(checkoutRootPath);
+        var resolvedTargetPath = ResolvePath(normalizedCheckoutRoot, targetPath);
+        if (!IsWithinRoot(normalizedCheckoutRoot, resolvedTargetPath))
+        {
+            throw new InvalidOperationException(
+                $"Child target path '{targetPath}' for '{executionUnit}' resolves outside the child checkout root '{normalizedCheckoutRoot}'. Parent-side clarification is required before generating or launching child work.");
+        }
+
+        if (!LooksLikePath(targetPart))
+        {
+            return;
+        }
+
+        var resolvedTargetPart = ResolvePath(resolvedTargetPath, targetPart);
+        if (!IsWithinRoot(normalizedCheckoutRoot, resolvedTargetPart))
+        {
+            throw new InvalidOperationException(
+                $"Child target part '{targetPart}' for '{executionUnit}' resolves outside the child checkout root '{normalizedCheckoutRoot}' when combined with target path '{targetPath}'. Parent-side clarification is required before generating or launching child work.");
+        }
+    }
+
+    private static bool ContainsHostRuntimeSegment(string value)
+    {
+        var segments = value.Replace('\\', '/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return segments.Contains(HostRuntimeSegment, StringComparer.Ordinal);
+    }
+
+    private static bool LooksLikePath(string value)
+    {
+        return value.StartsWith(".", StringComparison.Ordinal)
+            || value.Contains('/', StringComparison.Ordinal)
+            || value.Contains('\\', StringComparison.Ordinal);
+    }
+
+    private static string ResolvePath(string rootPath, string relativeOrAbsolutePath)
+    {
+        return Path.GetFullPath(Path.Combine(
+            rootPath,
+            relativeOrAbsolutePath.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static bool IsWithinRoot(string rootPath, string candidatePath)
+    {
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var normalizedRoot = rootPath.TrimEnd(Path.DirectorySeparatorChar);
+
+        return string.Equals(candidatePath, normalizedRoot, comparison)
+            || candidatePath.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, comparison);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
@@ -144,6 +144,12 @@ internal static class IntakeIssueCommand
 
         foreach (var unit in units.OrderBy(item => item.ExecutionUnitId, StringComparer.Ordinal))
         {
+            ChildWorkTargetGuard.EnsureTargetAllowed(
+                unit.ExecutionUnitId,
+                Path.Combine(repoRoot, ".intent-cli", "__child-target-guard__", unit.ExecutionUnitId),
+                baseline.TargetPath,
+                unit.TargetPart);
+
             var parentRefs = ResolveParentRefs(repoRoot, unit, baseline);
             var packet = PacketGenerator.Generate(
                 CreateRow(unit, baseline, parentRefs),

--- a/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
@@ -146,6 +146,8 @@ internal static class IntakeIssueCommand
         {
             ChildWorkTargetGuard.EnsureTargetAllowed(
                 unit.ExecutionUnitId,
+                repoRoot,
+                baseline.TargetRepo,
                 Path.Combine(repoRoot, ".intent-cli", "__child-target-guard__", unit.ExecutionUnitId),
                 baseline.TargetPath,
                 unit.TargetPart);

--- a/src/IntentSystem.Cli/Commands/ProjectionPacketRuntimeReader.cs
+++ b/src/IntentSystem.Cli/Commands/ProjectionPacketRuntimeReader.cs
@@ -10,6 +10,8 @@ internal static class ProjectionPacketRuntimeReader
         string ExecutionUnit,
         string IssueTitle,
         string TargetRepo,
+        string TargetPath,
+        string TargetPart,
         IReadOnlyList<string> Dependencies,
         string ClarificationReturnPath);
 
@@ -24,6 +26,8 @@ internal static class ProjectionPacketRuntimeReader
                 packet.ImplementationIssuePacket.SourceExecutionUnit,
                 packet.ImplementationIssuePacket.IssueTitle,
                 packet.ImplementationIssuePacket.TargetRepo,
+                packet.ImplementationIssuePacket.TargetPath,
+                packet.ImplementationIssuePacket.TargetPart,
                 packet.ImplementationIssuePacket.Dependencies,
                 packet.ReviewContextPacket.ClarificationReturnPath);
         }
@@ -151,12 +155,26 @@ internal static class ProjectionPacketRuntimeReader
             throw new InvalidOperationException("Implementation issue must contain required field 'target_repo'.");
         }
 
+        var targetPath = TryGetScalar(implementationIssue, "target_path") ?? ".";
+        var targetPart = TryGetScalar(implementationIssue, "target_part") ?? issueTitle;
+
         return new RuntimePacket(
             executionUnit,
             issueTitle,
             targetRepo,
+            targetPath,
+            targetPart,
             GetOptionalList(implementationIssue, "dependencies"),
             DefaultClarificationReturnPath);
+    }
+
+    private static string? TryGetScalar(
+        IReadOnlyDictionary<string, object> values,
+        string key)
+    {
+        return values.TryGetValue(key, out var value)
+            ? value as string
+            : null;
     }
 
     private static IReadOnlyList<string> GetOptionalList(

--- a/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
@@ -106,6 +106,12 @@ internal static class QueueDispatchCommand
             throw new InvalidOperationException("Projection packet must contain a target repo.");
         }
 
+        ChildWorkTargetGuard.EnsureTargetAllowed(
+            executionUnit,
+            RunStartCommand.ResolveWorktreePath(context, executionUnit),
+            packet.TargetPath,
+            packet.TargetPart);
+
         var issueTitle = packet.IssueTitle;
         if (string.IsNullOrWhiteSpace(issueTitle))
         {

--- a/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
@@ -108,6 +108,8 @@ internal static class QueueDispatchCommand
 
         ChildWorkTargetGuard.EnsureTargetAllowed(
             executionUnit,
+            context.RepoRoot,
+            packet.TargetRepo,
             RunStartCommand.ResolveWorktreePath(context, executionUnit),
             packet.TargetPath,
             packet.TargetPart);

--- a/src/IntentSystem.Cli/Commands/RunFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixCommand.cs
@@ -109,6 +109,8 @@ internal static class RunFixCommand
 
         ChildWorkTargetGuard.EnsureTargetAllowed(
             executionUnit,
+            context.RepoRoot,
+            packet.ImplementationIssuePacket.TargetRepo,
             worktreePath,
             packet.ImplementationIssuePacket.TargetPath,
             packet.ImplementationIssuePacket.TargetPart);

--- a/src/IntentSystem.Cli/Commands/RunFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixCommand.cs
@@ -107,6 +107,12 @@ internal static class RunFixCommand
             throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
         }
 
+        ChildWorkTargetGuard.EnsureTargetAllowed(
+            executionUnit,
+            worktreePath,
+            packet.ImplementationIssuePacket.TargetPath,
+            packet.ImplementationIssuePacket.TargetPart);
+
         var reviewContext = ReviewContextMarkdownParser.Parse(File.ReadAllText(reviewContextPath));
         if (!string.Equals(reviewContext.SourceExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
         {

--- a/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
@@ -99,6 +99,12 @@ internal static class RunImplementCommand
             throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
         }
 
+        ChildWorkTargetGuard.EnsureTargetAllowed(
+            executionUnit,
+            worktreePath,
+            packet.ImplementationIssuePacket.TargetPath,
+            packet.ImplementationIssuePacket.TargetPart);
+
         var reviewContext = ReviewContextMarkdownParser.Parse(File.ReadAllText(reviewContextPath));
         if (!string.Equals(reviewContext.SourceExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
         {

--- a/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
@@ -101,6 +101,8 @@ internal static class RunImplementCommand
 
         ChildWorkTargetGuard.EnsureTargetAllowed(
             executionUnit,
+            context.RepoRoot,
+            packet.ImplementationIssuePacket.TargetRepo,
             worktreePath,
             packet.ImplementationIssuePacket.TargetPath,
             packet.ImplementationIssuePacket.TargetPart);

--- a/src/IntentSystem.Cli/Commands/RunStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunStartCommand.cs
@@ -92,6 +92,8 @@ internal static class RunStartCommand
 
         ChildWorkTargetGuard.EnsureTargetAllowed(
             executionUnit,
+            context.RepoRoot,
+            packet.TargetRepo,
             worktreePath,
             packet.TargetPath,
             packet.TargetPart);

--- a/src/IntentSystem.Cli/Commands/RunStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunStartCommand.cs
@@ -90,6 +90,12 @@ internal static class RunStartCommand
             throw new InvalidOperationException($"Worktree path already exists at {worktreePath}");
         }
 
+        ChildWorkTargetGuard.EnsureTargetAllowed(
+            executionUnit,
+            worktreePath,
+            packet.TargetPath,
+            packet.TargetPart);
+
         var branchName = ResolveBranchName(executionUnit, queueItem.LinkedIssue);
         var gitRunner = GitCommandRunnerFactory();
         CreateWorktree(childRepoPath, worktreePath, branchName, gitRunner);

--- a/tests/IntentSystem.Cli.Tests/IntakeIssueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeIssueCommandTests.cs
@@ -204,6 +204,40 @@ public sealed class IntakeIssueCommandTests
         Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Execute_GivenRuntimeOnlyTargetPart_ReturnsExitCodeOneWithoutGeneratingChildFacingArtifacts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            CreateExecutionBaselineMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateSingleExecutionArtifactMarkdown(
+                "auth",
+                "AUTH-01",
+                "intents/intent-cli/concepts/oauth2.md",
+                ".intent-cli/intake",
+                "Auth Concept"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "00-map.md"),
+            "# Intent CLI Map");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "clarifications", "open.md"),
+            "# Clarifications");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
+            "# Auth Concept");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeIssueCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("host runtime-only '.intent-cli/**' content", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "github-body.md")));
+    }
+
     private static string CreateExecutionBaselineMarkdown(string namespaceSegment = "intent-cli")
     {
         return $$"""

--- a/tests/IntentSystem.Cli.Tests/IntakeIssueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeIssueCommandTests.cs
@@ -238,14 +238,50 @@ public sealed class IntakeIssueCommandTests
         Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "github-body.md")));
     }
 
-    private static string CreateExecutionBaselineMarkdown(string namespaceSegment = "intent-cli")
+    [Fact]
+    public void Execute_GivenRuntimeOnlyTargetRepo_ReturnsExitCodeOneWithoutGeneratingChildFacingArtifacts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            CreateExecutionBaselineMarkdown(targetRepo: ".intent-cli"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateSingleExecutionArtifactMarkdown(
+                "auth",
+                "AUTH-01",
+                "intents/intent-cli/concepts/oauth2.md",
+                "concepts",
+                "Auth Concept"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "00-map.md"),
+            "# Intent CLI Map");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "clarifications", "open.md"),
+            "# Clarifications");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "concepts", "oauth2.md"),
+            "# Auth Concept");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeIssueCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Child target repo '.intent-cli'", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "AUTH-01", "github-body.md")));
+    }
+
+    private static string CreateExecutionBaselineMarkdown(
+        string namespaceSegment = "intent-cli",
+        string targetRepo = "submodules/intent-system")
     {
         return $$"""
             # Post-MVP Sub-Slices
 
             | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
             |---|---|---|---|---|---|---|---|
-            | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | submodules/intent-system | . | cli intake issue command | yes |
+            | G37 | G | `intake issue <domain>` を CLI shell から使えるようにし、updated intake-origin `execution/` source-of-truth から issue-ready execution unit の issue artifact 群を deterministic に生成できるようにする | G2, G35, G36 | {{targetRepo}} | . | cli intake issue command | yes |
 
             ## G37 の current baseline
 

--- a/tests/IntentSystem.Cli.Tests/QueueDispatchCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueDispatchCommandTests.cs
@@ -295,6 +295,45 @@ public sealed class QueueDispatchCommandTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenRuntimeOnlyTargetRepo_ReturnsExitCodeOneWithoutCreatingIssue()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreatePacketYaml(targetRepo: ".intent-cli"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        using var writer = new StringWriter();
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+
+        try
+        {
+            QueueDispatchCommand.PublisherFactory = () => new ThrowingPublisher();
+            var originalQueueState = File.ReadAllText(queueStatePath);
+
+            var exitCode = QueueDispatchCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("Child target repo '.intent-cli'", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Empty(File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+        }
+    }
+
     [Theory]
     [InlineData("https://github.com/J-Tech-Japan/intent-system.git", "J-Tech-Japan/intent-system")]
     [InlineData("git@github.com:J-Tech-Japan/intent-system.git", "J-Tech-Japan/intent-system")]

--- a/tests/IntentSystem.Cli.Tests/QueueDispatchCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueDispatchCommandTests.cs
@@ -256,6 +256,45 @@ public sealed class QueueDispatchCommandTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenRuntimeOnlyTargetPart_ReturnsExitCodeOneWithoutCreatingIssue()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreatePacketYaml(targetPart: ".intent-cli/intake"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        using var writer = new StringWriter();
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+
+        try
+        {
+            QueueDispatchCommand.PublisherFactory = () => new ThrowingPublisher();
+            var originalQueueState = File.ReadAllText(queueStatePath);
+
+            var exitCode = QueueDispatchCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("host runtime-only '.intent-cli/**' content", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Empty(File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+        }
+    }
+
     [Theory]
     [InlineData("https://github.com/J-Tech-Japan/intent-system.git", "J-Tech-Japan/intent-system")]
     [InlineData("git@github.com:J-Tech-Japan/intent-system.git", "J-Tech-Japan/intent-system")]
@@ -331,7 +370,8 @@ public sealed class QueueDispatchCommandTests
 
     private static string CreatePacketYaml(
         string targetRepo = "submodules/intent-system",
-        string issueTitle = "[G13] Queue Dispatch Command")
+        string issueTitle = "[G13] Queue Dispatch Command",
+        string targetPart = "cli queue dispatch command")
     {
         return $"""
         implementation_issue_packet:
@@ -345,7 +385,7 @@ public sealed class QueueDispatchCommandTests
             - "worker execution"
           target_repo: "{targetRepo}"
           target_path: "."
-          target_part: "cli queue dispatch command"
+          target_part: "{targetPart}"
           dependencies:
             - "G3"
           technical_baseline:

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -142,6 +142,48 @@ public sealed class RunFixCommandTests
         Assert.Contains("requires an execution unit", writer.ToString(), StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Execute_GivenRuntimeOnlyTargetPart_ReturnsExitCodeOneWithoutWritingRepairArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml(targetPart: ".intent-cli/intake"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+        var originalLauncherFactory = RunFixCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            RunFixCommand.DirectRunLauncherFactory = () => throw new InvalidOperationException("launcher should not be called");
+
+            var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("host runtime-only '.intent-cli/**' content", writer.ToString(), StringComparison.Ordinal);
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "fix", "G20.request.md")));
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "runs", "G20.request.json")));
+        }
+        finally
+        {
+            RunFixCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
     private sealed class FakeDirectRunLauncher(
         string providerSessionId,
         string provider,
@@ -727,7 +769,7 @@ public sealed class RunFixCommandTests
         };
     }
 
-    private static string CreatePacketYaml()
+    private static string CreatePacketYaml(string targetPart = "cli run fix command")
     {
         return """
         implementation_issue_packet:
@@ -743,7 +785,7 @@ public sealed class RunFixCommandTests
             - "worker start"
           target_repo: "submodules/intent-system"
           target_path: "."
-          target_part: "cli run fix command"
+          target_part: "__TARGET_PART__"
           dependencies:
             - "G19"
           technical_baseline:
@@ -776,7 +818,7 @@ public sealed class RunFixCommandTests
           deterministic_review_checks:
             - "run fix command remains handoff-only"
           clarification_return_path: "intents/intent-cli/clarifications/open.md"
-        """;
+        """.Replace("__TARGET_PART__", targetPart, StringComparison.Ordinal);
     }
 
     private static string CreateReviewContextMarkdown(string executionUnit = "G20")

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -323,6 +323,45 @@ public sealed class RunImplementCommandTests
     }
 
     [Fact]
+    public void Execute_GivenRuntimeOnlyTargetPart_ReturnsExitCodeOneWithoutWritingHandoffArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G19"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml(targetPart: ".intent-cli/intake"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+        var originalLauncherFactory = RunImplementCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            RunImplementCommand.DirectRunLauncherFactory = () => throw new InvalidOperationException("launcher should not be called");
+
+            var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("host runtime-only '.intent-cli/**' content", writer.ToString(), StringComparison.Ordinal);
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "implement", "G19.request.md")));
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "runs", "G19.request.json")));
+        }
+        finally
+        {
+            RunImplementCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenMissingQueueItem_ReturnsExitCodeOne()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -598,7 +637,7 @@ public sealed class RunImplementCommandTests
         };
     }
 
-    private static string CreatePacketYaml()
+    private static string CreatePacketYaml(string targetPart = "cli run implement command")
     {
         return """
         implementation_issue_packet:
@@ -614,7 +653,7 @@ public sealed class RunImplementCommandTests
             - "worker start"
           target_repo: "submodules/intent-system"
           target_path: "."
-          target_part: "cli run implement command"
+          target_part: "__TARGET_PART__"
           dependencies:
             - "G18"
           technical_baseline:
@@ -647,7 +686,7 @@ public sealed class RunImplementCommandTests
           deterministic_review_checks:
             - "run implement command remains handoff-only"
           clarification_return_path: "intents/intent-cli/clarifications/open.md"
-        """;
+        """.Replace("__TARGET_PART__", targetPart, StringComparison.Ordinal);
     }
 
     private static string CreateReviewContextMarkdown(string executionUnit = "G19")

--- a/tests/IntentSystem.Cli.Tests/RunStartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunStartCommandTests.cs
@@ -298,6 +298,44 @@ public sealed class RunStartCommandTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenRuntimeOnlyTargetRepo_ReturnsExitCodeOneWithoutCreatingWorktreeOrMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml(targetRepo: ".intent-cli"));
+        using var writer = new StringWriter();
+        var gitRunner = new FakeGitRunner();
+        var originalGitFactory = RunStartCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunStartCommand.GitCommandRunnerFactory = () => gitRunner;
+            var originalQueueState = File.ReadAllText(queueStatePath);
+
+            var exitCode = RunStartCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("Child target repo '.intent-cli'", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Empty(File.ReadAllText(runLogPath));
+            Assert.Empty(gitRunner.Calls);
+        }
+        finally
+        {
+            RunStartCommand.GitCommandRunnerFactory = originalGitFactory;
+        }
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext
@@ -363,7 +401,9 @@ public sealed class RunStartCommandTests
         };
     }
 
-    private static string CreatePacketYaml(string targetPart = "cli run start command")
+    private static string CreatePacketYaml(
+        string targetPart = "cli run start command",
+        string targetRepo = "submodules/intent-system")
     {
         return """
         implementation_issue_packet:
@@ -375,7 +415,7 @@ public sealed class RunStartCommandTests
             - "run start command"
           out_of_scope:
             - "worker start"
-          target_repo: "submodules/intent-system"
+          target_repo: "__TARGET_REPO__"
           target_path: "."
           target_part: "__TARGET_PART__"
           dependencies:
@@ -410,7 +450,9 @@ public sealed class RunStartCommandTests
           deterministic_review_checks:
             - "run start remains thin"
           clarification_return_path: "intents/intent-cli/clarifications/open.md"
-        """.Replace("__TARGET_PART__", targetPart, StringComparison.Ordinal);
+        """
+            .Replace("__TARGET_PART__", targetPart, StringComparison.Ordinal)
+            .Replace("__TARGET_REPO__", targetRepo, StringComparison.Ordinal);
     }
 
     private sealed class FakeGitRunner(bool failOnWorktreeAdd = false) : IGitCommandRunner

--- a/tests/IntentSystem.Cli.Tests/RunStartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunStartCommandTests.cs
@@ -260,6 +260,44 @@ public sealed class RunStartCommandTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenRuntimeOnlyTargetPart_ReturnsExitCodeOneWithoutCreatingWorktreeOrMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml(targetPart: ".intent-cli/intake"));
+        using var writer = new StringWriter();
+        var gitRunner = new FakeGitRunner();
+        var originalGitFactory = RunStartCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunStartCommand.GitCommandRunnerFactory = () => gitRunner;
+            var originalQueueState = File.ReadAllText(queueStatePath);
+
+            var exitCode = RunStartCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("host runtime-only '.intent-cli/**' content", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Empty(File.ReadAllText(runLogPath));
+            Assert.Empty(gitRunner.Calls);
+        }
+        finally
+        {
+            RunStartCommand.GitCommandRunnerFactory = originalGitFactory;
+        }
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext
@@ -325,7 +363,7 @@ public sealed class RunStartCommandTests
         };
     }
 
-    private static string CreatePacketYaml()
+    private static string CreatePacketYaml(string targetPart = "cli run start command")
     {
         return """
         implementation_issue_packet:
@@ -339,7 +377,7 @@ public sealed class RunStartCommandTests
             - "worker start"
           target_repo: "submodules/intent-system"
           target_path: "."
-          target_part: "cli run start command"
+          target_part: "__TARGET_PART__"
           dependencies:
             - "G13"
           technical_baseline:
@@ -372,7 +410,7 @@ public sealed class RunStartCommandTests
           deterministic_review_checks:
             - "run start remains thin"
           clarification_return_path: "intents/intent-cli/clarifications/open.md"
-        """;
+        """.Replace("__TARGET_PART__", targetPart, StringComparison.Ordinal);
     }
 
     private sealed class FakeGitRunner(bool failOnWorktreeAdd = false) : IGitCommandRunner


### PR DESCRIPTION
## Summary
- add a shared child-target guard that rejects host runtime-only `.intent-cli/**` targets and paths that resolve outside the child checkout root
- stop `intake issue`, `queue dispatch`, `run start`, `run implement`, and `run fix` before generating or launching child work when the target contract is invalid
- add focused regression coverage for child-facing artifact generation and launch guards

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "Execute_GivenRuntimeOnlyTargetPart_ReturnsExitCodeOneWithoutGeneratingChildFacingArtifacts|Execute_GivenRuntimeOnlyTargetPart_ReturnsExitCodeOneWithoutCreatingIssue|Execute_GivenRuntimeOnlyTargetPart_ReturnsExitCodeOneWithoutCreatingWorktreeOrMutatingFiles|Execute_GivenRuntimeOnlyTargetPart_ReturnsExitCodeOneWithoutWritingHandoffArtifact|Execute_GivenRuntimeOnlyTargetPart_ReturnsExitCodeOneWithoutWritingRepairArtifact" --logger "console;verbosity=minimal"
- dotnet test IntentSystem.sln --logger "console;verbosity=minimal"

Closes #266
