### PR TITLE
Fix #295: generalize startup-only Codex preamble handling

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -21,6 +21,28 @@ internal static class DirectRunFixOutcomeSupport
         "upsert_needed",
         "slow path"
     ];
+    private static readonly string[] StartupPreamblePrefixes =
+    [
+        "openai codex v",
+        "--------",
+        "workdir:",
+        "model:",
+        "provider:",
+        "approval:",
+        "sandbox:",
+        "reasoning effort:",
+        "reasoning summaries:",
+        "session id:",
+        "user"
+    ];
+    private static readonly string[] EchoedStartupRequestMarkers =
+    [
+        "please ",
+        "use the request artifact at",
+        "bounded source of truth for this direct run",
+        "continue beyond initial repository inspection",
+        "do not stop after a single inspection command"
+    ];
 
     public static DirectRunProviderEvent? CreateCanonicalContractGapEventIfNeeded(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
@@ -109,8 +131,18 @@ internal static class DirectRunFixOutcomeSupport
             }
 
             if (TryResolveExplicitContractGapDetail(providerEvent.Payload, executionUnit, out _)
-                || ContainsSuccessfulInitialRepoInspection(providerEvent.Payload)
-                || ContainsBoundedFixProgressSignal(providerEvent.Payload))
+                || ContainsSuccessfulInitialRepoInspection(providerEvent.Payload))
+            {
+                return false;
+            }
+
+            if (!sawStartupNoise
+                && IsIgnorableStartupPreamble(providerEvent.Payload))
+            {
+                continue;
+            }
+
+            if (ContainsBoundedFixProgressSignal(providerEvent.Payload))
             {
                 return false;
             }
@@ -118,12 +150,6 @@ internal static class DirectRunFixOutcomeSupport
             if (IsIgnorableStartupNoise(providerEvent.Payload))
             {
                 sawStartupNoise = true;
-                continue;
-            }
-
-            if (!sawStartupNoise
-                && IsIgnorableStartupPreamble(providerEvent.Payload))
-            {
                 continue;
             }
 
@@ -303,8 +329,20 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         var value = payload.GetString();
-        return !string.IsNullOrWhiteSpace(value)
-            && !ContainsBoundedFixProgressSignal(payload);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+        if (StartupPreamblePrefixes.Any(prefix => normalized.StartsWith(prefix, StringComparison.Ordinal))
+            || EchoedStartupRequestMarkers.Any(marker => normalized.StartsWith(marker, StringComparison.Ordinal)
+                || normalized.Contains(marker, StringComparison.Ordinal)))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     private static bool IsIgnorableStartupNoise(JsonElement payload)

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -6,23 +6,6 @@ internal static class DirectRunFixOutcomeSupport
 {
     private const string DeterministicContractGapStopReason = "deterministic-contract-gap";
     private const string InspectionOnlyExitReason = "fix-session-ended-after-initial-inspection";
-    private static readonly string[] StartupPreamblePrefixes =
-    [
-        "openai codex v",
-        "model:",
-        "reasoning summaries:",
-        "session id:",
-        "workdir:",
-        "provider:",
-        "approval:",
-        "sandbox:",
-        "reasoning effort:"
-    ];
-    private static readonly string[] StartupPreambleExactLines =
-    [
-        "--------",
-        "user"
-    ];
     private static readonly string[] StartupWarningMarkers =
     [
         "warn",
@@ -116,7 +99,6 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         var sawStartupNoise = false;
-        var sawStartupPreamble = false;
         for (var index = 0; index < failingBackendExitIndex; index++)
         {
             var providerEvent = providerEvents[index];
@@ -139,15 +121,8 @@ internal static class DirectRunFixOutcomeSupport
                 continue;
             }
 
-            if (IsIgnorableStartupPreamble(providerEvent.Payload))
-            {
-                sawStartupPreamble = true;
-                continue;
-            }
-
-            if (sawStartupPreamble
-                && !sawStartupNoise
-                && IsIgnorablePromptEcho(providerEvent.Payload))
+            if (!sawStartupNoise
+                && IsIgnorableStartupPreamble(providerEvent.Payload))
             {
                 continue;
             }
@@ -322,19 +297,14 @@ internal static class DirectRunFixOutcomeSupport
 
     private static bool IsIgnorableStartupPreamble(JsonElement payload)
     {
-        var sawString = false;
-        foreach (var value in EnumeratePayloadStrings(payload))
+        if (payload.ValueKind != JsonValueKind.String)
         {
-            sawString = true;
-            var normalized = value.Trim().ToLowerInvariant();
-            if (!StartupPreamblePrefixes.Any(prefix => normalized.StartsWith(prefix, StringComparison.Ordinal))
-                && !StartupPreambleExactLines.Any(line => string.Equals(normalized, line, StringComparison.Ordinal)))
-            {
-                return false;
-            }
+            return false;
         }
 
-        return sawString;
+        var value = payload.GetString();
+        return !string.IsNullOrWhiteSpace(value)
+            && !ContainsBoundedFixProgressSignal(payload);
     }
 
     private static bool IsIgnorableStartupNoise(JsonElement payload)
@@ -351,25 +321,6 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         return sawString;
-    }
-
-    private static bool IsIgnorablePromptEcho(JsonElement payload)
-    {
-        if (payload.ValueKind != JsonValueKind.String)
-        {
-            return false;
-        }
-
-        var value = payload.GetString();
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return false;
-        }
-
-        var normalized = value.Trim().ToLowerInvariant();
-        return !StartupPreamblePrefixes.Any(prefix => normalized.StartsWith(prefix, StringComparison.Ordinal))
-            && !StartupWarningMarkers.Any(marker => normalized.Contains(marker, StringComparison.Ordinal))
-            && !ContainsBoundedFixProgressSignal(payload);
     }
 
     private static bool ContainsBoundedFixProgressSignal(JsonElement payload)

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -781,6 +781,24 @@ internal static class RunSuperviseCommand
                 RunStatus = "failed"
             }));
 
