### PR TITLE
Fix #312 detached fix spec/source/test read parity boundary

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -32,6 +32,8 @@ internal static class DirectRunCommandSupport
     private const string LifecycleEventName = "provider-lifecycle";
     private const string ReviewCompletionWaitWindowEnvVar = "INTENT_DIRECT_RUN_REVIEW_COMPLETION_WAIT_MS";
     private const string ReviewSessionMaxWaitWindowEnvVar = "INTENT_DIRECT_RUN_REVIEW_SESSION_MAX_WAIT_MS";
+    private static readonly TimeSpan FixBoundaryObservationWindow = TimeSpan.FromSeconds(8);
+    private static readonly TimeSpan FixBoundaryPostTerminationWaitWindow = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan DefaultReviewCompletionWaitWindow = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan DefaultReviewSessionMaxWaitWindow = TimeSpan.FromMinutes(10);
     private static readonly TimeSpan ReviewCompletionPollInterval = TimeSpan.FromMilliseconds(250);
@@ -126,6 +128,17 @@ internal static class DirectRunCommandSupport
                 launchResult.ProviderSessionId);
         }
 
+        if (ShouldAwaitFixBoundary(entryKind, launcher, policy.Command))
+        {
+            AwaitFixBoundary(
+                absoluteProviderEventLogPath,
+                executionUnit,
+                entryKindValue,
+                launchResult.Provider,
+                launchResult.ProviderSessionId,
+                launchedAt);
+        }
+
         var synthesis = SynthesizeAndPersistResult(
             context,
             executionUnit,
@@ -149,6 +162,18 @@ internal static class DirectRunCommandSupport
         ArgumentException.ThrowIfNullOrWhiteSpace(command);
 
         return entryKind == DirectRunEntryKind.Review
+            && launcher is DirectRunLauncher
+            && IsCodexLikeCommand(command);
+    }
+
+    private static bool ShouldAwaitFixBoundary(
+        DirectRunEntryKind entryKind,
+        IDirectRunLauncher launcher,
+        string command)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(command);
+
+        return entryKind == DirectRunEntryKind.Fix
             && launcher is DirectRunLauncher
             && IsCodexLikeCommand(command);
     }
@@ -252,6 +277,125 @@ internal static class DirectRunCommandSupport
             provider,
             providerSessionId,
             1));
+    }
+
+    private static void AwaitFixBoundary(
+        string providerEventLogPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        var deadline = DateTimeOffset.UtcNow + FixBoundaryObservationWindow;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (TryReadCurrentProviderEvents(
+                providerEventLogPath,
+                providerSessionId,
+                launchedAt,
+                out var currentProviderEvents)
+                && (DirectRunFixOutcomeSupport.HasSpecAndProductReadProgressSignal(currentProviderEvents)
+                    || DirectRunFixOutcomeSupport.TryResolveContractGapDetail(currentProviderEvents, executionUnit, out _)
+                    || TryResolveBackendExitCode(currentProviderEvents, out _)))
+            {
+                return;
+            }
+
+            if (!IsProviderSessionAlive(providerSessionId))
+            {
+                WaitForFixBoundaryAfterSessionTermination(
+                    providerEventLogPath,
+                    executionUnit,
+                    entryKind,
+                    provider,
+                    providerSessionId,
+                    launchedAt);
+                return;
+            }
+
+            Thread.Sleep(ReviewCompletionPollInterval);
+        }
+    }
+
+    private static void WaitForFixBoundaryAfterSessionTermination(
+        string providerEventLogPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        var deadline = DateTimeOffset.UtcNow + FixBoundaryPostTerminationWaitWindow;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (TryReadCurrentProviderEvents(
+                providerEventLogPath,
+                providerSessionId,
+                launchedAt,
+                out var currentProviderEvents)
+                && (DirectRunFixOutcomeSupport.HasSpecAndProductReadProgressSignal(currentProviderEvents)
+                    || DirectRunFixOutcomeSupport.TryResolveContractGapDetail(currentProviderEvents, executionUnit, out _)
+                    || TryResolveBackendExitCode(currentProviderEvents, out _)))
+            {
+                return;
+            }
+
+            Thread.Sleep(ReviewCompletionPollInterval);
+        }
+
+        ClassifyMissingFixBoundary(
+            providerEventLogPath,
+            executionUnit,
+            entryKind,
+            provider,
+            providerSessionId,
+            launchedAt);
+    }
+
+    private static void ClassifyMissingFixBoundary(
+        string providerEventLogPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        if (!TryReadCurrentProviderEvents(
+                providerEventLogPath,
+                providerSessionId,
+                launchedAt,
+                out var currentProviderEvents))
+        {
+            return;
+        }
+
+        var timestamp = DateTimeOffset.UtcNow;
+        var boundaryEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            currentProviderEvents,
+            timestamp,
+            executionUnit,
+            entryKind,
+            provider,
+            providerSessionId,
+            providerSessionAlive: false);
+        if (boundaryEvent is null)
+        {
+            return;
+        }
+
+        var writer = new DirectRunProviderEventWriter(providerEventLogPath);
+        writer.Append(boundaryEvent);
+        if (!DirectRunSessionBoundary.HasBackendExitEvent(providerEventLogPath, providerSessionId, launchedAt))
+        {
+            writer.Append(DirectRunProviderEventFactory.CreateBackendExitEvent(
+                timestamp,
+                executionUnit,
+                entryKind,
+                provider,
+                providerSessionId,
+                1));
+        }
     }
 
     private static void TryTerminateProviderSession(string providerSessionId)
