### PR TITLE
Detect meaningful fix worktree progress before parent block

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -24,6 +24,9 @@ internal static class RunSuperviseCommand
     public static Func<CliContext, string, RunFixResult> RunFixExecutor { get; set; } =
         RunFixCommand.ExecuteCore;
 
+    public static Func<IGitCommandRunner> GitCommandRunnerFactory { get; set; } =
+        () => new GitCommandRunner();
+
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -166,7 +169,7 @@ internal static class RunSuperviseCommand
                 session.WorkerEntry,
                 out var deadWorkerFailure))
         {
-            if (deadWorkerFailure.IsStartupOnly)
+            if (deadWorkerFailure.ReportAsNonRetryableFailure)
             {
                 return BlockForTerminalFailure(
                     context,
@@ -313,7 +316,7 @@ internal static class RunSuperviseCommand
                 session.WorkerEntry,
                 out var deadWorkerFailure))
         {
-            if (deadWorkerFailure.IsStartupOnly)
+            if (deadWorkerFailure.ReportAsNonRetryableFailure)
             {
                 return BlockForTerminalFailure(
                     context,
@@ -730,6 +733,24 @@ internal static class RunSuperviseCommand
         var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerLogPath));
         var currentProviderEvents = SelectCurrentSessionEvents(providerEvents, requestArtifact.ProviderSessionId, requestArtifact.LaunchedAt);
 
+        if (string.Equals(expectedEntryKind, "fix", StringComparison.Ordinal)
+            && TryResolveFixWorktreeProgressFailure(
+                currentProviderEvents,
+                executionUnit,
+                requestArtifact.ProviderSessionId,
+                resultArtifact.Worktree.Path,
+                out failure))
+        {
+            File.WriteAllText(
+                resultArtifactPath,
+                DirectRunResultArtifactJson.Serialize(resultArtifact with
+                {
+                    RunStatus = "failed"
+                }));
+
+            return true;
+        }
+
         if (TryResolveTerminalFailureReason(
                 currentProviderEvents,
                 executionUnit,
@@ -787,14 +808,24 @@ internal static class RunSuperviseCommand
             providerEventsWithSyntheticExit.AddRange(currentProviderEvents);
             providerEventsWithSyntheticExit.Add(backendExitEvent);
 
+            if (TryResolveFixWorktreeProgressFailure(
+                    providerEventsWithSyntheticExit,
+                    executionUnit,
+                    requestArtifact.ProviderSessionId,
+                    resultArtifact.Worktree.Path,
+                    out failure))
+            {
+                return true;
+            }
+
             if (DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
                     providerEventsWithSyntheticExit,
                     executionUnit,
                     out var startupOnlyDetail))
             {
-                failure = new WorkerSessionFailure(
-                    $"Worker session '{requestArtifact.ProviderSessionId}' for '{executionUnit}' exited with backend exit code 1. {startupOnlyDetail}",
-                    IsStartupOnly: true);
+                    failure = new WorkerSessionFailure(
+                        $"Worker session '{requestArtifact.ProviderSessionId}' for '{executionUnit}' exited with backend exit code 1. {startupOnlyDetail}",
+                        ReportAsNonRetryableFailure: true);
                 return true;
             }
         }
@@ -869,6 +900,39 @@ internal static class RunSuperviseCommand
         return false;
     }
 
+    private static bool TryResolveFixWorktreeProgressFailure(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        string providerSessionId,
+        string worktreePath,
+        out WorkerSessionFailure failure)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
+
+        failure = null!;
+        if (!TryFindFailingBackendExitCode(providerEvents, out var exitCode)
+            || DirectRunFixOutcomeSupport.TryResolveContractGapDetail(providerEvents, executionUnit, out _)
+            || !DirectRunFixOutcomeSupport.HasBoundedProgressSignal(providerEvents)
+            || !TryResolveMeaningfulWorktreeDiffPaths(worktreePath, out var changedPaths))
+        {
+            return false;
+        }
+
+        var summarizedPaths = string.Join(", ", changedPaths.Take(3));
+        if (changedPaths.Count > 3)
+        {
+            summarizedPaths += ", ...";
+        }
+
+        failure = new WorkerSessionFailure(
+            $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode} after bounded fix progress and left meaningful execution-unit worktree changes. Changed paths: {summarizedPaths}.",
+            ReportAsNonRetryableFailure: true);
+        return true;
+    }
+
     private static bool TryResolveTerminalFailureReason(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string executionUnit,
@@ -901,25 +965,124 @@ internal static class RunSuperviseCommand
                 {
                     failure = new WorkerSessionFailure(
                         $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode}. {startupOnlyDetail}",
-                        IsStartupOnly: true);
+                        ReportAsNonRetryableFailure: true);
                     return true;
                 }
 
                 failure = new WorkerSessionFailure(
                     $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode}.",
-                    IsStartupOnly: false);
+                    ReportAsNonRetryableFailure: false);
             }
             else
             {
                 failure = new WorkerSessionFailure(
                     $"Worker session '{providerSessionId}' for '{executionUnit}' exited after a terminal backend-exit event.",
-                    IsStartupOnly: false);
+                    ReportAsNonRetryableFailure: false);
             }
 
             return true;
         }
 
         return false;
