### PR TITLE
Fix supervise backend-exit race window

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -10,6 +10,8 @@ namespace IntentSystem.Cli.Commands;
 internal static class RunSuperviseCommand
 {
     private const string TransitionActor = "intent-cli";
+    internal static TimeSpan TerminalFailureRaceWindow { get; set; } = TimeSpan.FromMilliseconds(100);
+    internal static TimeSpan TerminalFailureRacePollInterval { get; set; } = TimeSpan.FromMilliseconds(10);
 
     public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
 
@@ -697,6 +699,23 @@ internal static class RunSuperviseCommand
             return true;
         }
 
+        if (TryAwaitTerminalFailureReason(
+                providerLogPath,
+                executionUnit,
+                requestArtifact.ProviderSessionId,
+                requestArtifact.LaunchedAt,
+                out reason))
+        {
+            File.WriteAllText(
+                resultArtifactPath,
+                DirectRunResultArtifactJson.Serialize(resultArtifact with
+                {
+                    RunStatus = "failed"
+                }));
+
+            return true;
+        }
+
         var backendExitEvent = DirectRunProviderEventFactory.CreateBackendExitEvent(
             DateTimeOffset.UtcNow,
             executionUnit,
@@ -716,6 +735,56 @@ internal static class RunSuperviseCommand
         reason =
             $"Worker session '{requestArtifact.ProviderSessionId}' for '{executionUnit}' is no longer alive and no terminal provider event was captured.";
         return true;
+    }
+
+    private static bool TryAwaitTerminalFailureReason(
+        string providerLogPath,
+        string executionUnit,
+        string providerSessionId,
+        string launchedAt,
+        out string reason)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerLogPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(launchedAt);
+
+        reason = string.Empty;
+        if (TerminalFailureRaceWindow <= TimeSpan.Zero)
+        {
+            return false;
+        }
+
+        var deadline = DateTimeOffset.UtcNow + TerminalFailureRaceWindow;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            Thread.Sleep(TerminalFailureRacePollInterval);
+            IReadOnlyList<DirectRunProviderEvent> providerEvents;
+            try
+            {
+                providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerLogPath));
+            }
+            catch (Exception exception) when (
+                exception is IOException
+                or InvalidOperationException
+                or ArgumentException
+                or JsonException)
+            {
+                continue;
+            }
+
+            var currentProviderEvents = SelectCurrentSessionEvents(providerEvents, providerSessionId, launchedAt);
+            if (TryResolveTerminalFailureReason(
+                    currentProviderEvents,
+                    executionUnit,
+                    providerSessionId,
+                    out reason))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool TryResolveTerminalFailureReason(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -1883,6 +1883,176 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public async Task ExecuteCore_GivenDeadImplementWorkerSessionWhenBackendExitLandsDuringRaceWindow_DoesNotReportMissingTerminalEvent()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Active))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G226.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "active",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = null,
+                CommentRef = null,
+                HandoffArtifactRef = ".intent-cli/implement/G226.request.md",
+                RetryCount = 0,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "implement", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "implement",
+            "running",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Claude",
+                    EntryKind = "implement",
+                    SessionId = "pid:999999",
+                    Kind = "session-metadata",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        model = "sonnet",
+                        transport = "sdk",
+                        command = "claude"
+                    })
+                }
+            ],
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var originalRunImplementExecutor = RunSuperviseCommand.RunImplementExecutor;
+        var originalRaceWindow = RunSuperviseCommand.TerminalFailureRaceWindow;
+        var originalRacePollInterval = RunSuperviseCommand.TerminalFailureRacePollInterval;
+
+        try
+        {
+            RunSuperviseCommand.TerminalFailureRaceWindow = TimeSpan.FromMilliseconds(200);
+            RunSuperviseCommand.TerminalFailureRacePollInterval = TimeSpan.FromMilliseconds(5);
+            RunSuperviseCommand.RunImplementExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunRequest(repoRoot, executionUnit, "implement", "pid:4242", provider: "Claude");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "running",
+                    providerEvents:
+                    [
+                        new DirectRunProviderEvent
+                        {
+                            Timestamp = "2026-04-10T12:01:00.0000000+00:00",
+                            ExecutionUnit = executionUnit,
+                            Provider = "Claude",
+                            EntryKind = "implement",
+                            SessionId = "pid:4242",
+                            Kind = "session-metadata",
+                            Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                            {
+                                model = "sonnet",
+                                transport = "sdk",
+                                command = "claude"
+                            })
+                        }
+                    ],
+                    sessionId: "pid:4242",
+                    provider: "Claude");
+
+                return new RunImplementResult
+                {
+                    Request = CreateRunImplementRequest(repoRoot, executionUnit) with
+                    {
+                        ImplementRole = "Claude"
+                    },
+                    ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md"
+                };
+            };
+
+            var appendTask = Task.Run(async () =>
+            {
+                await Task.Delay(20);
+                new DirectRunProviderEventWriter(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl"))
+                    .Append(new DirectRunProviderEvent
+                    {
+                        Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                        ExecutionUnit = "G226",
+                        Provider = "Claude",
+                        EntryKind = "implement",
+                        SessionId = "pid:999999",
+                        Kind = "provider-event",
+                        Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                        {
+                            type = "backend-exit",
+                            exit_code = 1
+                        })
+                    });
+            });
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+            await appendTask;
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Contains("auto-resumed", result.Detail, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("no terminal provider event was captured", result.Detail, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Contains("backend exit code 1", runEvents[^2].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain("no terminal provider event was captured", runEvents[^2].Reason, StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunSuperviseCommand.RunImplementExecutor = originalRunImplementExecutor;
+            RunSuperviseCommand.TerminalFailureRaceWindow = originalRaceWindow;
+            RunSuperviseCommand.TerminalFailureRacePollInterval = originalRacePollInterval;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenFixingItemWithoutExistingSessionAndDeadFixWorkerSession_DoesNotRemainUnderSupervision()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -505,6 +505,115 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public async Task Execute_GivenDeadImplementWorkerSessionWhenBackendExitLandsDuringRaceWindow_AutoResumesUsingBackendExitReason()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Active)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateActiveRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G25.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession()));
+        WriteDeadImplementDirectRunArtifacts(repoRoot, "pid:999999");
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalRunImplementExecutor = RunSuperviseCommand.RunImplementExecutor;
+        var originalRaceWindow = RunSuperviseCommand.TerminalFailureRaceWindow;
+        var originalRacePollInterval = RunSuperviseCommand.TerminalFailureRacePollInterval;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+            RunSuperviseCommand.TerminalFailureRaceWindow = TimeSpan.FromMilliseconds(200);
+            RunSuperviseCommand.TerminalFailureRacePollInterval = TimeSpan.FromMilliseconds(5);
+            RunSuperviseCommand.RunImplementExecutor = (_, executionUnit) =>
+            {
+                WriteLiveImplementDirectRunArtifacts(repoRoot, executionUnit, "pid:4242");
+
+                return new RunImplementResult
+                {
+                    Request = new RunImplementRequest
+                    {
+                        ExecutionUnit = executionUnit,
+                        State = "active",
+                        ImplementRole = "Claude",
+                        QueueWorkerRole = "coder",
+                        QueueReviewRole = "reviewer",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = "issue-178-g25",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/178",
+                        LatestLinkedPr = null,
+                        PacketRef = ".intent-cli/issues/G25/packet.yaml",
+                        ReviewContextRef = ".intent-cli/issues/G25/review-context.md",
+                        IssueTitle = "[G25] Run Supervise Command",
+                        Goal = "Supervise retryable run interruptions.",
+                        TargetPart = "cli run supervise command",
+                        TargetRepo = "submodules/intent-system",
+                        TargetPath = ".",
+                        InScope = [],
+                        OutOfScope = [],
+                        AcceptanceCriteria = [],
+                        DeterministicReviewChecks = [],
+                        ExpectedEvidence = []
+                    },
+                    ArtifactPath = ".intent-cli/implement/G25.request.md"
+                };
+            };
+
+            var appendTask = Task.Run(async () =>
+            {
+                await Task.Delay(20);
+                new DirectRunProviderEventWriter(Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"))
+                    .Append(new DirectRunProviderEvent
+                    {
+                        Timestamp = "2026-04-08T10:20:01.0000000+00:00",
+                        ExecutionUnit = "G25",
+                        Provider = "Claude",
+                        EntryKind = "implement",
+                        SessionId = "pid:999999",
+                        Kind = "provider-event",
+                        Payload = JsonSerializer.SerializeToElement(new
+                        {
+                            type = "backend-exit",
+                            exit_code = 1
+                        })
+                    });
+            });
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+            await appendTask;
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("retry-attempted", runEvents[^2].Event);
+            Assert.Contains("backend exit code 1", runEvents[^2].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain("no terminal provider event was captured", runEvents[^2].Reason, StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.RunImplementExecutor = originalRunImplementExecutor;
+            RunSuperviseCommand.TerminalFailureRaceWindow = originalRaceWindow;
+            RunSuperviseCommand.TerminalFailureRacePollInterval = originalRacePollInterval;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenActiveItemWithoutExistingSessionAndDeadImplementWorkerSession_CapturesFailureAndAutoResumesImplementLoop()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- wait briefly for a same-session backend-exit event before persisting the synthetic missing-terminal failure reason
- prefer the canonical backend-exit reason when it lands inside the bounded race window
- cover the race in both run supervise and root run tests

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunSuperviseCommandTests|FullyQualifiedName~RunCommandTests" --logger "console;verbosity=minimal"
- dotnet test IntentSystem.sln --logger "console;verbosity=minimal"

Closes #276