### PR TITLE
Fix #289: avoid reusing stale failed fix results after retry

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -4,6 +4,7 @@ using IntentSystem.Projection.Serialization;
 using IntentSystem.Review;
 using IntentSystem.Supervisor;
 using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -170,7 +171,8 @@ internal static class RunCommand
                                 $"Fixing item '{inProgressItem.ExecutionUnit}' requires {ReviewCommentArtifactPathResolver.Resolve(inProgressItem.ExecutionUnit)}.");
                         }
 
-                        if (!ArtifactExists(context, RunFixArtifactPathResolver.Resolve(inProgressItem.ExecutionUnit)))
+                        var hasFixArtifact = ArtifactExists(context, RunFixArtifactPathResolver.Resolve(inProgressItem.ExecutionUnit));
+                        if (!hasFixArtifact)
                         {
                             ExecuteAction(
                                 context,
@@ -191,10 +193,24 @@ internal static class RunCommand
                                 currentFixTargetContractGap);
                         }
 
-                        var fixRunStatus = TryReadDirectRunStatus(
-                            context,
-                            inProgressItem.ExecutionUnit,
-                            "fix");
+                        var fixRequestArtifact = TryReadDirectRunRequestArtifact(context, inProgressItem.ExecutionUnit);
+                        var fixResultArtifact = TryReadDirectRunResultArtifact(context, inProgressItem.ExecutionUnit, "fix");
+                        if (ShouldLaunchFreshFixAttempt(
+                                context,
+                                inProgressItem.ExecutionUnit,
+                                fixRequestArtifact,
+                                fixResultArtifact))
+                        {
+                            ExecuteAction(
+                                context,
+                                actions,
+                                "run fix",
+                                inProgressItem.ExecutionUnit,
+                                () => RunFixExecutor(context, inProgressItem.ExecutionUnit));
+                            continue;
+                        }
+
+                        var fixRunStatus = fixResultArtifact?.RunStatus;
                         if (string.Equals(fixRunStatus, "succeeded", StringComparison.Ordinal))
                         {
                             ExecuteAction(
@@ -445,6 +461,48 @@ internal static class RunCommand
             DescribeSupervisionResult(superviseResult));
     }
 
+    private static bool ShouldLaunchFreshFixAttempt(
+        CliContext context,
+        string executionUnit,
+        DirectRunRequestArtifact? requestArtifact,
+        DirectRunResultArtifact? resultArtifact)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        if (ArtifactExists(
+                context,
+                RunSupervisionSessionArtifactPathResolver.Resolve(
+                    context.Config.Supervision.ArtifactRoot,
+                    executionUnit)))
+        {
+            return false;
+        }
+
+        if (requestArtifact is null || resultArtifact is null)
+        {
+            return true;
+        }
+
+        if (!MatchesCurrentDirectRunRequestBoundary(requestArtifact, resultArtifact))
+        {
+            return true;
+        }
+
+        if (string.Equals(resultArtifact.RunStatus, "running", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!DirectRunSessionBoundary.TryParseLaunchedAt(requestArtifact.LaunchedAt, out var launchedAt))
+        {
+            return false;
+        }
+
+        var latestFixRequestedAt = TryResolveLatestFixRequestedTimestamp(context, executionUnit);
+        return latestFixRequestedAt is not null && latestFixRequestedAt > launchedAt;
+    }
+
     private static string? TryReadDirectRunStatus(
         CliContext context,
         string executionUnit,
@@ -566,6 +624,31 @@ internal static class RunCommand
         return $"{root}/{executionUnit.Trim()}.provider.jsonl";
     }
 
+    private static DateTimeOffset? TryResolveLatestFixRequestedTimestamp(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            return null;
+        }
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        for (var index = runEvents.Count - 1; index >= 0; index--)
+        {
+            var runEvent = runEvents[index];
+            if (string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                && string.Equals(runEvent.Event, "fix-requested", StringComparison.Ordinal))
+            {
+                return runEvent.Ts;
+            }
+        }
+
+        return null;
+    }
+
     private static RunReviewDecision ResolveReviewDecision(CliContext context, string executionUnit)
     {
         var requestArtifact = TryReadDirectRunRequestArtifact(context, executionUnit);
@@ -588,7 +671,7 @@ internal static class RunCommand
             };
         }
 
-        if (!MatchesCurrentReviewRequestBoundary(requestArtifact, resultArtifact))
+        if (!MatchesCurrentDirectRunRequestBoundary(requestArtifact, resultArtifact))
         {
             return new RunReviewDecision
             {
@@ -913,7 +996,7 @@ internal static class RunCommand
             parsedLaunchedAt == default ? null : parsedLaunchedAt);
     }
 