+    }
+
+    private static bool TryFindFailingBackendExitCode(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        out int exitCode)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            var providerEvent = providerEvents[index];
+            if (!HasBackendExitType(providerEvent)
+                || !providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
+                || !exitCodeElement.TryGetInt32(out exitCode)
+                || exitCode == 0)
+            {
+                continue;
+            }
+
+            return true;
+        }
+
+        exitCode = default;
+        return false;
+    }
+
+    private static bool TryResolveMeaningfulWorktreeDiffPaths(
+        string worktreePath,
+        out IReadOnlyList<string> changedPaths)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
+
+        changedPaths = [];
+        GitCommandResult statusResult;
+        try
+        {
+            statusResult = GitCommandRunnerFactory().Run(
+                worktreePath,
+                ["status", "--short", "--untracked-files=all"]);
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException
+            or ArgumentException
+            or DirectoryNotFoundException
+            or System.ComponentModel.Win32Exception)
+        {
+            return false;
+        }
+
+        if (statusResult.ExitCode != 0 || string.IsNullOrWhiteSpace(statusResult.StdOut))
+        {
+            return false;
+        }
+
+        var paths = new List<string>();
+        foreach (var rawLine in statusResult.StdOut.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            var line = rawLine.TrimEnd();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var pathText = line.Length > 3 ? line[3..].Trim() : line.Trim();
+            if (string.IsNullOrWhiteSpace(pathText))
+            {
+                continue;
+            }
+
+            var normalizedPath = pathText.Contains(" -> ", StringComparison.Ordinal)
+                ? pathText[(pathText.LastIndexOf(" -> ", StringComparison.Ordinal) + 4)..].Trim()
+                : pathText;
+            normalizedPath = normalizedPath.Trim().Trim('"').Replace('\\', '/');
+            if (string.IsNullOrWhiteSpace(normalizedPath)
+                || IsIgnoredWorktreeArtifactPath(normalizedPath))
+            {
+                continue;
+            }
+
+            paths.Add(normalizedPath);
+        }
+
+        if (paths.Count == 0)
+        {
+            return false;
+        }
+
+        changedPaths = paths;
+        return true;
+    }
+
+    private static bool IsIgnoredWorktreeArtifactPath(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        return path.StartsWith(".intent-cli/", StringComparison.Ordinal)
+            || path.StartsWith(".takt/", StringComparison.Ordinal)
+            || path.StartsWith("node_modules/", StringComparison.Ordinal);
     }
 
     private static string ResolveDirectRunRequestArtifactPath(CliContext context, string executionUnit)
@@ -1069,7 +1232,7 @@ internal static class RunSuperviseCommand
         };
     }
 
