### PR TITLE
Propagate invalid fix target contracts through root run

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using IntentSystem.Projection.Serialization;
 using IntentSystem.Review;
 using IntentSystem.Supervisor;
 using IntentSystem.Supervisor.Models;
@@ -178,6 +179,16 @@ internal static class RunCommand
                                 inProgressItem.ExecutionUnit,
                                 () => RunFixExecutor(context, inProgressItem.ExecutionUnit));
                             continue;
+                        }
+
+                        var currentFixTargetContractGap = TryResolveCurrentFixTargetContractGap(context, inProgressItem);
+                        if (!string.IsNullOrWhiteSpace(currentFixTargetContractGap))
+                        {
+                            return CreateStopResult(
+                                DeterministicContractGapStopReason,
+                                actions,
+                                inProgressItem.ExecutionUnit,
+                                currentFixTargetContractGap);
                         }
 
                         var fixRunStatus = TryReadDirectRunStatus(
@@ -461,6 +472,52 @@ internal static class RunCommand
         return string.Equals(artifact.EntryKind, expectedEntryKind, StringComparison.Ordinal)
             ? artifact
             : null;
+    }
+
+    private static string? TryResolveCurrentFixTargetContractGap(CliContext context, QueueItem queueItem)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(queueItem);
+
+        var packetPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            queueItem.PacketPaths.Yaml.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(packetPath))
+        {
+            return $"Projection packet artifact was not found at {packetPath}";
+        }
+
+        try
+        {
+            var packet = ProjectionPacketRuntimeReader.Read(File.ReadAllText(packetPath));
+            var childRepoPath = Path.IsPathRooted(packet.TargetRepo)
+                ? Path.GetFullPath(packet.TargetRepo)
+                : Path.GetFullPath(Path.Combine(context.RepoRoot, packet.TargetRepo));
+            if (!Directory.Exists(childRepoPath))
+            {
+                return $"Child repo path was not found at {childRepoPath}";
+            }
+
+            var worktreePath = RunStartCommand.ResolveWorktreePath(context, queueItem.ExecutionUnit);
+            if (!Directory.Exists(worktreePath))
+            {
+                return $"Worktree path was not found at {worktreePath}";
+            }
+
+            ChildWorkTargetGuard.EnsureTargetAllowed(
+                queueItem.ExecutionUnit,
+                context.RepoRoot,
+                packet.TargetRepo,
+                worktreePath,
+                packet.TargetPath,
+                packet.TargetPart);
+
+            return null;
+        }
+        catch (InvalidOperationException exception)
+        {
+            return exception.Message;
+        }
     }
 
     private static IReadOnlyList<DirectRunProviderEvent> TryReadDirectRunProviderEvents(CliContext context, string executionUnit)

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -1741,6 +1741,58 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFixingItemWithStaleFailedFixResultAndRuntimeOnlyTarget_StopsWithDeterministicContractGap()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: ".intent-cli/intake"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        WriteDirectRunResult(repoRoot, "G226", "fix", "failed");
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("deterministic-contract-gap", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("host runtime-only '.intent-cli/**' content", result.Detail, StringComparison.Ordinal);
+        Assert.DoesNotContain("Fix direct run failed", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ExecuteCore_GivenClarifyBlockedItem_StopsWithClarificationRequired()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- revalidate the current fixing packet target contract in `RunCommand` before reusing stale fix result artifacts
- surface invalid child target contracts as `deterministic-contract-gap` instead of collapsing them to a generic failed-fix stop
- add regression coverage for a fixing item with a stale failed fix result plus a runtime-only target contract

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "ExecuteCore_GivenFixingItemWithStaleFailedFixResultAndRuntimeOnlyTarget_StopsWithDeterministicContractGap" --logger "console;verbosity=minimal"
- dotnet test IntentSystem.sln --logger "console;verbosity=minimal"

Closes #268
