### PR TITLE
Repair detached Codex fix launch boundary

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
@@ -13,6 +13,7 @@ internal static class DirectRunDetachedCaptureCommand
     private static readonly TimeSpan ExitPollInterval = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan OutputDrainGracePeriod = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan ExitCodeResolutionGracePeriod = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan FixStandardInputGracePeriod = TimeSpan.FromSeconds(1);
 
     public static bool TryExecute(string[] args, out int exitCode)
     {
@@ -108,6 +109,9 @@ internal static class DirectRunDetachedCaptureCommand
             var closePreservedStandardInputAfterLaunch = ShouldClosePreservedStandardInputAfterLaunch(
                 startInfo.FileName,
                 options);
+            var delayClosingPreservedStandardInputAfterLaunch = ShouldDelayClosingPreservedStandardInputAfterLaunch(
+                startInfo.FileName,
+                options);
 
             process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException($"Failed to start detached direct run process '{options.Command}'.");
@@ -121,6 +125,10 @@ internal static class DirectRunDetachedCaptureCommand
                     // while this helper-owned stdin pipe remains open, which suppresses terminal events.
                     preservedStandardInput.Dispose();
                     preservedStandardInput = null;
+                }
+                else if (delayClosingPreservedStandardInputAfterLaunch)
+                {
+                    SchedulePreservedStandardInputClosure(preservedStandardInput);
                 }
             }
             providerSessionId = $"pid:{process.Id}";
@@ -513,8 +521,49 @@ internal static class DirectRunDetachedCaptureCommand
             return false;
         }
 
+        if (string.Equals(options.EntryKind, "fix", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
         var executableName = Path.GetFileNameWithoutExtension(providerExecutablePath.Trim());
         return string.Equals(executableName, "script", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool ShouldDelayClosingPreservedStandardInputAfterLaunch(
+        string providerExecutablePath,
+        DirectRunDetachedCaptureOptions options)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerExecutablePath);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (!string.Equals(options.EntryKind, "fix", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var executableName = Path.GetFileNameWithoutExtension(providerExecutablePath.Trim());
+        return string.Equals(executableName, "script", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void SchedulePreservedStandardInputClosure(StreamWriter preservedStandardInput)
+    {
+        ArgumentNullException.ThrowIfNull(preservedStandardInput);
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(FixStandardInputGracePeriod).ConfigureAwait(false);
+                preservedStandardInput.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        });
     }
 
     private static string? TryResolveScriptExecutable(DirectRunDetachedCaptureOptions options)

--- a/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
@@ -87,11 +87,18 @@ internal static class DirectRunExitMonitorCommand
 
         if (DirectRunSessionBoundary.HasBackendExitEvent(options.ProviderEventLogPath, options.ProviderSessionId, options.LaunchedAt))
         {
+            var resolvedExitCode = DirectRunSessionBoundary.TryResolveBackendExitCode(
+                options.ProviderEventLogPath,
+                options.ProviderSessionId,
+                options.LaunchedAt,
+                out var existingExitCode)
+                ? existingExitCode
+                : 1;
             DirectRunTerminalArtifactUpdater.PersistTerminalRunStatusIfCurrent(
                 options.ProviderEventLogPath,
                 options.ProviderSessionId,
                 options.LaunchedAt,
-                exitCode: 1);
+                resolvedExitCode);
             return 0;
         }
 

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -77,6 +77,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             processInvocation.FileName,
             processInvocation.Arguments,
             processInvocation.InheritStandardInput,
+            processInvocation.KeepStandardInputOpen,
             DefaultEarlyExitWindow,
             processId =>
             {
@@ -388,6 +389,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 Arguments = arguments,
                 RequiresPersistentExitMonitor = false,
                 InheritStandardInput = false,
+                KeepStandardInputOpen = false,
                 UsesDetachedCaptureHelper = false,
                 StartedProcessCarriesProviderSession = true
             };
@@ -405,17 +407,35 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             command,
             arguments);
 
+        if (string.Equals(entryKind, "fix", StringComparison.Ordinal))
+        {
+            return new ResolvedProcessInvocation
+            {
+                FileName = helperStartInfo.FileName,
+                Arguments = helperStartInfo.ArgumentList.ToArray(),
+                RequiresPersistentExitMonitor = false,
+                InheritStandardInput = false,
+                KeepStandardInputOpen = true,
+                UsesDetachedCaptureHelper = true,
+                StartedProcessCarriesProviderSession = true
+            };
+        }
+
         if (detachHelperFromLauncherSession
             && !OperatingSystem.IsWindows()
             && !string.Equals(entryKind, "review", StringComparison.Ordinal))
         {
-            var detachedLauncherStartInfo = CreateDetachedHelperLauncherStartInfo(helperStartInfo);
+            var keepDetachedHelperStandardInputOpen = string.Equals(entryKind, "fix", StringComparison.Ordinal);
+            var detachedLauncherStartInfo = CreateDetachedHelperLauncherStartInfo(
+                helperStartInfo,
+                keepDetachedHelperStandardInputOpen);
             return new ResolvedProcessInvocation
             {
                 FileName = detachedLauncherStartInfo.FileName,
                 Arguments = detachedLauncherStartInfo.ArgumentList.ToArray(),
                 RequiresPersistentExitMonitor = false,
                 InheritStandardInput = false,
+                KeepStandardInputOpen = keepDetachedHelperStandardInputOpen,
                 UsesDetachedCaptureHelper = true,
                 StartedProcessCarriesProviderSession = false
             };
@@ -427,12 +447,15 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             Arguments = helperStartInfo.ArgumentList.ToArray(),
             RequiresPersistentExitMonitor = false,
             InheritStandardInput = false,
+            KeepStandardInputOpen = false,
             UsesDetachedCaptureHelper = true,
             StartedProcessCarriesProviderSession = true
         };
     }
 
