### PR TITLE
Add post-fix salvage confirmation and auto-continue policy

### DIFF
--- a/src/IntentSystem.Cli/CliRuntimeContracts.cs
+++ b/src/IntentSystem.Cli/CliRuntimeContracts.cs
@@ -15,6 +15,7 @@ internal static class CliRuntimeContracts
     public const string ParentIntentRepoRootKey = "parent_intent_repo_root";
     public const string RolesSectionName = "roles";
     public const string SupervisionSectionName = "supervision";
+    public const string RunSectionName = "run";
     public const string DirectRunSectionName = "direct_backend";
     public const string ImplementRoleKey = "implement";
     public const string ReviewRoleKey = "review";
@@ -28,6 +29,7 @@ internal static class CliRuntimeContracts
     public const string StaleHeartbeatTimeoutMinutesKey = "stale_heartbeat_timeout_minutes";
     public const string RetryDelayMinutesKey = "retry_delay_minutes";
     public const string RetryBudgetKey = "retry_budget";
+    public const string PostFixWorktreeProgressPolicyKey = "post_fix_worktree_progress_policy";
     public const string DefaultWorktreeRoot = ".intent-cli/worktrees";
     public const string DefaultSupervisionArtifactRoot = ".intent-cli/supervision";
     public const string DefaultDirectRunArtifactRoot = ".intent-cli/runs";
@@ -38,6 +40,9 @@ internal static class CliRuntimeContracts
     public const string DefaultReviewRole = "Codex";
     public const string DefaultInterviewRole = "Claude";
     public const string DefaultClarifyRole = "Codex";
+    public const string ConfirmPostFixWorktreeProgressPolicy = "confirm";
+    public const string AutoContinuePostFixWorktreeProgressPolicy = "auto-continue";
+    public const string DefaultPostFixWorktreeProgressPolicy = ConfirmPostFixWorktreeProgressPolicy;
     public const string DefaultDirectRunModel = "default";
     public const string DefaultCodexDirectRunModel = "gpt-5.4-mini";
     public const string DefaultDirectRunTransport = "stdio";

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -559,7 +559,7 @@ internal static class RunCommand
         ArgumentNullException.ThrowIfNull(blockedItem);
         ArgumentNullException.ThrowIfNull(session);
 
-        CommitPostFixWorktreeProgress(context, blockedItem);
+        var carryForwardCommit = CommitPostFixWorktreeProgress(context, blockedItem);
         var rollbackState = CapturePostFixProgressRollbackState(context, blockedItem.ExecutionUnit);
 
         try
@@ -581,6 +581,17 @@ internal static class RunCommand
         catch
         {
             RestorePostFixProgressRollbackState(rollbackState);
+            try
+            {
+                RollBackPostFixCarryForwardCommit(carryForwardCommit);
+            }
+            catch (InvalidOperationException rollbackException)
+            {
+                throw new RunDeterministicGapException(
+                    blockedItem.ExecutionUnit,
+                    $"Failed to roll back auto-continue carry-forward for '{blockedItem.ExecutionUnit}': {rollbackException.Message}");
+            }
+
             throw;
         }
 
@@ -639,7 +650,7 @@ internal static class RunCommand
             }));
     }
 
-    private static void CommitPostFixWorktreeProgress(CliContext context, QueueItem blockedItem)
+    private static PostFixCarryForwardCommit CommitPostFixWorktreeProgress(CliContext context, QueueItem blockedItem)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(blockedItem);
@@ -689,6 +700,24 @@ internal static class RunCommand
                 $"Current worktree branch '{currentBranch}' must match expected branch '{expectedBranchName}'.");
         }
 
+        var headResult = gitRunner.Run(worktreePath, ["rev-parse", "HEAD"]);
+        if (headResult.ExitCode != 0)
+        {
+            throw new RunDeterministicGapException(
+                blockedItem.ExecutionUnit,
+                string.IsNullOrWhiteSpace(headResult.StdErr)
+                    ? "git rev-parse HEAD failed."
+                    : headResult.StdErr.Trim());
+        }
+
+        var originalHead = headResult.StdOut.Trim();
+        if (string.IsNullOrWhiteSpace(originalHead))
+        {
+            throw new RunDeterministicGapException(
+                blockedItem.ExecutionUnit,
+                "git rev-parse HEAD returned an empty commit id.");
+        }
+
         var addArguments = new List<string> { "add", "--" };
         addArguments.AddRange(changedPaths);
         var addResult = gitRunner.Run(worktreePath, addArguments);
@@ -728,6 +757,25 @@ internal static class RunCommand
                 string.IsNullOrWhiteSpace(commitResult.StdErr)
                     ? "git commit failed."
                     : commitResult.StdErr.Trim());
+        }
+
+        return new PostFixCarryForwardCommit(worktreePath, originalHead);
+    }
+
+    private static void RollBackPostFixCarryForwardCommit(PostFixCarryForwardCommit carryForwardCommit)
+    {
+        ArgumentNullException.ThrowIfNull(carryForwardCommit);
+
+        var gitRunner = GitCommandRunnerFactory();
+        var resetResult = gitRunner.Run(
+            carryForwardCommit.WorktreePath,
+            ["reset", "--mixed", carryForwardCommit.PreviousHead]);
+        if (resetResult.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                string.IsNullOrWhiteSpace(resetResult.StdErr)
+                    ? "git reset --mixed failed."
+                    : resetResult.StdErr.Trim());
         }
     }
 
@@ -1623,4 +1671,8 @@ internal static class RunCommand
         string SessionArtifactContent,
         string RunLogPath,
         string RunLogContent);
+
+    private sealed record PostFixCarryForwardCommit(
+        string WorktreePath,
+        string PreviousHead);
 }

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -56,6 +56,11 @@ internal static class RunCommand
     public static Func<CliContext, string, ReviewAcceptResult> ReviewAcceptExecutor { get; set; } =
         ReviewAcceptCommand.ExecuteCore;
 
