### PR TITLE
[G110] Preserve Detached Fix Planning Parity After Initial Inventory

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
@@ -13,9 +13,8 @@ internal static class DirectRunDetachedCaptureCommand
     private static readonly TimeSpan ExitPollInterval = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan OutputDrainGracePeriod = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan ExitCodeResolutionGracePeriod = TimeSpan.FromSeconds(3);
-    private static readonly TimeSpan ImplementProgressObservationWindow = TimeSpan.FromSeconds(20);
-    private static readonly TimeSpan ImplementProgressPollInterval = TimeSpan.FromMilliseconds(100);
-    private static readonly TimeSpan FixStandardInputGracePeriod = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan StandardInputProgressObservationWindow = TimeSpan.FromSeconds(20);
+    private static readonly TimeSpan StandardInputProgressPollInterval = TimeSpan.FromMilliseconds(100);
 
     public static bool TryExecute(string[] args, out int exitCode)
     {
@@ -178,9 +177,11 @@ internal static class DirectRunDetachedCaptureCommand
                 }
                 else
                 {
-                    SchedulePreservedStandardInputClosure(
+                    ScheduleFixStandardInputClosure(
                         preservedStandardInput,
-                        FixStandardInputGracePeriod);
+                        options.ProviderEventLogPath,
+                        providerSessionId,
+                        options.LaunchedAt);
                 }
             }
 
