### PR TITLE
Protect runtime concept YAML during intake apply

### DIFF
--- a/src/IntentSystem.Cli/Commands/IntakePatchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakePatchCommand.cs
@@ -56,7 +56,7 @@ internal static class IntakePatchCommand
     private static IntakePatchRequest CreateRequest(string repoRoot, IntakePatchFoldinDraft foldinDraft)
     {
         var targetFilePaths = foldinDraft.ReturnToIntentPaths
-            .Concat(foldinDraft.SourceConceptRefs)
+            .Concat(foldinDraft.SourceConceptRefs.Where(path => !IsRuntimeConceptArtifactPath(path)))
             .Distinct(StringComparer.Ordinal)
             .OrderBy(path => path, StringComparer.Ordinal)
             .ToArray();
@@ -172,5 +172,13 @@ internal static class IntakePatchCommand
         return values.Count == 0
             ? "none"
             : string.Join(", ", values.OrderBy(value => value, StringComparer.Ordinal));
+    }
+
+    private static bool IsRuntimeConceptArtifactPath(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        return path.StartsWith(".intent-cli/intake/", StringComparison.Ordinal)
+            && path.EndsWith(".concept.yaml", StringComparison.Ordinal);
     }
 }

--- a/tests/IntentSystem.Cli.Tests/IntakeActivateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeActivateCommandTests.cs
@@ -195,6 +195,87 @@ public sealed class IntakeActivateCommandTests
         Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Execute_GivenRuntimeConceptArtifactSourceRef_DoesNotCorruptConceptYaml()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var conceptArtifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.concept.yaml");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