+    public static Func<IGitCommandRunner> GitCommandRunnerFactory { get; set; } =
+        () => new GitCommandRunner();
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -156,6 +161,11 @@ internal static class RunCommand
                         {
                             if (superviseResult.ReportAsNonRetryableFailure)
                             {
+                                if (superviseResult.RequiresPostFixWorktreeProgressDecision)
+                                {
+                                    continue;
+                                }
+
                                 return CreateMonitoringStopResult(actions, inProgressItem.ExecutionUnit, superviseResult);
                             }
 
@@ -266,6 +276,11 @@ internal static class RunCommand
                         {
                             if (superviseResult.ReportAsNonRetryableFailure)
                             {
+                                if (superviseResult.RequiresPostFixWorktreeProgressDecision)
+                                {
+                                    continue;
+                                }
+
                                 return CreateMonitoringStopResult(actions, inProgressItem.ExecutionUnit, superviseResult);
                             }
 
@@ -369,6 +384,16 @@ internal static class RunCommand
                 var blockedItem = queueState.Items.FirstOrDefault(item => item.State == QueueItemState.Blocked);
                 if (blockedItem is not null)
                 {
+                    if (TryHandlePostFixWorktreeProgressBoundary(context, actions, blockedItem, out var decisionResult))
+                    {
+                        if (decisionResult is not null)
+                        {
+                            return decisionResult;
+                        }
+
+                        continue;
+                    }
+
                     return CreateStopResult(
                         ParentIntentUpdateRequiredStopReason,
                         actions,
@@ -446,6 +471,267 @@ internal static class RunCommand
             context.RepoRoot,
             artifactRef.Replace('/', Path.DirectorySeparatorChar)));
         return File.Exists(artifactPath);
+    }
+
+    private static bool TryHandlePostFixWorktreeProgressBoundary(
+        CliContext context,
+        List<RunCommandAction> actions,
+        QueueItem blockedItem,
+        out RunCommandResult? decisionResult)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(actions);
+        ArgumentNullException.ThrowIfNull(blockedItem);
+
+        decisionResult = null;
+        if (!TryResolvePostFixWorktreeProgressDecisionSession(context, blockedItem.ExecutionUnit, out var session))
+        {
+            return false;
+        }
+
+        if (!string.Equals(
+                context.Config.Run.PostFixWorktreeProgressPolicy,
+                CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy,
+                StringComparison.Ordinal))
+        {
+            decisionResult = CreateStopResult(
+                ClarificationRequiredStopReason,
+                actions,
+                blockedItem.ExecutionUnit,
+                CreatePostFixWorktreeProgressClarificationDetail(blockedItem.ExecutionUnit, session));
+            return true;
+        }
+
+        ExecuteAutoContinuePostFixWorktreeProgress(context, actions, blockedItem, session);
+        return true;
+    }
+
+    private static bool TryResolvePostFixWorktreeProgressDecisionSession(
+        CliContext context,
+        string executionUnit,
+        out RunSupervisionSession session)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        session = null!;
+        var sessionArtifactRef = RunSupervisionSessionArtifactPathResolver.Resolve(
+            context.Config.Supervision.ArtifactRoot,
+            executionUnit);
+        var sessionArtifactPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            sessionArtifactRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(sessionArtifactPath))
+        {
+            return false;
+        }
+
+        session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(sessionArtifactPath));
+        return session.WorkerEntry == RunSupervisionWorkerEntry.Fix
+            && session.Status == RunSupervisionSessionStatus.Blocked
+            && session.RequiresPostFixWorktreeProgressDecision;
+    }
+
+    private static string CreatePostFixWorktreeProgressClarificationDetail(
+        string executionUnit,
+        RunSupervisionSession session)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(session);
+
+        var reason = string.IsNullOrWhiteSpace(session.LastInterruptionReason)
+            ? $"Meaningful fix progress exists in the execution-unit worktree for '{executionUnit}'."
+            : session.LastInterruptionReason;
+        return $"{reason} Confirm whether to carry this progress forward. " +
+               $"To continue automatically on the next root run, set [run] " +
+               $"{CliRuntimeContracts.PostFixWorktreeProgressPolicyKey} = " +
+               $"\"{CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy}\" and rerun.";
+    }
+
+    private static void ExecuteAutoContinuePostFixWorktreeProgress(
+        CliContext context,
+        List<RunCommandAction> actions,
+        QueueItem blockedItem,
+        RunSupervisionSession session)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(actions);
+        ArgumentNullException.ThrowIfNull(blockedItem);
+        ArgumentNullException.ThrowIfNull(session);
+
+        RestoreFixingStateAfterPostFixProgressBoundary(context, blockedItem.ExecutionUnit, session);
+        CommitPostFixWorktreeProgress(context, blockedItem);
+        ExecuteAction(
+            context,
+            actions,
+            "run resubmit",
+            blockedItem.ExecutionUnit,
+            () => RunResubmitExecutor(context, blockedItem.ExecutionUnit));
+        ExecuteAction(
+            context,
+            actions,
+            "run rereview",
+            blockedItem.ExecutionUnit,
+            () => RunRereviewExecutor(context, blockedItem.ExecutionUnit));
+    }
+
+    private static void RestoreFixingStateAfterPostFixProgressBoundary(
+        CliContext context,
+        string executionUnit,
+        RunSupervisionSession session)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(session);
+
+        var queueState = LoadQueueStateOrThrow(context);
+        var queueStatePath = context.GetQueueStatePath();
+        var now = TimestampFactory();
+        var updatedState = queueState with
+        {
+            UpdatedAt = now,
+            Items = queueState.Items.Select(item =>
+                string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                    ? item with
+                    {
+                        State = QueueItemState.Fixing,
+                        BlockedBy = []
+                    }
+                    : item).ToArray()
+        };
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+
+        var sessionArtifactRef = RunSupervisionSessionArtifactPathResolver.Resolve(
+            context.Config.Supervision.ArtifactRoot,
+            executionUnit);
+        var sessionArtifactPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            sessionArtifactRef.Replace('/', Path.DirectorySeparatorChar)));
+        File.WriteAllText(
+            sessionArtifactPath,
+            RunSupervisionSessionArtifactJson.Serialize(session with
+            {
+                RequiresPostFixWorktreeProgressDecision = false,
+                UpdatedAt = now
+            }));
+
+        AppendRunEvent(
+            context.GetRunLogPath(),
+            new RunEvent
+            {
+                Ts = now,
+                ExecutionUnit = executionUnit,
+                Event = "post-fix-progress-accepted",
+                By = "intent-cli",
+                LinkedPr = session.LinkedPr,
+                CommentRef = session.CommentRef,
+                Reason = "Auto-continued repair from meaningful post-fix worktree progress."
+            });
+    }
+
+    private static void CommitPostFixWorktreeProgress(CliContext context, QueueItem blockedItem)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(blockedItem);
+
+        if (blockedItem.LinkedIssue is null)
+        {
+            throw new RunDeterministicGapException(
+                blockedItem.ExecutionUnit,
+                $"Blocked execution unit '{blockedItem.ExecutionUnit}' must have a linked issue before carry-forward.");
+        }
+
+        var worktreePath = RunStartCommand.ResolveWorktreePath(context, blockedItem.ExecutionUnit);
+        if (!Directory.Exists(worktreePath))
+        {
+            throw new RunDeterministicGapException(
+                blockedItem.ExecutionUnit,
+                $"Worktree path was not found at {worktreePath}.");
+        }
+
+        var gitRunner = GitCommandRunnerFactory();
+        if (!RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths(
+                gitRunner,
+                worktreePath,
+                out var changedPaths))
+        {
+            throw new RunDeterministicGapException(
+                blockedItem.ExecutionUnit,
+                $"Meaningful post-fix worktree progress for '{blockedItem.ExecutionUnit}' was no longer present.");
+        }
+
+        var expectedBranchName = RunStartCommand.ResolveBranchName(blockedItem.ExecutionUnit, blockedItem.LinkedIssue);
+        var branchResult = gitRunner.Run(worktreePath, ["rev-parse", "--abbrev-ref", "HEAD"]);
+        if (branchResult.ExitCode != 0)
+        {
+            throw new RunDeterministicGapException(
+                blockedItem.ExecutionUnit,
+                string.IsNullOrWhiteSpace(branchResult.StdErr)
+                    ? "git rev-parse --abbrev-ref HEAD failed."
+                    : branchResult.StdErr.Trim());
+        }
+
+        var currentBranch = branchResult.StdOut.Trim();
+        if (!string.Equals(currentBranch, expectedBranchName, StringComparison.Ordinal))
+        {
+            throw new RunDeterministicGapException(
+                blockedItem.ExecutionUnit,
+                $"Current worktree branch '{currentBranch}' must match expected branch '{expectedBranchName}'.");
+        }
+
+        var addArguments = new List<string> { "add", "--" };
+        addArguments.AddRange(changedPaths);
+        var addResult = gitRunner.Run(worktreePath, addArguments);
+        if (addResult.ExitCode != 0)
+        {
+            throw new RunDeterministicGapException(
+                blockedItem.ExecutionUnit,
+                string.IsNullOrWhiteSpace(addResult.StdErr)
+                    ? "git add failed."
+                    : addResult.StdErr.Trim());
+        }
+
+        var diffResult = gitRunner.Run(worktreePath, ["diff", "--cached", "--quiet"]);
+        if (diffResult.ExitCode == 0)
+        {
+            throw new RunDeterministicGapException(
+                blockedItem.ExecutionUnit,
+                $"Carry-forward commit for '{blockedItem.ExecutionUnit}' had no staged changes.");
+        }
+
+        if (diffResult.ExitCode != 1)
+        {
+            throw new RunDeterministicGapException(
+                blockedItem.ExecutionUnit,
+                string.IsNullOrWhiteSpace(diffResult.StdErr)
+                    ? "git diff --cached --quiet failed."
+                    : diffResult.StdErr.Trim());
+        }
+
+        var commitResult = gitRunner.Run(
+            worktreePath,
+            ["commit", "-m", $"Carry forward post-fix progress for {blockedItem.ExecutionUnit}"]);
+        if (commitResult.ExitCode != 0)
+        {
+            throw new RunDeterministicGapException(
+                blockedItem.ExecutionUnit,
+                string.IsNullOrWhiteSpace(commitResult.StdErr)
+                    ? "git commit failed."
+                    : commitResult.StdErr.Trim());
+        }
+    }
+
+    private static void AppendRunEvent(string runLogPath, RunEvent runEvent)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runLogPath);
+        ArgumentNullException.ThrowIfNull(runEvent);
+
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(
+            runLogPath,
+            RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
     }
 
     private static string DescribeSupervisionResult(RunSuperviseResult superviseResult)

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -559,20 +559,43 @@ internal static class RunCommand
         ArgumentNullException.ThrowIfNull(blockedItem);
         ArgumentNullException.ThrowIfNull(session);
 