-    private static ProcessStartInfo CreateDetachedHelperLauncherStartInfo(ProcessStartInfo helperStartInfo)
+    private static ProcessStartInfo CreateDetachedHelperLauncherStartInfo(
+        ProcessStartInfo helperStartInfo,
+        bool inheritStandardInput)
     {
         var launcherStartInfo = new ProcessStartInfo
         {
@@ -444,13 +467,21 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
 
         launcherStartInfo.ArgumentList.Add("-c");
         launcherStartInfo.ArgumentList.Add(
-            """
-            if command -v nohup >/dev/null 2>&1; then
-                nohup "$@" >/dev/null 2>&1 </dev/null &
-            else
-                "$@" >/dev/null 2>&1 </dev/null &
-            fi
-            """);
+            inheritStandardInput
+                ? """
+                  if command -v nohup >/dev/null 2>&1; then
+                      nohup "$@" >/dev/null 2>&1 &
+                  else
+                      "$@" >/dev/null 2>&1 &
+                  fi
+                  """
+                : """
+                  if command -v nohup >/dev/null 2>&1; then
+                      nohup "$@" >/dev/null 2>&1 </dev/null &
+                  else
+                      "$@" >/dev/null 2>&1 </dev/null &
+                  fi
+                  """);
         launcherStartInfo.ArgumentList.Add("direct-run-detached-capture-launcher");
         launcherStartInfo.ArgumentList.Add(helperStartInfo.FileName);
         foreach (var argument in helperStartInfo.ArgumentList)
@@ -711,6 +742,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         public required bool RequiresPersistentExitMonitor { get; init; }
 
         public required bool InheritStandardInput { get; init; }
+
+        public required bool KeepStandardInputOpen { get; init; }
 
         public required bool UsesDetachedCaptureHelper { get; init; }
 

--- a/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunProcessRunner.cs
@@ -13,6 +13,7 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
         string fileName,
         IReadOnlyList<string> arguments,
         bool inheritStandardInput,
+        bool keepStandardInputOpen,
         TimeSpan earlyExitWindow,
         Action<int> onStarted,
         Action<int> onExited,
@@ -34,7 +35,7 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
                 FileName = fileName,
                 WorkingDirectory = workingDirectory,
                 UseShellExecute = false,
-                RedirectStandardInput = !inheritStandardInput,
+                RedirectStandardInput = !inheritStandardInput || keepStandardInputOpen,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
@@ -47,7 +48,7 @@ internal sealed class DirectRunProcessRunner : IDirectRunProcessRunner
             var process = Process.Start(startInfo)
                 ?? throw new InvalidOperationException($"Failed to start direct run process '{fileName}'.");
 
-            if (!inheritStandardInput)
+            if (!inheritStandardInput && !keepStandardInputOpen)
             {
                 process.StandardInput.Close();
             }

--- a/src/IntentSystem.Cli/Commands/DirectRunSessionBoundary.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunSessionBoundary.cs
@@ -61,6 +61,52 @@ internal static class DirectRunSessionBoundary
         return false;
     }
 
