### PR TITLE
[G106] Preserve Codex implement session through detached capture

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
@@ -96,6 +96,7 @@ internal static class DirectRunDetachedCaptureCommand
     {
         var writer = new DirectRunProviderEventWriter(options.ProviderEventLogPath);
         Process? process = null;
+        StreamWriter? preservedStandardInput = null;
         Task? stdoutPump = null;
         Task? stderrPump = null;
         var providerSessionId = string.Empty;
@@ -107,6 +108,11 @@ internal static class DirectRunDetachedCaptureCommand
 
             process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException($"Failed to start detached direct run process '{options.Command}'.");
+            if (startInfo.RedirectStandardInput)
+            {
+                preservedStandardInput = process.StandardInput;
+                preservedStandardInput.AutoFlush = true;
+            }
             providerSessionId = $"pid:{process.Id}";
             TryWriteSessionId(providerSessionId);
             Console.SetOut(TextWriter.Null);
@@ -184,6 +190,8 @@ internal static class DirectRunDetachedCaptureCommand
 
                 process.Dispose();
             }
+
+            preservedStandardInput?.Dispose();
         }
     }
 
@@ -417,23 +425,107 @@ internal static class DirectRunDetachedCaptureCommand
 
     private static ProcessStartInfo CreateProviderStartInfo(DirectRunDetachedCaptureOptions options)
     {
+        var providerInvocation = ResolveProviderInvocation(options);
+        var preserveStandardInput = ShouldPreserveProviderStandardInput(options);
         var startInfo = new ProcessStartInfo
         {
             WorkingDirectory = options.WorkingDirectory,
             UseShellExecute = false,
-            RedirectStandardInput = false,
+            RedirectStandardInput = preserveStandardInput,
             RedirectStandardOutput = true,
             RedirectStandardError = true
         };
 
-        startInfo.FileName = options.Command;
+        startInfo.FileName = providerInvocation.FileName;
 
-        foreach (var argument in options.Arguments)
+        foreach (var argument in providerInvocation.Arguments)
         {
             startInfo.ArgumentList.Add(argument);
         }
 
         return startInfo;
+    }
+
+    private static ResolvedProviderInvocation ResolveProviderInvocation(DirectRunDetachedCaptureOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var scriptExecutable = TryResolveScriptExecutable(options);
+        if (string.IsNullOrWhiteSpace(scriptExecutable))
+        {
+            return new ResolvedProviderInvocation(options.Command, options.Arguments);
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            return new ResolvedProviderInvocation(
+                scriptExecutable,
+                ["-q", "/dev/null", options.Command, .. options.Arguments]);
+        }
+
+        return new ResolvedProviderInvocation(
+            scriptExecutable,
+            ["-q", "-e", "-c", CreateShellCommand(options.Command, options.Arguments), "/dev/null"]);
+    }
+
+    private static bool ShouldPreserveProviderStandardInput(DirectRunDetachedCaptureOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (string.Equals(options.EntryKind, "review", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return string.Equals(options.Provider, "codex", StringComparison.OrdinalIgnoreCase)
+            || IsCodexLikeCommand(options.Command);
+    }
+
+    private static string? TryResolveScriptExecutable(DirectRunDetachedCaptureOptions options)
+    {
+        if (OperatingSystem.IsWindows()
+            || string.Equals(options.EntryKind, "review", StringComparison.Ordinal)
+            || (!string.Equals(options.Provider, "codex", StringComparison.OrdinalIgnoreCase)
+                && !IsCodexLikeCommand(options.Command)))
+        {
+            return null;
+        }
+
+        const string macOsScriptPath = "/usr/bin/script";
+        if (OperatingSystem.IsMacOS())
+        {
+            return File.Exists(macOsScriptPath) ? macOsScriptPath : null;
+        }
+
+        return File.Exists(macOsScriptPath) ? macOsScriptPath : "script";
+    }
+
+    private static bool IsCodexLikeCommand(string command)
+    {
+        var fileName = Path.GetFileName(command.Trim());
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return false;
+        }
+
+        var commandStem = Path.GetFileNameWithoutExtension(fileName);
+        return commandStem.StartsWith("codex", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string CreateShellCommand(string command, IReadOnlyList<string> arguments)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        return string.Join(
+            " ",
+            new[] { command }.Concat(arguments).Select(QuoteShellArgument));
+    }
+
+    private static string QuoteShellArgument(string argument)
+    {
+        ArgumentNullException.ThrowIfNull(argument);
+        return "'" + argument.Replace("'", "'\"'\"'", StringComparison.Ordinal) + "'";
     }
 
     private static string NormalizeCapturedLine(string line)
@@ -498,5 +590,9 @@ internal static class DirectRunDetachedCaptureCommand
         DateTimeOffset LaunchedAt,
         string WorkingDirectory,
         string Command,
+        IReadOnlyList<string> Arguments);
+
+    private sealed record ResolvedProviderInvocation(
+        string FileName,
         IReadOnlyList<string> Arguments);
 }

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -661,6 +661,92 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public async Task Launch_GivenWrappedCodexImplementProcess_DetachedCaptureProvidesTerminalToProvider()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14implement.provider.jsonl");
+        var worktreePath = tempDirectory.GetPath("repo");
+        Directory.CreateDirectory(worktreePath);
+        var codexPath = tempDirectory.CreateExecutableFile(
+            "repo/codex-experimental",
+            """
+            #!/bin/sh
+            if [ -t 0 ]; then
+                printf '%s\n' '{"type":"tty-present"}'
+            else
+                printf '%s\n' '{"type":"tty-missing"}'
+            fi
+            sleep 1
+            """);
+        var launcher = new DirectRunLauncher();
+
+        var result = launcher.Launch(
+            "G14implement",
+            "implement",
+            ".intent-cli/runs/G14implement.request.json",
+            ".intent-cli/runs/G14implement.provider.jsonl",
+            "Codex",
+            "gpt-5.4-mini",
+            "responses",
+            codexPath,
+            ["exec", "test prompt"],
+            DateTimeOffset.Parse("2026-04-09T11:17:00Z"),
+            worktreePath,
+            tempDirectory.GetPath(".intent-cli/implement/G14implement.request.md"),
+            providerEventLogPath);
+
+        await TemporaryDirectory.WaitForConditionAsync(
+            () =>
+            {
+                if (!File.Exists(providerEventLogPath))
+                {
+                    return false;
+                }
+
+                var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                return events.Any(providerEvent =>
+                           providerEvent.Kind == "provider-event"
+                           && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                           && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                           && string.Equals(typeElement.GetString(), "tty-present", StringComparison.Ordinal)
+                           && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal))
+                       && events.Any(providerEvent =>
+                           providerEvent.Kind == "provider-event"
+                           && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                           && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                           && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                           && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+            },
+            TimeSpan.FromSeconds(8));
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.DoesNotContain(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "tty-missing", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "tty-present", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        var backendExitEvent = Assert.Single(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.Equal(0, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+    }
+
+    [Fact]
     public async Task DirectRunExitMonitorCommand_GivenDetachedProcess_AppendsBackendExitForCurrentSession()
     {
         if (OperatingSystem.IsWindows())


### PR DESCRIPTION
## Summary
- allocate a PTY-backed provider invocation for non-review Codex detached runs so implement/fix sessions keep terminal semantics under detached capture
- keep detached capture ownership of backend-exit logging on the current session instead of relying on later supervision synthesis
- add focused launcher coverage that proves review still sees closed stdin while implement now gets a terminal under detached capture

## Verification
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~DirectRunLauncherTests.Launch_GivenWrappedCodexProcess_DetachedCaptureClosesProviderStandardInput|FullyQualifiedName~DirectRunLauncherTests.Launch_GivenWrappedCodexImplementProcess_DetachedCaptureProvidesTerminalToProvider" --logger "console;verbosity=minimal"
- dotnet test IntentSystem.sln --logger "console;verbosity=minimal"
- toy-calc dogfood using `/Users/tomohisa/.codex/bin/codex-isolated` from `/Users/tomohisa/dev/GitHub/MyIntentHost/submodules/toy-calc-sample`
  - `queue transition TOY-CALC-V0-01 active`
  - `run implement TOY-CALC-V0-01`
  - observed direct provider output on current session `pid:49341` and later canonical current-session `backend-exit` before root auto-resume

Closes #272