-        RestoreFixingStateAfterPostFixProgressBoundary(context, blockedItem.ExecutionUnit, session);
         CommitPostFixWorktreeProgress(context, blockedItem);
-        ExecuteAction(
-            context,
-            actions,
-            "run resubmit",
-            blockedItem.ExecutionUnit,
-            () => RunResubmitExecutor(context, blockedItem.ExecutionUnit));
-        ExecuteAction(
-            context,
-            actions,
-            "run rereview",
-            blockedItem.ExecutionUnit,
-            () => RunRereviewExecutor(context, blockedItem.ExecutionUnit));
+        var rollbackState = CapturePostFixProgressRollbackState(context, blockedItem.ExecutionUnit);
+
+        try
+        {
+            RestoreFixingStateAfterPostFixProgressBoundary(context, blockedItem.ExecutionUnit, session);
+            ExecuteAction(
+                context,
+                actions,
+                "run resubmit",
+                blockedItem.ExecutionUnit,
+                () => RunResubmitExecutor(context, blockedItem.ExecutionUnit));
+            ExecuteAction(
+                context,
+                actions,
+                "run rereview",
+                blockedItem.ExecutionUnit,
+                () => RunRereviewExecutor(context, blockedItem.ExecutionUnit));
+        }
+        catch
+        {
+            RestorePostFixProgressRollbackState(rollbackState);
+            throw;
+        }
+
+        AppendRunEvent(
+            context.GetRunLogPath(),
+            new RunEvent
+            {
+                Ts = TimestampFactory(),
+                ExecutionUnit = blockedItem.ExecutionUnit,
+                Event = "post-fix-progress-accepted",
+                By = "intent-cli",
+                LinkedPr = session.LinkedPr,
+                CommentRef = session.CommentRef,
+                Reason = "Auto-continued repair from meaningful post-fix worktree progress."
+            });
     }
 
     private static void RestoreFixingStateAfterPostFixProgressBoundary(
@@ -614,19 +637,6 @@ internal static class RunCommand
                 RequiresPostFixWorktreeProgressDecision = false,
                 UpdatedAt = now
             }));
-
-        AppendRunEvent(
-            context.GetRunLogPath(),
-            new RunEvent
-            {
-                Ts = now,
-                ExecutionUnit = executionUnit,
-                Event = "post-fix-progress-accepted",
-                By = "intent-cli",
-                LinkedPr = session.LinkedPr,
-                CommentRef = session.CommentRef,
-                Reason = "Auto-continued repair from meaningful post-fix worktree progress."
-            });
     }
 
     private static void CommitPostFixWorktreeProgress(CliContext context, QueueItem blockedItem)
@@ -732,6 +742,40 @@ internal static class RunCommand
         File.AppendAllText(
             runLogPath,
             RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
+    }
+
+    private static PostFixProgressRollbackState CapturePostFixProgressRollbackState(
+        CliContext context,
+        string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var queueStatePath = context.GetQueueStatePath();
+        var runLogPath = context.GetRunLogPath();
+        var sessionArtifactRef = RunSupervisionSessionArtifactPathResolver.Resolve(
+            context.Config.Supervision.ArtifactRoot,
+            executionUnit);
+        var sessionArtifactPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            sessionArtifactRef.Replace('/', Path.DirectorySeparatorChar)));
+
+        return new PostFixProgressRollbackState(
+            queueStatePath,
+            File.ReadAllText(queueStatePath),
+            sessionArtifactPath,
+            File.ReadAllText(sessionArtifactPath),
+            runLogPath,
+            File.Exists(runLogPath) ? File.ReadAllText(runLogPath) : string.Empty);
+    }
+
+    private static void RestorePostFixProgressRollbackState(PostFixProgressRollbackState rollbackState)
+    {
+        ArgumentNullException.ThrowIfNull(rollbackState);
+
+        File.WriteAllText(rollbackState.QueueStatePath, rollbackState.QueueStateContent);
+        File.WriteAllText(rollbackState.SessionArtifactPath, rollbackState.SessionArtifactContent);
+        File.WriteAllText(rollbackState.RunLogPath, rollbackState.RunLogContent);
     }
 
     private static string DescribeSupervisionResult(RunSuperviseResult superviseResult)
@@ -1571,4 +1615,12 @@ internal static class RunCommand
 
         public required string Detail { get; init; }
     }
+
+    private sealed record PostFixProgressRollbackState(
+        string QueueStatePath,
+        string QueueStateContent,
+        string SessionArtifactPath,
+        string SessionArtifactContent,
+        string RunLogPath,
+        string RunLogContent);
 }

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -183,7 +183,8 @@ internal static class RunSuperviseCommand
                     deadWorkerFailure.Reason,
                     incrementRetryCount: false,
                     emitRetryExhaustedEvent: false,
-                    reportAsNonRetryableFailure: true);
+                    reportAsNonRetryableFailure: true,
+                    requiresPostFixWorktreeProgressDecision: deadWorkerFailure.RequiresPostFixWorktreeProgressDecision);
             }
 
             if (session.RetryCount >= session.RetryBudget)
