### PR TITLE
Repair wrapper direct-run terminal capture

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
@@ -203,6 +203,11 @@ internal static class DirectRunDetachedCaptureCommand
     {
         if (DirectRunSessionBoundary.HasBackendExitEvent(options.ProviderEventLogPath, providerSessionId, options.LaunchedAt))
         {
+            DirectRunTerminalArtifactUpdater.PersistTerminalRunStatusIfCurrent(
+                options.ProviderEventLogPath,
+                providerSessionId,
+                options.LaunchedAt,
+                exitCode);
             return;
         }
 
@@ -213,6 +218,11 @@ internal static class DirectRunDetachedCaptureCommand
             options.Provider,
             providerSessionId,
             exitCode));
+        DirectRunTerminalArtifactUpdater.PersistTerminalRunStatusIfCurrent(
+            options.ProviderEventLogPath,
+            providerSessionId,
+            options.LaunchedAt,
+            exitCode);
     }
 
     private static void StartProviderExitMonitorIfPossible(

--- a/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
@@ -87,6 +87,11 @@ internal static class DirectRunExitMonitorCommand
 
         if (DirectRunSessionBoundary.HasBackendExitEvent(options.ProviderEventLogPath, options.ProviderSessionId, options.LaunchedAt))
         {
+            DirectRunTerminalArtifactUpdater.PersistTerminalRunStatusIfCurrent(
+                options.ProviderEventLogPath,
+                options.ProviderSessionId,
+                options.LaunchedAt,
+                exitCode: 1);
             return 0;
         }
 
@@ -98,6 +103,11 @@ internal static class DirectRunExitMonitorCommand
             options.Provider,
             options.ProviderSessionId,
             1));
+        DirectRunTerminalArtifactUpdater.PersistTerminalRunStatusIfCurrent(
+            options.ProviderEventLogPath,
+            options.ProviderSessionId,
+            options.LaunchedAt,
+            exitCode: 1);
 
         return 0;
     }

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -180,6 +180,14 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 absoluteProviderEventLogPath,
                 launchedAt,
                 providerSessionId);
+            StartDetachedProviderExitMonitorIfNeeded(
+                processInvocation.StartedProcessCarriesProviderSession,
+                absoluteProviderEventLogPath,
+                executionUnit,
+                entryKind,
+                provider,
+                providerSessionId,
+                launchedAt);
         }
 
         if (process.ExitedEarly && process.ExitCode != 0)
@@ -482,6 +490,15 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         if (string.IsNullOrWhiteSpace(providerSessionId)
             || DirectRunSessionBoundary.HasBackendExitEvent(providerEventLogPath, providerSessionId, launchedAt))
         {
+            if (!string.IsNullOrWhiteSpace(providerSessionId))
+            {
+                DirectRunTerminalArtifactUpdater.PersistTerminalRunStatusIfCurrent(
+                    providerEventLogPath,
+                    providerSessionId,
+                    launchedAt,
+                    exitCode);
+            }
+
             return;
         }
 
@@ -492,6 +509,11 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             provider,
             providerSessionId,
             exitCode));
+        DirectRunTerminalArtifactUpdater.PersistTerminalRunStatusIfCurrent(
+            providerEventLogPath,
+            providerSessionId,
+            launchedAt,
+            exitCode);
     }
 
     private static void StartPersistentExitMonitorIfNeeded(
@@ -542,6 +564,32 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         }
 
         using var launcher = Process.Start(launcherStartInfo);
