### PR TITLE
Fix #295: classify startup-only direct fix failures

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -6,6 +6,15 @@ internal static class DirectRunFixOutcomeSupport
 {
     private const string DeterministicContractGapStopReason = "deterministic-contract-gap";
     private const string InspectionOnlyExitReason = "fix-session-ended-after-initial-inspection";
+    private static readonly string[] StartupPreamblePrefixes =
+    [
+        "openai codex v",
+        "workdir:",
+        "provider:",
+        "approval:",
+        "sandbox:",
+        "reasoning effort:"
+    ];
     private static readonly string[] StartupWarningMarkers =
     [
         "warn",
@@ -99,6 +108,7 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         var sawStartupNoise = false;
+        var sawStartupPreamble = false;
         for (var index = 0; index < failingBackendExitIndex; index++)
         {
             var providerEvent = providerEvents[index];
@@ -110,12 +120,31 @@ internal static class DirectRunFixOutcomeSupport
 
             if (TryResolveExplicitContractGapDetail(providerEvent.Payload, executionUnit, out _)
                 || ContainsSuccessfulInitialRepoInspection(providerEvent.Payload)
-                || !IsIgnorableStartupNoise(providerEvent.Payload))
+                || ContainsBoundedFixProgressSignal(providerEvent.Payload))
             {
                 return false;
             }
 
-            sawStartupNoise = true;
+            if (IsIgnorableStartupNoise(providerEvent.Payload))
+            {
+                sawStartupNoise = true;
+                continue;
+            }
+
+            if (IsIgnorableStartupPreamble(providerEvent.Payload))
+            {
+                sawStartupPreamble = true;
+                continue;
+            }
+
+            if (sawStartupPreamble
+                && !sawStartupNoise
+                && IsIgnorablePromptEcho(providerEvent.Payload))
+            {
+                continue;
+            }
+
+            return false;
         }
 
         if (!sawStartupNoise)
@@ -283,6 +312,22 @@ internal static class DirectRunFixOutcomeSupport
             && string.Equals(type, "ready", StringComparison.Ordinal);
     }
 