@@ -330,7 +331,8 @@ internal static class RunSuperviseCommand
                     deadWorkerFailure.Reason,
                     incrementRetryCount: false,
                     emitRetryExhaustedEvent: false,
-                    reportAsNonRetryableFailure: true);
+                    reportAsNonRetryableFailure: true,
+                    requiresPostFixWorktreeProgressDecision: deadWorkerFailure.RequiresPostFixWorktreeProgressDecision);
             }
 
             if (session.RetryCount >= session.RetryBudget)
@@ -473,7 +475,8 @@ internal static class RunSuperviseCommand
         string reason,
         bool incrementRetryCount,
         bool emitRetryExhaustedEvent = true,
-        bool reportAsNonRetryableFailure = false)
+        bool reportAsNonRetryableFailure = false,
+        bool requiresPostFixWorktreeProgressDecision = false)
     {
         var transition = QueueManager.TransitionBlocking(
             queueState,
@@ -489,7 +492,8 @@ internal static class RunSuperviseCommand
             UpdatedAt = now,
             NextRetryAt = null,
             LastInterruptionReason = reason,
-            RetryCount = incrementRetryCount ? session.RetryCount + 1 : session.RetryCount
+            RetryCount = incrementRetryCount ? session.RetryCount + 1 : session.RetryCount,
+            RequiresPostFixWorktreeProgressDecision = requiresPostFixWorktreeProgressDecision
         };
 
         PersistQueueState(context, transition.UpdatedState);
@@ -518,7 +522,8 @@ internal static class RunSuperviseCommand
             sessionArtifactRef,
             blockedSession,
             blocked: true,
-            reportAsNonRetryableFailure: reportAsNonRetryableFailure);
+            reportAsNonRetryableFailure: reportAsNonRetryableFailure,
+            requiresPostFixWorktreeProgressDecision: requiresPostFixWorktreeProgressDecision);
     }
 
     private static RunSupervisionSession BuildResumedSession(
@@ -916,20 +921,18 @@ internal static class RunSuperviseCommand
         if (!TryFindFailingBackendExitCode(providerEvents, out var exitCode)
             || DirectRunFixOutcomeSupport.TryResolveContractGapDetail(providerEvents, executionUnit, out _)
             || !DirectRunFixOutcomeSupport.HasBoundedProgressSignal(providerEvents)
-            || !TryResolveMeaningfulWorktreeDiffPaths(worktreePath, out var changedPaths))
+            || !RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths(
+                GitCommandRunnerFactory(),
+                worktreePath,
+                out var changedPaths))
         {
             return false;
         }
 
-        var summarizedPaths = string.Join(", ", changedPaths.Take(3));
-        if (changedPaths.Count > 3)
-        {
-            summarizedPaths += ", ...";
-        }
-
         failure = new WorkerSessionFailure(
-            $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode} after bounded fix progress and left meaningful execution-unit worktree changes. Changed paths: {summarizedPaths}.",
-            ReportAsNonRetryableFailure: true);
+            $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode} after bounded fix progress and left meaningful execution-unit worktree changes. Changed paths: {RunWorktreeProgressSupport.SummarizePaths(changedPaths)}.",
+            ReportAsNonRetryableFailure: true,
+            RequiresPostFixWorktreeProgressDecision: true);
         return true;
     }
 
@@ -1008,97 +1011,6 @@ internal static class RunSuperviseCommand
 
         exitCode = default;
         return false;
-    }
-
-    private static bool TryResolveMeaningfulWorktreeDiffPaths(
-        string worktreePath,
-        out IReadOnlyList<string> changedPaths)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
-
-        changedPaths = [];
-        GitCommandResult statusResult;
-        try
-        {
-            statusResult = GitCommandRunnerFactory().Run(
-                worktreePath,
-                ["status", "--short", "--untracked-files=all"]);
-        }
-        catch (Exception exception) when (
-            exception is InvalidOperationException
-            or IOException
-            or ArgumentException
-            or DirectoryNotFoundException
-            or System.ComponentModel.Win32Exception)
-        {
-            return false;
-        }
-
-        if (statusResult.ExitCode != 0 || string.IsNullOrWhiteSpace(statusResult.StdOut))
-        {
-            return false;
-        }
-
-        var paths = new List<string>();
-        foreach (var rawLine in statusResult.StdOut.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
-        {
-            var line = rawLine.TrimEnd();
-            if (string.IsNullOrWhiteSpace(line))
-            {
-                continue;
-            }
-
-            var pathText = line.Length > 3 ? line[3..].Trim() : line.Trim();
-            if (string.IsNullOrWhiteSpace(pathText))
-            {
-                continue;
-            }
-
-            var normalizedPath = pathText.Contains(" -> ", StringComparison.Ordinal)
-                ? pathText[(pathText.LastIndexOf(" -> ", StringComparison.Ordinal) + 4)..].Trim()
-                : pathText;
-            normalizedPath = normalizedPath.Trim().Trim('"').Replace('\\', '/');
-            if (string.IsNullOrWhiteSpace(normalizedPath)
-                || IsIgnoredWorktreeArtifactPath(normalizedPath))
-            {
-                continue;
-            }
-
-            paths.Add(normalizedPath);
-        }
-
-        if (paths.Count == 0)
-        {
-            return false;
-        }
-
-        changedPaths = paths;
-        return true;
-    }
-
-    private static bool IsIgnoredWorktreeArtifactPath(string path)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(path);
-
-        var normalizedPath = path.Replace('\\', '/').Trim('/');
-        if (string.IsNullOrWhiteSpace(normalizedPath))
-        {
-            return true;
-        }
-
-        if (normalizedPath.StartsWith(".intent-cli/", StringComparison.Ordinal)
-            || normalizedPath.StartsWith(".takt/", StringComparison.Ordinal)
-            || normalizedPath.StartsWith("node_modules/", StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        var segments = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        return segments.Any(segment =>
-            string.Equals(segment, "bin", StringComparison.Ordinal)
-            || string.Equals(segment, "obj", StringComparison.Ordinal)
-            || string.Equals(segment, "TestResults", StringComparison.Ordinal)
-            || string.Equals(segment, ".vs", StringComparison.Ordinal));
     }
 
     private static string ResolveDirectRunRequestArtifactPath(CliContext context, string executionUnit)
@@ -1228,7 +1140,8 @@ internal static class RunSuperviseCommand
         bool retryScheduled = false,
         bool autoResumed = false,
         bool blocked = false,
-        bool reportAsNonRetryableFailure = false)
+        bool reportAsNonRetryableFailure = false,
+        bool requiresPostFixWorktreeProgressDecision = false)
     {
         return new RunSuperviseResult
         {
@@ -1244,11 +1157,15 @@ internal static class RunSuperviseCommand
             AutoResumed = autoResumed,
             Blocked = blocked,
             FailureReason = blocked ? session.LastInterruptionReason : null,
-            ReportAsNonRetryableFailure = reportAsNonRetryableFailure
+            ReportAsNonRetryableFailure = reportAsNonRetryableFailure,
+            RequiresPostFixWorktreeProgressDecision = requiresPostFixWorktreeProgressDecision
         };
     }
 
