### PR TITLE
Fix rerun clarification rehydration for blocked post-fix progress

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -484,7 +484,7 @@ internal static class RunCommand
         ArgumentNullException.ThrowIfNull(blockedItem);
 
         decisionResult = null;
-        if (!TryResolvePostFixWorktreeProgressDecisionSession(context, blockedItem.ExecutionUnit, out var session))
+        if (!TryResolvePostFixWorktreeProgressDecisionSession(context, blockedItem, out var session))
         {
             return false;
         }
@@ -508,16 +508,16 @@ internal static class RunCommand
 
     private static bool TryResolvePostFixWorktreeProgressDecisionSession(
         CliContext context,
-        string executionUnit,
+        QueueItem blockedItem,
         out RunSupervisionSession session)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(blockedItem);
 
         session = null!;
         var sessionArtifactRef = RunSupervisionSessionArtifactPathResolver.Resolve(
             context.Config.Supervision.ArtifactRoot,
-            executionUnit);
+            blockedItem.ExecutionUnit);
         var sessionArtifactPath = Path.GetFullPath(Path.Combine(
             context.RepoRoot,
             sessionArtifactRef.Replace('/', Path.DirectorySeparatorChar)));
@@ -527,9 +527,29 @@ internal static class RunCommand
         }
 
         session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(sessionArtifactPath));
-        return session.WorkerEntry == RunSupervisionWorkerEntry.Fix
-            && session.Status == RunSupervisionSessionStatus.Blocked
-            && session.RequiresPostFixWorktreeProgressDecision;
+        if (session.WorkerEntry != RunSupervisionWorkerEntry.Fix
+            || session.Status != RunSupervisionSessionStatus.Blocked)
+        {
+            return false;
+        }
+
+        if (session.RequiresPostFixWorktreeProgressDecision)
+        {
+            return true;
+        }
+
+        if (!TryUpgradeLegacyPostFixWorktreeProgressDecisionSession(
+                context,
+                blockedItem,
+                sessionArtifactPath,
+                session,
+                out var upgradedSession))
+        {
+            return false;
+        }
+
+        session = upgradedSession;
+        return true;
     }
 
     private static string CreatePostFixWorktreeProgressClarificationDetail(
@@ -546,6 +566,80 @@ internal static class RunCommand
                $"To continue automatically on the next root run, set [run] " +
                $"{CliRuntimeContracts.PostFixWorktreeProgressPolicyKey} = " +
                $"\"{CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy}\" and rerun.";
+    }
+
+    private static bool TryUpgradeLegacyPostFixWorktreeProgressDecisionSession(
+        CliContext context,
+        QueueItem blockedItem,
+        string sessionArtifactPath,
+        RunSupervisionSession session,
+        out RunSupervisionSession upgradedSession)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(blockedItem);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionArtifactPath);
+        ArgumentNullException.ThrowIfNull(session);
+
+        upgradedSession = null!;
+        if (!blockedItem.BlockedBy.Any(reason =>
+                reason.Contains("meaningful execution-unit worktree changes", StringComparison.Ordinal)))
+        {
+            return false;
+        }
+
+        var worktreePath = string.IsNullOrWhiteSpace(session.WorktreePath)
+            ? RunStartCommand.ResolveWorktreePath(context, blockedItem.ExecutionUnit)
+            : session.WorktreePath;
+        if (!Directory.Exists(worktreePath))
+        {
+            return false;
+        }
+
+        if (!RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths(
+                GitCommandRunnerFactory(),
+                worktreePath,
+                out var changedPaths))
+        {
+            return false;
+        }
+
+        var interruptionReason = ResolveLegacyPostFixWorktreeProgressReason(blockedItem, changedPaths);
+        upgradedSession = session with
+        {
+            QueueState = "blocked",
+            WorktreePath = worktreePath,
+            LastInterruptionReason = interruptionReason,
+            RequiresPostFixWorktreeProgressDecision = true,
+            UpdatedAt = TimestampFactory()
+        };
+
+        File.WriteAllText(
+            sessionArtifactPath,
+            RunSupervisionSessionArtifactJson.Serialize(upgradedSession));
+        return true;
+    }
+
+    private static string ResolveLegacyPostFixWorktreeProgressReason(
+        QueueItem blockedItem,
+        IReadOnlyList<string> changedPaths)
+    {
+        ArgumentNullException.ThrowIfNull(blockedItem);
+        ArgumentNullException.ThrowIfNull(changedPaths);
+
+        var blockedReason = blockedItem.BlockedBy.FirstOrDefault(reason =>
+            reason.Contains("meaningful execution-unit worktree changes", StringComparison.Ordinal));
+        if (string.IsNullOrWhiteSpace(blockedReason))
+        {
+            return $"Meaningful fix progress exists in the execution-unit worktree for '{blockedItem.ExecutionUnit}'. " +
+                   $"Changed paths: {RunWorktreeProgressSupport.SummarizePaths(changedPaths)}.";
+        }
+
+        if (blockedReason.Contains("Changed paths:", StringComparison.Ordinal))
+        {
+            return blockedReason;
+        }
+
+        return $"{blockedReason.TrimEnd()} Changed paths: {RunWorktreeProgressSupport.SummarizePaths(changedPaths)}.";
     }
 
     private static void ExecuteAutoContinuePostFixWorktreeProgress(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -4576,6 +4576,77 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenLegacyBlockedFixSessionWithMeaningfulWorktreeProgress_RehydratesClarificationRequired()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(
+                CreateQueueState(
+                    CreateQueueItem(QueueItemState.Blocked) with
+                    {
+                        BlockedBy =
+                        [
+                            "Worker session 'pid:76095' for 'G226' exited with backend exit code 1 after bounded fix progress and left meaningful execution-unit worktree changes. Changed paths: src/ToyCalc/Calculator.cs, src/ToyCalc/CommandLine.cs, tests/ToyCalc.Tests/CalculatorTests.cs."
+                        ]
+                    })));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Blocked,
+                QueueState = "blocked",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 3,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:20:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T12:20:00Z"),
+                LastInterruptionReason = "backend exit code 1"
+            }));
+        var originalGitCommandRunnerFactory = RunCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M src/ToyCalc/Calculator.cs
+                 M src/ToyCalc/CommandLine.cs
+                 M tests/ToyCalc.Tests/CalculatorTests.cs
+                """);
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("clarification-required", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("meaningful execution-unit worktree changes", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("src/ToyCalc/Calculator.cs", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("post_fix_worktree_progress_policy", result.Detail, StringComparison.Ordinal);
+            Assert.Empty(result.Actions);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
+            Assert.True(session.RequiresPostFixWorktreeProgressDecision);
+            Assert.Contains("meaningful execution-unit worktree changes", session.LastInterruptionReason, StringComparison.Ordinal);
+            Assert.Contains("src/ToyCalc/Calculator.cs", session.LastInterruptionReason, StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenMultipleInProgressItems_StopsWithParallelWorkDetected()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- rehydrate legacy blocked fix sessions into the accepted post-fix worktree clarification boundary on rerun
- normalize the saved supervision session when blocked salvage markers and meaningful worktree changes still exist
- add regression coverage for the rerun clarification path while preserving generic blocked behavior

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests.ExecuteCore_GivenLegacyBlockedFixSessionWithMeaningfulWorktreeProgress_RehydratesClarificationRequired|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenBlockedItem_StopsWithParentIntentUpdateRequired|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWithMeaningfulWorktreeDiff_StopsWithClarificationRequired|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWhenWorktreeDiffIsRuntimeOnly_BlocksWithoutClarificationBoundary" --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~RunCommandTests --nologo

Closes #306