### PR TITLE
[G106] Preserve Codex implement startup through detached capture

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
@@ -13,6 +13,8 @@ internal static class DirectRunDetachedCaptureCommand
     private static readonly TimeSpan ExitPollInterval = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan OutputDrainGracePeriod = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan ExitCodeResolutionGracePeriod = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan ImplementProgressObservationWindow = TimeSpan.FromSeconds(20);
+    private static readonly TimeSpan ImplementProgressPollInterval = TimeSpan.FromMilliseconds(100);
     private static readonly TimeSpan FixStandardInputGracePeriod = TimeSpan.FromSeconds(1);
 
     public static bool TryExecute(string[] args, out int exitCode)
@@ -128,7 +130,6 @@ internal static class DirectRunDetachedCaptureCommand
                 }
                 else if (delayClosingPreservedStandardInputAfterLaunch)
                 {
-                    SchedulePreservedStandardInputClosure(preservedStandardInput);
                 }
             }
             providerSessionId = $"pid:{process.Id}";
@@ -163,6 +164,25 @@ internal static class DirectRunDetachedCaptureCommand
                 writer,
                 options,
                 providerSessionId);
+
+            if (delayClosingPreservedStandardInputAfterLaunch
+                && preservedStandardInput is not null)
+            {
+                if (string.Equals(options.EntryKind, "implement", StringComparison.Ordinal))
+                {
+                    ScheduleImplementStandardInputClosure(
+                        preservedStandardInput,
+                        options.ProviderEventLogPath,
+                        providerSessionId,
+                        options.LaunchedAt);
+                }
+                else
+                {
+                    SchedulePreservedStandardInputClosure(
+                        preservedStandardInput,
+                        FixStandardInputGracePeriod);
+                }
+            }
 
             exitedEarly = process.WaitForExit((int)StartupSuccessWindow.TotalMilliseconds);
             WaitForProcessExit(process);
@@ -526,6 +546,11 @@ internal static class DirectRunDetachedCaptureCommand
             return false;
         }
 