-    private sealed record WorkerSessionFailure(string Reason, bool ReportAsNonRetryableFailure);
+    private sealed record WorkerSessionFailure(
+        string Reason,
+        bool ReportAsNonRetryableFailure,
+        bool RequiresPostFixWorktreeProgressDecision = false);
 
     private static string FormatQueueState(QueueItemState state)
     {

--- a/src/IntentSystem.Cli/Commands/RunSuperviseResult.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseResult.cs
@@ -27,4 +27,6 @@ internal sealed record RunSuperviseResult
     public string? FailureReason { get; init; }
 
     public bool ReportAsNonRetryableFailure { get; init; }
+
+    public bool RequiresPostFixWorktreeProgressDecision { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/RunSupervisionSession.cs
+++ b/src/IntentSystem.Cli/Commands/RunSupervisionSession.cs
@@ -37,4 +37,6 @@ internal sealed record RunSupervisionSession
     public DateTimeOffset? NextRetryAt { get; init; }
 
     public string? LastInterruptionReason { get; init; }
+
+    public bool RequiresPostFixWorktreeProgressDecision { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/RunWorktreeProgressSupport.cs
+++ b/src/IntentSystem.Cli/Commands/RunWorktreeProgressSupport.cs
@@ -1,0 +1,112 @@
+using IntentSystem.Review;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class RunWorktreeProgressSupport
+{
+    public static bool TryResolveMeaningfulWorktreeDiffPaths(
+        IGitCommandRunner gitCommandRunner,
+        string worktreePath,
+        out IReadOnlyList<string> changedPaths)
+    {
+        ArgumentNullException.ThrowIfNull(gitCommandRunner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
+
+        changedPaths = [];
+        GitCommandResult statusResult;
+        try
+        {
+            statusResult = gitCommandRunner.Run(
+                worktreePath,
+                ["status", "--short", "--untracked-files=all"]);
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException
+            or ArgumentException
+            or DirectoryNotFoundException
+            or System.ComponentModel.Win32Exception)
+        {
+            return false;
+        }
+
+        if (statusResult.ExitCode != 0 || string.IsNullOrWhiteSpace(statusResult.StdOut))
+        {
+            return false;
+        }
+
+        var paths = new List<string>();
+        foreach (var rawLine in statusResult.StdOut.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            var line = rawLine.TrimEnd();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var pathText = line.Length > 3 ? line[3..].Trim() : line.Trim();
+            if (string.IsNullOrWhiteSpace(pathText))
+            {
+                continue;
+            }
+
+            var normalizedPath = pathText.Contains(" -> ", StringComparison.Ordinal)
+                ? pathText[(pathText.LastIndexOf(" -> ", StringComparison.Ordinal) + 4)..].Trim()
+                : pathText;
+            normalizedPath = normalizedPath.Trim().Trim('"').Replace('\\', '/');
+            if (string.IsNullOrWhiteSpace(normalizedPath)
+                || IsIgnoredWorktreeArtifactPath(normalizedPath))
+            {
+                continue;
+            }
+
+            paths.Add(normalizedPath);
+        }
+
+        if (paths.Count == 0)
+        {
+            return false;
+        }
+
+        changedPaths = paths;
+        return true;
+    }
+
+    public static string SummarizePaths(IReadOnlyList<string> changedPaths)
+    {
+        ArgumentNullException.ThrowIfNull(changedPaths);
+
+        var summarizedPaths = string.Join(", ", changedPaths.Take(3));
+        if (changedPaths.Count > 3)
+        {
+            summarizedPaths += ", ...";
+        }
+
+        return summarizedPaths;
+    }
+
+    private static bool IsIgnoredWorktreeArtifactPath(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var normalizedPath = path.Replace('\\', '/').Trim('/');
+        if (string.IsNullOrWhiteSpace(normalizedPath))
+        {
+            return true;
+        }
+
+        if (normalizedPath.StartsWith(".intent-cli/", StringComparison.Ordinal)
+            || normalizedPath.StartsWith(".takt/", StringComparison.Ordinal)
+            || normalizedPath.StartsWith("node_modules/", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        var segments = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segments.Any(segment =>
+            string.Equals(segment, "bin", StringComparison.Ordinal)
+            || string.Equals(segment, "obj", StringComparison.Ordinal)
+            || string.Equals(segment, "TestResults", StringComparison.Ordinal)
+            || string.Equals(segment, ".vs", StringComparison.Ordinal));
+    }
+}

--- a/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
+++ b/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
@@ -58,6 +58,7 @@ internal static class CliConfigLoader
             ?? string.Empty;
         var roles = ReadRoles(rootTable);
         var supervision = ReadSupervision(rootTable);
+        var run = ReadRun(rootTable);
         var directRun = ReadDirectRun(rootTable);
 
         config = CreateConfig(
@@ -68,6 +69,7 @@ internal static class CliConfigLoader
             parentIntentRepoRoot,
             roles,
             supervision,
+            run,
             directRun);
         return true;
     }
@@ -100,6 +102,7 @@ internal static class CliConfigLoader
             ?? string.Empty;
         var roles = ReadRoles(rootTable);
         var supervision = ReadSupervision(rootTable);
+        var run = ReadRun(rootTable);
         var directRun = ReadDirectRun(rootTable);
 
         config = CreateConfig(
@@ -110,6 +113,7 @@ internal static class CliConfigLoader
             parentIntentRepoRoot,
             roles,
             supervision,
+            run,
             directRun);
         return true;
     }
@@ -122,6 +126,7 @@ internal static class CliConfigLoader
         string parentIntentRepoRoot,
         RoleMappings roles,
         SupervisionConfig supervision,
+        RunConfig run,
         DirectRunConfig directRun)
     {
         return new CliConfig
@@ -136,6 +141,7 @@ internal static class CliConfigLoader
             },
             Roles = roles,
             Supervision = supervision,
+            Run = run,
             DirectRun = directRun
         };
     }
@@ -199,6 +205,28 @@ internal static class CliConfigLoader
                 ?? CliRuntimeContracts.DefaultSupervisionRetryDelayMinutes,
             RetryBudget = TryGetOptionalInt32(supervisionTable, CliRuntimeContracts.RetryBudgetKey)
                 ?? CliRuntimeContracts.DefaultSupervisionRetryBudget
+        };
+    }
+
+    private static RunConfig ReadRun(TomlTable rootTable)
+    {
+        ArgumentNullException.ThrowIfNull(rootTable);
+
+        if (!rootTable.TryGetValue(CliRuntimeContracts.RunSectionName, out var section)
+            || section is not TomlTable runTable)
+        {
+            return new RunConfig();
+        }
+
+        var postFixWorktreeProgressPolicy = TryGetOptionalString(
+                runTable,
+                CliRuntimeContracts.PostFixWorktreeProgressPolicyKey)
+            ?? CliRuntimeContracts.DefaultPostFixWorktreeProgressPolicy;
+        ValidatePostFixWorktreeProgressPolicy(postFixWorktreeProgressPolicy);
+
+        return new RunConfig
+        {
+            PostFixWorktreeProgressPolicy = postFixWorktreeProgressPolicy
         };
     }
 
@@ -345,5 +373,21 @@ internal static class CliConfigLoader
         }
 
         return values;
+    }
+
+    private static void ValidatePostFixWorktreeProgressPolicy(string policy)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(policy);
+
+        if (string.Equals(policy, CliRuntimeContracts.ConfirmPostFixWorktreeProgressPolicy, StringComparison.Ordinal)
+            || string.Equals(policy, CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"CLI config value '{CliRuntimeContracts.PostFixWorktreeProgressPolicyKey}' must be " +
+            $"'{CliRuntimeContracts.ConfirmPostFixWorktreeProgressPolicy}' or " +
+            $"'{CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy}'.");
     }
 }