+        if (string.Equals(expectedEntryKind, "fix", StringComparison.Ordinal))
+        {
+            var providerEventsWithSyntheticExit = new List<DirectRunProviderEvent>(currentProviderEvents.Count + 1);
+            providerEventsWithSyntheticExit.AddRange(currentProviderEvents);
+            providerEventsWithSyntheticExit.Add(backendExitEvent);
+
+            if (DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
+                    providerEventsWithSyntheticExit,
+                    executionUnit,
+                    out var startupOnlyDetail))
+            {
+                failure = new WorkerSessionFailure(
+                    $"Worker session '{requestArtifact.ProviderSessionId}' for '{executionUnit}' exited with backend exit code 1. {startupOnlyDetail}",
+                    IsStartupOnly: true);
+                return true;
+            }
+        }
+
         if (!TryResolveTerminalFailureReason(
                 [backendExitEvent],
                 executionUnit,

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -11,8 +11,9 @@ internal static class RunSuperviseCommand
 {
     private const string TransitionActor = "intent-cli";
     // Detached terminal callbacks can trail the dead-process probe slightly; keep the handoff bounded
-    // while still allowing the same-session backend-exit reason to win deterministically.
-    internal static TimeSpan TerminalFailureRaceWindow { get; set; } = TimeSpan.FromMilliseconds(500);
+    // while still allowing the same-session backend-exit reason to win deterministically even when
+    // the provider appends it a little after startup warnings finish flushing.
+    internal static TimeSpan TerminalFailureRaceWindow { get; set; } = TimeSpan.FromSeconds(1);
     internal static TimeSpan TerminalFailureRacePollInterval { get; set; } = TimeSpan.FromMilliseconds(10);
 
     public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class DirectRunFixOutcomeSupportTests
+{
+    [Fact]
+    public void TryResolveStartupOnlyFailureDetail_GivenIssue295CurrentSessionRawShape_ReturnsStartupOnlyDetail()
+    {
+        var providerEvents = CreateIssue295CurrentSessionRawEvents();
+
+        var resolved = DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
+            providerEvents,
+            "TOY-CALC-V0-01",
+            out var detail);
+
+        Assert.True(resolved);
+        Assert.Contains("during provider startup", detail, StringComparison.Ordinal);
+        Assert.Contains("Current-session provider output only contained startup warnings or noise", detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryResolveStartupOnlyFailureDetail_GivenEchoedStartupRequestMentionsInspectionCommands_StillReturnsStartupOnlyDetail()
+    {
+        var providerEvents = CreateIssue295CurrentSessionRawEvents(
+            echoedRequest:
+            "Use the request artifact at '/tmp/TOY-CALC-V0-01.request.md' as the bounded source of truth for this direct run. Continue beyond initial repository inspection even if the request mentions rg --files, git diff, or dotnet test, and do not stop after a single inspection command without producing one of those outcomes.");
+
+        var resolved = DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
+            providerEvents,
+            "TOY-CALC-V0-01",
+            out var detail);
+
+        Assert.True(resolved);
+        Assert.Contains("during provider startup", detail, StringComparison.Ordinal);
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateIssue295CurrentSessionRawEvents(string? echoedRequest = null)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T08:08:23.1658640+00:00",
+                ExecutionUnit = "TOY-CALC-V0-01",
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = "pid:97771",
+                Kind = "session-metadata",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    model = "gpt-5.4-mini",
+                    transport = "stdio",
+                    command = "/Users/tomohisa/bin/codex-isolated"
+                })
+            },
+            CreateProviderEvent("OpenAI Codex v0.118.0 (research preview)"),
+            CreateProviderEvent("--------"),
+            CreateProviderEvent("workdir: /Users/tomohisa/dev/GitHub/MyIntentHost/submodules/toy-calc-sample/.intent-cli/worktrees/TOY-CALC-V0-01"),
+            CreateProviderEvent("model: gpt-5.4-mini"),
+            CreateProviderEvent("provider: openai"),
+            CreateProviderEvent("approval: never"),
+            CreateProviderEvent("sandbox: danger-full-access"),
+            CreateProviderEvent("reasoning effort: high"),
+            CreateProviderEvent("reasoning summaries: none"),
+            CreateProviderEvent("session id: 019d9555-85e9-7af2-a46d-d0836b0f8ecd"),
+            CreateProviderEvent("--------"),
+            CreateProviderEvent("user"),
+            CreateProviderEvent(
+                echoedRequest
+                ?? "Use the request artifact at '/Users/tomohisa/dev/GitHub/MyIntentHost/submodules/toy-calc-sample/.intent-cli/fix/TOY-CALC-V0-01.request.md' as the bounded source of truth for this direct run. Continue beyond initial repository inspection and either complete the bounded repair attempt from that artifact or end with a deterministic refusal or contract-gap explanation. Do not stop after a single inspection command without producing one of those outcomes."),
+            CreateProviderEvent("2026-04-16T08:08:23.310822Z  WARN codex_rollout::list: state db discrepancy during find_thread_path_by_id_str_in_subdir: falling_back"),
+            CreateProviderEvent("2026-04-16T08:08:23.310983Z  WARN codex_rollout::state_db: state db discrepancy during read_repair_rollout_path: upsert_needed (slow path)"),
+            CreateProviderEvent("2026-04-16T08:08:23.311130Z  WARN codex_rollout::state_db: state db reconcile_rollout extraction failed /Users/tomohisa/.codex-direct-backend/sessions/2026/04/15/rollout-2026-04-15T15-24-25-019d933e-e4e4-7743-abbb-ef13bb2666cf.jsonl: empty session file"),
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T08:32:47.8815580+00:00",
+                ExecutionUnit = "TOY-CALC-V0-01",
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = "pid:97771",
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    type = "backend-exit",
+                    exit_code = 1
+                })
+            }
+        ];
+    }
+
+    private static DirectRunProviderEvent CreateProviderEvent(string payload)
+    {
+        return new DirectRunProviderEvent
+        {
+            Timestamp = "2026-04-16T08:08:23.2829410+00:00",
+            ExecutionUnit = "TOY-CALC-V0-01",
+            Provider = "Codex",
+            EntryKind = "fix",
+            SessionId = "pid:97771",
+            Kind = "provider-event",
+            Payload = JsonSerializer.SerializeToElement(payload)
+        };
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -3279,6 +3279,117 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenStartupOnlyDeadFixWorkerSessionWithoutCapturedTerminalEvent_StopsWithNonRetryableFailureDetail()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 0,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents: CreateStartupOnlyFixProviderEvents("G226", "pid:999999", includeBackendExit: false),
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var originalRaceWindow = RunSuperviseCommand.TerminalFailureRaceWindow;
+
+        try
+        {
+            RunSuperviseCommand.TerminalFailureRaceWindow = TimeSpan.Zero;
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("non-retryable-failure", result.StopReason);
+            Assert.Contains("during provider startup", result.Detail, StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("during provider startup", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                && providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
+                && exitCodeElement.GetInt32() == 1);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TerminalFailureRaceWindow = originalRaceWindow;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWithoutCapturedTerminalEvent_BlocksUsingSyntheticBackendExitReason()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -3155,6 +3155,130 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public async Task ExecuteCore_GivenStartupOnlyDeadFixWorkerSessionWhenBackendExitLandsDuringRaceWindow_StopsWithNonRetryableFailureDetail()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 0,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents: CreateStartupOnlyFixProviderEvents("G226", "pid:999999", includeBackendExit: false),
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var originalRaceWindow = RunSuperviseCommand.TerminalFailureRaceWindow;
+        var originalRacePollInterval = RunSuperviseCommand.TerminalFailureRacePollInterval;
+
+        try
+        {
+            RunSuperviseCommand.TerminalFailureRaceWindow = TimeSpan.FromMilliseconds(700);
+            RunSuperviseCommand.TerminalFailureRacePollInterval = TimeSpan.FromMilliseconds(5);
+
+            var appendTask = Task.Run(async () =>
+            {
+                await Task.Delay(600);
+                new DirectRunProviderEventWriter(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl"))
+                    .Append(new DirectRunProviderEvent
+                    {
+                        Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                        ExecutionUnit = "G226",
+                        Provider = "Claude",
+                        EntryKind = "fix",
+                        SessionId = "pid:999999",
+                        Kind = "provider-event",
+                        Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                        {
+                            type = "backend-exit",
+                            exit_code = 1
+                        })
+                    });
+            });
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+            await appendTask;
+
+            Assert.Equal("non-retryable-failure", result.StopReason);
+            Assert.Contains("during provider startup", result.Detail, StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("during provider startup", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TerminalFailureRaceWindow = originalRaceWindow;
+            RunSuperviseCommand.TerminalFailureRacePollInterval = originalRacePollInterval;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWithoutCapturedTerminalEvent_BlocksUsingSyntheticBackendExitReason()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -3738,9 +3862,12 @@ public sealed class RunCommandTests
             string.Join(Environment.NewLine, providerEvents.Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
     }
 
-    private static IReadOnlyList<DirectRunProviderEvent> CreateStartupOnlyFixProviderEvents(string executionUnit, string sessionId)
+    private static IReadOnlyList<DirectRunProviderEvent> CreateStartupOnlyFixProviderEvents(
+        string executionUnit,
+        string sessionId,
+        bool includeBackendExit = true)
     {
-        return
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
         [
             new DirectRunProviderEvent
             {
@@ -3897,22 +4024,32 @@ public sealed class RunCommandTests
                 Kind = "provider-event",
                 Payload = System.Text.Json.JsonSerializer.SerializeToElement(
                     "2026-04-10T12:00:00.9500000Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at \"/tmp/snapshot\"")
-            },
-            new DirectRunProviderEvent
-            {
-                Timestamp = "2026-04-10T12:00:01.0000000+00:00",
-                ExecutionUnit = executionUnit,
-                Provider = "Claude",
-                EntryKind = "fix",
-                SessionId = sessionId,
-                Kind = "provider-event",
-                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
-                {
-                    type = "backend-exit",
-                    exit_code = 1
-                })
             }
         ];
+
+        if (includeBackendExit)
+        {
+            providerEvents =
+            [
+                .. providerEvents,
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = executionUnit,
+                    Provider = "Claude",
+                    EntryKind = "fix",
+                    SessionId = sessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                }
+            ];
+        }
+
+        return providerEvents;
     }
 
     private static void WriteDirectRunRequest(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -3769,13 +3769,23 @@ public sealed class RunCommandTests
             },
             new DirectRunProviderEvent
             {
-                Timestamp = "2026-04-10T12:00:00.3000000+00:00",
+                Timestamp = "2026-04-10T12:00:00.2500000+00:00",
                 ExecutionUnit = executionUnit,
                 Provider = "Claude",
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",
                 Payload = System.Text.Json.JsonSerializer.SerializeToElement("--------")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.3000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("workdir: /repo/.intent-cli/worktrees/G226")
             },
             new DirectRunProviderEvent
             {
@@ -3816,16 +3826,6 @@ public sealed class RunCommandTests
                 SessionId = sessionId,
                 Kind = "provider-event",
                 Payload = System.Text.Json.JsonSerializer.SerializeToElement("user")
-            },
-            new DirectRunProviderEvent
-            {
-                Timestamp = "2026-04-10T12:00:00.5500000+00:00",
-                ExecutionUnit = executionUnit,
-                Provider = "Claude",
-                EntryKind = "fix",
-                SessionId = sessionId,
-                Kind = "provider-event",
-                Payload = System.Text.Json.JsonSerializer.SerializeToElement("workdir: /repo/.intent-cli/worktrees/G226")
             },
             new DirectRunProviderEvent
             {
@@ -3886,6 +3886,17 @@ public sealed class RunCommandTests
                 SessionId = sessionId,
                 Kind = "provider-event",
                 Payload = System.Text.Json.JsonSerializer.SerializeToElement("warn plugin manifest falling_back after state db discrepancy on slow path")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.9500000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                    "2026-04-10T12:00:00.9500000Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at \"/tmp/snapshot\"")
             },
             new DirectRunProviderEvent
             {

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -1449,13 +1449,23 @@ public sealed class RunSuperviseCommandTests
             }),
             DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
             {
-                Timestamp = "2026-04-08T10:20:00.3000000+00:00",
+                Timestamp = "2026-04-08T10:20:00.2500000+00:00",
                 ExecutionUnit = "G25",
                 Provider = "Claude",
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",
                 Payload = JsonSerializer.SerializeToElement("--------")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.3000000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("workdir: /repo/.intent-cli/worktrees/G25")
             }),
             DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
             {
@@ -1496,16 +1506,6 @@ public sealed class RunSuperviseCommandTests
                 SessionId = sessionId,
                 Kind = "provider-event",
                 Payload = JsonSerializer.SerializeToElement("user")
-            }),
-            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
-            {
-                Timestamp = "2026-04-08T10:20:00.5500000+00:00",
-                ExecutionUnit = "G25",
-                Provider = "Claude",
-                EntryKind = "fix",
-                SessionId = sessionId,
-                Kind = "provider-event",
-                Payload = JsonSerializer.SerializeToElement("workdir: /repo/.intent-cli/worktrees/G25")
             }),
             DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
             {
@@ -1566,6 +1566,17 @@ public sealed class RunSuperviseCommandTests
                 SessionId = sessionId,
                 Kind = "provider-event",
                 Payload = JsonSerializer.SerializeToElement("warn state db discrepancy detected on slow path while reconcile_rollout started")
+            }),
+            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.9500000+00:00",
+                ExecutionUnit = "G25",
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(
+                    "2026-04-08T10:20:00.9500000Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at \"/tmp/snapshot\"")
             }),
             DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
             {

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -985,6 +985,86 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public async Task Execute_GivenStartupOnlyDeadFixWorkerSessionWhenBackendExitLandsDuringRaceWindow_BlocksWithoutAutoResume()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateFixingRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G25.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession(workerEntry: RunSupervisionWorkerEntry.Fix)));
+        WriteStartupOnlyDeadFixDirectRunArtifacts(repoRoot, "pid:999999", includeBackendExit: false);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalRaceWindow = RunSuperviseCommand.TerminalFailureRaceWindow;
+        var originalRacePollInterval = RunSuperviseCommand.TerminalFailureRacePollInterval;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+            RunSuperviseCommand.TerminalFailureRaceWindow = TimeSpan.FromMilliseconds(700);
+            RunSuperviseCommand.TerminalFailureRacePollInterval = TimeSpan.FromMilliseconds(5);
+
+            var appendTask = Task.Run(async () =>
+            {
+                await Task.Delay(600);
+                new DirectRunProviderEventWriter(Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"))
+                    .Append(new DirectRunProviderEvent
+                    {
+                        Timestamp = "2026-04-08T10:20:01.0000000+00:00",
+                        ExecutionUnit = "G25",
+                        Provider = "Claude",
+                        EntryKind = "fix",
+                        SessionId = "pid:999999",
+                        Kind = "provider-event",
+                        Payload = JsonSerializer.SerializeToElement(new
+                        {
+                            type = "backend-exit",
+                            exit_code = 1
+                        })
+                    });
+            });
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+            await appendTask;
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(0, session.RetryCount);
+            Assert.Contains("during provider startup", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.TerminalFailureRaceWindow = originalRaceWindow;
+            RunSuperviseCommand.TerminalFailureRacePollInterval = originalRacePollInterval;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenFixingItemWithoutExistingSessionAndDeadFixWorkerSession_CapturesFailureAndAutoResumesFixLoop()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -1387,7 +1467,7 @@ public sealed class RunSuperviseCommandTests
         File.WriteAllText(Path.Combine(runsPath, "G25.provider.jsonl"), string.Join(Environment.NewLine, providerEvents) + Environment.NewLine);
     }
 
-    private static void WriteStartupOnlyDeadFixDirectRunArtifacts(string repoRoot, string sessionId)
+    private static void WriteStartupOnlyDeadFixDirectRunArtifacts(string repoRoot, string sessionId, bool includeBackendExit = true)
     {
         var requestArtifact = new DirectRunRequestArtifact
         {
@@ -1578,21 +1658,28 @@ public sealed class RunSuperviseCommandTests
                 Payload = JsonSerializer.SerializeToElement(
                     "2026-04-08T10:20:00.9500000Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at \"/tmp/snapshot\"")
             }),
-            DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
-            {
-                Timestamp = "2026-04-08T10:20:01.0000000+00:00",
-                ExecutionUnit = "G25",
-                Provider = "Claude",
-                EntryKind = "fix",
-                SessionId = sessionId,
-                Kind = "provider-event",
-                Payload = JsonSerializer.SerializeToElement(new
-                {
-                    type = "backend-exit",
-                    exit_code = 1
-                })
-            })
         };