+        if (string.Equals(options.EntryKind, "implement", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
         var executableName = Path.GetFileNameWithoutExtension(providerExecutablePath.Trim());
         return string.Equals(executableName, "script", StringComparison.OrdinalIgnoreCase);
     }
@@ -537,7 +562,8 @@ internal static class DirectRunDetachedCaptureCommand
         ArgumentException.ThrowIfNullOrWhiteSpace(providerExecutablePath);
         ArgumentNullException.ThrowIfNull(options);
 
-        if (!string.Equals(options.EntryKind, "fix", StringComparison.Ordinal))
+        if (!string.Equals(options.EntryKind, "fix", StringComparison.Ordinal)
+            && !string.Equals(options.EntryKind, "implement", StringComparison.Ordinal))
         {
             return false;
         }
@@ -546,7 +572,9 @@ internal static class DirectRunDetachedCaptureCommand
         return string.Equals(executableName, "script", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static void SchedulePreservedStandardInputClosure(StreamWriter preservedStandardInput)
+    private static void SchedulePreservedStandardInputClosure(
+        StreamWriter preservedStandardInput,
+        TimeSpan gracePeriod)
     {
         ArgumentNullException.ThrowIfNull(preservedStandardInput);
 
@@ -554,7 +582,7 @@ internal static class DirectRunDetachedCaptureCommand
         {
             try
             {
-                await Task.Delay(FixStandardInputGracePeriod).ConfigureAwait(false);
+                await Task.Delay(gracePeriod).ConfigureAwait(false);
                 preservedStandardInput.Dispose();
             }
             catch (ObjectDisposedException)
@@ -564,6 +592,69 @@ internal static class DirectRunDetachedCaptureCommand
             {
             }
         });
+    }
+
+    private static void ScheduleImplementStandardInputClosure(
+        StreamWriter preservedStandardInput,
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        ArgumentNullException.ThrowIfNull(preservedStandardInput);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerEventLogPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+
+        _ = Task.Run(async () =>
+        {
+            var deadline = DateTimeOffset.UtcNow + ImplementProgressObservationWindow;
+            try
+            {
+                while (DateTimeOffset.UtcNow < deadline)
+                {
+                    if (HasImplementProgressSignal(providerEventLogPath, providerSessionId, launchedAt)
+                        || DirectRunSessionBoundary.HasBackendExitEvent(providerEventLogPath, providerSessionId, launchedAt))
+                    {
+                        break;
+                    }
+
+                    await Task.Delay(ImplementProgressPollInterval).ConfigureAwait(false);
+                }
+
+                preservedStandardInput.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        });
+    }
+
+    private static bool HasImplementProgressSignal(
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        if (!File.Exists(providerEventLogPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            var currentProviderEvents = DirectRunSessionBoundary.SelectEvents(providerEvents, providerSessionId, launchedAt);
+            return DirectRunFixOutcomeSupport.HasBoundedProgressSignal(currentProviderEvents);
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or InvalidOperationException
+            or ArgumentException
+            or System.Text.Json.JsonException)
+        {
+            return false;
+        }
     }
 
     private static string? TryResolveScriptExecutable(DirectRunDetachedCaptureOptions options)

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -193,14 +193,16 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 launchedAt);
         }
 
-        if (string.Equals(entryKind, "fix", StringComparison.Ordinal)
+        if ((string.Equals(entryKind, "fix", StringComparison.Ordinal)
+                || string.Equals(entryKind, "implement", StringComparison.Ordinal))
             && processInvocation.StartedProcessCarriesProviderSession)
         {
-            WaitForFixProgressBoundary(
+            WaitForProgressBoundary(
                 absoluteProviderEventLogPath,
                 providerSessionId,
                 launchedAt,
-                process.ProcessId);
+                process.ProcessId,
+                entryKind);
         }
 
         if (process.ExitedEarly && process.ExitCode != 0)
@@ -419,7 +421,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             command,
             arguments);
 
-        if (string.Equals(entryKind, "fix", StringComparison.Ordinal))
+        if (string.Equals(entryKind, "fix", StringComparison.Ordinal)
+            || string.Equals(entryKind, "implement", StringComparison.Ordinal))
         {
             return new ResolvedProcessInvocation
             {
@@ -427,7 +430,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 Arguments = helperStartInfo.ArgumentList.ToArray(),
                 RequiresPersistentExitMonitor = false,
                 InheritStandardInput = false,
-                KeepStandardInputOpen = true,
+                KeepStandardInputOpen = string.Equals(entryKind, "fix", StringComparison.Ordinal)
+                    || string.Equals(entryKind, "implement", StringComparison.Ordinal),
                 UsesDetachedCaptureHelper = true,
                 StartedProcessCarriesProviderSession = true
             };
@@ -491,11 +495,12 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         return launcherStartInfo;
     }
 
-    private static void WaitForFixProgressBoundary(
+    private static void WaitForProgressBoundary(
         string providerEventLogPath,
         string providerSessionId,
         DateTimeOffset launchedAt,
-        int processId)
+        int processId,
+        string entryKind)
     {
         if (string.IsNullOrWhiteSpace(providerSessionId))
         {
@@ -505,7 +510,7 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         var deadline = DateTimeOffset.UtcNow + FixProgressObservationWindow;
         while (DateTimeOffset.UtcNow < deadline)
         {
-            if (HasFixProgressSignal(providerEventLogPath, providerSessionId, launchedAt)
+            if (HasProgressSignal(providerEventLogPath, providerSessionId, launchedAt, entryKind)
                 || DirectRunSessionBoundary.HasBackendExitEvent(providerEventLogPath, providerSessionId, launchedAt)
                 || !IsProcessAlive(processId))
             {
@@ -516,10 +521,11 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         }
     }
 
-    private static bool HasFixProgressSignal(
+    private static bool HasProgressSignal(
         string providerEventLogPath,
         string providerSessionId,
-        DateTimeOffset launchedAt)
+        DateTimeOffset launchedAt,
+        string entryKind)
     {
         if (!File.Exists(providerEventLogPath))
         {
@@ -530,7 +536,13 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         {
             var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
             var currentProviderEvents = DirectRunSessionBoundary.SelectEvents(providerEvents, providerSessionId, launchedAt);
-            return DirectRunFixOutcomeSupport.HasBoundedProgressSignal(currentProviderEvents);
+            if (string.Equals(entryKind, "fix", StringComparison.Ordinal)
+                || string.Equals(entryKind, "implement", StringComparison.Ordinal))
+            {
+                return DirectRunFixOutcomeSupport.HasBoundedProgressSignal(currentProviderEvents);
+            }
+
+            return false;
         }
         catch (Exception exception) when (
             exception is IOException

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -831,6 +831,170 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public async Task Launch_GivenWrappedCodexImplementProcess_PreservesStandardInputLongEnoughForStartupActivity()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14implement-stdin.provider.jsonl");
+        var worktreePath = tempDirectory.GetPath("repo");
+        Directory.CreateDirectory(worktreePath);
+        var codexPath = tempDirectory.CreateExecutableFile(
+            "repo/codex-experimental",
+            """
+            #!/bin/sh
+            printf '%s\n' 'OpenAI Codex v0.118.0 (research preview)'
+            printf '%s\n' '--------'
+            printf '%s\n' "workdir: $PWD"
+            printf '%s\n' 'user'
+            /usr/bin/python3 -c 'import os,select,sys; fd = sys.stdin.fileno(); os.isatty(fd) or (print("tty-missing", flush=True), sys.exit(1)); readable, _, _ = select.select([sys.stdin], [], [], 0.2); data = os.read(fd, 1) if readable else None; data != b"" or (print("stdin-eof", flush=True), sys.exit(1)); print("pwd && rg --files .", flush=True); print("git status --short", flush=True)'
+            sleep 1
+            """);
+        var launcher = new DirectRunLauncher();
+
+        var result = launcher.Launch(
+            "G14implement-stdin",
+            "implement",
+            ".intent-cli/runs/G14implement-stdin.request.json",
+            ".intent-cli/runs/G14implement-stdin.provider.jsonl",
+            "Codex",
+            "gpt-5.4-mini",
+            "responses",
+            codexPath,
+            ["exec", "test prompt"],
+            DateTimeOffset.Parse("2026-04-16T21:00:00Z"),
+            worktreePath,
+            tempDirectory.GetPath(".intent-cli/implement/G14implement-stdin.request.md"),
+            providerEventLogPath);
+
+        await TemporaryDirectory.WaitForConditionAsync(
+            () =>
+            {
+                if (!File.Exists(providerEventLogPath))
+                {
+                    return false;
+                }
+
+                var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                return events.Any(providerEvent =>
+                           providerEvent.Kind == "provider-event"
+                           && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                           && string.Equals(providerEvent.Payload.GetString(), "pwd && rg --files .", StringComparison.Ordinal)
+                           && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal))
+                       && events.Any(providerEvent =>
+                           providerEvent.Kind == "provider-event"
+                           && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                           && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                           && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                           && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+            },
+            TimeSpan.FromSeconds(8));
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.DoesNotContain(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+            && string.Equals(providerEvent.Payload.GetString(), "stdin-eof", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.DoesNotContain(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+            && string.Equals(providerEvent.Payload.GetString(), "tty-missing", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+            && string.Equals(providerEvent.Payload.GetString(), "pwd && rg --files .", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+            && string.Equals(providerEvent.Payload.GetString(), "git status --short", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Launch_GivenWrappedCodexImplementProcess_PreservesStandardInputThroughDelayedStartup()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14implement-delayed.provider.jsonl");
+        var worktreePath = tempDirectory.GetPath("repo");
+        Directory.CreateDirectory(worktreePath);
+        var codexPath = tempDirectory.CreateExecutableFile(
+            "repo/codex-experimental",
+            """
+            #!/bin/sh
+            sleep 2
+            /usr/bin/python3 -c 'import os,select,sys; fd = sys.stdin.fileno(); os.isatty(fd) or (print("tty-missing", flush=True), sys.exit(1)); readable, _, _ = select.select([sys.stdin], [], [], 0.2); data = os.read(fd, 1) if readable else None; data != b"" or (print("stdin-eof", flush=True), sys.exit(1)); print("delayed-startup-ok", flush=True)'
+            sleep 1
+            """);
+        var launcher = new DirectRunLauncher();
+
+        var result = launcher.Launch(
+            "G14implement-delayed",
+            "implement",
+            ".intent-cli/runs/G14implement-delayed.request.json",
+            ".intent-cli/runs/G14implement-delayed.provider.jsonl",
+            "Codex",
+            "gpt-5.4-mini",
+            "responses",
+            codexPath,
+            ["exec", "test prompt"],
+            DateTimeOffset.Parse("2026-04-17T02:10:00Z"),
+            worktreePath,
+            tempDirectory.GetPath(".intent-cli/implement/G14implement-delayed.request.md"),
+            providerEventLogPath);
+
+        await TemporaryDirectory.WaitForConditionAsync(
+            () =>
+            {
+                if (!File.Exists(providerEventLogPath))
+                {
+                    return false;
+                }
+
+                var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                return events.Any(providerEvent =>
+                           providerEvent.Kind == "provider-event"
+                           && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                           && string.Equals(providerEvent.Payload.GetString(), "delayed-startup-ok", StringComparison.Ordinal)
+                           && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal))
+                       && events.Any(providerEvent =>
+                           providerEvent.Kind == "provider-event"
+                           && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                           && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                           && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+                           && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+            },
+            TimeSpan.FromSeconds(10));
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.DoesNotContain(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+            && string.Equals(providerEvent.Payload.GetString(), "stdin-eof", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.DoesNotContain(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+            && string.Equals(providerEvent.Payload.GetString(), "tty-missing", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+            && string.Equals(providerEvent.Payload.GetString(), "delayed-startup-ok", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, result.ProviderSessionId, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task Launch_GivenWrappedCodexFixProcess_PreservesStandardInputLongEnoughForBoundedRepoActivity()
     {
         if (OperatingSystem.IsWindows())


### PR DESCRIPTION
## Summary
- keep implement direct runs on the helper-backed capture path instead of the extra detached launcher hop so the current session stays attached through startup
- hold helper stdin open for implement until bounded repo-inspection progress appears, instead of closing the preserved pipe during startup
- add launcher regressions for implement startup stdin preservation, delayed startup, and keep the existing detached-capture review/fix coverage green

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~DirectRunLauncherTests.Launch_GivenWrappedCodexImplementProcess_PreservesStandardInputLongEnoughForStartupActivity|FullyQualifiedName~DirectRunLauncherTests.Launch_GivenWrappedCodexImplementProcess_PreservesStandardInputThroughDelayedStartup|FullyQualifiedName~DirectRunLauncherTests.Launch_GivenWrappedCodexImplementProcess_DetachedCaptureProvidesTerminalToProvider|FullyQualifiedName~DirectRunLauncherTests.Launch_GivenWrappedCodexFixProcess_PreservesStandardInputLongEnoughForBoundedRepoActivity|FullyQualifiedName~DirectRunLauncherTests.Launch_GivenWrappedCodexProcess_DetachedCaptureClosesProviderStandardInput|FullyQualifiedName~DirectRunLauncherTests.Launch_GivenReviewOutputSchemaPlaceholder_ExpandsSchemaPath" --logger "console;verbosity=minimal"`
- `dotnet test IntentSystem.sln --logger "console;verbosity=minimal"`
- toy-calc dogfood on a disposable clone of `MyIntentHost/submodules/toy-calc-sample`
  - `queue transition TOY-CALC-V0-01 active`
  - `run implement TOY-CALC-V0-01`
  - observed current-session implement provider output advance past `session-metadata` into repo inspection (`rg --files` / file listing) instead of dying immediately with only startup metadata

Closes #272