+            CreateConceptArtifactYaml("auth"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewArtifactYaml(CreateAnsweredItem(sourceConceptRef: ".intent-cli/intake/auth.concept.yaml")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means" + Environment.NewLine + Environment.NewLine + "- Existing rule" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "00-map.md"),
+            "# Intent CLI Map");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "clarifications", "open.md"),
+            "# Clarifications");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            CreateExecutionBaselineMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var originalEnqueueTimestampFactory = QueueEnqueueCommand.TimestampFactory;
+        var originalPublisherFactory = QueueDispatchCommand.PublisherFactory;
+        var originalRemoteGitFactory = QueueDispatchCommand.GitCommandRunnerFactory;
+        var originalDispatchTimestampFactory = QueueDispatchCommand.TimestampFactory;
+        var originalStartGitFactory = RunStartCommand.GitCommandRunnerFactory;
+        var originalStartTimestampFactory = RunStartCommand.TimestampFactory;
+        var startGitRunner = new FakeStartGitRunner();
+        var publisher = new FakePublisher();
+
+        try
+        {
+            QueueEnqueueCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:00:00Z");
+            QueueDispatchCommand.PublisherFactory = () => publisher;
+            QueueDispatchCommand.GitCommandRunnerFactory = () => new FakeRemoteGitRunner();
+            QueueDispatchCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:05:00Z");
+            RunStartCommand.GitCommandRunnerFactory = () => startGitRunner;
+            RunStartCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-06T11:10:00Z");
+
+            var originalConceptYaml = File.ReadAllText(conceptArtifactPath);
+            var exitCode = IntakeActivateCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(originalConceptYaml, File.ReadAllText(conceptArtifactPath));
+            var packet = IntakeConceptArtifactYaml.Deserialize(File.ReadAllText(conceptArtifactPath));
+            Assert.Equal("auth", packet.DomainSlug);
+
+            var output = writer.ToString();
+            Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("- .intent-cli/intake/auth.concept.yaml", output, StringComparison.Ordinal);
+            Assert.Contains("- AUTH-01", output, StringComparison.Ordinal);
+
+            var patchDraft = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.patch.md"));
+            Assert.Contains("- .intent-cli/intake/auth.concept.yaml", patchDraft, StringComparison.Ordinal);
+            Assert.DoesNotContain("### `.intent-cli/intake/auth.concept.yaml`", patchDraft, StringComparison.Ordinal);
+        }
+        finally
+        {
+            QueueEnqueueCommand.TimestampFactory = originalEnqueueTimestampFactory;
+            QueueDispatchCommand.PublisherFactory = originalPublisherFactory;
+            QueueDispatchCommand.GitCommandRunnerFactory = originalRemoteGitFactory;
+            QueueDispatchCommand.TimestampFactory = originalDispatchTimestampFactory;
+            RunStartCommand.GitCommandRunnerFactory = originalStartGitFactory;
+            RunStartCommand.TimestampFactory = originalStartTimestampFactory;
+        }
+    }
+
     private static string CreateExecutionBaselineMarkdown()
     {
         return """
@@ -275,12 +356,13 @@ public sealed class IntakeActivateCommandTests
         };
     }
 
-    private static IntentSystem.ConceptIntake.Models.InterviewQueueItem CreateAnsweredItem()
+    private static IntentSystem.ConceptIntake.Models.InterviewQueueItem CreateAnsweredItem(
+        string sourceConceptRef = "intents/intent-cli/concepts/auth-oauth2.md")
     {
         return new IntentSystem.ConceptIntake.Models.InterviewQueueItem
         {
             DomainSlug = "auth",
-            SourceConceptRef = "intents/intent-cli/concepts/auth-oauth2.md",
+            SourceConceptRef = sourceConceptRef,
             QuestionId = "iq-1",
             QuestionText = "What should be updated?",
             Reason = "Clarify auth direction.",

--- a/tests/IntentSystem.Cli.Tests/IntakeAdvanceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeAdvanceCommandTests.cs
@@ -105,6 +105,55 @@ public sealed class IntakeAdvanceCommandTests
     }
 
     [Fact]
+    public void Execute_GivenRuntimeConceptArtifactSourceRef_DoesNotCorruptConceptYaml()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var conceptArtifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.concept.yaml");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
+            CreateConceptArtifactYaml("auth"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.yaml"),
+            CreateInterviewArtifactYaml(CreateAnsweredItem(sourceConceptRef: ".intent-cli/intake/auth.concept.yaml")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "auth", "iq-1.md"),
+            "# Interview Question");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means" + Environment.NewLine + Environment.NewLine + "- Existing rule" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "execution", "05-post-mvp-sub-slices.md"),
+            """
+            # Post-MVP Sub-Slices
+
+            ## G36 の current baseline
+
+            - `intake execution apply <domain>` を最初の execution source-of-truth apply command にする
+            - canonical source は current `.intent-cli/intake/<domain>.execution.md` と current `execution/` source files, plus the `G29` / `G30` / `G32` / `G33` / `G34` / `G35` intake baseline である
+            - successful output は execution draft で指定された source files だけを deterministic に更新することを baseline にする
+            """);
+        using var writer = new StringWriter();
+
+        var originalConceptYaml = File.ReadAllText(conceptArtifactPath);
+        var exitCode = IntakeAdvanceCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(originalConceptYaml, File.ReadAllText(conceptArtifactPath));
+        var packet = IntakeConceptArtifactYaml.Deserialize(File.ReadAllText(conceptArtifactPath));
+        Assert.Equal("auth", packet.DomainSlug);
+
+        var output = writer.ToString();
+        Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("- .intent-cli/intake/auth.concept.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("- intents/intent-cli/intent-tree/means/auth-oauth2.md", output, StringComparison.Ordinal);
+
+        var patchDraft = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.patch.md"));
+        Assert.Contains("- .intent-cli/intake/auth.concept.yaml", patchDraft, StringComparison.Ordinal);
+        Assert.DoesNotContain("### `.intent-cli/intake/auth.concept.yaml`", patchDraft, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
     {
         using var writer = new StringWriter();
@@ -131,12 +180,13 @@ public sealed class IntakeAdvanceCommandTests
         };
     }
 
-    private static IntentSystem.ConceptIntake.Models.InterviewQueueItem CreateAnsweredItem()
+    private static IntentSystem.ConceptIntake.Models.InterviewQueueItem CreateAnsweredItem(
+        string sourceConceptRef = "intents/intent-cli/concepts/auth-oauth2.md")
     {
         return new IntentSystem.ConceptIntake.Models.InterviewQueueItem
         {
             DomainSlug = "auth",
-            SourceConceptRef = "intents/intent-cli/concepts/auth-oauth2.md",
+            SourceConceptRef = sourceConceptRef,
             QuestionId = "iq-1",
             QuestionText = "What should be updated?",
             Reason = "Clarify auth direction.",

--- a/tests/IntentSystem.Cli.Tests/IntakeApplyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeApplyCommandTests.cs
@@ -167,6 +167,75 @@ public sealed class IntakeApplyCommandTests
         Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Execute_GivenRuntimeConceptArtifactSourceRef_KeepsConceptYamlDeserializable()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.patch.md"),
+            """
+            # Intake Patch Draft
+
+            ## Domain
+
+            `auth`
+
+            target_file_paths:
+            - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+            source_concept_refs:
+            - .intent-cli/intake/auth.concept.yaml
+
+            ## File-By-File Patch Candidates
+
+            ### `intents/intent-cli/intent-tree/means/auth-oauth2.md`
+
+            current_file_state: present
+            foldin_anchors:
+            - answered_question_ids:iq-1
+            - recommended_updates:Add device-code note
+            source_concept_refs:
+            - .intent-cli/intake/auth.concept.yaml
+            proposed_edits:
+            - Apply update candidate: Add device-code note
+            rationale:
+            - This path is listed in return_to_intent_paths.
+            current_file_excerpt:
+            ```text
+            # Auth Means
+            Existing line
+            ```
+            """);
+        var conceptArtifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "auth.concept.yaml");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
+            """
+            domain_slug: auth
+            concept_source: interactive
+            concept_text: "Add OAuth2 provider support."
+            upstream_paths: []
+            initial_goal: "Add OAuth2 provider support."
+            constraints: []
+            known_unknowns: []
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means" + Environment.NewLine + "Existing line");
+        using var writer = new StringWriter();
+
+        var originalConceptYaml = File.ReadAllText(conceptArtifactPath);
+        var exitCode = IntakeApplyCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(originalConceptYaml, File.ReadAllText(conceptArtifactPath));
+        var packet = IntakeConceptArtifactYaml.Deserialize(File.ReadAllText(conceptArtifactPath));
+        Assert.Equal("auth", packet.DomainSlug);
+
+        var updatedMeans = File.ReadAllText(Path.Combine(repoRoot, "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"));
+        Assert.Contains("- Add device-code note", updatedMeans, StringComparison.Ordinal);
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/IntakePatchCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakePatchCommandTests.cs
@@ -124,6 +124,59 @@ public sealed class IntakePatchCommandTests
         Assert.Contains("requires a domain", writer.ToString(), StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Execute_GivenRuntimeConceptArtifactSourceRef_DoesNotDraftYamlArtifactAsPatchTarget()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.foldin.md"),
+            """
+            # Intake Fold-In Draft
+
+            ## Domain
+
+            `auth`
+
+            answered_question_ids:
+            - iq-1
+
+            recommended_updates:
+            - Add device-code note
+
+            return_to_intent_paths:
+            - intents/intent-cli/intent-tree/means/auth-oauth2.md
+
+            source_concept_refs:
+            - .intent-cli/intake/auth.concept.yaml
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.concept.yaml"),
+            """
+            domain_slug: auth
+            concept_source: interactive
+            concept_text: "Add OAuth2 provider support."
+            upstream_paths: []
+            initial_goal: "Add OAuth2 provider support."
+            constraints: []
+            known_unknowns: []
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "intent-cli", "intent-tree", "means", "auth-oauth2.md"),
+            "# Auth Means" + Environment.NewLine + "Existing line");
+        using var writer = new StringWriter();
+
+        var exitCode = IntakePatchCommand.Execute(CreateContext(repoRoot), ["auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var markdown = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "intake", "auth.patch.md"));
+        Assert.Contains("source_concept_refs:", markdown, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/intake/auth.concept.yaml", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("### `.intent-cli/intake/auth.concept.yaml`", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("Reconcile this source concept file with the current fold-in draft.", markdown, StringComparison.Ordinal);
+        Assert.Contains("### `intents/intent-cli/intent-tree/means/auth-oauth2.md`", markdown, StringComparison.Ordinal);
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext


### PR DESCRIPTION
## Summary
- keep runtime `.intent-cli/intake/*.concept.yaml` source refs out of intake patch target files so apply/activate do not treat YAML artifacts like markdown sources
- preserve runtime concept YAML unchanged while still applying real parent-source updates from return-to-intent paths
- add regressions for patch, apply, advance, and activate when `source_concept_refs` points at a runtime concept artifact

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IntakePatchCommandTests|FullyQualifiedName~IntakeApplyCommandTests|FullyQualifiedName~IntakeAdvanceCommandTests|FullyQualifiedName~IntakeActivateCommandTests" --logger "console;verbosity=minimal"
- dotnet test IntentSystem.sln --logger "console;verbosity=minimal"

Closes #280