+        if (includeBackendExit)
+        {
+            providerEvents =
+            [
+                .. providerEvents,
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-08T10:20:01.0000000+00:00",
+                    ExecutionUnit = "G25",
+                    Provider = "Claude",
+                    EntryKind = "fix",
+                    SessionId = sessionId,
+                    Kind = "provider-event",
+                    Payload = JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                })
+            ];
+        }
 
         var runsPath = Path.Combine(repoRoot, ".intent-cli", "runs");
         Directory.CreateDirectory(runsPath);

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -395,6 +395,7 @@ public sealed class RunSuperviseCommandTests
             Assert.Contains(providerEvents, providerEvent =>
                 providerEvent.Kind == "provider-event"
                 && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == JsonValueKind.Object
                 && providerEvent.Payload.TryGetProperty("type", out var typeElement)
                 && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
                 && providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
@@ -784,6 +785,7 @@ public sealed class RunSuperviseCommandTests
             Assert.Contains(providerEvents, providerEvent =>
                 providerEvent.Kind == "provider-event"
                 && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == JsonValueKind.Object
                 && providerEvent.Payload.TryGetProperty("type", out var typeElement)
                 && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
                 && providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
@@ -893,6 +895,7 @@ public sealed class RunSuperviseCommandTests
             Assert.Contains(providerEvents, providerEvent =>
                 providerEvent.Kind == "provider-event"
                 && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == JsonValueKind.Object
                 && providerEvent.Payload.TryGetProperty("type", out var typeElement)
                 && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
                 && providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
@@ -1061,6 +1064,74 @@ public sealed class RunSuperviseCommandTests
             RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
             RunSuperviseCommand.TerminalFailureRaceWindow = originalRaceWindow;
             RunSuperviseCommand.TerminalFailureRacePollInterval = originalRacePollInterval;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenStartupOnlyDeadFixWorkerSessionWithoutCapturedTerminalEvent_BlocksUsingSyntheticStartupOnlyReason()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateFixingRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G25.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession(workerEntry: RunSupervisionWorkerEntry.Fix)));
+        WriteStartupOnlyDeadFixDirectRunArtifacts(repoRoot, "pid:999999", includeBackendExit: false);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalRaceWindow = RunSuperviseCommand.TerminalFailureRaceWindow;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+            RunSuperviseCommand.TerminalFailureRaceWindow = TimeSpan.Zero;
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(0, session.RetryCount);
+            Assert.Contains("during provider startup", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                && providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
+                && exitCodeElement.GetInt32() == 1);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("during provider startup", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.TerminalFailureRaceWindow = originalRaceWindow;
         }
     }
 


### PR DESCRIPTION
## Summary
- treat all current-session string payloads before the startup warning block as ignorable startup preamble unless they show bounded fix progress
- keep startup-only classification focused on sessions that still end in warning-only output plus canonical backend-exit=1
- update the runtime regression fixtures to match the real toy-calc Codex log shape, including shell snapshot warnings

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~Execute_GivenStartupOnlyDeadFixWorkerSession_BlocksWithoutConsumingRetryBudget|FullyQualifiedName~ExecuteCore_GivenStartupOnlyDeadFixWorkerSession_StopsWithNonRetryableFailureDetail|FullyQualifiedName~Execute_GivenDeadFixWorkerSession_CapturesFailureAndAutoResumesFixLoop|FullyQualifiedName~ExecuteCore_GivenFixingItemWithoutExistingSessionAndDeadFixWorkerSession_DoesNotRemainUnderSupervision" --logger "console;verbosity=minimal"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests|FullyQualifiedName~RunFixCommandTests" --logger "console;verbosity=minimal"
- attempted: dotnet test IntentSystem.sln --logger "console;verbosity=minimal" (other test projects passed; CLI test host hung at the end, same as existing local behavior)