--- a/src/IntentSystem.Cli/Models/CliConfig.cs
+++ b/src/IntentSystem.Cli/Models/CliConfig.cs
@@ -8,6 +8,8 @@ internal sealed record CliConfig
 
     public SupervisionConfig Supervision { get; init; } = new();
 
+    public RunConfig Run { get; init; } = new();
+
     public DirectRunConfig DirectRun { get; init; } = new();
 }
 
@@ -45,6 +47,12 @@ internal sealed record SupervisionConfig
     public int RetryDelayMinutes { get; init; } = CliRuntimeContracts.DefaultSupervisionRetryDelayMinutes;
 
     public int RetryBudget { get; init; } = CliRuntimeContracts.DefaultSupervisionRetryBudget;
+}
+
+internal sealed record RunConfig
+{
+    public string PostFixWorktreeProgressPolicy { get; init; } =
+        CliRuntimeContracts.DefaultPostFixWorktreeProgressPolicy;
 }
 
 internal sealed record DirectRunConfig

--- a/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
@@ -127,6 +127,22 @@ public sealed class CliConfigLoaderTests
     }
 
     [Fact]
+    public void Load_GivenRunSection_RestoresPostFixWorktreeProgressPolicy()
+    {
+        var toml = """
+        default_domain = "intent-cli"
+        artifact_root = ".intent-cli"
+
+        [run]
+        post_fix_worktree_progress_policy = "auto-continue"
+        """;
+
+        var config = CliConfigLoader.Load(toml);
+
+        Assert.Equal("auto-continue", config.Run.PostFixWorktreeProgressPolicy);
+    }
+
+    [Fact]
     public void Load_GivenDirectBackendSection_RestoresDefaultAndEntrySpecificPolicies()
     {
         var toml = """
@@ -217,6 +233,22 @@ public sealed class CliConfigLoaderTests
         var exception = Assert.Throws<InvalidOperationException>(() => CliConfigLoader.Load(toml));
 
         Assert.Contains("workflow_engine", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_GivenInvalidPostFixWorktreeProgressPolicy_ThrowsInvalidOperationException()
+    {
+        var toml = """
+        default_domain = "intent-cli"
+        artifact_root = ".intent-cli"
+
+        [run]
+        post_fix_worktree_progress_policy = "always"
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => CliConfigLoader.Load(toml));
+
+        Assert.Contains("post_fix_worktree_progress_policy", exception.Message, StringComparison.Ordinal);
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -3746,6 +3746,12 @@ public sealed class RunCommandTests
                 StdOut = "issue-226-g226\n",
                 StdErr = string.Empty
             },
+            [FakeGitRunner.CreateCommandKey(["rev-parse", "HEAD"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "base-commit-226\n",
+                StdErr = string.Empty
+            },
             [FakeGitRunner.CreateCommandKey(["add", "--", "src/ToyCalc/Calculator.cs", "src/ToyCalc/CommandLine.cs", "tests/ToyCalc.Tests/CalculatorTests.cs"])] = new GitCommandResult
             {
                 ExitCode = 0,
@@ -3762,6 +3768,12 @@ public sealed class RunCommandTests
             {
                 ExitCode = 0,
                 StdOut = "[issue-226-g226 abc123] Carry forward post-fix progress for G226\n",
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["reset", "--mixed", "base-commit-226"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
                 StdErr = string.Empty
             }
         });
@@ -3943,6 +3955,12 @@ public sealed class RunCommandTests
                 StdOut = "issue-226-g226\n",
                 StdErr = string.Empty
             },
+            [FakeGitRunner.CreateCommandKey(["rev-parse", "HEAD"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "base-commit-226\n",
+                StdErr = string.Empty
+            },
             [FakeGitRunner.CreateCommandKey(["add", "--", "src/ToyCalc/Calculator.cs", "src/ToyCalc/CommandLine.cs", "tests/ToyCalc.Tests/CalculatorTests.cs"])] = new GitCommandResult
             {
                 ExitCode = 0,
@@ -3959,6 +3977,12 @@ public sealed class RunCommandTests
             {
                 ExitCode = 0,
                 StdOut = "[issue-226-g226 abc123] Carry forward post-fix progress for G226\n",
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["reset", "--mixed", "base-commit-226"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
                 StdErr = string.Empty
             }
         });
@@ -3993,12 +4017,231 @@ public sealed class RunCommandTests
             var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
             Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "post-fix-progress-accepted", StringComparison.Ordinal));
             Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "resubmitted", StringComparison.Ordinal));
+            Assert.Contains(gitRunner.Commands, command =>
+                command.SequenceEqual(["reset", "--mixed", "base-commit-226"]));
         }
         finally
         {
             RunSuperviseCommand.GitCommandRunnerFactory = originalSuperviseGitCommandRunnerFactory;
             RunCommand.GitCommandRunnerFactory = originalRunGitCommandRunnerFactory;
             RunCommand.RunResubmitExecutor = originalRunResubmitExecutor;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenRetryAfterAutoContinueResubmitFailure_ReplaysSameBoundarySuccessfully()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "review-context.md"),