-    private static bool MatchesCurrentReviewRequestBoundary(
+    private static bool MatchesCurrentDirectRunRequestBoundary(
         DirectRunRequestArtifact requestArtifact,
         DirectRunResultArtifact resultArtifact)
     {

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -1410,6 +1410,189 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFixingItemWithFailedFixResultBeforeOperatorRetry_LaunchesFreshFixAttempt()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            {"ts":"2026-04-10T12:05:00Z","execution_unit":"G226","event":"blocked","by":"intent-cli","reason":"backend exit code 1"}
+            {"ts":"2026-04-10T12:10:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:94914", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "failed",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:01:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Claude",
+                    EntryKind = "fix",
+                    SessionId = "pid:94914",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                }
+            ],
+            sessionId: "pid:94914",
+            provider: "Claude");
+        var originalRunFixExecutor = RunCommand.RunFixExecutor;
+        var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
+
+        try
+        {
+            RunCommand.RunFixExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunRequest(repoRoot, executionUnit, "fix", "pid:4242", provider: "Claude");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "fix",
+                    "running",
+                    providerEvents:
+                    [
+                        new DirectRunProviderEvent
+                        {
+                            Timestamp = "2026-04-10T12:10:01.0000000+00:00",
+                            ExecutionUnit = executionUnit,
+                            Provider = "Claude",
+                            EntryKind = "fix",
+                            SessionId = "pid:4242",
+                            Kind = "session-metadata",
+                            Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                            {
+                                model = "gpt-5.4-mini",
+                                transport = "responses",
+                                command = "claude"
+                            })
+                        }
+                    ],
+                    sessionId: "pid:4242",
+                    provider: "Claude");
+
+                return new RunFixResult
+                {
+                    Request = new RunFixRequest
+                    {
+                        ExecutionUnit = executionUnit,
+                        State = "fixing",
+                        ImplementRole = "Codex",
+                        QueueWorkerRole = "coder",
+                        QueueReviewRole = "reviewer",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = $"issue-226-{executionUnit.ToLowerInvariant()}",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        LatestLinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                        LatestCommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                        PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                        ReviewCommentArtifactRef = $".intent-cli/reviews/{executionUnit}.comment.json",
+                        ReviewRequestRef = $".intent-cli/reviews/{executionUnit}.request.json",
+                        ReviewCommentBodyPath = $".intent-cli/reviews/{executionUnit}.comment.md",
+                        IssueTitle = "[G226] Root Run Orchestration Command",
+                        Goal = "Coordinate the root run loop.",
+                        TargetPart = "run command",
+                        TargetRepo = "submodules/intent-system",
+                        TargetPath = ".",
+                        InScope = [],
+                        OutOfScope = [],
+                        AcceptanceCriteria = [],
+                        DeterministicReviewChecks = [],
+                        ExpectedEvidence = []
+                    },
+                    ArtifactPath = $".intent-cli/fix/{executionUnit}.request.md",
+                    DirectRun = new DirectRunLaunchResult
+                    {
+                        RequestArtifactPath = $".intent-cli/runs/{executionUnit}.request.json",
+                        ProviderEventLogPath = $".intent-cli/runs/{executionUnit}.provider.jsonl",
+                        ResultArtifactPath = $".intent-cli/runs/{executionUnit}.result.json",
+                        Provider = "Claude",
+                        Model = "gpt-5.4-mini",
+                        Transport = "responses",
+                        ProviderSessionId = "pid:4242",
+                        TransportSummary = "launched"
+                    }
+                };
+            };
+            RunCommand.RunSuperviseExecutor = (_, executionUnit) => new RunSuperviseResult
+            {
+                ExecutionUnit = executionUnit,
+                SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                RetryCount = 0,
+                RetryBudget = 3,
+                HandoffArtifactRef = $".intent-cli/fix/{executionUnit}.request.md"
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Equal(2, result.Actions.Count);
+            Assert.Equal("run fix", result.Actions[0].Name);
+            Assert.Equal("run supervise", result.Actions[1].Name);
+            Assert.Contains("under supervision", result.Detail, StringComparison.Ordinal);
+
+            var requestArtifact = DirectRunRequestArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.request.json")));
+            Assert.Equal("pid:4242", requestArtifact.ProviderSessionId);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+        }
+        finally
+        {
+            RunCommand.RunFixExecutor = originalRunFixExecutor;
+            RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenFixingItemWithStaleImplementSupervisionSession_RealignsAndContinuesMonitoring()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- make root `intent-cli run` relaunch a fresh fix attempt when an operator has explicitly moved a terminal fix item back to `fixing` after the previous launched boundary
- keep existing supervise/contract-gap behavior intact by only applying the retry reset logic after fix handoff validation and by deferring to existing supervision sessions
- add a regression proving a blocked-to-fixing retry does not reuse the stale failed fix result as the current attempt boundary

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests.ExecuteCore_GivenFixingItemWithFailedFixResultBeforeOperatorRetry_LaunchesFreshFixAttempt|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenFixingItemWithStaleImplementSupervisionSession_RealignsAndContinuesMonitoring|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenFixingItemWithStaleFailedFixResultAndRuntimeOnlyTarget_StopsWithDeterministicContractGap" --logger "console;verbosity=minimal"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --logger "console;verbosity=minimal"
- dotnet test IntentSystem.sln --logger "console;verbosity=minimal"