-    private sealed record WorkerSessionFailure(string Reason, bool IsStartupOnly);
+    private sealed record WorkerSessionFailure(string Reason, bool ReportAsNonRetryableFailure);
 
     private static string FormatQueueState(QueueItemState state)
     {

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -1080,9 +1080,25 @@ internal static class RunSuperviseCommand
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
 
-        return path.StartsWith(".intent-cli/", StringComparison.Ordinal)
-            || path.StartsWith(".takt/", StringComparison.Ordinal)
-            || path.StartsWith("node_modules/", StringComparison.Ordinal);
+        var normalizedPath = path.Replace('\\', '/').Trim('/');
+        if (string.IsNullOrWhiteSpace(normalizedPath))
+        {
+            return true;
+        }
+
+        if (normalizedPath.StartsWith(".intent-cli/", StringComparison.Ordinal)
+            || normalizedPath.StartsWith(".takt/", StringComparison.Ordinal)
+            || normalizedPath.StartsWith("node_modules/", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        var segments = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segments.Any(segment =>
+            string.Equals(segment, "bin", StringComparison.Ordinal)
+            || string.Equals(segment, "obj", StringComparison.Ordinal)
+            || string.Equals(segment, "TestResults", StringComparison.Ordinal)
+            || string.Equals(segment, ".vs", StringComparison.Ordinal));
     }
 
     private static string ResolveDirectRunRequestArtifactPath(CliContext context, string executionUnit)

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -3520,6 +3520,118 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWithMeaningfulWorktreeDiff_StopsWithNonRetryableFailure()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 3,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents: CreateMeaningfulFixWorktreeProgressProviderEvents("G226", "pid:999999"),
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var originalGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M src/ToyCalc/Calculator.cs
+                 M src/ToyCalc/CommandLine.cs
+                 M tests/ToyCalc.Tests/CalculatorTests.cs
+                """);
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("non-retryable-failure", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("meaningful execution-unit worktree changes", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("src/ToyCalc/Calculator.cs", result.Detail, StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("meaningful execution-unit worktree changes", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Contains("meaningful execution-unit worktree changes", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("meaningful execution-unit worktree changes", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public async Task ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWhenBackendExitLandsAfterObservedDelay_BlocksUsingBackendExitReason()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -4163,6 +4275,64 @@ public sealed class RunCommandTests
         return providerEvents;
     }
 
+    private static IReadOnlyList<DirectRunProviderEvent> CreateMeaningfulFixWorktreeProgressProviderEvents(
+        string executionUnit,
+        string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "session-metadata",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    model = "sonnet",
+                    transport = "sdk",
+                    command = "claude"
+                })
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.5000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'rg --files' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.7500000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("git status --short")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    type = "backend-exit",
+                    exit_code = 1
+                })
+            }
+        ];
+    }
+
     private static void WriteDirectRunRequest(
         string repoRoot,
         string executionUnit,
@@ -4231,6 +4401,20 @@ public sealed class RunCommandTests
         {
             CallCount++;
             return $"{linkedPr}#issuecomment-generated";
+        }
+    }
+
+    private sealed class FakeGitRunner(string statusOutput) : IGitCommandRunner
+    {
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Assert.Equal(["status", "--short", "--untracked-files=all"], arguments);
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = statusOutput,
+                StdErr = string.Empty
+            };
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -3632,6 +3632,120 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWithBuildOutputOnlyDiff_StaysOnBackendExitPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 3,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents: CreateMeaningfulFixWorktreeProgressProviderEvents("G226", "pid:999999"),
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var originalGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M src/ToyCalc/bin/Debug/net10.0/ToyCalc.dll
+                 M src/ToyCalc/obj/Debug/net10.0/ToyCalc.GeneratedMSBuildEditorConfig.editorconfig
+                 M tests/ToyCalc.Tests/TestResults/result.trx
+                """);
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("parent-intent-update-required", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.DoesNotContain("meaningful execution-unit worktree changes", result.Detail, StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("backend exit code 1", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("meaningful execution-unit worktree changes", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Contains("backend exit code 1", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("retry-exhausted", runEvents[^2].Event);
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("backend exit code 1", runEvents[^2].Reason, StringComparison.Ordinal);
+            Assert.Contains("backend exit code 1", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain("meaningful execution-unit worktree changes", runEvents[^1].Reason, StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public async Task ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWhenBackendExitLandsAfterObservedDelay_BlocksUsingBackendExitReason()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -1,5 +1,6 @@
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Review;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 using System.Text.Json;
@@ -1242,6 +1243,75 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenDeadFixWorkerSessionWithMeaningfulWorktreeDiff_BlocksAsNonRetryableFailure()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateFixingRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G25.request.md"),
+            "# Repair Worker Handoff");
+        WriteDeadFixDirectRunArtifacts(repoRoot, "pid:999999");
+        File.AppendAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                CreateMeaningfulFixWorktreeProgressEvents("G25", "pid:999999")
+                    .Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+            RunSuperviseCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M src/ToyCalc/Calculator.cs
+                 M src/ToyCalc/CommandLine.cs
+                 M tests/ToyCalc.Tests/CalculatorTests.cs
+                """);
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("meaningful execution-unit worktree changes", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("src/ToyCalc/Calculator.cs", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Contains("meaningful execution-unit worktree changes", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("meaningful execution-unit worktree changes", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenNonRetryableAutoResumeFailure_BlocksSelectedItemAndAppendsTerminalEvents()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -1943,6 +2013,61 @@ public sealed class RunSuperviseCommandTests
             }) + Environment.NewLine);
         File.WriteAllText(Path.Combine(repoRoot, ".intent-cli", "runs", $"{executionUnit}.request.json"), DirectRunRequestArtifactJson.Serialize(requestArtifact));
         File.WriteAllText(Path.Combine(repoRoot, ".intent-cli", "runs", $"{executionUnit}.result.json"), DirectRunResultArtifactJson.Serialize(resultArtifact));
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateMeaningfulFixWorktreeProgressEvents(string executionUnit, string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.1000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'rg --files' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.2000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("git status --short")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:01.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    type = "backend-exit",
+                    exit_code = 1
+                })
+            }
+        ];
+    }
+
+    private sealed class FakeGitRunner(string statusOutput) : IGitCommandRunner
+    {
+        public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Assert.Equal(["status", "--short", "--untracked-files=all"], arguments);
+            return new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = statusOutput,
+                StdErr = string.Empty
+            };
+        }
     }
 
     private sealed class TemporaryDirectory : IDisposable


### PR DESCRIPTION
## Summary
- implement issue #301 by detecting meaningful execution-unit worktree diffs after a failed fix session with bounded progress
- classify that boundary as a child-side non-retryable failure instead of collapsing it to a generic backend-exit parent-planning block
- add focused supervise/root-run tests for the reproduced fix-worktree-diff path

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunSuperviseCommandTests|FullyQualifiedName~RunCommandTests" --logger "console;verbosity=minimal"`
- `dotnet test IntentSystem.sln --logger "console;verbosity=minimal"` *(non-CLI test projects passed; `IntentSystem.Cli.Tests` still hangs without further output in the full-solution run)*

Closes #301