+    public static bool TryResolveBackendExitCode(
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset? launchedAt,
+        out int exitCode)
+    {
+        exitCode = default;
+        if (!File.Exists(providerEventLogPath))
+        {
+            return false;
+        }
+
+        var resolved = false;
+        foreach (var line in File.ReadLines(providerEventLogPath))
+        {
+            DirectRunProviderEvent providerEvent;
+            try
+            {
+                providerEvent = DirectRunProviderEventJsonl.DeserializeLine(line);
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or ArgumentException
+                or System.Text.Json.JsonException)
+            {
+                continue;
+            }
+
+            if (!IsMatchingSessionEvent(providerEvent, providerSessionId, launchedAt)
+                || providerEvent.Kind != "provider-event"
+                || providerEvent.Payload.ValueKind != System.Text.Json.JsonValueKind.Object
+                || !providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                || !string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                || !providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
+                || !exitCodeElement.TryGetInt32(out var parsedExitCode))
+            {
+                continue;
+            }
+
+            exitCode = parsedExitCode;
+            resolved = true;
+        }
+
+        return resolved;
+    }
+
     public static bool IsMatchingSessionEvent(
         DirectRunProviderEvent providerEvent,
         string providerSessionId,

--- a/src/IntentSystem.Cli/Commands/IDirectRunProcessRunner.cs
+++ b/src/IntentSystem.Cli/Commands/IDirectRunProcessRunner.cs
@@ -7,6 +7,7 @@ internal interface IDirectRunProcessRunner
         string fileName,
         IReadOnlyList<string> arguments,
         bool inheritStandardInput,
+        bool keepStandardInputOpen,
         TimeSpan earlyExitWindow,
         Action<int> onStarted,
         Action<int> onExited,

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -831,6 +831,85 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public async Task Launch_GivenWrappedCodexFixProcess_PreservesStandardInputLongEnoughForBoundedRepoActivity()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14fix.provider.jsonl");
+        var worktreePath = tempDirectory.GetPath("repo");
+        Directory.CreateDirectory(worktreePath);
+        var codexPath = tempDirectory.CreateExecutableFile(
+            "repo/codex-experimental",
+            """
+            #!/bin/sh
+            printf '%s\n' 'OpenAI Codex v0.118.0 (research preview)'
+            printf '%s\n' '--------'
+            printf '%s\n' "workdir: $PWD"
+            printf '%s\n' 'user'
+            /usr/bin/python3 -c 'import os,select,sys; fd = sys.stdin.fileno(); os.isatty(fd) or (print("tty-missing", flush=True), sys.exit(1)); readable, _, _ = select.select([sys.stdin], [], [], 0.2); data = os.read(fd, 1) if readable else None; data != b"" or (print("stdin-eof", flush=True), sys.exit(1)); print("pwd && rg --files .", flush=True); print("git status --short", flush=True); print("dotnet test", flush=True)'
+            sleep 1
+            """);
+        var launcher = new DirectRunLauncher();
+
+        var result = launcher.Launch(
+            "G14fix",
+            "fix",
+            ".intent-cli/runs/G14fix.request.json",
+            ".intent-cli/runs/G14fix.provider.jsonl",
+            "Codex",
+            "gpt-5.4-mini",
+            "responses",
+            codexPath,
+            ["exec", "test prompt"],
+            DateTimeOffset.Parse("2026-04-16T18:15:00Z"),
+            worktreePath,
+            tempDirectory.GetPath(".intent-cli/fix/G14fix.request.md"),
+            providerEventLogPath);
+
+        await TemporaryDirectory.WaitForConditionAsync(
+            () =>
+            {
+                if (!File.Exists(providerEventLogPath))
+                {
+                    return false;
+                }
+
+                var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                return events.Any(providerEvent =>
+                           providerEvent.Kind == "provider-event"
+                           && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                           && string.Equals(providerEvent.Payload.GetString(), "pwd && rg --files .", StringComparison.Ordinal));
+            },
+            TimeSpan.FromSeconds(8));
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.DoesNotContain(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+            && string.Equals(providerEvent.Payload.GetString(), "stdin-eof", StringComparison.Ordinal));
+        Assert.DoesNotContain(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+            && string.Equals(providerEvent.Payload.GetString(), "tty-missing", StringComparison.Ordinal));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+            && string.Equals(providerEvent.Payload.GetString(), "pwd && rg --files .", StringComparison.Ordinal));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+            && string.Equals(providerEvent.Payload.GetString(), "git status --short", StringComparison.Ordinal));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+            && string.Equals(providerEvent.Payload.GetString(), "dotnet test", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task DirectRunExitMonitorCommand_GivenDetachedProcess_AppendsBackendExitForCurrentSession()
     {
         if (OperatingSystem.IsWindows())
@@ -1303,6 +1382,7 @@ public sealed class DirectRunLauncherTests
             string fileName,
             IReadOnlyList<string> arguments,
             bool inheritStandardInput,
+            bool keepStandardInputOpen,
             TimeSpan earlyExitWindow,
             Action<int> onStarted,
             Action<int> onExited,
@@ -1321,7 +1401,7 @@ public sealed class DirectRunLauncherTests
                     FileName = fileName,
                     WorkingDirectory = workingDirectory,
                     UseShellExecute = false,
-                    RedirectStandardInput = !inheritStandardInput,
+                    RedirectStandardInput = !inheritStandardInput || keepStandardInputOpen,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true
                 };
@@ -1334,7 +1414,7 @@ public sealed class DirectRunLauncherTests
                 var process = System.Diagnostics.Process.Start(startInfo)
                     ?? throw new InvalidOperationException("Failed to start wrapper process.");
 
-                if (!inheritStandardInput)
+                if (!inheritStandardInput && !keepStandardInputOpen)
                 {
                     process.StandardInput.Close();
                 }

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -922,6 +922,141 @@ public sealed class RunFixCommandTests
     }
 
     [Fact]
