### PR TITLE
Fix #281: keep review-run PR comment publication canonical

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -325,6 +325,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             + " and a required field 'comment_body' that must be a string when a review comment is required or null when no comment is required."
             + " Use 'accepted' or 'approved' only when no review comment is required."
             + " Use 'comment', 'commented', 'fix-requested', or 'changes-requested' only when a deterministic review comment is required."
+            + " Do not post GitHub or pull request comments, do not run 'gh pr comment', and do not publish or mutate any external review state from this direct review run."
+            + " Persist only the review outcome JSON for downstream handling because the separate 'review comment' step owns PR comment publication."
             + " Do not return wrapper fields such as 'stop_reason', 'actions', or execution envelopes instead of 'disposition'."
             + " If you detect a deterministic contract gap or need follow-up work, still return 'disposition':'fix-requested' with an actionable 'comment_body'."
             + " For accepted or approved outcomes, return 'comment_body': null."

--- a/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
@@ -35,6 +35,9 @@ internal sealed record DirectRunResultArtifact
     [JsonPropertyName("review_comment_body_path")]
     public string? ReviewCommentBodyPath { get; init; }
 
+    [JsonPropertyName("review_comment_ref")]
+    public string? ReviewCommentRef { get; init; }
+
     [JsonPropertyName("raw_log_ref")]
     public required string RawLogRef { get; init; }
 

--- a/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunReviewOutcomeSupport.cs
@@ -1,9 +1,14 @@
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace IntentSystem.Cli.Commands;
 
 internal static class DirectRunReviewOutcomeSupport
 {
+    private static readonly Regex ReviewCommentUrlPattern = new(
+        @"https://github\.com/[^\s/]+/[^\s/]+/pull/\d+#issuecomment-\d+",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     public static bool IsAcceptOutcome(string outcome)
     {
         return string.Equals(outcome, "accepted", StringComparison.Ordinal)
@@ -105,6 +110,26 @@ internal static class DirectRunReviewOutcomeSupport
             Directory.CreateDirectory(directoryPath);
             File.WriteAllText(absolutePath, bodyOrPath);
             commentBodyPath = relativePath;
+            return true;
+        }
+
+        return false;
+    }
+
+    public static bool TryResolvePublishedReviewCommentRef(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string? linkedPr,
+        out string reviewCommentRef)
+    {
+        reviewCommentRef = string.Empty;
+
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            if (!TryResolvePublishedReviewCommentRef(providerEvents[index].Payload, linkedPr, out reviewCommentRef))
+            {
+                continue;
+            }
+
             return true;
         }
 
@@ -456,6 +481,77 @@ internal static class DirectRunReviewOutcomeSupport
         }
 
         return false;