+    private static bool IsIgnorableStartupPreamble(JsonElement payload)
+    {
+        var sawString = false;
+        foreach (var value in EnumeratePayloadStrings(payload))
+        {
+            sawString = true;
+            var normalized = value.Trim().ToLowerInvariant();
+            if (!StartupPreamblePrefixes.Any(prefix => normalized.StartsWith(prefix, StringComparison.Ordinal)))
+            {
+                return false;
+            }
+        }
+
+        return sawString;
+    }
+
     private static bool IsIgnorableStartupNoise(JsonElement payload)
     {
         var sawString = false;
@@ -297,6 +342,46 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         return sawString;
+    }
+
+    private static bool IsIgnorablePromptEcho(JsonElement payload)
+    {
+        if (payload.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        var value = payload.GetString();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+        return !StartupPreamblePrefixes.Any(prefix => normalized.StartsWith(prefix, StringComparison.Ordinal))
+            && !StartupWarningMarkers.Any(marker => normalized.Contains(marker, StringComparison.Ordinal))
+            && !ContainsBoundedFixProgressSignal(payload);
+    }
+
+    private static bool ContainsBoundedFixProgressSignal(JsonElement payload)
+    {
+        foreach (var value in EnumeratePayloadStrings(payload))
+        {
+            var normalized = value.Trim().ToLowerInvariant();
+            if (normalized.Contains("rg --files", StringComparison.Ordinal)
+                || normalized.Contains("apply_patch", StringComparison.Ordinal)
+                || normalized.Contains("dotnet test", StringComparison.Ordinal)
+                || normalized.Contains("git diff", StringComparison.Ordinal)
+                || normalized.Contains("git status", StringComparison.Ordinal)
+                || normalized.Contains("ls ", StringComparison.Ordinal)
+                || normalized.Contains("cat ", StringComparison.Ordinal)
+                || normalized.Contains("sed -n", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static IEnumerable<string> EnumeratePayloadStrings(JsonElement payload)

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -9,11 +9,19 @@ internal static class DirectRunFixOutcomeSupport
     private static readonly string[] StartupPreamblePrefixes =
     [
         "openai codex v",
+        "model:",
+        "reasoning summaries:",
+        "session id:",
         "workdir:",
         "provider:",
         "approval:",
         "sandbox:",
         "reasoning effort:"
+    ];
+    private static readonly string[] StartupPreambleExactLines =
+    [
+        "--------",
+        "user"
     ];
     private static readonly string[] StartupWarningMarkers =
     [
@@ -319,7 +327,8 @@ internal static class DirectRunFixOutcomeSupport
         {
             sawString = true;
             var normalized = value.Trim().ToLowerInvariant();
-            if (!StartupPreamblePrefixes.Any(prefix => normalized.StartsWith(prefix, StringComparison.Ordinal)))
+            if (!StartupPreamblePrefixes.Any(prefix => normalized.StartsWith(prefix, StringComparison.Ordinal))
+                && !StartupPreambleExactLines.Any(line => string.Equals(normalized, line, StringComparison.Ordinal)))
             {
                 return false;
             }

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -6,6 +6,21 @@ internal static class DirectRunFixOutcomeSupport
 {
     private const string DeterministicContractGapStopReason = "deterministic-contract-gap";
     private const string InspectionOnlyExitReason = "fix-session-ended-after-initial-inspection";
+    private static readonly string[] StartupWarningMarkers =
+    [
+        "warn",
+        "warn ",
+        "warning",
+        "state db discrepancy",
+        "find_thread_path_by_id_str_in_subdir",
+        "read_repair_rollout_path",
+        "reconcile_rollout",
+        "empty session file",
+        "plugin manifest",
+        "falling_back",
+        "upsert_needed",
+        "slow path"
+    ];
 
     public static DirectRunProviderEvent? CreateCanonicalContractGapEventIfNeeded(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
@@ -66,6 +81,51 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         return TryResolveInspectionOnlyFailureDetail(providerEvents, executionUnit, out detail);
+    }
+
+    public static bool TryResolveStartupOnlyFailureDetail(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        out string detail)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        detail = string.Empty;
+        var failingBackendExitIndex = FindFailingBackendExitIndex(providerEvents);
+        if (failingBackendExitIndex < 0)
+        {
+            return false;
+        }
+
+        var sawStartupNoise = false;
+        for (var index = 0; index < failingBackendExitIndex; index++)
+        {
+            var providerEvent = providerEvents[index];
+            if (providerEvent.Kind == "session-metadata"
+                || IsIgnorableReadyEvent(providerEvent.Payload))
+            {
+                continue;
+            }
+
+            if (TryResolveExplicitContractGapDetail(providerEvent.Payload, executionUnit, out _)
+                || ContainsSuccessfulInitialRepoInspection(providerEvent.Payload)
+                || !IsIgnorableStartupNoise(providerEvent.Payload))
+            {
+                return false;
+            }
+
+            sawStartupNoise = true;
+        }
+
+        if (!sawStartupNoise)
+        {
+            return false;
+        }
+
+        detail =
+            $"Fix direct run for '{executionUnit}' exited during provider startup before any bounded repo inspection, edit, test, refusal, or contract-gap output was emitted. Current-session provider output only contained startup warnings or noise before the backend exit.";
+        return true;
     }
 
     private static bool TryResolveInspectionOnlyFailureDetail(
@@ -221,6 +281,22 @@ internal static class DirectRunFixOutcomeSupport
         return payload.ValueKind == JsonValueKind.Object
             && TryReadString(payload, "type", out var type)
             && string.Equals(type, "ready", StringComparison.Ordinal);
+    }
+
+    private static bool IsIgnorableStartupNoise(JsonElement payload)
+    {
+        var sawString = false;
+        foreach (var value in EnumeratePayloadStrings(payload))
+        {
+            sawString = true;
+            var normalized = value.Trim().ToLowerInvariant();
+            if (!StartupWarningMarkers.Any(marker => normalized.Contains(marker, StringComparison.Ordinal)))
+            {
+                return false;
+            }
+        }
+
+        return sawString;
     }
 
     private static IEnumerable<string> EnumeratePayloadStrings(JsonElement payload)

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -154,6 +154,11 @@ internal static class RunCommand
 
                         if (superviseResult.Blocked)
                         {
+                            if (superviseResult.ReportAsNonRetryableFailure)
+                            {
+                                return CreateMonitoringStopResult(actions, inProgressItem.ExecutionUnit, superviseResult);
+                            }
+
                             continue;
                         }
 
@@ -259,6 +264,11 @@ internal static class RunCommand
 
                         if (superviseResult.Blocked)
                         {
+                            if (superviseResult.ReportAsNonRetryableFailure)
+                            {
+                                return CreateMonitoringStopResult(actions, inProgressItem.ExecutionUnit, superviseResult);
+                            }
+
                             continue;
                         }
 
@@ -464,7 +474,8 @@ internal static class RunCommand
                 NonRetryableFailureStopReason,
                 actions,
                 executionUnit,
-                $"Supervisor blocked '{executionUnit}' after non-retryable failure.");
+                superviseResult.FailureReason
+                ?? $"Supervisor blocked '{executionUnit}' after non-retryable failure.");
         }
 
         return CreateStopResult(

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -163,8 +163,25 @@ internal static class RunSuperviseCommand
                 context,
                 executionUnit,
                 session.WorkerEntry,
-                out var deadWorkerReason))
+                out var deadWorkerFailure))
         {
+            if (deadWorkerFailure.IsStartupOnly)
+            {
+                return BlockForTerminalFailure(
+                    context,
+                    queueState,
+                    executionUnit,
+                    sessionArtifactPath,
+                    sessionArtifactRef,
+                    runLogPath,
+                    session,
+                    now,
+                    deadWorkerFailure.Reason,
+                    incrementRetryCount: false,
+                    emitRetryExhaustedEvent: false,
+                    reportAsNonRetryableFailure: true);
+            }
+
             if (session.RetryCount >= session.RetryBudget)
             {
                 return ExhaustRetryBudget(
@@ -176,13 +193,13 @@ internal static class RunSuperviseCommand
                     runLogPath,
                     session,
                     now,
-                    deadWorkerReason);
+                    deadWorkerFailure.Reason);
             }
 
             var interruptedSession = session with
             {
                 UpdatedAt = now,
-                LastInterruptionReason = deadWorkerReason
+                LastInterruptionReason = deadWorkerFailure.Reason
             };
 
             return AttemptAutoResume(
@@ -293,8 +310,25 @@ internal static class RunSuperviseCommand
                 context,
                 executionUnit,
                 session.WorkerEntry,
-                out var deadWorkerReason))
+                out var deadWorkerFailure))
         {
+            if (deadWorkerFailure.IsStartupOnly)
+            {
+                return BlockForTerminalFailure(
+                    context,
+                    queueState,
+                    executionUnit,
+                    sessionArtifactPath,
+                    sessionArtifactRef,
+                    runLogPath,
+                    session,
+                    now,
+                    deadWorkerFailure.Reason,
+                    incrementRetryCount: false,
+                    emitRetryExhaustedEvent: false,
+                    reportAsNonRetryableFailure: true);
+            }
+
             if (session.RetryCount >= session.RetryBudget)
             {
                 return ExhaustRetryBudget(
@@ -306,13 +340,13 @@ internal static class RunSuperviseCommand
                     runLogPath,
                     session,
                     now,
-                    deadWorkerReason);
+                    deadWorkerFailure.Reason);
             }
 
             var interruptedSession = session with
             {
                 UpdatedAt = now,
-                LastInterruptionReason = deadWorkerReason
+                LastInterruptionReason = deadWorkerFailure.Reason
             };
 
             return AttemptAutoResume(
@@ -433,7 +467,9 @@ internal static class RunSuperviseCommand
         RunSupervisionSession session,
         DateTimeOffset now,
         string reason,
-        bool incrementRetryCount)
+        bool incrementRetryCount,
+        bool emitRetryExhaustedEvent = true,
+        bool reportAsNonRetryableFailure = false)
     {
         var transition = QueueManager.TransitionBlocking(
             queueState,
@@ -454,23 +490,31 @@ internal static class RunSuperviseCommand
 
         PersistQueueState(context, transition.UpdatedState);
         PersistSession(sessionArtifactPath, blockedSession);
+        List<RunEvent> runEvents = [];
+        if (emitRetryExhaustedEvent)
+        {
+            runEvents.Add(new RunEvent
+            {
+                Ts = now,
+                ExecutionUnit = executionUnit,
+                Event = "retry-exhausted",
+                By = TransitionActor,
+                LinkedPr = session.LinkedPr,
+                CommentRef = session.CommentRef,
+                Reason = reason
+            });
+        }
+
+        runEvents.Add(transition.Event);
         AppendRunEvents(
             runLogPath,
-            [
-                new RunEvent
-                {
-                    Ts = now,
-                    ExecutionUnit = executionUnit,
-                    Event = "retry-exhausted",
-                    By = TransitionActor,
-                    LinkedPr = session.LinkedPr,
-                    CommentRef = session.CommentRef,
-                    Reason = reason
-                },
-                transition.Event
-            ]);
+            runEvents);
 
-        return CreateResult(sessionArtifactRef, blockedSession, blocked: true);
+        return CreateResult(
+            sessionArtifactRef,
+            blockedSession,
+            blocked: true,
+            reportAsNonRetryableFailure: reportAsNonRetryableFailure);
     }
 
     private static RunSupervisionSession BuildResumedSession(
@@ -650,12 +694,12 @@ internal static class RunSuperviseCommand
         CliContext context,
         string executionUnit,
         RunSupervisionWorkerEntry workerEntry,
-        out string reason)
+        out WorkerSessionFailure failure)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
 
