### PR TITLE
Fix #291: strengthen Codex fix handoff contract

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -697,6 +697,21 @@ internal static class DirectRunCommandSupport
         var model = ResolveModel(currentProviderEvents, launchResult.Model);
         var sessionId = ResolveSessionId(currentProviderEvents, launchResult.ProviderSessionId);
         var provider = ResolveProvider(currentProviderEvents, launchResult.Provider);
+        var fixContractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            currentProviderEvents,
+            DateTimeOffset.UtcNow,
+            executionUnit,
+            entryKind,
+            provider,
+            sessionId);
+        if (fixContractGapEvent is not null)
+        {
+            var writer = new DirectRunProviderEventWriter(providerEventLogPath);
+            writer.Append(fixContractGapEvent);
+            providerEvents = [.. providerEvents, fixContractGapEvent];
+            currentProviderEvents = [.. currentProviderEvents, fixContractGapEvent];
+        }
+
         var runStatus = ResolveRunStatus(currentProviderEvents);
         if (string.Equals(entryKind, "review", StringComparison.Ordinal))
         {

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -7,17 +7,6 @@ internal static class DirectRunFixOutcomeSupport
     private const string DeterministicContractGapStopReason = "deterministic-contract-gap";
     private const string InspectionOnlyExitReason = "fix-session-ended-after-initial-inspection";
 
-    private static readonly string[] ActionProgressMarkers =
-    [
-        "apply_patch",
-        "dotnet test",
-        "dotnet build",
-        "git diff",
-        "git add ",
-        "git commit",
-        "git push"
-    ];
-
     public static DirectRunProviderEvent? CreateCanonicalContractGapEventIfNeeded(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         DateTimeOffset timestamp,
@@ -92,7 +81,7 @@ internal static class DirectRunFixOutcomeSupport
             return false;
         }
 
-        var sawSuccessfulRepoListing = false;
+        var initialInspectionEventIndex = -1;
         for (var index = 0; index < failingBackendExitIndex; index++)
         {
             var providerEvent = providerEvents[index];
@@ -102,19 +91,26 @@ internal static class DirectRunFixOutcomeSupport
                 continue;
             }
 
-            if (HasActionProgress(providerEvent.Payload)
-                || TryResolveExplicitContractGapDetail(providerEvent.Payload, executionUnit, out _))
+            if (TryResolveExplicitContractGapDetail(providerEvent.Payload, executionUnit, out _))
             {
                 return false;
             }
 
             if (ContainsSuccessfulInitialRepoInspection(providerEvent.Payload))
             {
-                sawSuccessfulRepoListing = true;
+                if (initialInspectionEventIndex >= 0)
+                {
+                    return false;
+                }
+
+                initialInspectionEventIndex = index;
+                continue;
             }
+
+            return false;
         }
 
-        if (!sawSuccessfulRepoListing)
+        if (initialInspectionEventIndex < 0)
         {
             return false;
         }
