### PR TITLE
Enforce fix retry budget and surface retry failure summary

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -394,6 +394,11 @@ internal static class RunCommand
                         continue;
                     }
 
+                    if (TryResolveBlockedFixRetryExhaustionResult(context, actions, blockedItem, out var blockedFixResult))
+                    {
+                        return blockedFixResult;
+                    }
+
                     return CreateStopResult(
                         ParentIntentUpdateRequiredStopReason,
                         actions,
@@ -503,6 +508,45 @@ internal static class RunCommand
         }
 
         ExecuteAutoContinuePostFixWorktreeProgress(context, actions, blockedItem, session);
+        return true;
+    }
+
+    private static bool TryResolveBlockedFixRetryExhaustionResult(
+        CliContext context,
+        IReadOnlyList<RunCommandAction> actions,
+        QueueItem blockedItem,
+        out RunCommandResult result)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(actions);
+        ArgumentNullException.ThrowIfNull(blockedItem);
+
+        result = null!;
+        var sessionArtifactRef = RunSupervisionSessionArtifactPathResolver.Resolve(
+            context.Config.Supervision.ArtifactRoot,
+            blockedItem.ExecutionUnit);
+        var sessionArtifactPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            sessionArtifactRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(sessionArtifactPath))
+        {
+            return false;
+        }
+
+        var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(sessionArtifactPath));
+        if (session.WorkerEntry != RunSupervisionWorkerEntry.Fix
+            || session.Status != RunSupervisionSessionStatus.Blocked
+            || session.RetryCount < session.RetryBudget
+            || string.IsNullOrWhiteSpace(session.LastInterruptionReason))
+        {
+            return false;
+        }
+
+        result = CreateStopResult(
+            NonRetryableFailureStopReason,
+            actions,
+            blockedItem.ExecutionUnit,
+            session.LastInterruptionReason);
         return true;
     }
 

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -1165,10 +1165,15 @@ internal static class RunSuperviseCommand
             : session.RetryCount;
         failedAttemptCount = Math.Max(failedAttemptCount, 1);
 
-        var sessionIds = ResolveRecentFixFailureSessionIds(context, executionUnit, failedAttemptCount);
+        var sessionIds = ResolveRecentFixFailureSessionIds(
+            context,
+            executionUnit,
+            session.CreatedAt,
+            failedAttemptCount);
         var failureReasons = ResolveRecentFixFailureReasons(
             context.GetRunLogPath(),
             executionUnit,
+            session.CreatedAt,
             failedAttemptCount,
             latestFailureReason);
         var latestOutput = TryResolveRepresentativeLatestFixOutput(context, executionUnit);
@@ -1199,6 +1204,7 @@ internal static class RunSuperviseCommand
     private static IReadOnlyList<string> ResolveRecentFixFailureSessionIds(
         CliContext context,
         string executionUnit,
+        DateTimeOffset sessionCreatedAt,
         int failedAttemptCount)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -1216,6 +1222,7 @@ internal static class RunSuperviseCommand
             if (!string.Equals(providerEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
                 || !string.Equals(providerEvent.EntryKind, "fix", StringComparison.Ordinal)
                 || string.IsNullOrWhiteSpace(providerEvent.SessionId)
+                || !IsProviderEventOnOrAfterSessionStart(providerEvent, sessionCreatedAt)
                 || orderedSessionIds.Contains(providerEvent.SessionId, StringComparer.Ordinal))
             {
                 continue;
@@ -1235,6 +1242,7 @@ internal static class RunSuperviseCommand
     private static IReadOnlyList<string> ResolveRecentFixFailureReasons(
         string runLogPath,
         string executionUnit,
+        DateTimeOffset sessionCreatedAt,
         int failedAttemptCount,
         string latestFailureReason)
     {
@@ -1249,6 +1257,7 @@ internal static class RunSuperviseCommand
                 .Where(runEvent =>
                     string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
                     && string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal)
+                    && runEvent.Ts >= sessionCreatedAt
                     && !string.IsNullOrWhiteSpace(runEvent.Reason))
                 .Select(runEvent => runEvent.Reason!)
                 .ToList();
@@ -1359,6 +1368,20 @@ internal static class RunSuperviseCommand
         return normalized.Length <= 240
             ? normalized
             : normalized[..237] + "...";
+    }
+
+    private static bool IsProviderEventOnOrAfterSessionStart(
+        DirectRunProviderEvent providerEvent,
+        DateTimeOffset sessionCreatedAt)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvent);
+
+        return DateTimeOffset.TryParse(
+                   providerEvent.Timestamp,
+                   System.Globalization.CultureInfo.InvariantCulture,
+                   System.Globalization.DateTimeStyles.RoundtripKind,
+                   out var providerEventTimestamp)
+               && providerEventTimestamp >= sessionCreatedAt;
     }
 
     private static void PersistQueueState(CliContext context, QueueState queueState)

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -187,7 +187,7 @@ internal static class RunSuperviseCommand
                     requiresPostFixWorktreeProgressDecision: deadWorkerFailure.RequiresPostFixWorktreeProgressDecision);
             }
 