-        reason = string.Empty;
+        failure = null!;
         var expectedEntryKind = ResolveDirectRunEntryKind(workerEntry);
         var requestArtifactPath = ResolveDirectRunRequestArtifactPath(context, executionUnit);
         var resultArtifactPath = ResolveDirectRunResultArtifactPath(context, executionUnit);
@@ -689,7 +733,8 @@ internal static class RunSuperviseCommand
                 currentProviderEvents,
                 executionUnit,
                 requestArtifact.ProviderSessionId,
-                out reason))
+                expectedEntryKind,
+                out failure))
         {
             File.WriteAllText(
                 resultArtifactPath,
@@ -706,7 +751,8 @@ internal static class RunSuperviseCommand
                 executionUnit,
                 requestArtifact.ProviderSessionId,
                 requestArtifact.LaunchedAt,
-                out reason))
+                expectedEntryKind,
+                out failure))
         {
             File.WriteAllText(
                 resultArtifactPath,
@@ -738,7 +784,8 @@ internal static class RunSuperviseCommand
                 [backendExitEvent],
                 executionUnit,
                 requestArtifact.ProviderSessionId,
-                out reason))
+                expectedEntryKind,
+                out failure))
         {
             throw new InvalidOperationException(
                 $"Synthetic backend-exit for '{executionUnit}' did not resolve to a terminal failure reason.");
@@ -752,14 +799,16 @@ internal static class RunSuperviseCommand
         string executionUnit,
         string providerSessionId,
         string launchedAt,
-        out string reason)
+        string expectedEntryKind,
+        out WorkerSessionFailure failure)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(providerLogPath);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
         ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
         ArgumentException.ThrowIfNullOrWhiteSpace(launchedAt);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedEntryKind);
 