+    }
+
+    private static void StartDetachedProviderExitMonitorIfNeeded(
+        bool startedProcessCarriesProviderSession,
+        string providerEventLogPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        if (startedProcessCarriesProviderSession
+            || !TryParseProcessId(providerSessionId, out var processId))
+        {
+            return;
+        }
+
+        StartPersistentExitMonitorIfNeeded(
+            requiresPersistentExitMonitor: true,
+            processId,
+            providerEventLogPath,
+            executionUnit,
+            entryKind,
+            provider,
+            providerSessionId,
+            launchedAt);
     }
 
     private static void BestEffortAppendBackendExitIfProcessExitedSoon(
@@ -605,6 +653,15 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         {
             return false;
         }
+    }
+
+    private static bool TryParseProcessId(string providerSessionId, out int processId)
+    {
+        processId = default;
+        const string prefix = "pid:";
+        return providerSessionId.StartsWith(prefix, StringComparison.Ordinal)
+            && int.TryParse(providerSessionId[prefix.Length..], out processId)
+            && processId > 0;
     }
 
     private static bool TryHandleDetachedCaptureHandshake(

--- a/src/IntentSystem.Cli/Commands/DirectRunTerminalArtifactUpdater.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunTerminalArtifactUpdater.cs
@@ -1,0 +1,90 @@
+using System.Globalization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class DirectRunTerminalArtifactUpdater
+{
+    public static void PersistTerminalRunStatusIfCurrent(
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset launchedAt,
+        int exitCode)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerEventLogPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+
+        if (!TryResolveSiblingArtifactPath(providerEventLogPath, ".provider.jsonl", ".result.json", out var resultArtifactPath)
+            || !TryResolveSiblingArtifactPath(providerEventLogPath, ".provider.jsonl", ".request.json", out var requestArtifactPath)
+            || !File.Exists(resultArtifactPath)
+            || !File.Exists(requestArtifactPath))
+        {
+            return;
+        }
+
+        DirectRunRequestArtifact requestArtifact;
+        DirectRunResultArtifact resultArtifact;
+        try
+        {
+            requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+            resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or InvalidOperationException
+            or ArgumentException
+            or System.Text.Json.JsonException)
+        {
+            return;
+        }
+
+        if (!string.Equals(requestArtifact.ProviderSessionId, providerSessionId, StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.SessionId, providerSessionId, StringComparison.Ordinal)
+            || !DateTimeOffset.TryParse(
+                requestArtifact.LaunchedAt,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind,
+                out var requestLaunchedAt)
+            || requestLaunchedAt != launchedAt)
+        {
+            return;
+        }
+
+        var terminalStatus = exitCode == 0 ? "succeeded" : "failed";
+        if (string.Equals(resultArtifact.RunStatus, terminalStatus, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        try
+        {
+            File.WriteAllText(
+                resultArtifactPath,
+                DirectRunResultArtifactJson.Serialize(resultArtifact with
+                {
+                    RunStatus = terminalStatus
+                }));
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or UnauthorizedAccessException
+            or InvalidOperationException)
+        {
+        }
+    }
+
+    private static bool TryResolveSiblingArtifactPath(
+        string providerEventLogPath,
+        string expectedSuffix,
+        string replacementSuffix,
+        out string artifactPath)
+    {
+        artifactPath = string.Empty;
+        if (!providerEventLogPath.EndsWith(expectedSuffix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        artifactPath = providerEventLogPath[..^expectedSuffix.Length] + replacementSuffix;
+        return true;
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -821,6 +821,99 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public async Task DirectRunExitMonitorCommand_GivenCurrentRunningResultArtifact_UpdatesRunStatusToFailed()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var externalProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-c", "sleep 1" }
+        });
+        Assert.NotNull(externalProcess);
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14b-result.provider.jsonl");
+        var requestArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-result.request.json");
+        var resultArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-result.result.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(providerEventLogPath)!);
+
+        var launchedAt = DateTimeOffset.UtcNow;
+        var providerSessionId = $"pid:{externalProcess!.Id}";
+        File.WriteAllText(
+            requestArtifactPath,
+            DirectRunRequestArtifactJson.Serialize(new DirectRunRequestArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-result",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-result.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                Transport = "responses",
+                LaunchedAt = launchedAt.ToString("O"),
+                ProviderSessionId = providerSessionId,
+                TransportSummary = "launched via wrapper"
+            }));
+        File.WriteAllText(
+            resultArtifactPath,
+            DirectRunResultArtifactJson.Serialize(new DirectRunResultArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-result",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-result.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                SessionId = providerSessionId,
+                RunStatus = "running",
+                RawLogRef = ".intent-cli/runs/G14b-result.provider.jsonl",
+                PacketRef = ".intent-cli/issues/G14b-result/packet.yaml",
+                ReviewContextRef = ".intent-cli/issues/G14b-result/review-context.md",
+                Worktree = new DirectRunWorktreeContext
+                {
+                    Path = "/repo/.intent-cli/worktrees/G14b-result"
+                }
+            }));
+
+        using var monitor = Process.Start(DirectRunExitMonitorCommand.CreateDetachedStartInfo(
+            externalProcess.Id,
+            providerEventLogPath,
+            "G14b-result",
+            "fix",
+            "Codex",
+            providerSessionId,
+            launchedAt));
+        Assert.NotNull(monitor);
+        monitor!.StandardInput.Close();
+        monitor.StandardOutput.Dispose();
+        monitor.StandardError.Dispose();
+
+        await TemporaryDirectory.WaitForConditionAsync(
+            () =>
+            {
+                if (!File.Exists(resultArtifactPath))
+                {
+                    return false;
+                }
+
+                var artifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+                return string.Equals(artifact.RunStatus, "failed", StringComparison.Ordinal);
+            },
+            TimeSpan.FromSeconds(5));
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        Assert.Equal(providerSessionId, resultArtifact.SessionId);
+        Assert.Equal("failed", resultArtifact.RunStatus);
+    }
+
+    [Fact]
     public async Task DirectRunExitMonitorCommand_GivenStaleBackendExitForSamePid_AppendsFreshBackendExit()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -346,6 +346,125 @@ public sealed class RunFixCommandTests
     }
 
     [Fact]