-            if (session.RetryCount >= session.RetryBudget)
+            if (ShouldExhaustRetryBudgetAfterCurrentFailure(session))
             {
                 return ExhaustRetryBudget(
                     context,
@@ -246,7 +246,7 @@ internal static class RunSuperviseCommand
 
         if (now - session.LastHeartbeatAt > heartbeatTimeout)
         {
-            if (session.RetryCount >= session.RetryBudget)
+            if (ShouldExhaustRetryBudgetAfterCurrentFailure(session))
             {
                 return ExhaustRetryBudget(
                     context,
@@ -450,6 +450,14 @@ internal static class RunSuperviseCommand
         DateTimeOffset now,
         string reason)
     {
+        var consumeCurrentFailureIntoRetryBudget = session.RetryCount < session.RetryBudget;
+        var terminalReason = CreateRetryExhaustionSummary(
+            context,
+            executionUnit,
+            session,
+            reason,
+            consumeCurrentFailureIntoRetryBudget);
+
         return BlockForTerminalFailure(
             context,
             queueState,
@@ -459,8 +467,11 @@ internal static class RunSuperviseCommand
             runLogPath,
             session,
             now,
-            reason,
-            incrementRetryCount: false);
+            terminalReason,
+            incrementRetryCount: consumeCurrentFailureIntoRetryBudget,
+            emitRetryExhaustedEvent: true,
+            emitRetryAttemptedEvent: consumeCurrentFailureIntoRetryBudget,
+            retryAttemptReason: reason);
     }
 
     private static RunSuperviseResult BlockForTerminalFailure(
@@ -475,6 +486,8 @@ internal static class RunSuperviseCommand
         string reason,
         bool incrementRetryCount,
         bool emitRetryExhaustedEvent = true,
+        bool emitRetryAttemptedEvent = false,
+        string? retryAttemptReason = null,
         bool reportAsNonRetryableFailure = false,
         bool requiresPostFixWorktreeProgressDecision = false)
     {
@@ -499,6 +512,20 @@ internal static class RunSuperviseCommand
         PersistQueueState(context, transition.UpdatedState);
         PersistSession(sessionArtifactPath, blockedSession);
         List<RunEvent> runEvents = [];
+        if (emitRetryAttemptedEvent)
+        {
+            runEvents.Add(new RunEvent
+            {
+                Ts = now,
+                ExecutionUnit = executionUnit,
+                Event = "retry-attempted",
+                By = TransitionActor,
+                LinkedPr = session.LinkedPr,
+                CommentRef = session.CommentRef,
+                Reason = retryAttemptReason ?? reason
+            });
+        }
+
         if (emitRetryExhaustedEvent)
         {
             runEvents.Add(new RunEvent
@@ -1101,6 +1128,237 @@ internal static class RunSuperviseCommand
             && providerEvent.Payload.ValueKind == JsonValueKind.Object
             && providerEvent.Payload.TryGetProperty("type", out var typeElement)
             && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal);
+    }
+
+    private static bool ShouldExhaustRetryBudgetAfterCurrentFailure(RunSupervisionSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        if (session.RetryBudget <= 0)
+        {
+            return true;
+        }
+
+        return session.RetryCount >= session.RetryBudget
+            || session.RetryCount + 1 >= session.RetryBudget;
+    }
+
+    private static string CreateRetryExhaustionSummary(
+        CliContext context,
+        string executionUnit,
+        RunSupervisionSession session,
+        string latestFailureReason,
+        bool consumeCurrentFailureIntoRetryBudget)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentException.ThrowIfNullOrWhiteSpace(latestFailureReason);
+
+        if (session.WorkerEntry != RunSupervisionWorkerEntry.Fix)
+        {
+            return latestFailureReason;
+        }
+
+        var failedAttemptCount = consumeCurrentFailureIntoRetryBudget && session.RetryCount < session.RetryBudget
+            ? session.RetryCount + 1
+            : session.RetryCount;
+        failedAttemptCount = Math.Max(failedAttemptCount, 1);
+
+        var sessionIds = ResolveRecentFixFailureSessionIds(context, executionUnit, failedAttemptCount);
+        var failureReasons = ResolveRecentFixFailureReasons(
+            context.GetRunLogPath(),
+            executionUnit,
+            failedAttemptCount,
+            latestFailureReason);
+        var latestOutput = TryResolveRepresentativeLatestFixOutput(context, executionUnit);
+
+        var segments = new List<string>
+        {
+            $"Fix retry budget exhausted for '{executionUnit}' after {failedAttemptCount} failed attempts."
+        };
+
+        if (sessionIds.Count > 0)
+        {
+            segments.Add($"Affected sessions: {string.Join(", ", sessionIds)}.");
+        }
+
+        if (failureReasons.Count > 0)
+        {
+            segments.Add($"Failure reasons: {string.Join(" | ", failureReasons)}.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(latestOutput))
+        {
+            segments.Add($"Representative latest output: {latestOutput}.");
+        }
+
+        return string.Join(" ", segments);
+    }
+
+    private static IReadOnlyList<string> ResolveRecentFixFailureSessionIds(
+        CliContext context,
+        string executionUnit,
+        int failedAttemptCount)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var providerLogPath = ResolveDirectRunProviderLogPath(context, executionUnit);
+        if (!File.Exists(providerLogPath))
+        {
+            return [];
+        }
+
+        var orderedSessionIds = new List<string>();
+        foreach (var providerEvent in DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerLogPath)))
+        {
+            if (!string.Equals(providerEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                || !string.Equals(providerEvent.EntryKind, "fix", StringComparison.Ordinal)
+                || string.IsNullOrWhiteSpace(providerEvent.SessionId)
+                || orderedSessionIds.Contains(providerEvent.SessionId, StringComparer.Ordinal))
+            {
+                continue;
+            }
+
+            orderedSessionIds.Add(providerEvent.SessionId);
+        }
+
+        if (orderedSessionIds.Count <= failedAttemptCount)
+        {
+            return orderedSessionIds;
+        }
+
+        return orderedSessionIds[^failedAttemptCount..];
+    }
+
+    private static IReadOnlyList<string> ResolveRecentFixFailureReasons(
+        string runLogPath,
+        string executionUnit,
+        int failedAttemptCount,
+        string latestFailureReason)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runLogPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(latestFailureReason);
+
+        var reasons = new List<string>();
+        if (File.Exists(runLogPath))
+        {
+            var historicalReasons = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath))
+                .Where(runEvent =>
+                    string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                    && string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal)
+                    && !string.IsNullOrWhiteSpace(runEvent.Reason))
+                .Select(runEvent => runEvent.Reason!)
+                .ToList();
+
+            var priorReasonCount = Math.Max(failedAttemptCount - 1, 0);
+            if (historicalReasons.Count > priorReasonCount)
+            {
+                historicalReasons = historicalReasons[^priorReasonCount..];
+            }
+
+            reasons.AddRange(historicalReasons);
+        }
+
+        reasons.Add(latestFailureReason);
+        return reasons;
+    }
+
+    private static string? TryResolveRepresentativeLatestFixOutput(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var requestArtifactPath = ResolveDirectRunRequestArtifactPath(context, executionUnit);
+        var providerLogPath = ResolveDirectRunProviderLogPath(context, executionUnit);
+        if (!File.Exists(requestArtifactPath) || !File.Exists(providerLogPath))
+        {
+            return null;
+        }
+
+        var requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+        if (!string.Equals(requestArtifact.EntryKind, "fix", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var currentSessionEvents = SelectCurrentSessionEvents(
+            DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerLogPath)),
+            requestArtifact.ProviderSessionId,
+            requestArtifact.LaunchedAt);
+
+        if (DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
+                currentSessionEvents,
+                executionUnit,
+                out var startupOnlyDetail))
+        {
+            return startupOnlyDetail;
+        }
+
+        for (var index = currentSessionEvents.Count - 1; index >= 0; index--)
+        {
+            var providerEvent = currentSessionEvents[index];
+            if (providerEvent.Kind == "session-metadata" || HasBackendExitType(providerEvent))
+            {
+                continue;
+            }
+
+            var summary = SummarizeProviderPayload(providerEvent.Payload);
+            if (!string.IsNullOrWhiteSpace(summary))
+            {
+                return summary;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? SummarizeProviderPayload(JsonElement payload)
+    {
+        return payload.ValueKind switch
+        {
+            JsonValueKind.String => NormalizeSummaryText(payload.GetString()),
+            JsonValueKind.Object => NormalizeSummaryText(ResolveObjectPayloadSummary(payload)),
+            _ => null
+        };
+    }
+
+    private static string? ResolveObjectPayloadSummary(JsonElement payload)
+    {
+        if (payload.TryGetProperty("detail", out var detailElement)
+            && detailElement.ValueKind == JsonValueKind.String)
+        {
+            return detailElement.GetString();
+        }
+
+        if (payload.TryGetProperty("reason", out var reasonElement)
+            && reasonElement.ValueKind == JsonValueKind.String)
+        {
+            return reasonElement.GetString();
+        }
+
+        if (payload.TryGetProperty("message", out var messageElement)
+            && messageElement.ValueKind == JsonValueKind.String)
+        {
+            return messageElement.GetString();
+        }
+
+        return payload.GetRawText();
+    }
+
+    private static string? NormalizeSummaryText(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var normalized = value.Trim();
+        return normalized.Length <= 240
+            ? normalized
+            : normalized[..237] + "...";
     }
 
     private static void PersistQueueState(CliContext context, QueueState queueState)

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -3494,12 +3494,16 @@ public sealed class RunCommandTests
 
         var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-        Assert.Equal("parent-intent-update-required", result.StopReason);
+        Assert.Equal("non-retryable-failure", result.StopReason);
         Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Contains("Fix retry budget exhausted", result.Detail, StringComparison.Ordinal);
+        Assert.Contains("after 3 failed attempts", result.Detail, StringComparison.Ordinal);
+        Assert.Contains("pid:999999", result.Detail, StringComparison.Ordinal);
 
         var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
         var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
         Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+        Assert.Contains("Fix retry budget exhausted", selectedItem.BlockedBy[0], StringComparison.Ordinal);
         Assert.Contains("backend exit code 1", selectedItem.BlockedBy[0], StringComparison.Ordinal);
         Assert.DoesNotContain("no terminal provider event was captured", selectedItem.BlockedBy[0], StringComparison.Ordinal);
 
@@ -4331,13 +4335,16 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("parent-intent-update-required", result.StopReason);
+            Assert.Equal("non-retryable-failure", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("Fix retry budget exhausted", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("after 3 failed attempts", result.Detail, StringComparison.Ordinal);
             Assert.DoesNotContain("meaningful execution-unit worktree changes", result.Detail, StringComparison.Ordinal);
 
             var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
             var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
             Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("Fix retry budget exhausted", selectedItem.BlockedBy[0], StringComparison.Ordinal);
             Assert.Contains("backend exit code 1", selectedItem.BlockedBy[0], StringComparison.Ordinal);
             Assert.DoesNotContain("meaningful execution-unit worktree changes", selectedItem.BlockedBy[0], StringComparison.Ordinal);
 
@@ -4478,12 +4485,15 @@ public sealed class RunCommandTests
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
             await appendTask;
 
-            Assert.Equal("parent-intent-update-required", result.StopReason);
+            Assert.Equal("non-retryable-failure", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("Fix retry budget exhausted", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("after 3 failed attempts", result.Detail, StringComparison.Ordinal);
 
             var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
             var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
             Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("Fix retry budget exhausted", selectedItem.BlockedBy[0], StringComparison.Ordinal);
             Assert.Contains("backend exit code 1", selectedItem.BlockedBy[0], StringComparison.Ordinal);
             Assert.DoesNotContain("no terminal provider event was captured", selectedItem.BlockedBy[0], StringComparison.Ordinal);
 

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -1243,6 +1243,104 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenDeadFixWorkerSessionOneFailureBeforeRetryBudget_BlocksWithoutLaunchingAnotherWorker()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateFixingRunLog() + string.Join(
+                Environment.NewLine,
+                [
+                    """{"ts":"2026-04-08T10:25:00Z","execution_unit":"G25","event":"retry-attempted","by":"intent-cli","reason":"Worker session 'pid:82625' for 'G25' exited with backend exit code 1."}""",
+                    """{"ts":"2026-04-08T10:25:00Z","execution_unit":"G25","event":"auto-resumed","by":"intent-cli","reason":"run fix"}""",
+                    """{"ts":"2026-04-08T10:27:00Z","execution_unit":"G25","event":"retry-attempted","by":"intent-cli","reason":"Worker session 'pid:83683' for 'G25' exited with backend exit code 1."}""",
+                    """{"ts":"2026-04-08T10:27:00Z","execution_unit":"G25","event":"auto-resumed","by":"intent-cli","reason":"run fix"}"""
+                ]) + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G25.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession(workerEntry: RunSupervisionWorkerEntry.Fix) with
+            {
+                RetryCount = 2,
+                RetryBudget = 3
+            }));
+        WriteDeadFixDirectRunArtifacts(repoRoot, "pid:84643");
+        File.WriteAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                new[]
+                {
+                    CreateProviderEvent("2026-04-08T10:24:00.0000000+00:00", "G25", "fix", "pid:82625", "session-metadata", new { model = "sonnet", transport = "sdk", command = "claude" }),
+                    CreateProviderEvent("2026-04-08T10:24:01.0000000+00:00", "G25", "fix", "pid:82625", "provider-event", new { type = "backend-exit", exit_code = 1 }),
+                    CreateProviderEvent("2026-04-08T10:26:00.0000000+00:00", "G25", "fix", "pid:83683", "session-metadata", new { model = "sonnet", transport = "sdk", command = "claude" }),
+                    CreateProviderEvent("2026-04-08T10:26:01.0000000+00:00", "G25", "fix", "pid:83683", "provider-event", new { type = "backend-exit", exit_code = 1 }),
+                    CreateProviderEvent("2026-04-08T10:28:00.0000000+00:00", "G25", "fix", "pid:84643", "session-metadata", new { model = "sonnet", transport = "sdk", command = "claude" }),
+                    CreateProviderEvent("2026-04-08T10:28:00.5000000+00:00", "G25", "fix", "pid:84643", "provider-event", "checked current review comment context before fix planning"),
+                    CreateProviderEvent("2026-04-08T10:28:00.7500000+00:00", "G25", "fix", "pid:84643", "provider-event", "warn plugin manifest falling_back after state db discrepancy on slow path"),
+                    CreateProviderEvent("2026-04-08T10:28:01.0000000+00:00", "G25", "fix", "pid:84643", "provider-event", new { type = "backend-exit", exit_code = 1 })
+                }
+                .Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalRunFixExecutor = RunSuperviseCommand.RunFixExecutor;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+            RunSuperviseCommand.RunFixExecutor = (_, _) =>
+                throw new InvalidOperationException("unexpected extra fix worker launch");
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("Fix retry budget exhausted", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("after 3 failed attempts", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("pid:82625", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("pid:83683", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("pid:84643", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("Representative latest output", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("warn plugin manifest", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(3, session.RetryCount);
+            Assert.Contains("Fix retry budget exhausted", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("retry-attempted", runEvents[^3].Event);
+            Assert.Equal("retry-exhausted", runEvents[^2].Event);
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("pid:84643", runEvents[^2].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "auto-resumed", StringComparison.Ordinal)
+                && runEvent.Ts == DateTimeOffset.Parse("2026-04-08T10:30:00Z"));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.RunFixExecutor = originalRunFixExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenDeadFixWorkerSessionWithMeaningfulWorktreeDiff_BlocksAsNonRetryableFailure()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -1547,6 +1645,26 @@ public sealed class RunSuperviseCommandTests
         {"ts":"2026-04-08T10:10:00Z","execution_unit":"G25","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/180"}
         {"ts":"2026-04-08T10:15:00Z","execution_unit":"G25","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1","reason":"contract mismatch"}
         """ + Environment.NewLine;
+    }
+
+    private static DirectRunProviderEvent CreateProviderEvent(
+        string timestamp,
+        string executionUnit,
+        string entryKind,
+        string sessionId,
+        string kind,
+        object payload)
+    {
+        return new DirectRunProviderEvent
+        {
+            Timestamp = timestamp,
+            ExecutionUnit = executionUnit,
+            Provider = "Claude",
+            EntryKind = entryKind,
+            SessionId = sessionId,
+            Kind = kind,
+            Payload = JsonSerializer.SerializeToElement(payload)
+        };
     }
 
     private static void WriteDeadFixDirectRunArtifacts(string repoRoot, string sessionId)

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -1341,6 +1341,103 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenRetryExhaustionWithOlderFixLoopHistory_ExcludesStaleSessionsFromSummary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateFixingRunLog() + string.Join(
+                Environment.NewLine,
+                [
+                    """{"ts":"2026-04-08T10:24:00Z","execution_unit":"G25","event":"retry-attempted","by":"intent-cli","reason":"Worker session 'pid:82625' for 'G25' exited with backend exit code 1."}""",
+                    """{"ts":"2026-04-08T10:24:00Z","execution_unit":"G25","event":"auto-resumed","by":"intent-cli","reason":"run fix"}""",
+                    """{"ts":"2026-04-08T10:25:00Z","execution_unit":"G25","event":"retry-attempted","by":"intent-cli","reason":"Worker session 'pid:83683' for 'G25' exited with backend exit code 1."}""",
+                    """{"ts":"2026-04-08T10:25:00Z","execution_unit":"G25","event":"auto-resumed","by":"intent-cli","reason":"run fix"}""",
+                    """{"ts":"2026-04-08T10:28:00Z","execution_unit":"G25","event":"retry-attempted","by":"intent-cli","reason":"Worker session 'pid:90001' for 'G25' exited with backend exit code 1."}""",
+                    """{"ts":"2026-04-08T10:28:00Z","execution_unit":"G25","event":"auto-resumed","by":"intent-cli","reason":"run fix"}""",
+                    """{"ts":"2026-04-08T10:29:00Z","execution_unit":"G25","event":"retry-attempted","by":"intent-cli","reason":"Worker session 'pid:90002' for 'G25' exited with backend exit code 1."}""",
+                    """{"ts":"2026-04-08T10:29:00Z","execution_unit":"G25","event":"auto-resumed","by":"intent-cli","reason":"run fix"}"""
+                ]) + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G25.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession(workerEntry: RunSupervisionWorkerEntry.Fix) with
+            {
+                RetryCount = 2,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-08T10:27:30Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-08T10:29:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-08T10:29:00Z")
+            }));
+        WriteDeadFixDirectRunArtifacts(repoRoot, "pid:90003");
+        File.WriteAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                new[]
+                {
+                    CreateProviderEvent("2026-04-08T10:24:00.0000000+00:00", "G25", "fix", "pid:82625", "session-metadata", new { model = "sonnet", transport = "sdk", command = "claude" }),
+                    CreateProviderEvent("2026-04-08T10:24:01.0000000+00:00", "G25", "fix", "pid:82625", "provider-event", new { type = "backend-exit", exit_code = 1 }),
+                    CreateProviderEvent("2026-04-08T10:25:00.0000000+00:00", "G25", "fix", "pid:83683", "session-metadata", new { model = "sonnet", transport = "sdk", command = "claude" }),
+                    CreateProviderEvent("2026-04-08T10:25:01.0000000+00:00", "G25", "fix", "pid:83683", "provider-event", new { type = "backend-exit", exit_code = 1 }),
+                    CreateProviderEvent("2026-04-08T10:28:00.0000000+00:00", "G25", "fix", "pid:90001", "session-metadata", new { model = "sonnet", transport = "sdk", command = "claude" }),
+                    CreateProviderEvent("2026-04-08T10:28:01.0000000+00:00", "G25", "fix", "pid:90001", "provider-event", new { type = "backend-exit", exit_code = 1 }),
+                    CreateProviderEvent("2026-04-08T10:29:00.0000000+00:00", "G25", "fix", "pid:90002", "session-metadata", new { model = "sonnet", transport = "sdk", command = "claude" }),
+                    CreateProviderEvent("2026-04-08T10:29:01.0000000+00:00", "G25", "fix", "pid:90002", "provider-event", new { type = "backend-exit", exit_code = 1 }),
+                    CreateProviderEvent("2026-04-08T10:30:00.0000000+00:00", "G25", "fix", "pid:90003", "session-metadata", new { model = "sonnet", transport = "sdk", command = "claude" }),
+                    CreateProviderEvent("2026-04-08T10:30:00.5000000+00:00", "G25", "fix", "pid:90003", "provider-event", "checked current review comment context before fix planning"),
+                    CreateProviderEvent("2026-04-08T10:30:00.7500000+00:00", "G25", "fix", "pid:90003", "provider-event", "warn plugin manifest falling_back after state db discrepancy on slow path"),
+                    CreateProviderEvent("2026-04-08T10:30:01.0000000+00:00", "G25", "fix", "pid:90003", "provider-event", new { type = "backend-exit", exit_code = 1 })
+                }
+                .Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalRunFixExecutor = RunSuperviseCommand.RunFixExecutor;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:31:00Z");
+            RunSuperviseCommand.RunFixExecutor = (_, _) =>
+                throw new InvalidOperationException("unexpected extra fix worker launch");
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Contains("pid:90001", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("pid:90002", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("pid:90003", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("pid:82625", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("pid:83683", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("10:24", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("10:25", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("Worker session 'pid:90001'", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("Worker session 'pid:90002'", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("Worker session 'pid:90003'", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("Worker session 'pid:82625'", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("Worker session 'pid:83683'", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.RunFixExecutor = originalRunFixExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenDeadFixWorkerSessionWithMeaningfulWorktreeDiff_BlocksAsNonRetryableFailure()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- stop fix supervision at the retry-budget boundary before launching one more auto-resume worker
- persist a readable retry-exhaustion summary with attempt count, failed session ids, failure reasons, and representative latest output
- surface blocked fix retry exhaustion from the root run command as a non-retryable failure instead of generic parent planning
- add focused regression coverage for the retry-budget boundary and root-run summary path

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunSuperviseCommandTests.Execute_GivenDeadFixWorkerSessionOneFailureBeforeRetryBudget_BlocksWithoutLaunchingAnotherWorker|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWithoutCapturedTerminalEvent_BlocksUsingSyntheticBackendExitReason|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWhenWorktreeDiffIsRuntimeOnly_BlocksWithoutClarificationBoundary|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenDeadFixWorkerSessionAtRetryExhaustionWhenBackendExitLandsAfterObservedDelay_BlocksUsingBackendExitReason" --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~RunCommandTests --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~RunSuperviseCommandTests --nologo
- dotnet test IntentSystem.sln --nologo

## Notes
- I did not rerun the external toy-calc dogfooding flow from MyIntentHost in this PR environment.

Closes #308