-        reason = string.Empty;
+        failure = null!;
         if (TerminalFailureRaceWindow <= TimeSpan.Zero)
         {
             return false;
@@ -791,7 +840,8 @@ internal static class RunSuperviseCommand
                     currentProviderEvents,
                     executionUnit,
                     providerSessionId,
-                    out reason))
+                    expectedEntryKind,
+                    out failure))
             {
                 return true;
             }
@@ -804,13 +854,15 @@ internal static class RunSuperviseCommand
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string executionUnit,
         string providerSessionId,
-        out string reason)
+        string expectedEntryKind,
+        out WorkerSessionFailure failure)
     {
         ArgumentNullException.ThrowIfNull(providerEvents);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
         ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedEntryKind);
 
-        reason = string.Empty;
+        failure = null!;
         for (var index = providerEvents.Count - 1; index >= 0; index--)
         {
             var providerEvent = providerEvents[index];
@@ -822,13 +874,27 @@ internal static class RunSuperviseCommand
             if (providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
                 && exitCodeElement.TryGetInt32(out var exitCode))
             {
-                reason =
-                    $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode}.";
+                if (string.Equals(expectedEntryKind, "fix", StringComparison.Ordinal)
+                    && DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
+                        providerEvents,
+                        executionUnit,
+                        out var startupOnlyDetail))
+                {
+                    failure = new WorkerSessionFailure(
+                        $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode}. {startupOnlyDetail}",
+                        IsStartupOnly: true);
+                    return true;
+                }
+
+                failure = new WorkerSessionFailure(
+                    $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode}.",
+                    IsStartupOnly: false);
             }
             else
             {
-                reason =
-                    $"Worker session '{providerSessionId}' for '{executionUnit}' exited after a terminal backend-exit event.";
+                failure = new WorkerSessionFailure(
+                    $"Worker session '{providerSessionId}' for '{executionUnit}' exited after a terminal backend-exit event.",
+                    IsStartupOnly: false);
             }
 
             return true;