@@ -218,23 +214,6 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         return sawRepoListing && sawSuccess;
-    }
-
-    private static bool HasActionProgress(JsonElement payload)
-    {
-        foreach (var value in EnumeratePayloadStrings(payload))
-        {
-            var normalized = value.Trim().ToLowerInvariant();
-            foreach (var marker in ActionProgressMarkers)
-            {
-                if (normalized.Contains(marker, StringComparison.Ordinal))
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 
     private static bool IsIgnorableReadyEvent(JsonElement payload)

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -1,0 +1,325 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class DirectRunFixOutcomeSupport
+{
+    private const string DeterministicContractGapStopReason = "deterministic-contract-gap";
+    private const string InspectionOnlyExitReason = "fix-session-ended-after-initial-inspection";
+
+    private static readonly string[] ActionProgressMarkers =
+    [
+        "apply_patch",
+        "dotnet test",
+        "dotnet build",
+        "git diff",
+        "git add ",
+        "git commit",
+        "git push"
+    ];
+
+    public static DirectRunProviderEvent? CreateCanonicalContractGapEventIfNeeded(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        DateTimeOffset timestamp,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+
+        if (!string.Equals(entryKind, "fix", StringComparison.Ordinal)
+            || HasExplicitContractGap(providerEvents)
+            || !TryResolveInspectionOnlyFailureDetail(providerEvents, executionUnit, out var detail))
+        {
+            return null;
+        }
+
+        return new DirectRunProviderEvent
+        {
+            Timestamp = timestamp.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = provider,
+            EntryKind = entryKind,
+            SessionId = providerSessionId,
+            Kind = "provider-event",
+            Payload = JsonSerializer.SerializeToElement(new
+            {
+                type = "contract-gap",
+                stop_reason = DeterministicContractGapStopReason,
+                reason = InspectionOnlyExitReason,
+                detail,
+                run_status = "failed"
+            })
+        };
+    }
+
+    public static bool TryResolveContractGapDetail(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        out string detail)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            if (!TryResolveExplicitContractGapDetail(providerEvents[index].Payload, executionUnit, out detail))
+            {
+                continue;
+            }
+
+            return true;
+        }
+
+        return TryResolveInspectionOnlyFailureDetail(providerEvents, executionUnit, out detail);
+    }
+
+    private static bool TryResolveInspectionOnlyFailureDetail(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        out string detail)
+    {
+        detail = string.Empty;
+
+        var failingBackendExitIndex = FindFailingBackendExitIndex(providerEvents);
+        if (failingBackendExitIndex < 0)
+        {
+            return false;
+        }
+
+        var sawSuccessfulRepoListing = false;
+        for (var index = 0; index < failingBackendExitIndex; index++)
+        {
+            var providerEvent = providerEvents[index];
+            if (providerEvent.Kind == "session-metadata"
+                || IsIgnorableReadyEvent(providerEvent.Payload))
+            {
+                continue;
+            }
+
+            if (HasActionProgress(providerEvent.Payload)
+                || TryResolveExplicitContractGapDetail(providerEvent.Payload, executionUnit, out _))
+            {
+                return false;
+            }
+
+            if (ContainsSuccessfulInitialRepoInspection(providerEvent.Payload))
+            {
+                sawSuccessfulRepoListing = true;
+            }
+        }
+
+        if (!sawSuccessfulRepoListing)
+        {
+            return false;
+        }
+
+        detail =
+            $"Fix direct run for '{executionUnit}' exited after the initial repo-inspection command completed without any repair, test, refusal, or contract-gap outcome.";
+        return true;
+    }
+
+    private static int FindFailingBackendExitIndex(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            var payload = providerEvents[index].Payload;
+            if (payload.ValueKind != JsonValueKind.Object
+                || !TryReadString(payload, "type", out var type)
+                || !string.Equals(type, "backend-exit", StringComparison.Ordinal)
+                || !TryReadInt32(payload, "exit_code", out var exitCode))
+            {
+                continue;
+            }
+
+            if (exitCode != 0)
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool HasExplicitContractGap(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        return providerEvents.Any(providerEvent =>
+            TryResolveExplicitContractGapDetail(providerEvent.Payload, providerEvent.ExecutionUnit ?? "fix", out _));
+    }
+
+    private static bool TryResolveExplicitContractGapDetail(
+        JsonElement payload,
+        string executionUnit,
+        out string detail)
+    {
+        detail = string.Empty;
+        if (payload.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (TryReadString(payload, "stop_reason", out var stopReason)
+            && string.Equals(stopReason, DeterministicContractGapStopReason, StringComparison.Ordinal))
+        {
+            if (!TryReadString(payload, "detail", out detail))
+            {
+                detail = $"Fix direct run for '{executionUnit}' reported a deterministic contract gap.";
+            }
+
+            return true;
+        }
+
+        if (TryReadString(payload, "type", out var type)
+            && string.Equals(type, "contract-gap", StringComparison.Ordinal))
+        {
+            if (!TryReadString(payload, "detail", out detail))
+            {
+                detail = $"Fix direct run for '{executionUnit}' reported a deterministic contract gap.";
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool ContainsSuccessfulInitialRepoInspection(JsonElement payload)
+    {
+        var sawRepoListing = false;
+        var sawSuccess = false;
+
+        foreach (var value in EnumeratePayloadStrings(payload))
+        {
+            var normalized = value.Trim().ToLowerInvariant();
+            if (normalized.Contains("rg --files", StringComparison.Ordinal))
+            {
+                sawRepoListing = true;
+            }
+
+            if (normalized.Contains("succeeded", StringComparison.Ordinal)
+                || normalized.Contains("exit code 0", StringComparison.Ordinal)
+                || normalized.Contains("exit_code=0", StringComparison.Ordinal))
+            {
+                sawSuccess = true;
+            }
+        }
+
+        if (payload.ValueKind == JsonValueKind.Object
+            && (TryReadInt32(payload, "exit_code", out var exitCode)
+                || TryReadInt32(payload, "exitCode", out exitCode))
+            && exitCode == 0)
+        {
+            sawSuccess = true;
+        }
+
+        return sawRepoListing && sawSuccess;
+    }
+
+    private static bool HasActionProgress(JsonElement payload)
+    {
+        foreach (var value in EnumeratePayloadStrings(payload))
+        {
+            var normalized = value.Trim().ToLowerInvariant();
+            foreach (var marker in ActionProgressMarkers)
+            {
+                if (normalized.Contains(marker, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsIgnorableReadyEvent(JsonElement payload)
+    {
+        return payload.ValueKind == JsonValueKind.Object
+            && TryReadString(payload, "type", out var type)
+            && string.Equals(type, "ready", StringComparison.Ordinal);
+    }
+
+    private static IEnumerable<string> EnumeratePayloadStrings(JsonElement payload)
+    {
+        switch (payload.ValueKind)
+        {
+            case JsonValueKind.String:
+            {
+                var value = payload.GetString();
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    yield return value;
+                }
+
+                yield break;
+            }
+            case JsonValueKind.Object:
+                foreach (var property in payload.EnumerateObject())
+                {
+                    foreach (var value in EnumeratePayloadStrings(property.Value))
+                    {
+                        yield return value;
+                    }
+                }
+
+                yield break;
+            case JsonValueKind.Array:
+                foreach (var item in payload.EnumerateArray())
+                {
+                    foreach (var value in EnumeratePayloadStrings(item))
+                    {
+                        yield return value;
+                    }
+                }
+
+                yield break;
+            default:
+                yield break;
+        }
+    }
+
+    private static bool TryReadString(JsonElement payload, string propertyName, out string value)
+    {
+        value = string.Empty;
+
+        if (!payload.TryGetProperty(propertyName, out var element)
+            || element.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        value = element.GetString() ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static bool TryReadInt32(JsonElement payload, string propertyName, out int value)
+    {
+        value = default;
+
+        if (!payload.TryGetProperty(propertyName, out var element))
+        {
+            return false;
+        }
+
+        if (element.ValueKind == JsonValueKind.Number)
+        {
+            return element.TryGetInt32(out value);
+        }
+
+        if (element.ValueKind == JsonValueKind.String)
+        {
+            return int.TryParse(
+                element.GetString(),
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out value);
+        }
+
+        return false;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -315,6 +315,14 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
     {
         var prompt =
             $"Use the request artifact at '{absoluteRequestArtifactPath}' as the bounded source of truth for this direct run.";
+        if (string.Equals(entryKind, "fix", StringComparison.Ordinal))
+        {
+            return prompt
+                + " Continue beyond initial repository inspection and either complete the bounded repair attempt from that artifact"
+                + " or end with a deterministic refusal or contract-gap explanation."
+                + " Do not stop after a single inspection command without producing one of those outcomes.";
+        }
+
         if (!string.Equals(entryKind, "review", StringComparison.Ordinal))
         {
             return prompt;

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -211,6 +211,19 @@ internal static class RunCommand
                         }
 
                         var fixRunStatus = fixResultArtifact?.RunStatus;
+                        var currentFixSessionContractGap = TryResolveCurrentFixSessionContractGap(
+                            context,
+                            inProgressItem.ExecutionUnit,
+                            fixRequestArtifact);
+                        if (!string.IsNullOrWhiteSpace(currentFixSessionContractGap))
+                        {
+                            return CreateStopResult(
+                                DeterministicContractGapStopReason,
+                                actions,
+                                inProgressItem.ExecutionUnit,
+                                currentFixSessionContractGap);
+                        }
+
                         if (string.Equals(fixRunStatus, "succeeded", StringComparison.Ordinal))
                         {
                             ExecuteAction(
@@ -576,6 +589,36 @@ internal static class RunCommand
         {
             return exception.Message;
         }
+    }
+
+    private static string? TryResolveCurrentFixSessionContractGap(
+        CliContext context,
+        string executionUnit,
+        DirectRunRequestArtifact? requestArtifact)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        if (requestArtifact is null
+            || !string.Equals(requestArtifact.EntryKind, "fix", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var providerEvents = TryReadDirectRunProviderEvents(context, executionUnit);
+        if (providerEvents.Count == 0)
+        {
+            return null;
+        }
+
+        providerEvents = SelectCurrentSessionEvents(
+            providerEvents,
+            requestArtifact.ProviderSessionId,
+            requestArtifact.LaunchedAt);
+
+        return DirectRunFixOutcomeSupport.TryResolveContractGapDetail(providerEvents, executionUnit, out var detail)
+            ? detail
+            : null;
     }
 
     private static IReadOnlyList<DirectRunProviderEvent> TryReadDirectRunProviderEvents(CliContext context, string executionUnit)

--- a/src/IntentSystem.Cli/Commands/RunFixRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixRenderer.cs
@@ -67,6 +67,12 @@ internal static class RunFixRenderer
         lines.Add("## Expected Evidence");
         lines.Add(string.Empty);
         lines.AddRange(FormatList(request.ExpectedEvidence));
+        lines.Add(string.Empty);
+        lines.Add("## Execution Contract");
+        lines.Add(string.Empty);
+        lines.Add("- Continue beyond initial repository inspection; do not stop after a single listing/read-only command.");
+        lines.Add("- Use the repair inputs to attempt the bounded fix inside the provided worktree when the change is feasible.");
+        lines.Add("- If no safe bounded repair can continue, end with a deterministic refusal or contract-gap explanation instead of silent termination.");
 
         return string.Join(Environment.NewLine, lines);
     }

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -192,6 +192,48 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public void Launch_GivenFixEntry_InjectsPromptThatRequiresRepairOrDeterministicRefusal()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var runner = new FakeDirectRunProcessRunner
+        {
+            Result = new DirectRunProcessLaunchResult
+            {
+                ProcessId = 4321,
+                ExitedEarly = false,
+                ExitCode = 0
+            }
+        };
+        var launcher = new DirectRunLauncher(runner);
+
+        launcher.Launch(
+            "G19",
+            "fix",
+            ".intent-cli/runs/G19.request.json",
+            ".intent-cli/runs/G19.provider.jsonl",
+            "Codex",
+            "gpt-5.4-mini",
+            "responses",
+            "codex",
+            [
+                "exec",
+                "--model",
+                "{model}",
+                "{prompt}"
+            ],
+            DateTimeOffset.Parse("2026-04-09T10:15:00Z"),
+            "/repo/.intent-cli/worktrees/G19",
+            "/repo/.intent-cli/fix/G19.request.md",
+            tempDirectory.GetPath(".intent-cli/runs/G19.provider.jsonl"));
+
+        var prompt = Assert.Single(runner.Arguments, argument => argument.Contains("bounded source of truth", StringComparison.Ordinal));
+        Assert.Contains("Continue beyond initial repository inspection", prompt, StringComparison.Ordinal);
+        Assert.Contains("complete the bounded repair attempt", prompt, StringComparison.Ordinal);
+        Assert.Contains("deterministic refusal or contract-gap explanation", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do not stop after a single inspection command", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Launch_GivenProcessExit_AppendsBackendExitProviderEvent()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -1695,6 +1695,119 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFixingItemWithFollowUpWorkAfterInitialInspection_DoesNotClassifyInspectionOnlyContractGap()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999998", provider: "Codex");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "failed",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:999998",
+                    Kind = "session-metadata",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        model = "gpt-5.4-mini",
+                        transport = "responses",
+                        command = "codex"
+                    })
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:999998",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                        "exec /bin/zsh -lc 'rg --files' succeeded in 0ms")
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:02.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:999998",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                        "exec /bin/zsh -lc 'sed -n ''1,120p'' src/Program.cs' succeeded in 0ms")
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:03.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:999998",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                }
+            ],
+            sessionId: "pid:999998",
+            provider: "Codex");
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("non-retryable-failure", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("Fix direct run failed for 'G226'.", result.Detail, StringComparison.Ordinal);
+        Assert.DoesNotContain("initial repo-inspection command", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ExecuteCore_GivenFixingItemWithStaleImplementSupervisionSession_RealignsAndContinuesMonitoring()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -1593,6 +1593,108 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFixingItemWithInspectionOnlyBackendExitFailure_StopsWithDeterministicContractGap()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Codex");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "failed",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:999999",
+                    Kind = "session-metadata",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        model = "gpt-5.4-mini",
+                        transport = "responses",
+                        command = "codex"
+                    })
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:999999",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                        "exec /bin/zsh -lc 'rg --files' succeeded in 0ms")
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:02.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:999999",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                }
+            ],
+            sessionId: "pid:999999",
+            provider: "Codex");
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("deterministic-contract-gap", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("initial repo-inspection command", result.Detail, StringComparison.Ordinal);
+        Assert.DoesNotContain("Fix direct run failed", result.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ExecuteCore_GivenFixingItemWithStaleImplementSupervisionSession_RealignsAndContinuesMonitoring()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -214,6 +214,75 @@ public sealed class RunFixCommandTests
     }
 
     [Fact]
+    public void Execute_GivenFollowUpWorkAfterInitialInspection_DoesNotAppendInspectionOnlyContractGapEvent()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunFixCommand.TimestampFactory;
+        var originalLauncherFactory = RunFixCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            RunFixCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-16T00:17:00Z");
+            RunFixCommand.DirectRunLauncherFactory = () => new FollowUpWorkFailureDirectRunLauncher();
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Codex",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    }
+                }
+            };
+
+            var exitCode = RunFixCommand.Execute(context, ["G20"], writer);
+
+            Assert.Equal(0, exitCode);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G20.result.json")));
+            Assert.Equal("failed", resultArtifact.RunStatus);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G20.provider.jsonl")));
+            Assert.DoesNotContain(providerEvents, providerEvent =>
+                string.Equals(providerEvent.SessionId, "pid:5321", StringComparison.Ordinal)
+                && providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("reason", out var reasonElement)
+                && string.Equals(reasonElement.GetString(), "fix-session-ended-after-initial-inspection", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunFixCommand.TimestampFactory = originalTimestampFactory;
+            RunFixCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenRuntimeOnlyTargetPart_ReturnsExitCodeOneWithoutWritingRepairArtifact()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -418,6 +487,98 @@ public sealed class RunFixCommandTests
                 Model = modelArg,
                 Transport = transportArg,
                 ProviderSessionId = "pid:4321",
+                TransportSummary =
+                    $"{transportArg} transport launched via '{command}' in '{workingDirectory}' for provider '{providerArg}'."
+            };
+        }
+    }
+
+    private sealed class FollowUpWorkFailureDirectRunLauncher : IDirectRunLauncher
+    {
+        public DirectRunLaunchResult Launch(
+            string executionUnit,
+            string entryKind,
+            string requestArtifactPath,
+            string providerEventLogPath,
+            string providerArg,
+            string modelArg,
+            string transportArg,
+            string command,
+            IReadOnlyList<string> argsTemplate,
+            DateTimeOffset launchedAt,
+            string workingDirectory,
+            string absoluteRequestArtifactPath,
+            string absoluteProviderEventLogPath)
+        {
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(absoluteProviderEventLogPath)
+                ?? throw new InvalidOperationException("Provider event log path did not contain a directory."));
+            var providerEvents = string.Join(
+                                     Environment.NewLine,
+                                     new[]
+                                     {
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = "pid:5321",
+                                             Kind = "session-metadata",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 model = modelArg,
+                                                 transport = transportArg,
+                                                 command
+                                             })
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(1).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = "pid:5321",
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                                                 "exec /bin/zsh -lc 'rg --files' succeeded in 0ms")
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(2).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = "pid:5321",
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                                                 "exec /bin/zsh -lc 'sed -n ''1,120p'' src/Program.cs' succeeded in 0ms")
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(3).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = "pid:5321",
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 type = "backend-exit",
+                                                 exit_code = 1
+                                             })
+                                         })
+                                     }) + Environment.NewLine;
+            File.WriteAllText(absoluteProviderEventLogPath, providerEvents);
+
+            return new DirectRunLaunchResult
+            {
+                RequestArtifactPath = requestArtifactPath,
+                ProviderEventLogPath = providerEventLogPath,
+                Provider = providerArg,
+                Model = modelArg,
+                Transport = transportArg,
+                ProviderSessionId = "pid:5321",
                 TransportSummary =
                     $"{transportArg} transport launched via '{command}' in '{workingDirectory}' for provider '{providerArg}'."
             };

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -143,6 +143,77 @@ public sealed class RunFixCommandTests
     }
 
     [Fact]