@@ -697,13 +841,15 @@ internal static class DirectRunCommandSupport
         var model = ResolveModel(currentProviderEvents, launchResult.Model);
         var sessionId = ResolveSessionId(currentProviderEvents, launchResult.ProviderSessionId);
         var provider = ResolveProvider(currentProviderEvents, launchResult.Provider);
+        var providerSessionAlive = IsProviderSessionAlive(sessionId);
         var fixContractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
             currentProviderEvents,
             DateTimeOffset.UtcNow,
             executionUnit,
             entryKind,
             provider,
-            sessionId);
+            sessionId,
+            providerSessionAlive);
         if (fixContractGapEvent is not null)
         {
             var writer = new DirectRunProviderEventWriter(providerEventLogPath);

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -192,9 +192,7 @@ internal static class DirectRunFixOutcomeSupport
     {
         ArgumentNullException.ThrowIfNull(providerEvents);
 
-        var sawSpecRead = providerEvents.Any(providerEvent =>
-            !IsIgnorableStartupPreamble(providerEvent.Payload)
-            && ContainsRepoLocalSpecReadAttempt(providerEvent.Payload));
+        var sawSpecRead = HasSuccessfulRepoLocalSpecRead(providerEvents);
         var sawProductRead = providerEvents.Any(providerEvent =>
                 !IsIgnorableStartupPreamble(providerEvent.Payload)
                 && ContainsProductSourceOrTestReadAttempt(providerEvent.Payload));
@@ -241,7 +239,7 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         var observedInventory = providerEvents.Any(providerEvent => ContainsInitialRepoInventory(providerEvent.Payload));
-        var observedSpecRead = providerEvents.Any(providerEvent => ContainsRepoLocalSpecReadAttempt(providerEvent.Payload));
+        var observedSpecRead = HasSuccessfulRepoLocalSpecRead(providerEvents);
         var observedProductRead = providerEvents.Any(providerEvent => ContainsProductSourceOrTestReadAttempt(providerEvent.Payload));
         var failingBackendExitIndex = FindFailingBackendExitIndex(providerEvents);
         if (failingBackendExitIndex >= 0)
@@ -555,6 +553,26 @@ internal static class DirectRunFixOutcomeSupport
         return false;
     }
 
+    private static bool HasSuccessfulRepoLocalSpecRead(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        for (var index = 0; index < providerEvents.Count; index++)
+        {
+            if (IsIgnorableStartupPreamble(providerEvents[index].Payload)
+                || !ContainsRepoLocalSpecReadAttempt(providerEvents[index].Payload))
+            {
+                continue;
+            }
+
+            if (TryResolveCommandOutcome(providerEvents, index, out var succeeded)
+                && succeeded)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static bool ContainsProductSourceOrTestReadAttempt(JsonElement payload)
     {
         foreach (var value in EnumeratePayloadStrings(payload))
@@ -581,6 +599,40 @@ internal static class DirectRunFixOutcomeSupport
             || normalized.Contains("sed -n", StringComparison.Ordinal)
             || normalized.Contains("head ", StringComparison.Ordinal)
             || normalized.Contains("tail ", StringComparison.Ordinal);
+    }
+
+    private static bool TryResolveCommandOutcome(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        int commandIndex,
+        out bool succeeded)
+    {
+        succeeded = false;
+
+        for (var index = commandIndex + 1; index < providerEvents.Count; index++)
+        {
+            foreach (var value in EnumeratePayloadStrings(providerEvents[index].Payload))
+            {
+                var normalized = value.Trim().ToLowerInvariant();
+                if (normalized == "exec")
+                {
+                    return false;
+                }
+
+                if (normalized.StartsWith("succeeded in ", StringComparison.Ordinal))
+                {
+                    succeeded = true;
+                    return true;
+                }
+
+                if (normalized.StartsWith("failed in ", StringComparison.Ordinal))
+                {
+                    succeeded = false;
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private static IEnumerable<string> EnumeratePayloadStrings(JsonElement payload)

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -6,6 +6,8 @@ internal static class DirectRunFixOutcomeSupport
 {
     private const string DeterministicContractGapStopReason = "deterministic-contract-gap";
     private const string InspectionOnlyExitReason = "fix-session-ended-after-initial-inspection";
+    private const string ProviderBackendEndedBeforeSpecSourceReadReason = "fix-session-ended-before-spec-source-test-read";
+    private const string MissingTerminalCaptureAfterRequestReadReason = "fix-session-terminal-boundary-missing-after-request-reread";
     private static readonly string[] StartupWarningMarkers =
     [
         "warn",
@@ -50,7 +52,8 @@ internal static class DirectRunFixOutcomeSupport
         string executionUnit,
         string entryKind,
         string provider,
-        string providerSessionId)
+        string providerSessionId,
+        bool providerSessionAlive = true)
     {
         ArgumentNullException.ThrowIfNull(providerEvents);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
@@ -60,7 +63,12 @@ internal static class DirectRunFixOutcomeSupport
 
         if (!string.Equals(entryKind, "fix", StringComparison.Ordinal)
             || HasExplicitContractGap(providerEvents)
-            || !TryResolveInspectionOnlyFailureDetail(providerEvents, executionUnit, out var detail))
+            || !TryResolveCanonicalFailureDetail(
+                providerEvents,
+                executionUnit,
+                providerSessionAlive,
+                out var reason,
+                out var detail))
         {
             return null;
         }
@@ -77,7 +85,7 @@ internal static class DirectRunFixOutcomeSupport
             {
                 type = "contract-gap",
                 stop_reason = DeterministicContractGapStopReason,
-                reason = InspectionOnlyExitReason,
+                reason,
                 detail,
                 run_status = "failed"
             })
@@ -177,9 +185,82 @@ internal static class DirectRunFixOutcomeSupport
     {
         ArgumentNullException.ThrowIfNull(providerEvents);
 
-        return providerEvents.Any(providerEvent =>
+        return HasSpecAndProductReadProgressSignal(providerEvents);
+    }
+
+    internal static bool HasSpecAndProductReadProgressSignal(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        var sawSpecRead = providerEvents.Any(providerEvent =>
             !IsIgnorableStartupPreamble(providerEvent.Payload)
-            && ContainsPlanningFixProgressSignal(providerEvent.Payload));
+            && ContainsRepoLocalSpecReadAttempt(providerEvent.Payload));
+        var sawProductRead = providerEvents.Any(providerEvent =>
+                !IsIgnorableStartupPreamble(providerEvent.Payload)
+                && ContainsProductSourceOrTestReadAttempt(providerEvent.Payload));
+
+        return sawSpecRead && sawProductRead;
+    }
+
+    private static bool TryResolveCanonicalFailureDetail(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        bool providerSessionAlive,
+        out string reason,
+        out string detail)
+    {
+        if (TryResolvePostRequestParityBoundaryDetail(
+                providerEvents,
+                executionUnit,
+                providerSessionAlive,
+                out reason,
+                out detail))
+        {
+            return true;
+        }
+
+        reason = InspectionOnlyExitReason;
+        return TryResolveInspectionOnlyFailureDetail(providerEvents, executionUnit, out detail);
+    }
+
+    private static bool TryResolvePostRequestParityBoundaryDetail(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        bool providerSessionAlive,
+        out string reason,
+        out string detail)
+    {
+        detail = string.Empty;
+        reason = string.Empty;
+
+        var observedRequestReread = providerEvents.Any(providerEvent => ContainsRequestArtifactRead(providerEvent.Payload));
+        if (!observedRequestReread
+            || HasSpecAndProductReadProgressSignal(providerEvents))
+        {
+            return false;
+        }
+
+        var observedInventory = providerEvents.Any(providerEvent => ContainsInitialRepoInventory(providerEvent.Payload));
+        var observedSpecRead = providerEvents.Any(providerEvent => ContainsRepoLocalSpecReadAttempt(providerEvent.Payload));
+        var observedProductRead = providerEvents.Any(providerEvent => ContainsProductSourceOrTestReadAttempt(providerEvent.Payload));
+        var failingBackendExitIndex = FindFailingBackendExitIndex(providerEvents);
+        if (failingBackendExitIndex >= 0)
+        {
+            reason = ProviderBackendEndedBeforeSpecSourceReadReason;
+            detail =
+                $"Fix direct run for '{executionUnit}' stopped before repo-local spec/source/test planning reads. Current-session evidence observed request_reread={observedRequestReread}, repo_inventory={observedInventory}, repo_local_spec_read={observedSpecRead}, product_source_or_test_read={observedProductRead}. A failing backend-exit was captured before any repo-local spec or product source/test read, which indicates the provider backend itself exited before the next bounded read.";
+            return true;
+        }
+
+        if (providerSessionAlive)
+        {
+            return false;
+        }
+
+        reason = MissingTerminalCaptureAfterRequestReadReason;
+        detail =
+            $"Fix direct run for '{executionUnit}' stopped before repo-local spec/source/test planning reads. Current-session evidence observed request_reread={observedRequestReread}, repo_inventory={observedInventory}, repo_local_spec_read={observedSpecRead}, product_source_or_test_read={observedProductRead}. The provider session is no longer alive, but no backend-exit or later bounded-read event was captured for the current session. This indicates the detached helper/current-session synthesis event capture dropped after the request reread layer rather than a completed repair attempt.";
+        return true;
     }
 
     private static bool TryResolveInspectionOnlyFailureDetail(
@@ -419,6 +500,87 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         return false;
+    }
+
+    private static bool ContainsRequestArtifactRead(JsonElement payload)
+    {
+        foreach (var value in EnumeratePayloadStrings(payload))
+        {
+            var normalized = value.Trim().ToLowerInvariant();
+            if (!ContainsReadCommand(normalized))
+            {
+                continue;
+            }
+
+            if (normalized.Contains(".intent-cli/fix/", StringComparison.Ordinal)
+                || normalized.Contains(".request.md", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsInitialRepoInventory(JsonElement payload)
+    {
+        foreach (var value in EnumeratePayloadStrings(payload))
+        {
+            if (value.Trim().ToLowerInvariant().Contains("rg --files", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsRepoLocalSpecReadAttempt(JsonElement payload)
+    {
+        foreach (var value in EnumeratePayloadStrings(payload))
+        {
+            var normalized = value.Trim().ToLowerInvariant();
+            if (!ContainsReadCommand(normalized))
+            {
+                continue;
+            }
+
+            if (normalized.Contains("/specs/", StringComparison.Ordinal)
+                || normalized.Contains("01-cli-surface.md", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsProductSourceOrTestReadAttempt(JsonElement payload)
+    {
+        foreach (var value in EnumeratePayloadStrings(payload))
+        {
+            var normalized = value.Trim().ToLowerInvariant();
+            if (!ContainsReadCommand(normalized))
+            {
+                continue;
+            }
+
+            if (normalized.Contains("src/", StringComparison.Ordinal)
+                || normalized.Contains("tests/", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsReadCommand(string normalized)
+    {
+        return normalized.Contains("cat ", StringComparison.Ordinal)
+            || normalized.Contains("sed -n", StringComparison.Ordinal)
+            || normalized.Contains("head ", StringComparison.Ordinal)
+            || normalized.Contains("tail ", StringComparison.Ordinal);
     }
 
     private static IEnumerable<string> EnumeratePayloadStrings(JsonElement payload)

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -53,7 +53,7 @@ public sealed class DirectRunFixOutcomeSupportTests
     }
 
     [Fact]
-    public void HasPlanningProgressSignalBeyondInitialInventory_GivenRequestReadAfterRepoListing_ReturnsTrue()
+    public void HasPlanningProgressSignalBeyondInitialInventory_GivenRequestReadAfterRepoListing_ReturnsFalse()
     {
         IReadOnlyList<DirectRunProviderEvent> providerEvents =
         [
@@ -65,7 +65,95 @@ public sealed class DirectRunFixOutcomeSupportTests
 
         var resolved = DirectRunFixOutcomeSupport.HasPlanningProgressSignalBeyondInitialInventory(providerEvents);
 
+        Assert.False(resolved);
+    }
+
+    [Fact]
+    public void HasPlanningProgressSignalBeyondInitialInventory_GivenOnlyRepoLocalSpecRead_ReturnsFalse()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("OpenAI Codex v0.118.0 (research preview)"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,160p'' .intent-cli/fix/TOY-CALC-V0-01.request.md' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' intents/toy-calc/specs/01-cli-surface.md' failed in 0ms")
+        ];
+
+        var resolved = DirectRunFixOutcomeSupport.HasPlanningProgressSignalBeyondInitialInventory(providerEvents);
+
+        Assert.False(resolved);
+    }
+
+    [Fact]
+    public void HasPlanningProgressSignalBeyondInitialInventory_GivenSpecAndProductRead_ReturnsTrue()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("OpenAI Codex v0.118.0 (research preview)"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,160p'' .intent-cli/fix/TOY-CALC-V0-01.request.md' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' intents/toy-calc/specs/01-cli-surface.md' failed in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Program.cs' succeeded in 0ms")
+        ];
+
+        var resolved = DirectRunFixOutcomeSupport.HasPlanningProgressSignalBeyondInitialInventory(providerEvents);
+
         Assert.True(resolved);
+    }
+
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenRequestRereadThenBackendExit_UsesPreSpecSourceBoundaryReason()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-01.request.md' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("2026-04-17T05:58:46.453938Z  WARN codex_core::plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported"),
+            CreateBackendExitEvent()
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-17T06:00:00Z"),
+            "TOY-CALC-V0-01",
+            "fix",
+            "Codex",
+            "pid:2579");
+
+        Assert.NotNull(contractGapEvent);
+        Assert.Equal("provider-event", contractGapEvent!.Kind);
+        Assert.Equal("fix-session-ended-before-spec-source-test-read", contractGapEvent.Payload.GetProperty("reason").GetString());
+        Assert.Contains(
+            "provider backend itself exited before the next bounded read",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenRequestRereadAndDeadSessionWithoutTerminalEvent_UsesMissingCaptureReason()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-01.request.md' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("2026-04-17T05:58:46.453938Z  WARN codex_core::plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported")
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-17T06:00:00Z"),
+            "TOY-CALC-V0-01",
+            "fix",
+            "Codex",
+            "pid:2579",
+            providerSessionAlive: false);
+
+        Assert.NotNull(contractGapEvent);
+        Assert.Equal("fix-session-terminal-boundary-missing-after-request-reread", contractGapEvent!.Payload.GetProperty("reason").GetString());
+        Assert.Contains(
+            "event capture dropped after the request reread layer",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.Ordinal);
     }
 
     private static IReadOnlyList<DirectRunProviderEvent> CreateIssue295CurrentSessionRawEvents(string? echoedRequest = null)
@@ -133,6 +221,24 @@ public sealed class DirectRunFixOutcomeSupportTests
             SessionId = "pid:97771",
             Kind = "provider-event",
             Payload = JsonSerializer.SerializeToElement(payload)
+        };
+    }
+
+    private static DirectRunProviderEvent CreateBackendExitEvent()
+    {
+        return new DirectRunProviderEvent
+        {
+            Timestamp = "2026-04-17T05:58:47.0000000+00:00",
+            ExecutionUnit = "TOY-CALC-V0-01",
+            Provider = "Codex",
+            EntryKind = "fix",
+            SessionId = "pid:97771",
+            Kind = "provider-event",
+            Payload = JsonSerializer.SerializeToElement(new
+            {
+                type = "backend-exit",
+                exit_code = 1
+            })
         };
     }
 }

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -92,13 +92,73 @@ public sealed class DirectRunFixOutcomeSupportTests
             CreateProviderEvent("OpenAI Codex v0.118.0 (research preview)"),
             CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,160p'' .intent-cli/fix/TOY-CALC-V0-01.request.md' succeeded in 0ms"),
             CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
-            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' intents/toy-calc/specs/01-cli-surface.md' failed in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' intents/toy-calc/specs/01-cli-surface.md'"),
+            CreateProviderEvent(" succeeded in 0ms:"),
             CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Program.cs' succeeded in 0ms")
         ];
 
         var resolved = DirectRunFixOutcomeSupport.HasPlanningProgressSignalBeyondInitialInventory(providerEvents);
 
         Assert.True(resolved);
+    }
+
+    [Fact]
+    public void HasPlanningProgressSignalBeyondInitialInventory_GivenFailedSpecReadThenProductReads_ReturnsFalse()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("OpenAI Codex v0.118.0 (research preview)"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,160p'' .intent-cli/fix/TOY-CALC-V0-01.request.md' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' intents/toy-calc/specs/01-cli-surface.md'"),
+            CreateProviderEvent(" failed in 0ms:"),
+            CreateProviderEvent("sed: intents/toy-calc/specs/01-cli-surface.md: No such file or directory"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Program.cs && printf ''\\n---\\n'' && sed -n ''1,220p'' src/ToyCalc/Calculator.cs'"),
+            CreateProviderEvent(" succeeded in 0ms:"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' tests/ToyCalc.Tests/CalculatorTests.cs'"),
+            CreateProviderEvent(" succeeded in 0ms:")
+        ];
+
+        var resolved = DirectRunFixOutcomeSupport.HasPlanningProgressSignalBeyondInitialInventory(providerEvents);
+
+        Assert.False(resolved);
+    }
+
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenFailedSpecReadThenProductReads_ReportsSpecBoundaryMissing()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-01.request.md' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' intents/toy-calc/specs/01-cli-surface.md'"),
+            CreateProviderEvent(" failed in 0ms:"),
+            CreateProviderEvent("sed: intents/toy-calc/specs/01-cli-surface.md: No such file or directory"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Program.cs && printf ''\\n---\\n'' && sed -n ''1,220p'' src/ToyCalc/Calculator.cs'"),
+            CreateProviderEvent(" succeeded in 0ms:"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' tests/ToyCalc.Tests/CalculatorTests.cs'"),
+            CreateProviderEvent(" succeeded in 0ms:"),
+            CreateBackendExitEvent()
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-17T06:00:00Z"),
+            "TOY-CALC-V0-01",
+            "fix",
+            "Codex",
+            "pid:2579");
+
+        Assert.NotNull(contractGapEvent);
+        Assert.Equal("fix-session-ended-before-spec-source-test-read", contractGapEvent!.Payload.GetProperty("reason").GetString());
+        Assert.Contains(
+            "repo_local_spec_read=False",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            "product_source_or_test_read=True",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- make detached fix progress gating wait for the accepted parity layer: repo-local spec plus product source/test reads
- keep fix runs from collapsing into a request-reread-only or spec-only boundary
- classify post-request detached failures with stronger deterministic contract-gap detail when the session dies before the required read layer is completed

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter DirectRunFixOutcomeSupportTests --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "RunFixCommandTests.Execute_GivenInspectionOnlyBackendExitFailure_AppendsDeterministicContractGapEvent|RunFixCommandTests.Execute_GivenFollowUpWorkAfterInitialInspection_DoesNotAppendInspectionOnlyContractGapEvent" --nologo
- dotnet test IntentSystem.sln --nologo
  - all displayed suites passed; the final CLI suite testhost stayed running, so I stopped the session after collecting the focused coverage above

## Actual Toy Calc Repro
- reran `run fix TOY-CALC-V0-01` against the toy-calc dogfooding repo using the current branch build
- detached current-session raw log reached `intents/toy-calc/specs/01-cli-surface.md`
- detached current-session raw log also reached product reads:
  - `src/ToyCalc/Program.cs`
  - `src/ToyCalc/Calculator.cs`
  - `src/ToyCalc/CommandLine.cs`
  - `tests/ToyCalc.Tests/CalculatorTests.cs`
- restored the external toy-calc runtime artifacts after the repro

Closes #312