@@ -963,7 +1029,8 @@ internal static class RunSuperviseCommand
         RunSupervisionSession session,
         bool retryScheduled = false,
         bool autoResumed = false,
-        bool blocked = false)
+        bool blocked = false,
+        bool reportAsNonRetryableFailure = false)
     {
         return new RunSuperviseResult
         {
@@ -977,9 +1044,13 @@ internal static class RunSuperviseCommand
             NextRetryAt = session.NextRetryAt?.ToString("O"),
             RetryScheduled = retryScheduled,
             AutoResumed = autoResumed,
-            Blocked = blocked
+            Blocked = blocked,
+            FailureReason = blocked ? session.LastInterruptionReason : null,
+            ReportAsNonRetryableFailure = reportAsNonRetryableFailure
         };
     }
+
+    private sealed record WorkerSessionFailure(string Reason, bool IsStartupOnly);
 
     private static string FormatQueueState(QueueItemState state)
     {

--- a/src/IntentSystem.Cli/Commands/RunSuperviseResult.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseResult.cs
@@ -23,4 +23,8 @@ internal sealed record RunSuperviseResult
     public bool AutoResumed { get; init; }
 
     public bool Blocked { get; init; }
+
+    public string? FailureReason { get; init; }
+
+    public bool ReportAsNonRetryableFailure { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -3054,6 +3054,107 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenStartupOnlyDeadFixWorkerSession_StopsWithNonRetryableFailureDetail()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 0,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents: CreateStartupOnlyFixProviderEvents("G226", "pid:999999"),
+            sessionId: "pid:999999",
+            provider: "Claude");
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("non-retryable-failure", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        var action = Assert.Single(result.Actions);
+        Assert.Equal("run supervise", action.Name);
+        Assert.Contains("during provider startup", result.Detail, StringComparison.Ordinal);
+        Assert.Contains("startup warnings or noise", result.Detail, StringComparison.Ordinal);
+        Assert.DoesNotContain("Supervisor blocked 'G226' after non-retryable failure.", result.Detail, StringComparison.Ordinal);
+
+        var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+        Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+        Assert.Contains("during provider startup", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+        var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
+        Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+        Assert.Equal(0, session.RetryCount);
+        Assert.Contains("during provider startup", session.LastInterruptionReason, StringComparison.Ordinal);
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        Assert.Equal("blocked", runEvents[^1].Event);
+        Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+        Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWithoutCapturedTerminalEvent_BlocksUsingSyntheticBackendExitReason()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -3635,6 +3736,56 @@ public sealed class RunCommandTests
         File.WriteAllText(
             Path.Combine(runsDirectory, $"{executionUnit}.provider.jsonl"),
             string.Join(Environment.NewLine, providerEvents.Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateStartupOnlyFixProviderEvents(string executionUnit, string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "session-metadata",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    model = "sonnet",
+                    transport = "sdk",
+                    command = "claude"
+                })
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.2000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    level = "warn",
+                    message = "plugin manifest falling_back after state db discrepancy on slow path"
+                })
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    type = "backend-exit",
+                    exit_code = 1
+                })
+            }
+        ];
     }
 
     private static void WriteDirectRunRequest(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -3765,11 +3765,77 @@ public sealed class RunCommandTests
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",
-                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
-                {
-                    level = "warn",
-                    message = "plugin manifest falling_back after state db discrepancy on slow path"
-                })
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("OpenAI Codex v0.118.0 (research preview)")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.3000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("workdir: /repo/.intent-cli/worktrees/G226")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.4000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("provider: openai")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.5000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("approval: never")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.6000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("sandbox: danger-full-access")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.7000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("reasoning effort: high")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.8000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("Please diagnose the startup-only backend exit reproduction for issue #295.")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.9000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("warn plugin manifest falling_back after state db discrepancy on slow path")
             },
             new DirectRunProviderEvent
             {

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -3775,7 +3775,17 @@ public sealed class RunCommandTests
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",
-                Payload = System.Text.Json.JsonSerializer.SerializeToElement("workdir: /repo/.intent-cli/worktrees/G226")
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("--------")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.3500000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("model: gpt-5.4")
             },
             new DirectRunProviderEvent
             {
@@ -3785,7 +3795,17 @@ public sealed class RunCommandTests
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",
-                Payload = System.Text.Json.JsonSerializer.SerializeToElement("provider: openai")
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("reasoning summaries: none")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.4500000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("session id: sess_123")
             },
             new DirectRunProviderEvent
             {
@@ -3795,7 +3815,17 @@ public sealed class RunCommandTests
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",
-                Payload = System.Text.Json.JsonSerializer.SerializeToElement("approval: never")
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("user")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.5500000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("workdir: /repo/.intent-cli/worktrees/G226")
             },
             new DirectRunProviderEvent
             {
@@ -3805,11 +3835,31 @@ public sealed class RunCommandTests
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",
-                Payload = System.Text.Json.JsonSerializer.SerializeToElement("sandbox: danger-full-access")
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("provider: openai")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.6500000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("approval: never")
             },
             new DirectRunProviderEvent
             {
                 Timestamp = "2026-04-10T12:00:00.7000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("sandbox: danger-full-access")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.7500000+00:00",
                 ExecutionUnit = executionUnit,
                 Provider = "Claude",
                 EntryKind = "fix",

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -917,6 +917,74 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenStartupOnlyDeadFixWorkerSession_BlocksWithoutConsumingRetryBudget()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateFixingRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G25.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession(workerEntry: RunSupervisionWorkerEntry.Fix)));
+        WriteStartupOnlyDeadFixDirectRunArtifacts(repoRoot, "pid:999999");
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            var selectedItem = Assert.Single(queueState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("during provider startup", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionWorkerEntry.Fix, session.WorkerEntry);
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(0, session.RetryCount);
+            Assert.Null(session.NextRetryAt);
+            Assert.Contains("during provider startup", session.LastInterruptionReason, StringComparison.Ordinal);
+            Assert.Contains("startup warnings or noise", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.result.json")));
+            Assert.Equal("pid:999999", resultArtifact.SessionId);
+            Assert.Equal("failed", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("during provider startup", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenFixingItemWithoutExistingSessionAndDeadFixWorkerSession_CapturesFailureAndAutoResumesFixLoop()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -1308,6 +1376,93 @@ public sealed class RunSuperviseCommandTests
                     model = "sonnet",
                     transport = "sdk",
                     command = "claude"
+                })
+            })
+        };
+
+        var runsPath = Path.Combine(repoRoot, ".intent-cli", "runs");
+        Directory.CreateDirectory(runsPath);
+        File.WriteAllText(Path.Combine(runsPath, "G25.request.json"), DirectRunRequestArtifactJson.Serialize(requestArtifact));
+        File.WriteAllText(Path.Combine(runsPath, "G25.result.json"), DirectRunResultArtifactJson.Serialize(resultArtifact));
+        File.WriteAllText(Path.Combine(runsPath, "G25.provider.jsonl"), string.Join(Environment.NewLine, providerEvents) + Environment.NewLine);
+    }
+
+    private static void WriteStartupOnlyDeadFixDirectRunArtifacts(string repoRoot, string sessionId)
+    {
+        var requestArtifact = new DirectRunRequestArtifact
+        {
+            SchemaVersion = "1",
+            ExecutionUnit = "G25",
+            EntryKind = "fix",
+            UpstreamRequestRef = ".intent-cli/fix/G25.request.md",
+            Provider = "Claude",
+            Model = "sonnet",
+            Transport = "sdk",
+            LaunchedAt = "2026-04-08T10:20:00.0000000+00:00",
+            ProviderSessionId = sessionId,
+            TransportSummary = "sdk transport"
+        };
+        var resultArtifact = new DirectRunResultArtifact
+        {
+            SchemaVersion = "1",
+            ExecutionUnit = "G25",
+            EntryKind = "fix",
+            UpstreamRequestRef = ".intent-cli/fix/G25.request.md",
+            Provider = "Claude",
+            Model = "sonnet",
+            SessionId = sessionId,
+            RunStatus = "running",
+            RawLogRef = ".intent-cli/runs/G25.provider.jsonl",
+            PacketRef = ".intent-cli/issues/G25/packet.yaml",
+            ReviewContextRef = ".intent-cli/issues/G25/review-context.md",
+            Worktree = new DirectRunWorktreeContext
+            {
+                Path = "/repo/.intent-cli/worktrees/G25"
+            }
+        };
+        var providerEvents = new[]
+        {
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.0000000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "session-metadata",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    model = "sonnet",
+                    transport = "sdk",
+                    command = "claude"
+                })
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.2000000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    level = "warn",
+                    message = "state db discrepancy detected on slow path while reconcile_rollout started"
+                })
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:01.0000000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    type = "backend-exit",
+                    exit_code = 1
                 })
             })
         };

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -1445,11 +1445,77 @@ public sealed class RunSuperviseCommandTests
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",
-                Payload = JsonSerializer.SerializeToElement(new
-                {
-                    level = "warn",
-                    message = "state db discrepancy detected on slow path while reconcile_rollout started"
-                })
+                Payload = JsonSerializer.SerializeToElement("OpenAI Codex v0.118.0 (research preview)")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.3000000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("workdir: /repo/.intent-cli/worktrees/G25")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.4000000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("provider: openai")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.5000000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("approval: never")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.6000000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("sandbox: danger-full-access")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.7000000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("reasoning effort: high")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.8000000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("Please diagnose the startup-only backend exit reproduction for issue #295.")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.9000000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("warn state db discrepancy detected on slow path while reconcile_rollout started")
             }),
             DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
             {

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -1455,7 +1455,17 @@ public sealed class RunSuperviseCommandTests
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",
-                Payload = JsonSerializer.SerializeToElement("workdir: /repo/.intent-cli/worktrees/G25")
+                Payload = JsonSerializer.SerializeToElement("--------")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.3500000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("model: gpt-5.4")
             }),
             DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
             {
@@ -1465,7 +1475,17 @@ public sealed class RunSuperviseCommandTests
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",
-                Payload = JsonSerializer.SerializeToElement("provider: openai")
+                Payload = JsonSerializer.SerializeToElement("reasoning summaries: none")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.4500000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("session id: sess_123")
             }),
             DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
             {
@@ -1475,7 +1495,17 @@ public sealed class RunSuperviseCommandTests
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",
-                Payload = JsonSerializer.SerializeToElement("approval: never")
+                Payload = JsonSerializer.SerializeToElement("user")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.5500000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("workdir: /repo/.intent-cli/worktrees/G25")
             }),
             DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
             {
@@ -1485,11 +1515,31 @@ public sealed class RunSuperviseCommandTests
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",
-                Payload = JsonSerializer.SerializeToElement("sandbox: danger-full-access")
+                Payload = JsonSerializer.SerializeToElement("provider: openai")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.6500000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("approval: never")
             }),
             DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
             {
                 Timestamp = "2026-04-08T10:20:00.7000000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("sandbox: danger-full-access")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.7500000+00:00",
                 ExecutionUnit = "G25",
                 Provider = "Claude",
                 EntryKind = "fix",


### PR DESCRIPTION
## Summary
- classify startup-only fix session backend exits separately from normal retryable fix failures
- block startup-only failures without consuming the ordinary fix retry loop and propagate the concrete failure detail back to `run`
- cover both supervise and root run flows with startup-only regression tests

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests|FullyQualifiedName~RunFixCommandTests" --logger "console;verbosity=minimal"
- dotnet test IntentSystem.sln --logger "console;verbosity=minimal"