+    public void Execute_GivenInspectionOnlyBackendExitFailure_AppendsDeterministicContractGapEvent()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunFixCommand.TimestampFactory;
+        var originalLauncherFactory = RunFixCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            RunFixCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-16T00:17:00Z");
+            RunFixCommand.DirectRunLauncherFactory = () => new InspectionOnlyFailureDirectRunLauncher();
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Codex",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    }
+                }
+            };
+
+            var exitCode = RunFixCommand.Execute(context, ["G20"], writer);
+
+            Assert.Equal(0, exitCode);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G20.result.json")));
+            Assert.Equal("failed", resultArtifact.RunStatus);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G20.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                string.Equals(providerEvent.SessionId, "pid:4321", StringComparison.Ordinal)
+                && providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("stop_reason", out var stopReasonElement)
+                && string.Equals(stopReasonElement.GetString(), "deterministic-contract-gap", StringComparison.Ordinal)
+                && providerEvent.Payload.TryGetProperty("reason", out var reasonElement)
+                && string.Equals(reasonElement.GetString(), "fix-session-ended-after-initial-inspection", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunFixCommand.TimestampFactory = originalTimestampFactory;
+            RunFixCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenRuntimeOnlyTargetPart_ReturnsExitCodeOneWithoutWritingRepairArtifact()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -268,6 +339,87 @@ public sealed class RunFixCommandTests
                 Transport = transportArg,
                 ProviderSessionId = providerSessionId,
                 TransportSummary = transportSummary
+            };
+        }
+    }
+
+    private sealed class InspectionOnlyFailureDirectRunLauncher : IDirectRunLauncher
+    {
+        public DirectRunLaunchResult Launch(
+            string executionUnit,
+            string entryKind,
+            string requestArtifactPath,
+            string providerEventLogPath,
+            string providerArg,
+            string modelArg,
+            string transportArg,
+            string command,
+            IReadOnlyList<string> argsTemplate,
+            DateTimeOffset launchedAt,
+            string workingDirectory,
+            string absoluteRequestArtifactPath,
+            string absoluteProviderEventLogPath)
+        {
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(absoluteProviderEventLogPath)
+                ?? throw new InvalidOperationException("Provider event log path did not contain a directory."));
+            var providerEvents = string.Join(
+                                     Environment.NewLine,
+                                     new[]
+                                     {
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = "pid:4321",
+                                             Kind = "session-metadata",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 model = modelArg,
+                                                 transport = transportArg,
+                                                 command
+                                             })
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(1).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = "pid:4321",
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                                                 "exec /bin/zsh -lc 'rg --files' succeeded in 0ms")
+                                         }),
+                                         DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                                         {
+                                             Timestamp = launchedAt.AddSeconds(2).ToString("O"),
+                                             ExecutionUnit = executionUnit,
+                                             Provider = providerArg,
+                                             EntryKind = entryKind,
+                                             SessionId = "pid:4321",
+                                             Kind = "provider-event",
+                                             Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                                             {
+                                                 type = "backend-exit",
+                                                 exit_code = 1
+                                             })
+                                         })
+                                     }) + Environment.NewLine;
+            File.WriteAllText(absoluteProviderEventLogPath, providerEvents);
+
+            return new DirectRunLaunchResult
+            {
+                RequestArtifactPath = requestArtifactPath,
+                ProviderEventLogPath = providerEventLogPath,
+                Provider = providerArg,
+                Model = modelArg,
+                Transport = transportArg,
+                ProviderSessionId = "pid:4321",
+                TransportSummary =
+                    $"{transportArg} transport launched via '{command}' in '{workingDirectory}' for provider '{providerArg}'."
             };
         }
     }