@@ -572,28 +573,6 @@ internal static class DirectRunDetachedCaptureCommand
         return string.Equals(executableName, "script", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static void SchedulePreservedStandardInputClosure(
-        StreamWriter preservedStandardInput,
-        TimeSpan gracePeriod)
-    {
-        ArgumentNullException.ThrowIfNull(preservedStandardInput);
-
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                await Task.Delay(gracePeriod).ConfigureAwait(false);
-                preservedStandardInput.Dispose();
-            }
-            catch (ObjectDisposedException)
-            {
-            }
-            catch (InvalidOperationException)
-            {
-            }
-        });
-    }
-
     private static void ScheduleImplementStandardInputClosure(
         StreamWriter preservedStandardInput,
         string providerEventLogPath,
@@ -606,7 +585,7 @@ internal static class DirectRunDetachedCaptureCommand
 
         _ = Task.Run(async () =>
         {
-            var deadline = DateTimeOffset.UtcNow + ImplementProgressObservationWindow;
+            var deadline = DateTimeOffset.UtcNow + StandardInputProgressObservationWindow;
             try
             {
                 while (DateTimeOffset.UtcNow < deadline)
@@ -617,7 +596,44 @@ internal static class DirectRunDetachedCaptureCommand
                         break;
                     }
 
-                    await Task.Delay(ImplementProgressPollInterval).ConfigureAwait(false);
+                    await Task.Delay(StandardInputProgressPollInterval).ConfigureAwait(false);
+                }
+
+                preservedStandardInput.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        });
+    }
+
+    private static void ScheduleFixStandardInputClosure(
+        StreamWriter preservedStandardInput,
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        ArgumentNullException.ThrowIfNull(preservedStandardInput);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerEventLogPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+
+        _ = Task.Run(async () =>
+        {
+            var deadline = DateTimeOffset.UtcNow + StandardInputProgressObservationWindow;
+            try
+            {
+                while (DateTimeOffset.UtcNow < deadline)
+                {
+                    if (HasFixPlanningProgressSignal(providerEventLogPath, providerSessionId, launchedAt)
+                        || DirectRunSessionBoundary.HasBackendExitEvent(providerEventLogPath, providerSessionId, launchedAt))
+                    {
+                        break;
+                    }
+
+                    await Task.Delay(StandardInputProgressPollInterval).ConfigureAwait(false);
                 }
 
                 preservedStandardInput.Dispose();
@@ -646,6 +662,32 @@ internal static class DirectRunDetachedCaptureCommand
             var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
             var currentProviderEvents = DirectRunSessionBoundary.SelectEvents(providerEvents, providerSessionId, launchedAt);
             return DirectRunFixOutcomeSupport.HasBoundedProgressSignal(currentProviderEvents);
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or InvalidOperationException
+            or ArgumentException
+            or System.Text.Json.JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool HasFixPlanningProgressSignal(
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        if (!File.Exists(providerEventLogPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            var currentProviderEvents = DirectRunSessionBoundary.SelectEvents(providerEvents, providerSessionId, launchedAt);
+            return DirectRunFixOutcomeSupport.HasPlanningProgressSignalBeyondInitialInventory(currentProviderEvents);
         }
         catch (Exception exception) when (
             exception is IOException

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -173,6 +173,15 @@ internal static class DirectRunFixOutcomeSupport
         return providerEvents.Any(providerEvent => ContainsBoundedFixProgressSignal(providerEvent.Payload));
     }
 
+    public static bool HasPlanningProgressSignalBeyondInitialInventory(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        return providerEvents.Any(providerEvent =>
+            !IsIgnorableStartupPreamble(providerEvent.Payload)
+            && ContainsPlanningFixProgressSignal(providerEvent.Payload));
+    }
+
     private static bool TryResolveInspectionOnlyFailureDetail(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string executionUnit,
@@ -381,6 +390,29 @@ internal static class DirectRunFixOutcomeSupport
                 || normalized.Contains("ls ", StringComparison.Ordinal)
                 || normalized.Contains("cat ", StringComparison.Ordinal)
                 || normalized.Contains("sed -n", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsPlanningFixProgressSignal(JsonElement payload)
+    {
+        foreach (var value in EnumeratePayloadStrings(payload))
+        {
+            var normalized = value.Trim().ToLowerInvariant();
+            if (normalized.Contains("apply_patch", StringComparison.Ordinal)
+                || normalized.Contains("dotnet test", StringComparison.Ordinal)
+                || normalized.Contains("git diff", StringComparison.Ordinal)
+                || normalized.Contains("git status", StringComparison.Ordinal)
+                || normalized.Contains("cat ", StringComparison.Ordinal)
+                || normalized.Contains("sed -n", StringComparison.Ordinal)
+                || normalized.Contains("head ", StringComparison.Ordinal)
+                || normalized.Contains("tail ", StringComparison.Ordinal)
+                || (normalized.Contains("rg ", StringComparison.Ordinal)
+                    && !normalized.Contains("rg --files", StringComparison.Ordinal)))
             {
                 return true;
             }

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -37,6 +37,37 @@ public sealed class DirectRunFixOutcomeSupportTests
         Assert.Contains("during provider startup", detail, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void HasPlanningProgressSignalBeyondInitialInventory_GivenOnlyRepoListing_ReturnsFalse()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("OpenAI Codex v0.118.0 (research preview)"),
+            CreateProviderEvent("Use the request artifact at '/tmp/TOY-CALC-V0-01.request.md' as the bounded source of truth for this direct run. Continue beyond initial repository inspection even if the request mentions rg --files, git diff, or dotnet test, and do not stop after a single inspection command without producing one of those outcomes."),
+            CreateProviderEvent("exec /bin/zsh -lc 'rg --files' succeeded in 0ms")
+        ];
+
+        var resolved = DirectRunFixOutcomeSupport.HasPlanningProgressSignalBeyondInitialInventory(providerEvents);
+
+        Assert.False(resolved);
+    }
+
+    [Fact]
+    public void HasPlanningProgressSignalBeyondInitialInventory_GivenRequestReadAfterRepoListing_ReturnsTrue()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("OpenAI Codex v0.118.0 (research preview)"),
+            CreateProviderEvent("Use the request artifact at '/tmp/TOY-CALC-V0-01.request.md' as the bounded source of truth for this direct run. Continue beyond initial repository inspection even if the request mentions rg --files, git diff, or dotnet test, and do not stop after a single inspection command without producing one of those outcomes."),
+            CreateProviderEvent("exec /bin/zsh -lc 'rg --files' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,160p'' .intent-cli/fix/TOY-CALC-V0-01.request.md' succeeded in 0ms")
+        ];
+
+        var resolved = DirectRunFixOutcomeSupport.HasPlanningProgressSignalBeyondInitialInventory(providerEvents);
+
+        Assert.True(resolved);
+    }
+
     private static IReadOnlyList<DirectRunProviderEvent> CreateIssue295CurrentSessionRawEvents(string? echoedRequest = null)
     {
         return

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -1057,6 +1057,151 @@ public sealed class RunFixCommandTests
     }
 
     [Fact]
+    public async Task Execute_GivenWrapperCodexFixCommand_KeepsStandardInputOpenUntilPostInventoryPlanningAppears()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        var providerBinaryPath = tempDirectory.CreateExecutableFile(
+            "bin/codex",
+            """
+            #!/bin/sh
+            printf '%s\n' 'OpenAI Codex v0.118.0 (research preview)'
+            printf '%s\n' '--------'
+            printf '%s\n' "workdir: $PWD"
+            printf '%s\n' 'user'
+            /usr/bin/python3 -c 'import os,select,sys,time; fd = sys.stdin.fileno(); os.isatty(fd) or (print("tty-missing", flush=True), sys.exit(1)); readable, _, _ = select.select([sys.stdin], [], [], 0.2); data = os.read(fd, 1) if readable else None; data != b"" or (print("stdin-eof", flush=True), sys.exit(1)); print("pwd && rg --files .", flush=True); time.sleep(1.4); readable, _, _ = select.select([sys.stdin], [], [], 0.2); data = os.read(fd, 1) if readable else None; data != b"" or (print("stdin-eof-after-inventory", flush=True), sys.exit(1)); print("sed -n 1,160p .intent-cli/fix/G20.request.md", flush=True); print("cat src/ToyCalc/Program.cs", flush=True)'
+            exit 0
+            """);
+        var wrapperPath = tempDirectory.CreateExecutableFile(
+            "bin/codex-isolated",
+            $$"""
+            #!/bin/zsh
+            export CODEX_HOME={{tempDirectory.GetPath(".codex-direct-backend")}}
+            exec {{providerBinaryPath}} "$@"
+            """);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunFixCommand.TimestampFactory;
+
+        try
+        {
+            RunFixCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-16T18:18:00Z");
+
+            var baseContext = CreateContext(repoRoot);
+            var context = baseContext with
+            {
+                Config = baseContext.Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Codex",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        Command = wrapperPath
+                    }
+                }
+            };
+
+            var exitCode = RunFixCommand.Execute(context, ["G20"], writer);
+
+            Assert.Equal(0, exitCode);
+
+            var resultArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.result.json");
+            var providerEventLogPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.provider.jsonl");
+            var initialArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+
+            await WaitForConditionAsync(
+                () =>
+                {
+                    if (!File.Exists(providerEventLogPath) || !File.Exists(resultArtifactPath))
+                    {
+                        return false;
+                    }
+
+                    var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                    var sawRequestRead = providerEvents.Any(providerEvent =>
+                        providerEvent.Kind == "provider-event"
+                        && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                        && string.Equals(
+                            providerEvent.Payload.GetString(),
+                            "sed -n 1,160p .intent-cli/fix/G20.request.md",
+                            StringComparison.Ordinal));
+                    if (!sawRequestRead)
+                    {
+                        return false;
+                    }
+
+                    var updatedArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+                    return string.Equals(updatedArtifact.SessionId, initialArtifact.SessionId, StringComparison.Ordinal)
+                        && !string.Equals(updatedArtifact.RunStatus, "failed", StringComparison.Ordinal);
+                },
+                TimeSpan.FromSeconds(10));
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            Assert.DoesNotContain(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && string.Equals(providerEvent.Payload.GetString(), "stdin-eof", StringComparison.Ordinal));
+            Assert.DoesNotContain(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && string.Equals(providerEvent.Payload.GetString(), "stdin-eof-after-inventory", StringComparison.Ordinal));
+            Assert.DoesNotContain(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && string.Equals(providerEvent.Payload.GetString(), "tty-missing", StringComparison.Ordinal));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && string.Equals(providerEvent.Payload.GetString(), "pwd && rg --files .", StringComparison.Ordinal));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && string.Equals(
+                    providerEvent.Payload.GetString(),
+                    "sed -n 1,160p .intent-cli/fix/G20.request.md",
+                    StringComparison.Ordinal));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && string.Equals(providerEvent.Payload.GetString(), "cat src/ToyCalc/Program.cs", StringComparison.Ordinal));
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+            Assert.Equal(initialArtifact.SessionId, resultArtifact.SessionId);
+            Assert.NotEqual("failed", resultArtifact.RunStatus);
+        }
+        finally
+        {
+            RunFixCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenMissingQueueItem_ReturnsExitCodeOne()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- keep detached `run fix` stdin open until post-inventory planning progress or backend exit instead of closing after a fixed 1 second
- detect request/spec/source/test-style planning signals separately from the initial `rg --files` inventory step
- add regression coverage for the post-inventory parity boundary in fix outcome and run-fix tests

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~DirectRunFixOutcomeSupportTests|FullyQualifiedName~Execute_GivenWrapperCodexFixCommand_KeepsStandardInputOpenUntilPostInventoryPlanningAppears" --nologo
- dotnet test IntentSystem.sln --nologo

Closes #310