+    }
+
+    private static bool TryResolvePublishedReviewCommentRef(
+        JsonElement payload,
+        string? linkedPr,
+        out string reviewCommentRef)
+    {
+        reviewCommentRef = string.Empty;
+
+        foreach (var candidate in EnumeratePayloadStrings(payload))
+        {
+            var match = ReviewCommentUrlPattern.Matches(candidate)
+                .Select(match => match.Value)
+                .LastOrDefault(value => IsMatchingLinkedPr(value, linkedPr));
+            if (!string.IsNullOrWhiteSpace(match))
+            {
+                reviewCommentRef = match;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> EnumeratePayloadStrings(JsonElement payload)
+    {
+        switch (payload.ValueKind)
+        {
+            case JsonValueKind.String:
+            {
+                var value = payload.GetString();
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    yield return value;
+                }
+
+                yield break;
+            }
+            case JsonValueKind.Object:
+                foreach (var property in payload.EnumerateObject())
+                {
+                    foreach (var value in EnumeratePayloadStrings(property.Value))
+                    {
+                        yield return value;
+                    }
+                }
+
+                yield break;
+            case JsonValueKind.Array:
+                foreach (var item in payload.EnumerateArray())
+                {
+                    foreach (var value in EnumeratePayloadStrings(item))
+                    {
+                        yield return value;
+                    }
+                }
+
+                yield break;
+            default:
+                yield break;
+        }
+    }
+
+    private static bool IsMatchingLinkedPr(string reviewCommentRef, string? linkedPr)
+    {
+        if (string.IsNullOrWhiteSpace(linkedPr))
+        {
+            return true;
+        }
+
+        return reviewCommentRef.StartsWith($"{linkedPr}#issuecomment-", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool TryResolveRunStatus(JsonElement payload, out string runStatus)

--- a/src/IntentSystem.Cli/Commands/ReviewCommentCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCommentCommand.cs
@@ -96,7 +96,7 @@ internal static class ReviewCommentCommand
             throw new InvalidOperationException("Review request must contain a linked PR.");
         }
 
-        var commentRef = PublisherFactory().PostComment(request.LinkedPr, body);
+        var commentRef = ResolveCommentRef(context, executionUnit, request.LinkedPr, body);
         var artifact = new ReviewCommentArtifact
         {
             ExecutionUnit = executionUnit,
@@ -131,6 +131,83 @@ internal static class ReviewCommentCommand
             ArtifactPath = Review.ReviewCommentArtifactPathResolver.Resolve(executionUnit),
             CommentRef = commentRef
         };
+    }
+
+    private static string ResolveCommentRef(CliContext context, string executionUnit, string linkedPr, string body)
+    {
+        if (TryResolveCurrentSessionCommentRef(context, executionUnit, linkedPr, out var existingCommentRef))
+        {
+            return existingCommentRef;
+        }
+
+        return PublisherFactory().PostComment(linkedPr, body);
+    }
+
+    private static bool TryResolveCurrentSessionCommentRef(
+        CliContext context,
+        string executionUnit,
+        string linkedPr,
+        out string commentRef)
+    {
+        commentRef = string.Empty;
+
+        var resultArtifactPath = Path.Combine(context.ResolveDirectRunArtifactRootPath(), $"{executionUnit}.result.json");
+        if (!File.Exists(resultArtifactPath))
+        {
+            return false;
+        }
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        if (!string.Equals(resultArtifact.EntryKind, "review", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(resultArtifact.ReviewCommentRef)
+            && resultArtifact.ReviewCommentRef.StartsWith($"{linkedPr}#issuecomment-", StringComparison.OrdinalIgnoreCase))
+        {
+            commentRef = resultArtifact.ReviewCommentRef;
+            return true;
+        }
+
+        var providerEventLogPath = Path.IsPathRooted(resultArtifact.RawLogRef)
+            ? Path.GetFullPath(resultArtifact.RawLogRef)
+            : Path.GetFullPath(Path.Combine(context.RepoRoot, resultArtifact.RawLogRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(providerEventLogPath))
+        {
+            return false;
+        }
+
+        DateTimeOffset? launchedAt = null;
+        var requestArtifactPath = Path.Combine(context.ResolveDirectRunArtifactRootPath(), $"{executionUnit}.request.json");
+        if (File.Exists(requestArtifactPath))
+        {
+            var requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+            if (string.Equals(requestArtifact.EntryKind, "review", StringComparison.Ordinal)
+                && DirectRunSessionBoundary.TryParseLaunchedAt(requestArtifact.LaunchedAt, out var parsedLaunchedAt))
+            {
+                launchedAt = parsedLaunchedAt;
+            }
+        }
+
+        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        var currentSessionEvents = DirectRunSessionBoundary.SelectEvents(providerEvents, resultArtifact.SessionId, launchedAt);
+        if (!DirectRunReviewOutcomeSupport.TryResolvePublishedReviewCommentRef(currentSessionEvents, linkedPr, out commentRef))
+        {
+            return false;
+        }
+
+        if (!string.Equals(resultArtifact.ReviewCommentRef, commentRef, StringComparison.Ordinal))
+        {
+            File.WriteAllText(
+                resultArtifactPath,
+                DirectRunResultArtifactJson.Serialize(resultArtifact with
+                {
+                    ReviewCommentRef = commentRef
+                }));
+        }
+
+        return true;
     }
 
     private static string ResolveBodyPath(string repoRoot, string rawPath)

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -150,6 +150,48 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public void Launch_GivenReviewEntry_InjectsPromptThatKeepsPrCommentPublicationCanonical()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var runner = new FakeDirectRunProcessRunner
+        {
+            Result = new DirectRunProcessLaunchResult
+            {
+                ProcessId = 4321,
+                ExitedEarly = false,
+                ExitCode = 0
+            }
+        };
+        var launcher = new DirectRunLauncher(runner);
+
+        launcher.Launch(
+            "G19",
+            "review",
+            ".intent-cli/runs/G19.request.json",
+            ".intent-cli/runs/G19.provider.jsonl",
+            "Codex",
+            "gpt-5.4-mini",
+            "responses",
+            "codex",
+            [
+                "exec",
+                "--json",
+                "--model",
+                "{model}",
+                "{prompt}"
+            ],
+            DateTimeOffset.Parse("2026-04-09T10:15:00Z"),
+            "/repo/.intent-cli/worktrees/G19",
+            "/repo/.intent-cli/reviews/G19.request.json",
+            tempDirectory.GetPath(".intent-cli/runs/G19.provider.jsonl"));
+
+        var prompt = Assert.Single(runner.Arguments, argument => argument.Contains("bounded source of truth", StringComparison.Ordinal));
+        Assert.Contains("Do not post GitHub or pull request comments", prompt, StringComparison.Ordinal);
+        Assert.Contains("do not run 'gh pr comment'", prompt, StringComparison.Ordinal);
+        Assert.Contains("the separate 'review comment' step owns PR comment publication", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Launch_GivenProcessExit_AppendsBackendExitProviderEvent()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/IntentSystem.Cli.Tests/DirectRunResultArtifactJsonTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunResultArtifactJsonTests.cs
@@ -19,6 +19,7 @@ public sealed class DirectRunResultArtifactJsonTests
             RunStatus = "running",
             ReviewOutcome = "fix-requested",
             ReviewCommentBodyPath = ".intent-cli/reviews/G19.comment.md",
+            ReviewCommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/67#issuecomment-3",
             RawLogRef = ".intent-cli/runs/G19.provider.jsonl",
             PacketRef = ".intent-cli/issues/G19/packet.yaml",
             ReviewContextRef = ".intent-cli/issues/G19/review-context.md",
@@ -52,6 +53,7 @@ public sealed class DirectRunResultArtifactJsonTests
         Assert.Equal("running", roundTripped.RunStatus);
         Assert.Equal("fix-requested", roundTripped.ReviewOutcome);
         Assert.Equal(".intent-cli/reviews/G19.comment.md", roundTripped.ReviewCommentBodyPath);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/67#issuecomment-3", roundTripped.ReviewCommentRef);
         Assert.Equal(".intent-cli/runs/G19.provider.jsonl", roundTripped.RawLogRef);
         Assert.Equal(".intent-cli/issues/G19/packet.yaml", roundTripped.PacketRef);
         Assert.Equal(".intent-cli/issues/G19/review-context.md", roundTripped.ReviewContextRef);
@@ -93,5 +95,6 @@ public sealed class DirectRunResultArtifactJsonTests
         Assert.Equal("pid:legacy", artifact.SessionId);
         Assert.Null(artifact.ReviewOutcome);
         Assert.Null(artifact.ReviewCommentBodyPath);
+        Assert.Null(artifact.ReviewCommentRef);
     }
 }

--- a/tests/IntentSystem.Cli.Tests/ReviewCommentCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewCommentCommandTests.cs
@@ -42,6 +42,7 @@ public sealed class ReviewCommentCommandTests
                 writer);
 
             Assert.Equal(0, exitCode);
+            Assert.Equal(1, publisher.CallCount);
             Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/46", publisher.LinkedPr);
             Assert.Equal("repair in place", publisher.Body);
             Assert.Contains("Review comment posted for G10", writer.ToString(), StringComparison.Ordinal);
@@ -65,6 +66,121 @@ public sealed class ReviewCommentCommandTests
             Assert.Equal("fix-requested", runEvents[^1].Event);
             Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/46", runEvents[^1].LinkedPr);
             Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1", runEvents[^1].CommentRef);
+        }
+        finally
+        {
+            ReviewCommentCommand.PublisherFactory = originalFactory;
+            ReviewCommentCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenCurrentReviewSessionAlreadyPublishedComment_ReusesExistingCommentRefWithoutPostingDuplicate()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var bodyPath = tempDirectory.CreateFile(Path.Combine("repo", "prepared-comment.md"), "repair in place");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G10.request.json"),
+            CreateReviewRequestJson());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """{"ts":"2026-04-03T10:00:00Z","execution_unit":"G10","event":"review-started","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/46"}""" + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs", "G10.request.json"),
+            """
+            {
+              "schema_version": "1",
+              "execution_unit": "G10",
+              "entry_kind": "review",
+              "upstream_request_ref": ".intent-cli/reviews/G10.request.json",
+              "provider": "Codex",
+              "model": "gpt-5.4-mini",
+              "transport": "responses",
+              "launched_at": "2026-04-04T04:35:00Z",
+              "provider_session_id": "pid:777",
+              "transport_summary": "launched"
+            }
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs", "G10.result.json"),
+            """
+            {
+              "schema_version": "1",
+              "execution_unit": "G10",
+              "entry_kind": "review",
+              "upstream_request_ref": ".intent-cli/reviews/G10.request.json",
+              "provider": "Codex",
+              "model": "gpt-5.4-mini",
+              "session_id": "pid:777",
+              "run_status": "succeeded",
+              "review_outcome": "fix-requested",
+              "review_comment_body_path": ".intent-cli/reviews/G10.comment.md",
+              "raw_log_ref": ".intent-cli/runs/G10.provider.jsonl",
+              "packet_ref": ".intent-cli/issues/G10/packet.yaml",
+              "review_context_ref": ".intent-cli/issues/G10/review-context.md",
+              "linked_pr": {
+                "repo": "J-Tech-Japan/intent-system",
+                "number": 46,
+                "url": "https://github.com/J-Tech-Japan/intent-system/pull/46"
+              },
+              "worktree": {
+                "path": "/repo/.intent-cli/worktrees/G10"
+              }
+            }
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs", "G10.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                [
+                    DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                    {
+                        Timestamp = "2026-04-04T04:35:00Z",
+                        ExecutionUnit = "G10",
+                        Provider = "Codex",
+                        EntryKind = "review",
+                        SessionId = "pid:777",
+                        Kind = "provider-event",
+                        Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                            "https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-9")
+                    })
+                ]) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var publisher = new FakePublisher();
+
+        var originalFactory = ReviewCommentCommand.PublisherFactory;
+        var originalTimestampFactory = ReviewCommentCommand.TimestampFactory;
+
+        try
+        {
+            ReviewCommentCommand.PublisherFactory = () => publisher;
+            ReviewCommentCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-04T04:40:00Z");
+
+            var exitCode = ReviewCommentCommand.Execute(
+                CreateContext(repoRoot),
+                ["G10", "--from-file", "prepared-comment.md"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(0, publisher.CallCount);
+            Assert.Contains("Review comment posted for G10", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = ReviewCommentArtifactSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "reviews", "G10.comment.json")));
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-9", artifact.CommentRef);
+            Assert.Equal(Path.GetFullPath(bodyPath), artifact.BodyPath);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "G10.result.json")));
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-9", resultArtifact.ReviewCommentRef);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-9", runEvents[^1].CommentRef);
         }
         finally
         {
@@ -231,8 +347,11 @@ public sealed class ReviewCommentCommandTests
 
         public string Body { get; private set; } = string.Empty;
 
+        public int CallCount { get; private set; }
+
         public string PostComment(string linkedPr, string body)
         {
+            CallCount++;
             LinkedPr = linkedPr;
             Body = body;
             return "https://github.com/J-Tech-Japan/intent-system/pull/46#issuecomment-1";

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -1,6 +1,8 @@
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Review;
+using IntentSystem.Review.Serialization;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 
@@ -943,6 +945,92 @@ public sealed class RunCommandTests
         finally
         {
             RunCommand.ReviewCommentExecutor = originalReviewCommentExecutor;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenCurrentReviewSessionAlreadyPublishedComment_DoesNotDuplicatePublicationDuringRootRun()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            """
+            {
+              "execution_unit": "G226",
+              "review_context_ref": ".intent-cli/issues/G226/review-context.md",
+              "linked_pr": "https://github.com/J-Tech-Japan/intent-system/pull/226",
+              "deterministic_review_checks": [],
+              "acceptance_criteria": [],
+              "expected_evidence": []
+            }
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.md"),
+            "Please cover the deterministic submit path.");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "review",
+            "succeeded",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "ReviewBot",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                        "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2")
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:02.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "ReviewBot",
+                    EntryKind = "review",
+                    SessionId = "pid:226",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 0
+                    })
+                }
+            ],
+            reviewOutcome: "fix-requested",
+            reviewCommentBodyPath: ".intent-cli/reviews/G226.comment.md");
+        var originalPublisherFactory = ReviewCommentCommand.PublisherFactory;
+        var publisher = new FakeReviewCommentPublisher();
+
+        try
+        {
+            ReviewCommentCommand.PublisherFactory = () => publisher;
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("deterministic-contract-gap", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Equal(0, publisher.CallCount);
+
+            var reviewCommentArtifact = ReviewCommentArtifactSerializer.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "reviews", "G226.comment.json")));
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2", reviewCommentArtifact.CommentRef);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2", resultArtifact.ReviewCommentRef);
+        }
+        finally
+        {
+            ReviewCommentCommand.PublisherFactory = originalPublisherFactory;
         }
     }
 
@@ -2722,6 +2810,17 @@ public sealed class RunCommandTests
     private static string CreateCapturedLastMessageFileName(string executionUnit, DateTimeOffset launchedAt)
     {
         return $"{executionUnit}.{DirectRunCommandSupport.CreateCapturedMessageSuffix(launchedAt)}.last-message.json";
+    }
+
+    private sealed class FakeReviewCommentPublisher : IReviewCommentPublisher
+    {
+        public int CallCount { get; private set; }
+
+        public string PostComment(string linkedPr, string body)
+        {
+            CallCount++;
+            return $"{linkedPr}#issuecomment-generated";
+        }
     }
 
     private sealed class TemporaryDirectory : IDisposable


### PR DESCRIPTION
## Summary
- prevent direct review-run prompts from posting GitHub PR comments or mutating external review state
- keep PR comment publication explicitly owned by the canonical review comment step
- add a regression test that asserts the review prompt carries the no-publication boundary

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~DirectRunLauncherTests" --logger "console;verbosity=minimal"
- dotnet test IntentSystem.sln --logger "console;verbosity=minimal"

Closes #281