--- a/tests/IntentSystem.Cli.Tests/RunFixRendererTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixRendererTests.cs
@@ -16,6 +16,9 @@ public sealed class RunFixRendererTests
         Assert.Contains("- review_request_ref: .intent-cli/reviews/G20.request.json", markdown, StringComparison.Ordinal);
         Assert.Contains("- review_comment_body_path: /repo/prepared-comment.md", markdown, StringComparison.Ordinal);
         Assert.Contains("## Deterministic Review Checks", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Execution Contract", markdown, StringComparison.Ordinal);
+        Assert.Contains("Continue beyond initial repository inspection", markdown, StringComparison.Ordinal);
+        Assert.Contains("deterministic refusal or contract-gap explanation", markdown, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- strengthen the Codex fix direct-run prompt so the fix session must continue past initial inspection and either attempt the bounded repair or return a deterministic refusal/contract-gap explanation
- add the same execution contract to the generated repair handoff markdown so the request artifact itself carries the non-silent completion boundary
- lock the fix handoff contract with focused launcher and renderer tests

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunFixRendererTests|FullyQualifiedName~DirectRunLauncherTests.Launch_GivenFixEntry_InjectsPromptThatRequiresRepairOrDeterministicRefusal|FullyQualifiedName~RunFixCommandTests" --logger "console;verbosity=minimal"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --logger "console;verbosity=minimal"
- dotnet test IntentSystem.sln --logger "console;verbosity=minimal"