+            "# Review Context");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 3,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents: CreateMeaningfulFixWorktreeProgressProviderEvents("G226", "pid:999999"),
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var gitRunner = new FakeGitRunner(new Dictionary<string, GitCommandResult>
+        {
+            [FakeGitRunner.CreateCommandKey(["status", "--short", "--untracked-files=all"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut =
+                    """
+                     M src/ToyCalc/Calculator.cs
+                     M src/ToyCalc/CommandLine.cs
+                     M tests/ToyCalc.Tests/CalculatorTests.cs
+                    """,
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["rev-parse", "--abbrev-ref", "HEAD"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "issue-226-g226\n",
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["rev-parse", "HEAD"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "base-commit-226\n",
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["add", "--", "src/ToyCalc/Calculator.cs", "src/ToyCalc/CommandLine.cs", "tests/ToyCalc.Tests/CalculatorTests.cs"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["diff", "--cached", "--quiet"])] = new GitCommandResult
+            {
+                ExitCode = 1,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["commit", "-m", "Carry forward post-fix progress for G226"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "[issue-226-g226 abc123] Carry forward post-fix progress for G226\n",
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["reset", "--mixed", "base-commit-226"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            }
+        });
+        var originalSuperviseGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+        var originalRunGitCommandRunnerFactory = RunCommand.GitCommandRunnerFactory;
+        var originalRunResubmitExecutor = RunCommand.RunResubmitExecutor;
+        var originalRunRereviewExecutor = RunCommand.RunRereviewExecutor;
+        var resubmitCalls = 0;
+
+        try
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = () => gitRunner;
+            RunCommand.GitCommandRunnerFactory = () => gitRunner;
+            RunCommand.RunResubmitExecutor = (_, executionUnit) =>
+            {
+                resubmitCalls++;
+                if (resubmitCalls == 1)
+                {
+                    throw new InvalidOperationException("git push failed.");
+                }
+
+                return new RunResubmitResult
+                {
+                    ExecutionUnit = executionUnit,
+                    Branch = "issue-226-g226",
+                    WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                    LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226"
+                };
+            };
+            RunCommand.RunRereviewExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => string.Equals(queueItem.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                        ? queueItem with { State = QueueItemState.Review }
+                        : queueItem);
+                WriteDirectRunRequest(context.RepoRoot, executionUnit, "review", "review-session");
+                WriteDirectRunResult(
+                    context.RepoRoot,
+                    executionUnit,
+                    "review",
+                    "running",
+                    providerEvents: [],
+                    sessionId: "review-session");
+
+                return new RunRereviewResult
+                {
+                    ExecutionUnit = executionUnit,
+                    LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226"
+                };
+            };
+
+            var firstResult = RunCommand.ExecuteCore(CreateContext(
+                repoRoot,
+                postFixWorktreeProgressPolicy: CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy));
+            var secondResult = RunCommand.ExecuteCore(CreateContext(
+                repoRoot,
+                postFixWorktreeProgressPolicy: CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy));
+
+            Assert.Equal("deterministic-contract-gap", firstResult.StopReason);
+            Assert.Equal("no-actionable-item", secondResult.StopReason);
+            Assert.Equal("G226", secondResult.ExecutionUnit);
+            Assert.Contains(secondResult.Actions, action => action.Name == "run resubmit" && action.ExecutionUnit == "G226");
+            Assert.Contains(secondResult.Actions, action => action.Name == "run rereview" && action.ExecutionUnit == "G226");
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Review, selectedItem.State);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
+            Assert.False(session.RequiresPostFixWorktreeProgressDecision);
+
+            Assert.Equal(2, gitRunner.Commands.Count(command =>
+                command.SequenceEqual(["commit", "-m", "Carry forward post-fix progress for G226"])));
+            Assert.Equal(1, gitRunner.Commands.Count(command =>
+                command.SequenceEqual(["reset", "--mixed", "base-commit-226"])));
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal(1, runEvents.Count(runEvent =>
+                string.Equals(runEvent.Event, "post-fix-progress-accepted", StringComparison.Ordinal)));
+        }
+        finally
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = originalSuperviseGitCommandRunnerFactory;
+            RunCommand.GitCommandRunnerFactory = originalRunGitCommandRunnerFactory;
+            RunCommand.RunResubmitExecutor = originalRunResubmitExecutor;
+            RunCommand.RunRereviewExecutor = originalRunRereviewExecutor;
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -1450,6 +1450,9 @@ public sealed class RunCommandTests
             Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
             "{}");
         tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
             "# Repair Worker Handoff");
         WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:94914", provider: "Claude");
@@ -1631,6 +1634,9 @@ public sealed class RunCommandTests
             """);
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
             "{}");
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
@@ -1835,6 +1841,12 @@ public sealed class RunCommandTests
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
             "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "review-context.md"),
+            "# Review Context");
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
             "# Repair Worker Handoff");
@@ -3520,7 +3532,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWithMeaningfulWorktreeDiff_StopsWithNonRetryableFailure()
+    public void ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWithMeaningfulWorktreeDiff_StopsWithClarificationRequired()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -3604,11 +3616,15 @@ public sealed class RunCommandTests
                 """);
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+            var rerunResult = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("non-retryable-failure", result.StopReason);
+            Assert.Equal("clarification-required", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             Assert.Contains("meaningful execution-unit worktree changes", result.Detail, StringComparison.Ordinal);
             Assert.Contains("src/ToyCalc/Calculator.cs", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("post_fix_worktree_progress_policy", result.Detail, StringComparison.Ordinal);
+            Assert.Equal("clarification-required", rerunResult.StopReason);
+            Assert.Contains("carry this progress forward", rerunResult.Detail, StringComparison.Ordinal);
 
             var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
             var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
@@ -3619,6 +3635,7 @@ public sealed class RunCommandTests
                 Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
             Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
             Assert.Contains("meaningful execution-unit worktree changes", session.LastInterruptionReason, StringComparison.Ordinal);
+            Assert.True(session.RequiresPostFixWorktreeProgressDecision);
 
             var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
             Assert.Equal("blocked", runEvents[^1].Event);
@@ -3628,6 +3645,209 @@ public sealed class RunCommandTests
         finally
         {
             RunSuperviseCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenAutoContinuePolicyForMeaningfulFixWorktreeDiff_CommitsProgressAndResubmits()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "review-context.md"),
+            "# Review Context");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 3,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents: CreateMeaningfulFixWorktreeProgressProviderEvents("G226", "pid:999999"),
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var gitRunner = new FakeGitRunner(new Dictionary<string, GitCommandResult>
+        {
+            [FakeGitRunner.CreateCommandKey(["status", "--short", "--untracked-files=all"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut =
+                    """
+                     M src/ToyCalc/Calculator.cs
+                     M src/ToyCalc/CommandLine.cs
+                     M tests/ToyCalc.Tests/CalculatorTests.cs
+                    """,
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["rev-parse", "--abbrev-ref", "HEAD"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "issue-226-g226\n",
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["add", "--", "src/ToyCalc/Calculator.cs", "src/ToyCalc/CommandLine.cs", "tests/ToyCalc.Tests/CalculatorTests.cs"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["diff", "--cached", "--quiet"])] = new GitCommandResult
+            {
+                ExitCode = 1,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["commit", "-m", "Carry forward post-fix progress for G226"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "[issue-226-g226 abc123] Carry forward post-fix progress for G226\n",
+                StdErr = string.Empty
+            }
+        });
+        var originalSuperviseGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+        var originalRunGitCommandRunnerFactory = RunCommand.GitCommandRunnerFactory;
+        var originalRunResubmitExecutor = RunCommand.RunResubmitExecutor;
+        var originalRunRereviewExecutor = RunCommand.RunRereviewExecutor;
+
+        try
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = () => gitRunner;
+            RunCommand.GitCommandRunnerFactory = () => gitRunner;
+            RunCommand.RunResubmitExecutor = (_, executionUnit) =>
+            {
+                Assert.Equal("G226", executionUnit);
+
+                return new RunResubmitResult
+                {
+                    ExecutionUnit = executionUnit,
+                    Branch = "issue-226-g226",
+                    WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                    LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226"
+                };
+            };
+            RunCommand.RunRereviewExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => string.Equals(queueItem.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                        ? queueItem with { State = QueueItemState.Review }
+                        : queueItem);
+                WriteDirectRunRequest(context.RepoRoot, executionUnit, "review", "review-session");
+                WriteDirectRunResult(
+                    context.RepoRoot,
+                    executionUnit,
+                    "review",
+                    "running",
+                    providerEvents: [],
+                    sessionId: "review-session");
+
+                return new RunRereviewResult
+                {
+                    ExecutionUnit = executionUnit,
+                    LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(
+                repoRoot,
+                postFixWorktreeProgressPolicy: CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("Review direct run for 'G226' is 'running'.", result.Detail, StringComparison.Ordinal);
+            Assert.Contains(result.Actions, action => action.Name == "run supervise" && action.ExecutionUnit == "G226");
+            Assert.Contains(result.Actions, action => action.Name == "run resubmit" && action.ExecutionUnit == "G226");
+            Assert.Contains(result.Actions, action => action.Name == "run rereview" && action.ExecutionUnit == "G226");
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Review, selectedItem.State);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
+            Assert.False(session.RequiresPostFixWorktreeProgressDecision);
+
+            Assert.Contains(gitRunner.Commands, command =>
+                command.SequenceEqual(["status", "--short", "--untracked-files=all"]));
+            Assert.Contains(gitRunner.Commands, command =>
+                command.SequenceEqual(["rev-parse", "--abbrev-ref", "HEAD"]));
+            Assert.Contains(gitRunner.Commands, command =>
+                command.SequenceEqual(["add", "--", "src/ToyCalc/Calculator.cs", "src/ToyCalc/CommandLine.cs", "tests/ToyCalc.Tests/CalculatorTests.cs"]));
+            Assert.Contains(gitRunner.Commands, command =>
+                command.SequenceEqual(["diff", "--cached", "--quiet"]));
+            Assert.Contains(gitRunner.Commands, command =>
+                command.SequenceEqual(["commit", "-m", "Carry forward post-fix progress for G226"]));
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Contains(runEvents, runEvent => string.Equals(runEvent.Event, "post-fix-progress-accepted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = originalSuperviseGitCommandRunnerFactory;
+            RunCommand.GitCommandRunnerFactory = originalRunGitCommandRunnerFactory;
+            RunCommand.RunResubmitExecutor = originalRunResubmitExecutor;
+            RunCommand.RunRereviewExecutor = originalRunRereviewExecutor;
         }
     }
 
@@ -4004,7 +4224,9 @@ public sealed class RunCommandTests
         Assert.Empty(result.Actions);
     }
 
-    private static CliContext CreateContext(string repoRoot)
+    private static CliContext CreateContext(
+        string repoRoot,
+        string postFixWorktreeProgressPolicy = CliRuntimeContracts.DefaultPostFixWorktreeProgressPolicy)
     {
         return new CliContext
         {
@@ -4028,6 +4250,10 @@ public sealed class RunCommandTests
                     StaleHeartbeatTimeoutMinutes = 15,
                     RetryDelayMinutes = 5,
                     RetryBudget = 3
+                },
+                Run = new RunConfig
+                {
+                    PostFixWorktreeProgressPolicy = postFixWorktreeProgressPolicy
                 },
                 DirectRun = new DirectRunConfig
                 {
@@ -4518,17 +4744,50 @@ public sealed class RunCommandTests
         }
     }
 
-    private sealed class FakeGitRunner(string statusOutput) : IGitCommandRunner
+    private sealed class FakeGitRunner : IGitCommandRunner
     {
+        private readonly string? statusOutput;
+        private readonly IReadOnlyDictionary<string, GitCommandResult>? scriptedResults;
+
+        public FakeGitRunner(string statusOutput)
+        {
+            this.statusOutput = statusOutput;
+        }
+
+        public FakeGitRunner(IReadOnlyDictionary<string, GitCommandResult> scriptedResults)
+        {
+            this.scriptedResults = scriptedResults;
+        }
+
+        public List<IReadOnlyList<string>> Commands { get; } = [];
+
         public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
         {
+            Commands.Add(arguments.ToArray());
+
+            if (scriptedResults is not null)
+            {
+                var key = CreateCommandKey(arguments);
+                if (!scriptedResults.TryGetValue(key, out var result))
+                {
+                    throw new Xunit.Sdk.XunitException($"Unexpected git command: {string.Join(" ", arguments)}");
+                }
+
+                return result;
+            }
+
             Assert.Equal(["status", "--short", "--untracked-files=all"], arguments);
             return new GitCommandResult
             {
                 ExitCode = 0,
-                StdOut = statusOutput,
+                StdOut = statusOutput ?? string.Empty,
                 StdErr = string.Empty
             };
+        }
+
+        public static string CreateCommandKey(IReadOnlyList<string> arguments)
+        {
+            return string.Join("\u001f", arguments);
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -3852,6 +3852,157 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenAutoContinueResubmitFailure_RollsBackConfirmationBoundaryState()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 3,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents: CreateMeaningfulFixWorktreeProgressProviderEvents("G226", "pid:999999"),
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var gitRunner = new FakeGitRunner(new Dictionary<string, GitCommandResult>
+        {
+            [FakeGitRunner.CreateCommandKey(["status", "--short", "--untracked-files=all"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut =
+                    """
+                     M src/ToyCalc/Calculator.cs
+                     M src/ToyCalc/CommandLine.cs
+                     M tests/ToyCalc.Tests/CalculatorTests.cs
+                    """,
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["rev-parse", "--abbrev-ref", "HEAD"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "issue-226-g226\n",
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["add", "--", "src/ToyCalc/Calculator.cs", "src/ToyCalc/CommandLine.cs", "tests/ToyCalc.Tests/CalculatorTests.cs"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["diff", "--cached", "--quiet"])] = new GitCommandResult
+            {
+                ExitCode = 1,
+                StdOut = string.Empty,
+                StdErr = string.Empty
+            },
+            [FakeGitRunner.CreateCommandKey(["commit", "-m", "Carry forward post-fix progress for G226"])] = new GitCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "[issue-226-g226 abc123] Carry forward post-fix progress for G226\n",
+                StdErr = string.Empty
+            }
+        });
+        var originalSuperviseGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+        var originalRunGitCommandRunnerFactory = RunCommand.GitCommandRunnerFactory;
+        var originalRunResubmitExecutor = RunCommand.RunResubmitExecutor;
+
+        try
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = () => gitRunner;
+            RunCommand.GitCommandRunnerFactory = () => gitRunner;
+            RunCommand.RunResubmitExecutor = (_, _) => throw new InvalidOperationException("git push failed.");
+
+            var result = RunCommand.ExecuteCore(CreateContext(
+                repoRoot,
+                postFixWorktreeProgressPolicy: CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy));
+
+            Assert.Equal("deterministic-contract-gap", result.StopReason);
+            Assert.Contains("run resubmit", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("git push failed.", result.Detail, StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("meaningful execution-unit worktree changes", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
+            Assert.True(session.RequiresPostFixWorktreeProgressDecision);
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "post-fix-progress-accepted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "resubmitted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = originalSuperviseGitCommandRunnerFactory;
+            RunCommand.GitCommandRunnerFactory = originalRunGitCommandRunnerFactory;
+            RunCommand.RunResubmitExecutor = originalRunResubmitExecutor;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWithBuildOutputOnlyDiff_StaysOnBackendExitPath()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- add a root-run `[run] post_fix_worktree_progress_policy` config with `confirm` and `auto-continue`
- persist post-fix worktree salvage decisions in supervision artifacts and surface them as `clarification-required` by default
- auto-continue bounded fix progress by restoring the fixing state, committing meaningful worktree changes, and reusing `run resubmit` / `run rereview`

## Validation
- dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj --no-restore
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~CliConfigLoaderTests|FullyQualifiedName~RunCommandTests|FullyQualifiedName~RunSuperviseCommandTests" --logger "console;verbosity=minimal"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWithMeaningfulWorktreeDiff_StopsWithClarificationRequired|FullyQualifiedName~ExecuteCore_GivenAutoContinuePolicyForMeaningfulFixWorktreeDiff_CommitsProgressAndResubmits|FullyQualifiedName~Load_GivenRunSection_RestoresPostFixWorktreeProgressPolicy|FullyQualifiedName~Load_GivenInvalidPostFixWorktreeProgressPolicy_ThrowsInvalidOperationException" --logger "console;verbosity=minimal"

Closes #303