+    public async Task Execute_GivenWrapperCodexFixCommand_PersistsBoundedRepoActivityForCurrentSession()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        var providerBinaryPath = tempDirectory.CreateExecutableFile(
+            "bin/codex",
+            """
+            #!/bin/sh
+            printf '%s\n' 'OpenAI Codex v0.118.0 (research preview)'
+            printf '%s\n' '--------'
+            printf '%s\n' "workdir: $PWD"
+            printf '%s\n' 'user'
+            /usr/bin/python3 -c 'import os,select,sys; fd = sys.stdin.fileno(); os.isatty(fd) or (print("tty-missing", flush=True), sys.exit(1)); readable, _, _ = select.select([sys.stdin], [], [], 0.2); data = os.read(fd, 1) if readable else None; data != b"" or (print("stdin-eof", flush=True), sys.exit(1)); print("pwd && rg --files .", flush=True); print("git status --short", flush=True); print("dotnet test", flush=True)'
+            exit 0
+            """);
+        var wrapperPath = tempDirectory.CreateExecutableFile(
+            "bin/codex-isolated",
+            $$"""
+            #!/bin/zsh
+            export CODEX_HOME={{tempDirectory.GetPath(".codex-direct-backend")}}
+            exec {{providerBinaryPath}} "$@"
+            """);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunFixCommand.TimestampFactory;
+
+        try
+        {
+            RunFixCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-16T18:16:00Z");
+
+            var baseContext = CreateContext(repoRoot);
+            var context = baseContext with
+            {
+                Config = baseContext.Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Codex",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        Command = wrapperPath
+                    }
+                }
+            };
+
+            var exitCode = RunFixCommand.Execute(context, ["G20"], writer);
+
+            Assert.Equal(0, exitCode);
+
+            var resultArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.result.json");
+            var providerEventLogPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.provider.jsonl");
+            var initialArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+
+            await WaitForConditionAsync(
+                () =>
+                {
+                    if (!File.Exists(providerEventLogPath) || !File.Exists(resultArtifactPath))
+                    {
+                        return false;
+                    }
+
+                    var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                    var sawBoundedProgress = providerEvents.Any(providerEvent =>
+                        providerEvent.Kind == "provider-event"
+                        && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                        && string.Equals(providerEvent.Payload.GetString(), "pwd && rg --files .", StringComparison.Ordinal));
+                    if (!sawBoundedProgress)
+                    {
+                        return false;
+                    }
+
+                    var updatedArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+                    return string.Equals(updatedArtifact.SessionId, initialArtifact.SessionId, StringComparison.Ordinal)
+                        && !string.Equals(updatedArtifact.RunStatus, "failed", StringComparison.Ordinal);
+                },
+                TimeSpan.FromSeconds(10));
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            Assert.DoesNotContain(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && string.Equals(providerEvent.Payload.GetString(), "stdin-eof", StringComparison.Ordinal));
+            Assert.DoesNotContain(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && string.Equals(providerEvent.Payload.GetString(), "tty-missing", StringComparison.Ordinal));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && string.Equals(providerEvent.Payload.GetString(), "pwd && rg --files .", StringComparison.Ordinal));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && string.Equals(providerEvent.Payload.GetString(), "git status --short", StringComparison.Ordinal));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && string.Equals(providerEvent.Payload.GetString(), "dotnet test", StringComparison.Ordinal));
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+            Assert.Equal(initialArtifact.SessionId, resultArtifact.SessionId);
+            Assert.NotEqual("failed", resultArtifact.RunStatus);
+        }
+        finally
+        {
+            RunFixCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenMissingQueueItem_ReturnsExitCodeOne()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- repair detached Codex fix launch so fix sessions keep stdin open long enough to progress beyond startup
- persist current-session backend exit status using the real detached backend exit code
- add focused CLI coverage for bounded repo activity in detached fix launches

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~Launch_GivenWrappedCodexFixProcess_PreservesStandardInputLongEnoughForBoundedRepoActivity|FullyQualifiedName~Execute_GivenWrapperCodexFixCommand_PersistsBoundedRepoActivityForCurrentSession"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunFixCommandTests"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~Launch_GivenWrappedCodexFixProcess_PreservesStandardInputLongEnoughForBoundedRepoActivity|FullyQualifiedName~Execute_GivenWrapperCodexFixCommand_PersistsBoundedRepoActivityForCurrentSession|FullyQualifiedName~Launch_GivenWrappedCodexImplementProcess_DetachedCaptureProvidesTerminalToProvider|FullyQualifiedName~Launch_GivenWrappedCodexProcess_DetachedCaptureClosesProviderStandardInput|FullyQualifiedName~Execute_GivenWrapperCodexCommandThatExitsImmediately_AppendsTerminalBackendExitAndUpdatesResultArtifact|FullyQualifiedName~Execute_GivenWrapperCodexCommandWithPartialProviderOutput_AppendsTerminalBackendExitAndUpdatesResultArtifact"
- dotnet test IntentSystem.sln --logger "console;verbosity=minimal"  
  - non-CLI test projects passed, but the run stalled without additional output while executing the full CLI suite in this environment

Closes #298