+    public async Task Execute_GivenWrapperCodexCommand_AppendsTerminalBackendExitAndUpdatesResultArtifact()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        var providerBinaryPath = tempDirectory.CreateExecutableFile(
+            "bin/codex",
+            """
+            #!/bin/sh
+            sleep 1
+            exit 1
+            """);
+        var wrapperPath = tempDirectory.CreateExecutableFile(
+            "bin/codex-isolated",
+            $$"""
+            #!/bin/zsh
+            export CODEX_HOME={{tempDirectory.GetPath(".codex-direct-backend")}}
+            exec {{providerBinaryPath}} "$@"
+            """);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunFixCommand.TimestampFactory;
+
+        try
+        {
+            RunFixCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-16T00:17:00Z");
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Codex",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        Command = wrapperPath
+                    }
+                }
+            };
+
+            var exitCode = RunFixCommand.Execute(context, ["G20"], writer);
+
+            Assert.Equal(0, exitCode);
+
+            var resultArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.result.json");
+            var providerEventLogPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.provider.jsonl");
+            var initialArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+
+            await WaitForConditionAsync(
+                () =>
+                {
+                    if (!File.Exists(providerEventLogPath) || !File.Exists(resultArtifactPath))
+                    {
+                        return false;
+                    }
+
+                    var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                    var terminalEventExists = providerEvents.Any(providerEvent =>
+                        string.Equals(providerEvent.SessionId, initialArtifact.SessionId, StringComparison.Ordinal)
+                        && providerEvent.Kind == "provider-event"
+                        && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                        && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                        && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+                    if (!terminalEventExists)
+                    {
+                        return false;
+                    }
+
+                    var updatedArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+                    return string.Equals(updatedArtifact.SessionId, initialArtifact.SessionId, StringComparison.Ordinal)
+                        && string.Equals(updatedArtifact.RunStatus, "failed", StringComparison.Ordinal);
+                },
+                TimeSpan.FromSeconds(10));
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            var backendExitEvent = Assert.Single(providerEvents, providerEvent =>
+                string.Equals(providerEvent.SessionId, initialArtifact.SessionId, StringComparison.Ordinal)
+                && providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+            Assert.Equal(1, backendExitEvent.Payload.GetProperty("exit_code").GetInt32());
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+            Assert.Equal(initialArtifact.SessionId, resultArtifact.SessionId);
+            Assert.Equal("failed", resultArtifact.RunStatus);
+        }
+        finally
+        {
+            RunFixCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenMissingQueueItem_ReturnsExitCodeOne()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -870,6 +989,22 @@ public sealed class RunFixCommandTests
         """ + Environment.NewLine;
     }
 
+    private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(100);
+        }
+
+        Assert.True(condition(), "Timed out waiting for condition.");
+    }
+
     private sealed class TemporaryDirectory : IDisposable
     {
         private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-run-fix-tests-").FullName;
@@ -890,6 +1025,31 @@ public sealed class RunFixCommandTests
             Directory.CreateDirectory(directoryPath);
             File.WriteAllText(fullPath, contents);
             return fullPath;
+        }
+
+        public string CreateExecutableFile(string relativePath, string contents)
+        {
+            var fullPath = CreateFile(relativePath, contents);
+            if (OperatingSystem.IsWindows())
+            {
+                return fullPath;
+            }
+
+            File.SetUnixFileMode(
+                fullPath,
+                UnixFileMode.UserRead
+                | UnixFileMode.UserWrite
+                | UnixFileMode.UserExecute
+                | UnixFileMode.GroupRead
+                | UnixFileMode.GroupExecute
+                | UnixFileMode.OtherRead
+                | UnixFileMode.OtherExecute);
+            return fullPath;
+        }
+
+        public string GetPath(string relativePath)
+        {
+            return Path.Combine(rootPath, relativePath);
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary
- keep canonical backend-exit capture alive for detached wrapper-backed direct runs by starting an actual provider-session exit monitor after session resolution
- update sibling direct run result artifacts from running to terminal status whenever backend-exit is observed or appended
- add regression coverage for wrapper-backed run fix sessions and exit-monitor result updates

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunFixCommandTests|FullyQualifiedName~DirectRunLauncherTests" --logger "console;verbosity=minimal"
- dotnet test IntentSystem.sln --logger "console;verbosity=minimal"

Closes #282