### PR TITLE
Fix #314 finalize detached fix terminal outcome after deep progress

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -146,6 +146,14 @@ internal static class DirectRunCommandSupport
             upstreamRequestRef,
             launchedAt,
             launchResult);
+        StartDeferredFixExitMonitorIfNeeded(
+            absoluteProviderEventLogPath,
+            executionUnit,
+            entryKindValue,
+            launchResult.Provider,
+            launchResult.ProviderSessionId,
+            launchedAt,
+            synthesis.RunStatus);
 
         return launchResult with
         {
@@ -288,6 +296,7 @@ internal static class DirectRunCommandSupport
         DateTimeOffset launchedAt)
     {
         var deadline = DateTimeOffset.UtcNow + FixBoundaryObservationWindow;
+        DateTimeOffset? deepProgressDeadline = null;
         while (DateTimeOffset.UtcNow < deadline)
         {
             if (TryReadCurrentProviderEvents(
@@ -295,11 +304,24 @@ internal static class DirectRunCommandSupport
                 providerSessionId,
                 launchedAt,
                 out var currentProviderEvents)
-                && (DirectRunFixOutcomeSupport.HasSpecAndProductReadProgressSignal(currentProviderEvents)
-                    || DirectRunFixOutcomeSupport.TryResolveContractGapDetail(currentProviderEvents, executionUnit, out _)
+                && (DirectRunFixOutcomeSupport.HasExplicitContractGapSignal(currentProviderEvents)
                     || TryResolveBackendExitCode(currentProviderEvents, out _)))
             {
                 return;
+            }
+
+            if (TryReadCurrentProviderEvents(
+                    providerEventLogPath,
+                    providerSessionId,
+                    launchedAt,
+                    out currentProviderEvents)
+                && DirectRunFixOutcomeSupport.HasDeepExecutionProgressSignal(currentProviderEvents))
+            {
+                deepProgressDeadline ??= DateTimeOffset.UtcNow + FixBoundaryPostTerminationWaitWindow;
+                if (deepProgressDeadline.Value > deadline)
+                {
+                    deadline = deepProgressDeadline.Value;
+                }
             }
 
             if (!IsProviderSessionAlive(providerSessionId))
@@ -334,8 +356,7 @@ internal static class DirectRunCommandSupport
                 providerSessionId,
                 launchedAt,
                 out var currentProviderEvents)
-                && (DirectRunFixOutcomeSupport.HasSpecAndProductReadProgressSignal(currentProviderEvents)
-                    || DirectRunFixOutcomeSupport.TryResolveContractGapDetail(currentProviderEvents, executionUnit, out _)
+                && (DirectRunFixOutcomeSupport.HasExplicitContractGapSignal(currentProviderEvents)
                     || TryResolveBackendExitCode(currentProviderEvents, out _)))
             {
                 return;
@@ -439,6 +460,64 @@ internal static class DirectRunCommandSupport
             System.Globalization.NumberStyles.Integer,
             System.Globalization.CultureInfo.InvariantCulture,
             out processId);
+    }
+
+    private static void StartDeferredFixExitMonitorIfNeeded(
+        string providerEventLogPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        DateTimeOffset launchedAt,
+        string runStatus)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerEventLogPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(runStatus);
+
+        if (OperatingSystem.IsWindows()
+            || !string.Equals(entryKind, "fix", StringComparison.Ordinal)
+            || !string.Equals(runStatus, "running", StringComparison.Ordinal)
+            || !TryParseSessionProcessId(providerSessionId, out var processId))
+        {
+            return;
+        }
+
+        var monitorStartInfo = DirectRunExitMonitorCommand.CreateDetachedStartInfo(
+            processId,
+            providerEventLogPath,
+            executionUnit,
+            entryKind,
+            provider,
+            providerSessionId,
+            launchedAt);
+        var launcherStartInfo = new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false
+        };
+        launcherStartInfo.ArgumentList.Add("-c");
+        launcherStartInfo.ArgumentList.Add(
+            """
+            if command -v nohup >/dev/null 2>&1; then
+                nohup "$@" >/dev/null 2>&1 </dev/null &
+            else
+                "$@" >/dev/null 2>&1 </dev/null &
+            fi
+            """);
+        launcherStartInfo.ArgumentList.Add("direct-run-exit-monitor-launcher");
+        launcherStartInfo.ArgumentList.Add(monitorStartInfo.FileName);
+        foreach (var argument in monitorStartInfo.ArgumentList)
+        {
+            launcherStartInfo.ArgumentList.Add(argument);
+        }
+
+        using var launcher = Process.Start(launcherStartInfo);
     }
 
     private static bool WaitForReviewOutcomeAfterSessionTermination(

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -502,30 +502,32 @@ internal static class DirectRunCommandSupport
             provider,
             providerSessionId,
             launchedAt);
-        var launcherStartInfo = new ProcessStartInfo
+        StartDeferredFixExitMonitor(monitorStartInfo);
+    }
+
+    private static void StartDeferredFixExitMonitor(ProcessStartInfo monitorStartInfo)
+    {
+        ArgumentNullException.ThrowIfNull(monitorStartInfo);
+
+        var monitor = Process.Start(monitorStartInfo);
+        if (monitor is null)
         {
-            FileName = "/bin/sh",
-            UseShellExecute = false,
-            RedirectStandardOutput = false,
-            RedirectStandardError = false
-        };
-        launcherStartInfo.ArgumentList.Add("-c");
-        launcherStartInfo.ArgumentList.Add(
-            """
-            if command -v nohup >/dev/null 2>&1; then
-                nohup "$@" >/dev/null 2>&1 </dev/null &
-            else
-                "$@" >/dev/null 2>&1 </dev/null &
-            fi
-            """);
-        launcherStartInfo.ArgumentList.Add("direct-run-exit-monitor-launcher");
-        launcherStartInfo.ArgumentList.Add(monitorStartInfo.FileName);
-        foreach (var argument in monitorStartInfo.ArgumentList)
-        {
-            launcherStartInfo.ArgumentList.Add(argument);
+            return;
         }
 
-        using var launcher = Process.Start(launcherStartInfo);
+        using (monitor)
+        {
+            try
+            {
+                monitor.StandardInput.Close();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            monitor.StandardOutput.Dispose();
+            monitor.StandardError.Dispose();
+        }
     }
 
     private static bool WaitForReviewOutcomeAfterSessionTermination(

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -146,7 +146,7 @@ internal static class DirectRunCommandSupport
             upstreamRequestRef,
             launchedAt,
             launchResult);
-        StartDeferredFixExitMonitorIfNeeded(
+        var effectiveRunStatus = DirectRunTerminalArtifactUpdater.FinalizeDeadFixSessionIfCurrent(
             absoluteProviderEventLogPath,
             executionUnit,
             entryKindValue,
@@ -154,11 +154,19 @@ internal static class DirectRunCommandSupport
             launchResult.ProviderSessionId,
             launchedAt,
             synthesis.RunStatus);
+        StartDeferredFixExitMonitorIfNeeded(
+            absoluteProviderEventLogPath,
+            executionUnit,
+            entryKindValue,
+            launchResult.Provider,
+            launchResult.ProviderSessionId,
+            launchedAt,
+            effectiveRunStatus);
 
         return launchResult with
         {
             ResultArtifactPath = synthesis.ResultArtifactPath,
-            RunStatus = synthesis.RunStatus
+            RunStatus = effectiveRunStatus
         };
     }
 

--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -146,12 +146,16 @@ internal static class DirectRunCommandSupport
             upstreamRequestRef,
             launchedAt,
             launchResult);
+        var effectiveProviderSessionId = DirectRunTerminalArtifactUpdater.SynchronizeArtifactsToLatestSessionIfCurrent(
+            absoluteProviderEventLogPath,
+            launchResult.ProviderSessionId,
+            launchedAt);
         var effectiveRunStatus = DirectRunTerminalArtifactUpdater.FinalizeDeadFixSessionIfCurrent(
             absoluteProviderEventLogPath,
             executionUnit,
             entryKindValue,
             launchResult.Provider,
-            launchResult.ProviderSessionId,
+            effectiveProviderSessionId,
             launchedAt,
             synthesis.RunStatus);
         StartDeferredFixExitMonitorIfNeeded(
@@ -159,13 +163,14 @@ internal static class DirectRunCommandSupport
             executionUnit,
             entryKindValue,
             launchResult.Provider,
-            launchResult.ProviderSessionId,
+            effectiveProviderSessionId,
             launchedAt,
             effectiveRunStatus);
 
         return launchResult with
         {
             ResultArtifactPath = synthesis.ResultArtifactPath,
+            ProviderSessionId = effectiveProviderSessionId,
             RunStatus = effectiveRunStatus
         };
     }

--- a/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunDetachedCaptureCommand.cs
@@ -286,31 +286,32 @@ internal static class DirectRunDetachedCaptureCommand
             provider,
             providerSessionId,
             launchedAt);
+        StartDetachedExitMonitorProcess(monitorStartInfo);
+    }
 
-        var launcherStartInfo = new ProcessStartInfo
+    private static void StartDetachedExitMonitorProcess(ProcessStartInfo monitorStartInfo)
+    {
+        ArgumentNullException.ThrowIfNull(monitorStartInfo);
+
+        var monitor = Process.Start(monitorStartInfo);
+        if (monitor is null)
         {
-            FileName = "/bin/sh",
-            UseShellExecute = false,
-            RedirectStandardOutput = false,
-            RedirectStandardError = false
-        };
-        launcherStartInfo.ArgumentList.Add("-c");
-        launcherStartInfo.ArgumentList.Add(
-            """
-            if command -v nohup >/dev/null 2>&1; then
-                nohup "$@" >/dev/null 2>&1 </dev/null &
-            else
-                "$@" >/dev/null 2>&1 </dev/null &
-            fi
-            """);
-        launcherStartInfo.ArgumentList.Add("direct-run-exit-monitor-launcher");
-        launcherStartInfo.ArgumentList.Add(monitorStartInfo.FileName);
-        foreach (var argument in monitorStartInfo.ArgumentList)
-        {
-            launcherStartInfo.ArgumentList.Add(argument);
+            return;
         }
 
-        using var launcher = Process.Start(launcherStartInfo);
+        using (monitor)
+        {
+            try
+            {
+                monitor.StandardInput.Close();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            monitor.StandardOutput.Dispose();
+            monitor.StandardError.Dispose();
+        }
     }
 
     private static void WaitForProcessExit(Process process)

--- a/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
@@ -174,6 +174,14 @@ internal static class DirectRunExitMonitorCommand
 
     private static bool ShouldAwaitResolvedSession(DirectRunExitMonitorOptions options)
     {
+        if (DirectRunSessionBoundary.HasBackendExitEvent(
+                options.ProviderEventLogPath,
+                options.ProviderSessionId,
+                options.LaunchedAt))
+        {
+            return false;
+        }
+
         if (!TryResolveSiblingArtifactPath(options.ProviderEventLogPath, ".provider.jsonl", ".request.json", out var requestArtifactPath)
             || !File.Exists(requestArtifactPath))
         {

--- a/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
@@ -10,6 +10,7 @@ internal static class DirectRunExitMonitorCommand
     private const string CommandName = "__direct-run-exit-monitor";
     private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan ExitGracePeriod = TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan DetachedSessionResolutionWaitWindow = TimeSpan.FromSeconds(10);
 
     public static bool TryExecute(string[] args, out int exitCode)
     {
@@ -124,13 +125,33 @@ internal static class DirectRunExitMonitorCommand
 
     private static DirectRunExitMonitorOptions ResolveEffectiveOptions(DirectRunExitMonitorOptions options)
     {
-        var effectiveSessionId = DirectRunTerminalArtifactUpdater.SynchronizeArtifactsToLatestSessionIfCurrent(
-            options.ProviderEventLogPath,
-            options.ProviderSessionId,
-            options.LaunchedAt);
-        if (string.Equals(effectiveSessionId, options.ProviderSessionId, StringComparison.Ordinal)
-            || !TryParseSessionProcessId(effectiveSessionId, out var effectiveProcessId)
-            || effectiveProcessId == options.ProcessId)
+        var effectiveSessionId = options.ProviderSessionId;
+        if (ShouldAwaitResolvedSession(options))
+        {
+            var deadline = DateTimeOffset.UtcNow + DetachedSessionResolutionWaitWindow;
+            while (DateTimeOffset.UtcNow < deadline)
+            {
+                effectiveSessionId = DirectRunTerminalArtifactUpdater.SynchronizeArtifactsToLatestSessionIfCurrent(
+                    options.ProviderEventLogPath,
+                    effectiveSessionId,
+                    options.LaunchedAt);
+                if (!string.Equals(effectiveSessionId, options.ProviderSessionId, StringComparison.Ordinal))
+                {
+                    break;
+                }
+
+                Thread.Sleep(PollInterval);
+            }
+        }
+        else
+        {
+            effectiveSessionId = DirectRunTerminalArtifactUpdater.SynchronizeArtifactsToLatestSessionIfCurrent(
+                options.ProviderEventLogPath,
+                effectiveSessionId,
+                options.LaunchedAt);
+        }
+
+        if (!TryParseSessionProcessId(effectiveSessionId, out var effectiveProcessId))
         {
             return options with
             {
@@ -138,13 +159,47 @@ internal static class DirectRunExitMonitorCommand
             };
         }
 
-        WaitForProcessExit(effectiveProcessId);
-        Thread.Sleep(ExitGracePeriod);
+        if (effectiveProcessId != options.ProcessId)
+        {
+            WaitForProcessExit(effectiveProcessId);
+            Thread.Sleep(ExitGracePeriod);
+        }
+
         return options with
         {
             ProcessId = effectiveProcessId,
             ProviderSessionId = effectiveSessionId
         };
+    }
+
+    private static bool ShouldAwaitResolvedSession(DirectRunExitMonitorOptions options)
+    {
+        if (!TryResolveSiblingArtifactPath(options.ProviderEventLogPath, ".provider.jsonl", ".request.json", out var requestArtifactPath)
+            || !File.Exists(requestArtifactPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+            return string.Equals(requestArtifact.ProviderSessionId, options.ProviderSessionId, StringComparison.Ordinal)
+                && DateTimeOffset.TryParse(
+                    requestArtifact.LaunchedAt,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind,
+                    out var launchedAt)
+                && launchedAt == options.LaunchedAt
+                && requestArtifact.TransportSummary.IndexOf("helper", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or InvalidOperationException
+            or ArgumentException
+            or JsonException)
+        {
+            return false;
+        }
     }
 
     private static void AppendDeterministicFixBoundaryIfNeeded(DirectRunExitMonitorOptions options)
@@ -231,6 +286,24 @@ internal static class DirectRunExitMonitorCommand
             NumberStyles.Integer,
             CultureInfo.InvariantCulture,
             out processId);
+    }
+
+    private static bool TryResolveSiblingArtifactPath(
+        string providerEventLogPath,
+        string currentSuffix,
+        string targetSuffix,
+        out string siblingArtifactPath)
+    {
+        siblingArtifactPath = string.Empty;
+        if (!providerEventLogPath.EndsWith(currentSuffix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        siblingArtifactPath = string.Concat(
+            providerEventLogPath.AsSpan(0, providerEventLogPath.Length - currentSuffix.Length),
+            targetSuffix);
+        return true;
     }
 
     private static string? TryReadUnixProcessState(int processId)

--- a/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
@@ -84,6 +84,7 @@ internal static class DirectRunExitMonitorCommand
     {
         WaitForProcessExit(options.ProcessId);
         Thread.Sleep(ExitGracePeriod);
+        options = ResolveEffectiveOptions(options);
 
         AppendDeterministicFixBoundaryIfNeeded(options);
 
@@ -119,6 +120,31 @@ internal static class DirectRunExitMonitorCommand
             exitCode: 1);
 
         return 0;
+    }
+
+    private static DirectRunExitMonitorOptions ResolveEffectiveOptions(DirectRunExitMonitorOptions options)
+    {
+        var effectiveSessionId = DirectRunTerminalArtifactUpdater.SynchronizeArtifactsToLatestSessionIfCurrent(
+            options.ProviderEventLogPath,
+            options.ProviderSessionId,
+            options.LaunchedAt);
+        if (string.Equals(effectiveSessionId, options.ProviderSessionId, StringComparison.Ordinal)
+            || !TryParseSessionProcessId(effectiveSessionId, out var effectiveProcessId)
+            || effectiveProcessId == options.ProcessId)
+        {
+            return options with
+            {
+                ProviderSessionId = effectiveSessionId
+            };
+        }
+
+        WaitForProcessExit(effectiveProcessId);
+        Thread.Sleep(ExitGracePeriod);
+        return options with
+        {
+            ProcessId = effectiveProcessId,
+            ProviderSessionId = effectiveSessionId
+        };
     }
 
     private static void AppendDeterministicFixBoundaryIfNeeded(DirectRunExitMonitorOptions options)
@@ -189,6 +215,22 @@ internal static class DirectRunExitMonitorCommand
         }
 
         return processState.IndexOf('Z') < 0;
+    }
+
+    private static bool TryParseSessionProcessId(string providerSessionId, out int processId)
+    {
+        processId = default;
+        const string prefix = "pid:";
+        if (!providerSessionId.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return int.TryParse(
+            providerSessionId[prefix.Length..],
+            NumberStyles.Integer,
+            CultureInfo.InvariantCulture,
+            out processId);
     }
 
     private static string? TryReadUnixProcessState(int processId)

--- a/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
@@ -85,6 +85,8 @@ internal static class DirectRunExitMonitorCommand
         WaitForProcessExit(options.ProcessId);
         Thread.Sleep(ExitGracePeriod);
 
+        AppendDeterministicFixBoundaryIfNeeded(options);
+
         if (DirectRunSessionBoundary.HasBackendExitEvent(options.ProviderEventLogPath, options.ProviderSessionId, options.LaunchedAt))
         {
             var resolvedExitCode = DirectRunSessionBoundary.TryResolveBackendExitCode(
@@ -117,6 +119,35 @@ internal static class DirectRunExitMonitorCommand
             exitCode: 1);
 
         return 0;
+    }
+
+    private static void AppendDeterministicFixBoundaryIfNeeded(DirectRunExitMonitorOptions options)
+    {
+        if (!string.Equals(options.EntryKind, "fix", StringComparison.Ordinal)
+            || !TryReadCurrentProviderEvents(
+                options.ProviderEventLogPath,
+                options.ProviderSessionId,
+                options.LaunchedAt,
+                out var currentProviderEvents))
+        {
+            return;
+        }
+
+        var boundaryEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            currentProviderEvents,
+            DateTimeOffset.UtcNow,
+            options.ExecutionUnit,
+            options.EntryKind,
+            options.Provider,
+            options.ProviderSessionId,
+            providerSessionAlive: false);
+        if (boundaryEvent is null)
+        {
+            return;
+        }
+
+        var eventWriter = new DirectRunProviderEventWriter(options.ProviderEventLogPath);
+        eventWriter.Append(boundaryEvent);
     }
 
     private static void WaitForProcessExit(int processId)
@@ -196,6 +227,37 @@ internal static class DirectRunExitMonitorCommand
             or InvalidOperationException)
         {
             return null;
+        }
+    }
+
+    private static bool TryReadCurrentProviderEvents(
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset launchedAt,
+        out IReadOnlyList<DirectRunProviderEvent> currentProviderEvents)
+    {
+        currentProviderEvents = [];
+        if (!File.Exists(providerEventLogPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            currentProviderEvents = DirectRunSessionBoundary.SelectEvents(
+                providerEvents,
+                providerSessionId,
+                launchedAt);
+            return currentProviderEvents.Count > 0;
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or InvalidOperationException
+            or ArgumentException
+            or JsonException)
+        {
+            return false;
         }
     }
 

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -266,6 +266,7 @@ internal static class DirectRunFixOutcomeSupport
         reason = string.Empty;
 
         if (providerSessionAlive
+            || HasSuccessfulBackendExit(providerEvents)
             || FindFailingBackendExitIndex(providerEvents) >= 0
             || !HasDeepExecutionProgressSignal(providerEvents))
         {
@@ -296,6 +297,7 @@ internal static class DirectRunFixOutcomeSupport
 
         var observedRequestReread = providerEvents.Any(providerEvent => ContainsRequestArtifactRead(providerEvent.Payload));
         if (!observedRequestReread
+            || HasSuccessfulBackendExit(providerEvents)
             || HasSpecAndProductReadProgressSignal(providerEvents))
         {
             return false;
@@ -396,6 +398,19 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         return -1;
+    }
+
+    private static bool HasSuccessfulBackendExit(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        return providerEvents.Any(providerEvent =>
+        {
+            var payload = providerEvent.Payload;
+            return payload.ValueKind == JsonValueKind.Object
+                && TryReadString(payload, "type", out var type)
+                && string.Equals(type, "backend-exit", StringComparison.Ordinal)
+                && TryReadInt32(payload, "exit_code", out var exitCode)
+                && exitCode == 0;
+        });
     }
 
     private static bool HasExplicitContractGap(IReadOnlyList<DirectRunProviderEvent> providerEvents)

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -266,7 +266,7 @@ internal static class DirectRunFixOutcomeSupport
         reason = string.Empty;
 
         if (providerSessionAlive
-            || HasSuccessfulBackendExit(providerEvents)
+            || HasCapturedSuccessfulTerminalOutcome(providerEvents)
             || FindFailingBackendExitIndex(providerEvents) >= 0
             || !HasDeepExecutionProgressSignal(providerEvents))
         {
@@ -297,7 +297,7 @@ internal static class DirectRunFixOutcomeSupport
 
         var observedRequestReread = providerEvents.Any(providerEvent => ContainsRequestArtifactRead(providerEvent.Payload));
         if (!observedRequestReread
-            || HasSuccessfulBackendExit(providerEvents)
+            || HasCapturedSuccessfulTerminalOutcome(providerEvents)
             || HasSpecAndProductReadProgressSignal(providerEvents))
         {
             return false;
@@ -400,6 +400,12 @@ internal static class DirectRunFixOutcomeSupport
         return -1;
     }
 
+    private static bool HasCapturedSuccessfulTerminalOutcome(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        return HasSuccessfulBackendExit(providerEvents)
+            && providerEvents.Any(providerEvent => ContainsSuccessfulTerminalNarrative(providerEvent.Payload));
+    }
+
     private static bool HasSuccessfulBackendExit(IReadOnlyList<DirectRunProviderEvent> providerEvents)
     {
         return providerEvents.Any(providerEvent =>
@@ -411,6 +417,43 @@ internal static class DirectRunFixOutcomeSupport
                 && TryReadInt32(payload, "exit_code", out var exitCode)
                 && exitCode == 0;
         });
+    }
+
+    private static bool ContainsSuccessfulTerminalNarrative(JsonElement payload)
+    {
+        if (payload.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        var value = payload.GetString();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var normalized = value.Trim();
+        var lower = normalized.ToLowerInvariant();
+        if (IsIgnorableStartupPreamble(payload)
+            || IsIgnorableStartupNoise(payload)
+            || lower == "exec"
+            || lower == "tokens used"
+            || lower.StartsWith("succeeded in ", StringComparison.Ordinal)
+            || lower.StartsWith("failed in ", StringComparison.Ordinal)
+            || lower.StartsWith("exited ", StringComparison.Ordinal)
+            || lower.StartsWith("/bin/", StringComparison.Ordinal)
+            || lower.StartsWith("sed: ", StringComparison.Ordinal)
+            || lower.Contains("rg --files", StringComparison.Ordinal)
+            || lower.Contains("sed -n", StringComparison.Ordinal)
+            || lower.Contains("dotnet test", StringComparison.Ordinal)
+            || lower.Contains("git status", StringComparison.Ordinal)
+            || lower.Contains("git diff", StringComparison.Ordinal)
+            || lower.Contains("apply_patch", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     private static bool HasExplicitContractGap(IReadOnlyList<DirectRunProviderEvent> providerEvents)

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -8,6 +8,7 @@ internal static class DirectRunFixOutcomeSupport
     private const string InspectionOnlyExitReason = "fix-session-ended-after-initial-inspection";
     private const string ProviderBackendEndedBeforeSpecSourceReadReason = "fix-session-ended-before-spec-source-test-read";
     private const string MissingTerminalCaptureAfterRequestReadReason = "fix-session-terminal-boundary-missing-after-request-reread";
+    private const string MissingTerminalCaptureAfterDeepProgressReason = "fix-session-terminal-boundary-missing-after-deep-progress";
     private static readonly string[] StartupWarningMarkers =
     [
         "warn",
@@ -188,6 +189,13 @@ internal static class DirectRunFixOutcomeSupport
         return HasSpecAndProductReadProgressSignal(providerEvents);
     }
 
+    internal static bool HasExplicitContractGapSignal(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        return HasExplicitContractGap(providerEvents);
+    }
+
     internal static bool HasSpecAndProductReadProgressSignal(IReadOnlyList<DirectRunProviderEvent> providerEvents)
     {
         ArgumentNullException.ThrowIfNull(providerEvents);
@@ -200,6 +208,22 @@ internal static class DirectRunFixOutcomeSupport
         return sawSpecRead && sawProductRead;
     }
 
+    internal static bool HasDeepExecutionProgressSignal(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        var observedRequestReread = providerEvents.Any(providerEvent => ContainsRequestArtifactRead(providerEvent.Payload));
+        var observedProductRead = providerEvents.Any(providerEvent =>
+            !IsIgnorableStartupPreamble(providerEvent.Payload)
+            && ContainsProductSourceOrTestReadAttempt(providerEvent.Payload));
+        var observedDotNetTest = providerEvents.Any(providerEvent =>
+            !IsIgnorableStartupPreamble(providerEvent.Payload)
+            && ContainsDotNetTestAttempt(providerEvent.Payload));
+
+        return observedRequestReread
+            && (observedProductRead || observedDotNetTest);
+    }
+
     private static bool TryResolveCanonicalFailureDetail(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string executionUnit,
@@ -207,6 +231,16 @@ internal static class DirectRunFixOutcomeSupport
         out string reason,
         out string detail)
     {
+        if (TryResolveMissingTerminalAfterDeepProgressDetail(
+                providerEvents,
+                executionUnit,
+                providerSessionAlive,
+                out reason,
+                out detail))
+        {
+            return true;
+        }
+
         if (TryResolvePostRequestParityBoundaryDetail(
                 providerEvents,
                 executionUnit,
@@ -219,6 +253,35 @@ internal static class DirectRunFixOutcomeSupport
 
         reason = InspectionOnlyExitReason;
         return TryResolveInspectionOnlyFailureDetail(providerEvents, executionUnit, out detail);
+    }
+
+    private static bool TryResolveMissingTerminalAfterDeepProgressDetail(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        bool providerSessionAlive,
+        out string reason,
+        out string detail)
+    {
+        detail = string.Empty;
+        reason = string.Empty;
+
+        if (providerSessionAlive
+            || FindFailingBackendExitIndex(providerEvents) >= 0
+            || !HasDeepExecutionProgressSignal(providerEvents))
+        {
+            return false;
+        }
+
+        var observedRequestReread = providerEvents.Any(providerEvent => ContainsRequestArtifactRead(providerEvent.Payload));
+        var observedInventory = providerEvents.Any(providerEvent => ContainsInitialRepoInventory(providerEvent.Payload));
+        var observedSpecRead = HasSuccessfulRepoLocalSpecRead(providerEvents);
+        var observedProductRead = providerEvents.Any(providerEvent => ContainsProductSourceOrTestReadAttempt(providerEvent.Payload));
+        var observedDotNetTest = providerEvents.Any(providerEvent => ContainsDotNetTestAttempt(providerEvent.Payload));
+
+        reason = MissingTerminalCaptureAfterDeepProgressReason;
+        detail =
+            $"Fix direct run for '{executionUnit}' reached deeper bounded work before the provider session died, but no same-session terminal outcome was captured. Current-session evidence observed request_reread={observedRequestReread}, repo_inventory={observedInventory}, repo_local_spec_read={observedSpecRead}, product_source_or_test_read={observedProductRead}, dotnet_test={observedDotNetTest}. The provider session is no longer alive, but neither backend-exit nor an explicit contract-gap was persisted for that same session, so the child runtime must synthesize a deterministic missing-terminal boundary instead of leaving run_status=running.";
+        return true;
     }
 
     private static bool TryResolvePostRequestParityBoundaryDetail(
@@ -585,6 +648,19 @@ internal static class DirectRunFixOutcomeSupport
 
             if (normalized.Contains("src/", StringComparison.Ordinal)
                 || normalized.Contains("tests/", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsDotNetTestAttempt(JsonElement payload)
+    {
+        foreach (var value in EnumeratePayloadStrings(payload))
+        {
+            if (value.Trim().ToLowerInvariant().Contains("dotnet test", StringComparison.Ordinal))
             {
                 return true;
             }

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -643,31 +643,32 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             provider,
             providerSessionId,
             launchedAt);
+        StartDetachedExitMonitorProcess(monitorStartInfo);
+    }
 
-        var launcherStartInfo = new ProcessStartInfo
+    private static void StartDetachedExitMonitorProcess(ProcessStartInfo monitorStartInfo)
+    {
+        ArgumentNullException.ThrowIfNull(monitorStartInfo);
+
+        var monitor = Process.Start(monitorStartInfo);
+        if (monitor is null)
         {
-            FileName = "/bin/sh",
-            UseShellExecute = false,
-            RedirectStandardOutput = false,
-            RedirectStandardError = false
-        };
-        launcherStartInfo.ArgumentList.Add("-c");
-        launcherStartInfo.ArgumentList.Add(
-            """
-            if command -v nohup >/dev/null 2>&1; then
-                nohup "$@" >/dev/null 2>&1 </dev/null &
-            else
-                "$@" >/dev/null 2>&1 </dev/null &
-            fi
-            """);
-        launcherStartInfo.ArgumentList.Add("direct-run-exit-monitor-launcher");
-        launcherStartInfo.ArgumentList.Add(monitorStartInfo.FileName);
-        foreach (var argument in monitorStartInfo.ArgumentList)
-        {
-            launcherStartInfo.ArgumentList.Add(argument);
+            return;
         }
 
-        using var launcher = Process.Start(launcherStartInfo);
+        using (monitor)
+        {
+            try
+            {
+                monitor.StandardInput.Close();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            monitor.StandardOutput.Dispose();
+            monitor.StandardError.Dispose();
+        }
     }
 
     private static void StartDetachedProviderExitMonitorIfNeeded(

--- a/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunLauncher.cs
@@ -184,7 +184,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
                 launchedAt,
                 providerSessionId);
             StartDetachedProviderExitMonitorIfNeeded(
-                processInvocation.StartedProcessCarriesProviderSession,
+                processInvocation.UsesDetachedCaptureHelper,
+                process.ProcessId,
                 absoluteProviderEventLogPath,
                 executionUnit,
                 entryKind,
@@ -670,7 +671,8 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
     }
 
     private static void StartDetachedProviderExitMonitorIfNeeded(
-        bool startedProcessCarriesProviderSession,
+        bool usesDetachedCaptureHelper,
+        int startedProcessId,
         string providerEventLogPath,
         string executionUnit,
         string entryKind,
@@ -678,8 +680,11 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
         string providerSessionId,
         DateTimeOffset launchedAt)
     {
-        if (startedProcessCarriesProviderSession
-            || !TryParseProcessId(providerSessionId, out var processId))
+        if (!ShouldStartDetachedProviderExitMonitor(
+                usesDetachedCaptureHelper,
+                startedProcessId,
+                providerSessionId,
+                out var processId))
         {
             return;
         }
@@ -693,6 +698,19 @@ internal sealed class DirectRunLauncher : IDirectRunLauncher
             provider,
             providerSessionId,
             launchedAt);
+    }
+
+    internal static bool ShouldStartDetachedProviderExitMonitor(
+        bool usesDetachedCaptureHelper,
+        int startedProcessId,
+        string providerSessionId,
+        out int providerProcessId)
+    {
+        providerProcessId = default;
+        return usesDetachedCaptureHelper
+            && startedProcessId > 0
+            && TryParseProcessId(providerSessionId, out providerProcessId)
+            && providerProcessId != startedProcessId;
     }
 
     private static void BestEffortAppendBackendExitIfProcessExitedSoon(

--- a/src/IntentSystem.Cli/Commands/DirectRunTerminalArtifactUpdater.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunTerminalArtifactUpdater.cs
@@ -9,6 +9,71 @@ internal static class DirectRunTerminalArtifactUpdater
 {
     private static readonly TimeSpan DeadSessionExitGracePeriod = TimeSpan.FromMilliseconds(250);
 
+    public static string SynchronizeArtifactsToLatestSessionIfCurrent(
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset launchedAt)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerEventLogPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+
+        if (!TryResolveLatestSessionId(providerEventLogPath, launchedAt, out var latestSessionId)
+            || string.IsNullOrWhiteSpace(latestSessionId)
+            || string.Equals(latestSessionId, providerSessionId, StringComparison.Ordinal)
+            || !TryResolveSiblingArtifactPath(providerEventLogPath, ".provider.jsonl", ".request.json", out var requestArtifactPath)
+            || !File.Exists(requestArtifactPath))
+        {
+            return providerSessionId;
+        }
+
+        try
+        {
+            var requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+            if (!string.Equals(requestArtifact.ProviderSessionId, providerSessionId, StringComparison.Ordinal)
+                || !DateTimeOffset.TryParse(
+                    requestArtifact.LaunchedAt,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind,
+                    out var requestLaunchedAt)
+                || requestLaunchedAt != launchedAt)
+            {
+                return providerSessionId;
+            }
+
+            File.WriteAllText(
+                requestArtifactPath,
+                DirectRunRequestArtifactJson.Serialize(requestArtifact with
+                {
+                    ProviderSessionId = latestSessionId
+                }));
+
+            if (TryResolveSiblingArtifactPath(providerEventLogPath, ".provider.jsonl", ".result.json", out var resultArtifactPath)
+                && File.Exists(resultArtifactPath))
+            {
+                var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+                if (string.Equals(resultArtifact.SessionId, providerSessionId, StringComparison.Ordinal))
+                {
+                    File.WriteAllText(
+                        resultArtifactPath,
+                        DirectRunResultArtifactJson.Serialize(resultArtifact with
+                        {
+                            SessionId = latestSessionId
+                        }));
+                }
+            }
+
+            return latestSessionId;
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or InvalidOperationException
+            or ArgumentException
+            or JsonException)
+        {
+            return providerSessionId;
+        }
+    }
+
     public static void PersistTerminalRunStatusIfCurrent(
         string providerEventLogPath,
         string providerSessionId,
@@ -264,6 +329,48 @@ internal static class DirectRunTerminalArtifactUpdater
             var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
             currentProviderEvents = DirectRunSessionBoundary.SelectEvents(providerEvents, providerSessionId, launchedAt);
             return true;
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or InvalidOperationException
+            or ArgumentException
+            or JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryResolveLatestSessionId(
+        string providerEventLogPath,
+        DateTimeOffset launchedAt,
+        out string latestSessionId)
+    {
+        latestSessionId = string.Empty;
+        if (!File.Exists(providerEventLogPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            foreach (var providerEvent in providerEvents)
+            {
+                if (string.IsNullOrWhiteSpace(providerEvent.SessionId)
+                    || !DateTimeOffset.TryParse(
+                        providerEvent.Timestamp,
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.RoundtripKind,
+                        out var providerEventTimestamp)
+                    || providerEventTimestamp < launchedAt)
+                {
+                    continue;
+                }
+
+                latestSessionId = providerEvent.SessionId;
+            }
+
+            return latestSessionId.Length > 0;
         }
         catch (Exception exception) when (
             exception is IOException

--- a/src/IntentSystem.Cli/Commands/DirectRunTerminalArtifactUpdater.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunTerminalArtifactUpdater.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -49,7 +50,11 @@ internal static class DirectRunTerminalArtifactUpdater
             return;
         }
 
-        var terminalStatus = exitCode == 0 ? "succeeded" : "failed";
+        var terminalStatus = ResolveEffectiveTerminalRunStatus(
+            providerEventLogPath,
+            providerSessionId,
+            launchedAt,
+            exitCode);
         if (string.Equals(resultArtifact.RunStatus, terminalStatus, StringComparison.Ordinal))
         {
             return;
@@ -70,6 +75,80 @@ internal static class DirectRunTerminalArtifactUpdater
             or InvalidOperationException)
         {
         }
+    }
+
+    private static string ResolveEffectiveTerminalRunStatus(
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset launchedAt,
+        int exitCode)
+    {
+        try
+        {
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            var currentProviderEvents = DirectRunSessionBoundary.SelectEvents(
+                providerEvents,
+                providerSessionId,
+                launchedAt);
+            if (currentProviderEvents.Any(providerEvent => IsExplicitFailureBoundary(providerEvent.Payload)))
+            {
+                return "failed";
+            }
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or InvalidOperationException
+            or ArgumentException
+            or JsonException)
+        {
+        }
+
+        return exitCode == 0 ? "succeeded" : "failed";
+    }
+
+    private static bool IsExplicitFailureBoundary(JsonElement payload)
+    {
+        if (payload.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (TryReadString(payload, "run_status", out var runStatus)
+            && string.Equals(runStatus, "failed", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (TryReadString(payload, "status", out var status)
+            && string.Equals(status, "failed", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (TryReadString(payload, "disposition", out var disposition))
+        {
+            var normalized = disposition.Trim().ToLowerInvariant();
+            if (normalized is "comment" or "commented" or "fix-requested" or "changes-requested" or "failed")
+            {
+                return true;
+            }
+        }
+
+        return TryReadString(payload, "type", out var type)
+            && string.Equals(type, "contract-gap", StringComparison.Ordinal);
+    }
+
+    private static bool TryReadString(JsonElement payload, string propertyName, out string value)
+    {
+        value = string.Empty;
+        if (!payload.TryGetProperty(propertyName, out var element)
+            || element.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        value = element.GetString() ?? string.Empty;
+        return value.Length > 0;
     }
 
     private static bool TryResolveSiblingArtifactPath(

--- a/src/IntentSystem.Cli/Commands/DirectRunTerminalArtifactUpdater.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunTerminalArtifactUpdater.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 
@@ -5,6 +7,8 @@ namespace IntentSystem.Cli.Commands;
 
 internal static class DirectRunTerminalArtifactUpdater
 {
+    private static readonly TimeSpan DeadSessionExitGracePeriod = TimeSpan.FromMilliseconds(250);
+
     public static void PersistTerminalRunStatusIfCurrent(
         string providerEventLogPath,
         string providerSessionId,
@@ -75,6 +79,82 @@ internal static class DirectRunTerminalArtifactUpdater
             or InvalidOperationException)
         {
         }
+    }
+
+    public static string FinalizeDeadFixSessionIfCurrent(
+        string providerEventLogPath,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        DateTimeOffset launchedAt,
+        string currentRunStatus)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerEventLogPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(currentRunStatus);
+
+        if (!string.Equals(entryKind, "fix", StringComparison.Ordinal)
+            || !string.Equals(currentRunStatus, "running", StringComparison.Ordinal)
+            || IsProviderSessionAlive(providerSessionId))
+        {
+            return currentRunStatus;
+        }
+
+        Thread.Sleep(DeadSessionExitGracePeriod);
+
+        IReadOnlyList<DirectRunProviderEvent> currentProviderEvents = [];
+        if (TryReadCurrentProviderEvents(
+                providerEventLogPath,
+                providerSessionId,
+                launchedAt,
+                out var resolvedCurrentProviderEvents))
+        {
+            currentProviderEvents = resolvedCurrentProviderEvents;
+            var boundaryEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+                currentProviderEvents,
+                DateTimeOffset.UtcNow,
+                executionUnit,
+                entryKind,
+                provider,
+                providerSessionId,
+                providerSessionAlive: false);
+            if (boundaryEvent is not null)
+            {
+                var writer = new DirectRunProviderEventWriter(providerEventLogPath);
+                writer.Append(boundaryEvent);
+                currentProviderEvents = [.. currentProviderEvents, boundaryEvent];
+            }
+        }
+
+        if (!DirectRunSessionBoundary.HasBackendExitEvent(providerEventLogPath, providerSessionId, launchedAt))
+        {
+            var writer = new DirectRunProviderEventWriter(providerEventLogPath);
+            writer.Append(DirectRunProviderEventFactory.CreateBackendExitEvent(
+                DateTimeOffset.UtcNow,
+                executionUnit,
+                entryKind,
+                provider,
+                providerSessionId,
+                1));
+        }
+
+        PersistTerminalRunStatusIfCurrent(
+            providerEventLogPath,
+            providerSessionId,
+            launchedAt,
+            exitCode: 1);
+
+        return TryReadResultRunStatusIfCurrent(
+            providerEventLogPath,
+            providerSessionId,
+            launchedAt,
+            out var updatedRunStatus)
+            ? updatedRunStatus
+            : "failed";
     }
 
     private static string ResolveEffectiveTerminalRunStatus(
@@ -165,5 +245,163 @@ internal static class DirectRunTerminalArtifactUpdater
 
         artifactPath = providerEventLogPath[..^expectedSuffix.Length] + replacementSuffix;
         return true;
+    }
+
+    private static bool TryReadCurrentProviderEvents(
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset launchedAt,
+        out IReadOnlyList<DirectRunProviderEvent> currentProviderEvents)
+    {
+        currentProviderEvents = [];
+        if (!File.Exists(providerEventLogPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            currentProviderEvents = DirectRunSessionBoundary.SelectEvents(providerEvents, providerSessionId, launchedAt);
+            return true;
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or InvalidOperationException
+            or ArgumentException
+            or JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryReadResultRunStatusIfCurrent(
+        string providerEventLogPath,
+        string providerSessionId,
+        DateTimeOffset launchedAt,
+        out string runStatus)
+    {
+        runStatus = string.Empty;
+        if (!TryResolveSiblingArtifactPath(providerEventLogPath, ".provider.jsonl", ".result.json", out var resultArtifactPath)
+            || !TryResolveSiblingArtifactPath(providerEventLogPath, ".provider.jsonl", ".request.json", out var requestArtifactPath)
+            || !File.Exists(resultArtifactPath)
+            || !File.Exists(requestArtifactPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+            if (!string.Equals(requestArtifact.ProviderSessionId, providerSessionId, StringComparison.Ordinal)
+                || !string.Equals(resultArtifact.SessionId, providerSessionId, StringComparison.Ordinal)
+                || !DateTimeOffset.TryParse(
+                    requestArtifact.LaunchedAt,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind,
+                    out var requestLaunchedAt)
+                || requestLaunchedAt != launchedAt)
+            {
+                return false;
+            }
+
+            runStatus = resultArtifact.RunStatus;
+            return !string.IsNullOrWhiteSpace(runStatus);
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or InvalidOperationException
+            or ArgumentException
+            or JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsProviderSessionAlive(string providerSessionId)
+    {
+        if (!TryParseSessionProcessId(providerSessionId, out var processId))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            process.Refresh();
+            if (process.HasExited)
+            {
+                return false;
+            }
+        }
+        catch (Exception exception) when (
+            exception is ArgumentException
+            or InvalidOperationException
+            or NotSupportedException)
+        {
+            return false;
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            return true;
+        }
+
+        var processState = TryReadUnixProcessState(processId);
+        return !string.IsNullOrWhiteSpace(processState)
+            && processState.IndexOf('Z') < 0;
+    }
+
+    private static bool TryParseSessionProcessId(string providerSessionId, out int processId)
+    {
+        processId = default;
+
+        const string prefix = "pid:";
+        return providerSessionId.StartsWith(prefix, StringComparison.Ordinal)
+            && int.TryParse(
+                providerSessionId[prefix.Length..],
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out processId);
+    }
+
+    private static string? TryReadUnixProcessState(int processId)
+    {
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "/bin/ps",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                ArgumentList =
+                {
+                    "-o",
+                    "stat=",
+                    "-p",
+                    processId.ToString(CultureInfo.InvariantCulture)
+                }
+            });
+
+            if (process is null)
+            {
+                return null;
+            }
+
+            using (process)
+            {
+                var output = process.StandardOutput.ReadToEnd();
+                process.WaitForExit();
+                return output.Trim();
+            }
+        }
+        catch (Exception exception) when (
+            exception is Win32Exception
+            or InvalidOperationException)
+        {
+            return null;
+        }
     }
 }

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -273,6 +273,7 @@ public sealed class DirectRunFixOutcomeSupportTests
             CreateProviderEvent(" succeeded in 0ms:"),
             CreateProviderEvent("exec /bin/zsh -lc 'dotnet test'"),
             CreateProviderEvent(" succeeded in 0ms:"),
+            CreateProviderEvent("- Updated src/ToyCalc/Program.cs to preserve successful multiply output."),
             CreateSuccessfulBackendExitEvent()
         ];
 

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -216,6 +216,47 @@ public sealed class DirectRunFixOutcomeSupportTests
             StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenDeepProgressAndDeadSessionWithoutTerminalEvent_UsesDeepProgressMissingTerminalReason()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-01.request.md' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' intents/toy-calc/specs/01-cli-surface.md'"),
+            CreateProviderEvent(" exited 1 in 0ms:"),
+            CreateProviderEvent("sed: intents/toy-calc/specs/01-cli-surface.md: No such file or directory"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Program.cs'"),
+            CreateProviderEvent(" succeeded in 0ms:"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' tests/ToyCalc.Tests/CalculatorTests.cs'"),
+            CreateProviderEvent(" succeeded in 0ms:"),
+            CreateProviderEvent("exec /bin/zsh -lc 'dotnet test'"),
+            CreateProviderEvent(" succeeded in 0ms:")
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-17T07:40:00Z"),
+            "TOY-CALC-V0-01",
+            "fix",
+            "Codex",
+            "pid:6210",
+            providerSessionAlive: false);
+
+        Assert.NotNull(contractGapEvent);
+        Assert.Equal(
+            "fix-session-terminal-boundary-missing-after-deep-progress",
+            contractGapEvent!.Payload.GetProperty("reason").GetString());
+        Assert.Contains(
+            "product_source_or_test_read=True",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            "dotnet_test=True",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
     private static IReadOnlyList<DirectRunProviderEvent> CreateIssue295CurrentSessionRawEvents(string? echoedRequest = null)
     {
         return

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -257,6 +257,37 @@ public sealed class DirectRunFixOutcomeSupportTests
             StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenDeepProgressAndSuccessfulBackendExit_DoesNotCreateFailureBoundary()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-01.request.md' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' intents/toy-calc/specs/01-cli-surface.md'"),
+            CreateProviderEvent(" exited 1 in 0ms:"),
+            CreateProviderEvent("sed: intents/toy-calc/specs/01-cli-surface.md: No such file or directory"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Program.cs'"),
+            CreateProviderEvent(" succeeded in 0ms:"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' tests/ToyCalc.Tests/CalculatorTests.cs'"),
+            CreateProviderEvent(" succeeded in 0ms:"),
+            CreateProviderEvent("exec /bin/zsh -lc 'dotnet test'"),
+            CreateProviderEvent(" succeeded in 0ms:"),
+            CreateSuccessfulBackendExitEvent()
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-17T07:40:00Z"),
+            "TOY-CALC-V0-01",
+            "fix",
+            "Codex",
+            "pid:6210",
+            providerSessionAlive: false);
+
+        Assert.Null(contractGapEvent);
+    }
+
     private static IReadOnlyList<DirectRunProviderEvent> CreateIssue295CurrentSessionRawEvents(string? echoedRequest = null)
     {
         return
@@ -339,6 +370,24 @@ public sealed class DirectRunFixOutcomeSupportTests
             {
                 type = "backend-exit",
                 exit_code = 1
+            })
+        };
+    }
+
+    private static DirectRunProviderEvent CreateSuccessfulBackendExitEvent()
+    {
+        return new DirectRunProviderEvent
+        {
+            Timestamp = "2026-04-17T05:58:47.0000000+00:00",
+            ExecutionUnit = "TOY-CALC-V0-01",
+            Provider = "Codex",
+            EntryKind = "fix",
+            SessionId = "pid:97771",
+            Kind = "provider-event",
+            Payload = JsonSerializer.SerializeToElement(new
+            {
+                type = "backend-exit",
+                exit_code = 0
             })
         };
     }

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -1456,6 +1456,94 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public void SynchronizeArtifactsToLatestSessionIfCurrent_GivenLaterCurrentSession_RewritesRequestAndResultArtifacts()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14b-sync.provider.jsonl");
+        var requestArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-sync.request.json");
+        var resultArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-sync.result.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(providerEventLogPath)!);
+
+        var launchedAt = DateTimeOffset.UtcNow;
+        const string helperSessionId = "pid:1111";
+        const string providerSessionId = "pid:2222";
+        File.WriteAllText(
+            requestArtifactPath,
+            DirectRunRequestArtifactJson.Serialize(new DirectRunRequestArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-sync",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-sync.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                Transport = "responses",
+                LaunchedAt = launchedAt.ToString("O"),
+                ProviderSessionId = helperSessionId,
+                TransportSummary = "launched via helper"
+            }));
+        File.WriteAllText(
+            resultArtifactPath,
+            DirectRunResultArtifactJson.Serialize(new DirectRunResultArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-sync",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-sync.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                SessionId = helperSessionId,
+                RunStatus = "running",
+                RawLogRef = ".intent-cli/runs/G14b-sync.provider.jsonl",
+                PacketRef = ".intent-cli/issues/G14b-sync/packet.yaml",
+                ReviewContextRef = ".intent-cli/issues/G14b-sync/review-context.md",
+                Worktree = new DirectRunWorktreeContext
+                {
+                    Path = "/repo/.intent-cli/worktrees/G14b-sync"
+                }
+            }));
+
+        File.WriteAllText(
+            providerEventLogPath,
+            string.Join(
+                Environment.NewLine,
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.ToString("O"),
+                    ExecutionUnit = "G14b-sync",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = helperSessionId,
+                    Kind = "session-metadata",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new { model = "gpt-5.4-mini" })
+                }),
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.AddMilliseconds(50).ToString("O"),
+                    ExecutionUnit = "G14b-sync",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "session-metadata",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new { model = "gpt-5.4-mini" })
+                }),
+                string.Empty));
+
+        var synchronizedSessionId = DirectRunTerminalArtifactUpdater.SynchronizeArtifactsToLatestSessionIfCurrent(
+            providerEventLogPath,
+            helperSessionId,
+            launchedAt);
+
+        Assert.Equal(providerSessionId, synchronizedSessionId);
+
+        var requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+        Assert.Equal(providerSessionId, requestArtifact.ProviderSessionId);
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        Assert.Equal(providerSessionId, resultArtifact.SessionId);
+    }
+
+    [Fact]
     public async Task DirectRunExitMonitorCommand_GivenStaleBackendExitForSamePid_AppendsFreshBackendExit()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -1525,6 +1525,177 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public async Task DirectRunExitMonitorCommand_GivenDeepProgressAndSuccessfulBackendExit_PreservesSucceededResult()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var externalProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-c", "sleep 1" }
+        });
+        Assert.NotNull(externalProcess);
+        externalProcess!.WaitForExit();
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14b-success.provider.jsonl");
+        var requestArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-success.request.json");
+        var resultArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-success.result.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(providerEventLogPath)!);
+
+        var launchedAt = DateTimeOffset.UtcNow;
+        var providerSessionId = $"pid:{externalProcess.Id}";
+        File.WriteAllText(
+            requestArtifactPath,
+            DirectRunRequestArtifactJson.Serialize(new DirectRunRequestArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-success",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-success.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                Transport = "responses",
+                LaunchedAt = launchedAt.ToString("O"),
+                ProviderSessionId = providerSessionId,
+                TransportSummary = "launched via helper"
+            }));
+        File.WriteAllText(
+            resultArtifactPath,
+            DirectRunResultArtifactJson.Serialize(new DirectRunResultArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-success",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-success.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                SessionId = providerSessionId,
+                RunStatus = "running",
+                RawLogRef = ".intent-cli/runs/G14b-success.provider.jsonl",
+                PacketRef = ".intent-cli/issues/G14b-success/packet.yaml",
+                ReviewContextRef = ".intent-cli/issues/G14b-success/review-context.md",
+                Worktree = new DirectRunWorktreeContext
+                {
+                    Path = "/repo/.intent-cli/worktrees/G14b-success"
+                }
+            }));
+        File.WriteAllText(
+            providerEventLogPath,
+            string.Join(
+                Environment.NewLine,
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.ToString("O"),
+                    ExecutionUnit = "G14b-success",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "session-metadata",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new { model = "gpt-5.4-mini" })
+                }),
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.AddMilliseconds(50).ToString("O"),
+                    ExecutionUnit = "G14b-success",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/G14b-success.request.md' succeeded in 0ms")
+                }),
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.AddMilliseconds(100).ToString("O"),
+                    ExecutionUnit = "G14b-success",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms")
+                }),
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.AddMilliseconds(150).ToString("O"),
+                    ExecutionUnit = "G14b-success",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Program.cs' succeeded in 0ms")
+                }),
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.AddMilliseconds(200).ToString("O"),
+                    ExecutionUnit = "G14b-success",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'dotnet test' succeeded in 0ms")
+                }),
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.AddMilliseconds(250).ToString("O"),
+                    ExecutionUnit = "G14b-success",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 0
+                    })
+                }),
+                string.Empty));
+
+        using var monitor = Process.Start(DirectRunExitMonitorCommand.CreateDetachedStartInfo(
+            externalProcess.Id,
+            providerEventLogPath,
+            "G14b-success",
+            "fix",
+            "Codex",
+            providerSessionId,
+            launchedAt));
+        Assert.NotNull(monitor);
+        monitor!.StandardInput.Close();
+        monitor.StandardOutput.Dispose();
+        monitor.StandardError.Dispose();
+
+        await TemporaryDirectory.WaitForConditionAsync(
+            () =>
+            {
+                if (!File.Exists(resultArtifactPath))
+                {
+                    return false;
+                }
+
+                var artifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+                return string.Equals(artifact.RunStatus, "succeeded", StringComparison.Ordinal);
+            },
+            TimeSpan.FromSeconds(5));
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        Assert.Equal(providerSessionId, resultArtifact.SessionId);
+        Assert.Equal("succeeded", resultArtifact.RunStatus);
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.DoesNotContain(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "contract-gap", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, providerSessionId, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void FinalizeDeadFixSessionIfCurrent_GivenStartupOnlyDeadSession_AppendsBackendExitAndFailsResult()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -1241,6 +1241,221 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public void FinalizeDeadFixSessionIfCurrent_GivenStartupOnlyDeadSession_AppendsBackendExitAndFailsResult()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var externalProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-c", "sleep 1" }
+        });
+        Assert.NotNull(externalProcess);
+        externalProcess!.WaitForExit();
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14b-rescue.provider.jsonl");
+        var requestArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-rescue.request.json");
+        var resultArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-rescue.result.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(providerEventLogPath)!);
+
+        var launchedAt = DateTimeOffset.UtcNow;
+        var providerSessionId = $"pid:{externalProcess.Id}";
+        File.WriteAllText(
+            requestArtifactPath,
+            DirectRunRequestArtifactJson.Serialize(new DirectRunRequestArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-rescue",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-rescue.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                Transport = "responses",
+                LaunchedAt = launchedAt.ToString("O"),
+                ProviderSessionId = providerSessionId,
+                TransportSummary = "launched via wrapper"
+            }));
+        File.WriteAllText(
+            resultArtifactPath,
+            DirectRunResultArtifactJson.Serialize(new DirectRunResultArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-rescue",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-rescue.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                SessionId = providerSessionId,
+                RunStatus = "running",
+                RawLogRef = ".intent-cli/runs/G14b-rescue.provider.jsonl",
+                PacketRef = ".intent-cli/issues/G14b-rescue/packet.yaml",
+                ReviewContextRef = ".intent-cli/issues/G14b-rescue/review-context.md",
+                Worktree = new DirectRunWorktreeContext
+                {
+                    Path = "/repo/.intent-cli/worktrees/G14b-rescue"
+                }
+            }));
+
+        var writer = new DirectRunProviderEventWriter(providerEventLogPath);
+        writer.Append(new DirectRunProviderEvent
+        {
+            Timestamp = launchedAt.ToString("O"),
+            ExecutionUnit = "G14b-rescue",
+            Provider = "Codex",
+            EntryKind = "fix",
+            SessionId = providerSessionId,
+            Kind = "provider-event",
+            Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                "2026-04-17T08:10:00.000000Z  WARN codex_core::plugins::manifest: ignoring interface.defaultPrompt")
+        });
+
+        var updatedRunStatus = DirectRunTerminalArtifactUpdater.FinalizeDeadFixSessionIfCurrent(
+            providerEventLogPath,
+            "G14b-rescue",
+            "fix",
+            "Codex",
+            providerSessionId,
+            launchedAt,
+            "running");
+
+        Assert.Equal("failed", updatedRunStatus);
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        Assert.Equal("failed", resultArtifact.RunStatus);
+
+        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.Contains(providerEvents, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+            && providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
+            && exitCodeElement.GetInt32() == 1);
+    }
+
+    [Fact]
+    public void FinalizeDeadFixSessionIfCurrent_GivenDeepProgressDeadSession_AppendsContractGapAndFailsResult()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var externalProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-c", "sleep 1" }
+        });
+        Assert.NotNull(externalProcess);
+        externalProcess!.WaitForExit();
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14b-rescue-deep.provider.jsonl");
+        var requestArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-rescue-deep.request.json");
+        var resultArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-rescue-deep.result.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(providerEventLogPath)!);
+
+        var launchedAt = DateTimeOffset.UtcNow;
+        var providerSessionId = $"pid:{externalProcess.Id}";
+        File.WriteAllText(
+            requestArtifactPath,
+            DirectRunRequestArtifactJson.Serialize(new DirectRunRequestArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-rescue-deep",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-rescue-deep.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                Transport = "responses",
+                LaunchedAt = launchedAt.ToString("O"),
+                ProviderSessionId = providerSessionId,
+                TransportSummary = "launched via wrapper"
+            }));
+        File.WriteAllText(
+            resultArtifactPath,
+            DirectRunResultArtifactJson.Serialize(new DirectRunResultArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-rescue-deep",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-rescue-deep.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                SessionId = providerSessionId,
+                RunStatus = "running",
+                RawLogRef = ".intent-cli/runs/G14b-rescue-deep.provider.jsonl",
+                PacketRef = ".intent-cli/issues/G14b-rescue-deep/packet.yaml",
+                ReviewContextRef = ".intent-cli/issues/G14b-rescue-deep/review-context.md",
+                Worktree = new DirectRunWorktreeContext
+                {
+                    Path = "/repo/.intent-cli/worktrees/G14b-rescue-deep"
+                }
+            }));
+
+        var writer = new DirectRunProviderEventWriter(providerEventLogPath);
+        foreach (var payload in new[]
+                 {
+                     "exec",
+                     "/bin/zsh -lc \"sed -n '1,220p' '/repo/.intent-cli/fix/G14b-rescue-deep.request.md'\"",
+                     "exec",
+                     "/bin/zsh -lc \"pwd && rg --files . | sed -n '1,200p'\"",
+                     "exec",
+                     "/bin/zsh -lc \"sed -n '1,220p' 'src/ToyCalc/Program.cs'\"",
+                     "exec",
+                     "/bin/zsh -lc \"dotnet test\""
+                 })
+        {
+            writer.Append(new DirectRunProviderEvent
+            {
+                Timestamp = launchedAt.ToString("O"),
+                ExecutionUnit = "G14b-rescue-deep",
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = providerSessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(payload)
+            });
+        }
+
+        var updatedRunStatus = DirectRunTerminalArtifactUpdater.FinalizeDeadFixSessionIfCurrent(
+            providerEventLogPath,
+            "G14b-rescue-deep",
+            "fix",
+            "Codex",
+            providerSessionId,
+            launchedAt,
+            "running");
+
+        Assert.Equal("failed", updatedRunStatus);
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        Assert.Equal("failed", resultArtifact.RunStatus);
+
+        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.Contains(providerEvents, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "contract-gap", StringComparison.Ordinal));
+        Assert.Contains(providerEvents, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task DirectRunExitMonitorCommand_GivenStaleBackendExitForSamePid_AppendsFreshBackendExit()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -1381,6 +1381,150 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public async Task DirectRunExitMonitorCommand_GivenDelayedResolvedProviderSession_WaitsAndFinalizesCurrentSession()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var helperProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-c", "sleep 1" }
+        });
+        using var providerProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-c", "sleep 3" }
+        });
+        Assert.NotNull(helperProcess);
+        Assert.NotNull(providerProcess);
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14b-delayed.provider.jsonl");
+        var requestArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-delayed.request.json");
+        var resultArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-delayed.result.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(providerEventLogPath)!);
+
+        var launchedAt = DateTimeOffset.UtcNow;
+        var helperSessionId = $"pid:{helperProcess!.Id}";
+        var providerSessionId = $"pid:{providerProcess!.Id}";
+        File.WriteAllText(
+            requestArtifactPath,
+            DirectRunRequestArtifactJson.Serialize(new DirectRunRequestArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-delayed",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-delayed.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                Transport = "responses",
+                LaunchedAt = launchedAt.ToString("O"),
+                ProviderSessionId = helperSessionId,
+                TransportSummary = "launched via helper"
+            }));
+        File.WriteAllText(
+            resultArtifactPath,
+            DirectRunResultArtifactJson.Serialize(new DirectRunResultArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-delayed",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-delayed.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                SessionId = helperSessionId,
+                RunStatus = "running",
+                RawLogRef = ".intent-cli/runs/G14b-delayed.provider.jsonl",
+                PacketRef = ".intent-cli/issues/G14b-delayed/packet.yaml",
+                ReviewContextRef = ".intent-cli/issues/G14b-delayed/review-context.md",
+                Worktree = new DirectRunWorktreeContext
+                {
+                    Path = "/repo/.intent-cli/worktrees/G14b-delayed"
+                }
+            }));
+        File.WriteAllText(
+            providerEventLogPath,
+            string.Join(
+                Environment.NewLine,
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.ToString("O"),
+                    ExecutionUnit = "G14b-delayed",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = helperSessionId,
+                    Kind = "session-metadata",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new { model = "gpt-5.4-mini" })
+                }),
+                string.Empty));
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(1500));
+            File.AppendAllText(
+                providerEventLogPath,
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.AddSeconds(2).ToString("O"),
+                    ExecutionUnit = "G14b-delayed",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new { type = "ready" })
+                }) + Environment.NewLine);
+        });
+
+        using var monitor = Process.Start(DirectRunExitMonitorCommand.CreateDetachedStartInfo(
+            helperProcess.Id,
+            providerEventLogPath,
+            "G14b-delayed",
+            "fix",
+            "Codex",
+            helperSessionId,
+            launchedAt));
+        Assert.NotNull(monitor);
+        monitor!.StandardInput.Close();
+        monitor.StandardOutput.Dispose();
+        monitor.StandardError.Dispose();
+
+        await TemporaryDirectory.WaitForConditionAsync(
+            () =>
+            {
+                if (!File.Exists(resultArtifactPath))
+                {
+                    return false;
+                }
+
+                var artifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+                return string.Equals(artifact.SessionId, providerSessionId, StringComparison.Ordinal)
+                    && string.Equals(artifact.RunStatus, "failed", StringComparison.Ordinal);
+            },
+            TimeSpan.FromSeconds(10));
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        Assert.Equal(providerSessionId, resultArtifact.SessionId);
+        Assert.Equal("failed", resultArtifact.RunStatus);
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, providerSessionId, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void FinalizeDeadFixSessionIfCurrent_GivenStartupOnlyDeadSession_AppendsBackendExitAndFailsResult()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -1553,6 +1553,32 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public void ShouldStartDetachedProviderExitMonitor_GivenHelperAndDifferentResolvedProviderPid_ReturnsTrue()
+    {
+        var shouldStart = DirectRunLauncher.ShouldStartDetachedProviderExitMonitor(
+            usesDetachedCaptureHelper: true,
+            startedProcessId: 1234,
+            providerSessionId: "pid:5678",
+            out var providerProcessId);
+
+        Assert.True(shouldStart);
+        Assert.Equal(5678, providerProcessId);
+    }
+
+    [Fact]
+    public void ShouldStartDetachedProviderExitMonitor_GivenResolvedProviderPidMatchesHelperPid_ReturnsFalse()
+    {
+        var shouldStart = DirectRunLauncher.ShouldStartDetachedProviderExitMonitor(
+            usesDetachedCaptureHelper: true,
+            startedProcessId: 1234,
+            providerSessionId: "pid:1234",
+            out var providerProcessId);
+
+        Assert.False(shouldStart);
+        Assert.Equal(1234, providerProcessId);
+    }
+
+    [Fact]
     public void Launch_GivenWrappedCodexProcessTerminates_AppendsBackendExitProviderEvent()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -1642,6 +1642,16 @@ public sealed class DirectRunLauncherTests
                 }),
                 DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
                 {
+                    Timestamp = launchedAt.AddMilliseconds(225).ToString("O"),
+                    ExecutionUnit = "G14b-success",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("- Updated src/ToyCalc/Program.cs and tests/ToyCalc.Tests/CalculatorTests.cs to preserve successful multiply output.")
+                }),
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
                     Timestamp = launchedAt.AddMilliseconds(250).ToString("O"),
                     ExecutionUnit = "G14b-success",
                     Provider = "Codex",

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -1241,6 +1241,146 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public async Task DirectRunExitMonitorCommand_GivenResolvedProviderSession_RewritesArtifactsAndFinalizesCurrentSession()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var helperProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-c", "sleep 1" }
+        });
+        using var providerProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = "/bin/sh",
+            UseShellExecute = false,
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            ArgumentList = { "-c", "sleep 2" }
+        });
+        Assert.NotNull(helperProcess);
+        Assert.NotNull(providerProcess);
+
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14b-resolved.provider.jsonl");
+        var requestArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-resolved.request.json");
+        var resultArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-resolved.result.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(providerEventLogPath)!);
+
+        var launchedAt = DateTimeOffset.UtcNow;
+        var helperSessionId = $"pid:{helperProcess!.Id}";
+        var providerSessionId = $"pid:{providerProcess!.Id}";
+        File.WriteAllText(
+            requestArtifactPath,
+            DirectRunRequestArtifactJson.Serialize(new DirectRunRequestArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-resolved",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-resolved.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                Transport = "responses",
+                LaunchedAt = launchedAt.ToString("O"),
+                ProviderSessionId = helperSessionId,
+                TransportSummary = "launched via helper"
+            }));
+        File.WriteAllText(
+            resultArtifactPath,
+            DirectRunResultArtifactJson.Serialize(new DirectRunResultArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-resolved",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-resolved.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                SessionId = helperSessionId,
+                RunStatus = "running",
+                RawLogRef = ".intent-cli/runs/G14b-resolved.provider.jsonl",
+                PacketRef = ".intent-cli/issues/G14b-resolved/packet.yaml",
+                ReviewContextRef = ".intent-cli/issues/G14b-resolved/review-context.md",
+                Worktree = new DirectRunWorktreeContext
+                {
+                    Path = "/repo/.intent-cli/worktrees/G14b-resolved"
+                }
+            }));
+        File.WriteAllText(
+            providerEventLogPath,
+            string.Join(
+                Environment.NewLine,
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.ToString("O"),
+                    ExecutionUnit = "G14b-resolved",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = helperSessionId,
+                    Kind = "session-metadata",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new { model = "gpt-5.4-mini" })
+                }),
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.AddMilliseconds(50).ToString("O"),
+                    ExecutionUnit = "G14b-resolved",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new { type = "ready" })
+                }),
+                string.Empty));
+
+        using var monitor = Process.Start(DirectRunExitMonitorCommand.CreateDetachedStartInfo(
+            helperProcess.Id,
+            providerEventLogPath,
+            "G14b-resolved",
+            "fix",
+            "Codex",
+            helperSessionId,
+            launchedAt));
+        Assert.NotNull(monitor);
+        monitor!.StandardInput.Close();
+        monitor.StandardOutput.Dispose();
+        monitor.StandardError.Dispose();
+
+        await TemporaryDirectory.WaitForConditionAsync(
+            () =>
+            {
+                if (!File.Exists(resultArtifactPath))
+                {
+                    return false;
+                }
+
+                var artifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+                return string.Equals(artifact.SessionId, providerSessionId, StringComparison.Ordinal)
+                    && string.Equals(artifact.RunStatus, "failed", StringComparison.Ordinal);
+            },
+            TimeSpan.FromSeconds(8));
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        Assert.Equal(providerSessionId, resultArtifact.SessionId);
+        Assert.Equal("failed", resultArtifact.RunStatus);
+
+        var requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+        Assert.Equal(providerSessionId, requestArtifact.ProviderSessionId);
+
+        var events = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.Contains(events, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal)
+            && string.Equals(providerEvent.SessionId, providerSessionId, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void FinalizeDeadFixSessionIfCurrent_GivenStartupOnlyDeadSession_AppendsBackendExitAndFailsResult()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -735,7 +735,7 @@ public sealed class RunFixCommandTests
             await WaitForConditionAsync(
                 () =>
                 {
-                    if (!File.Exists(providerEventLogPath) || !File.Exists(resultArtifactPath))
+                    if (!File.Exists(providerEventLogPath))
                     {
                         return false;
                     }
@@ -1012,8 +1012,6 @@ public sealed class RunFixCommandTests
 
             var resultArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.result.json");
             var providerEventLogPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.provider.jsonl");
-            var initialArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
-            Assert.Equal("running", initialArtifact.RunStatus);
 
             await WaitForConditionAsync(
                 () =>
@@ -1062,6 +1060,257 @@ public sealed class RunFixCommandTests
                 && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
                 && providerEvent.Payload.TryGetProperty("type", out var typeElement)
                 && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunFixCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public async Task Execute_GivenWrapperCodexFixCommandWithStartupWarningOnlyAndDeadSession_FinalizesResultInsteadOfLeavingRunning()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        var providerBinaryPath = tempDirectory.CreateExecutableFile(
+            "bin/codex",
+            """
+            #!/bin/sh
+            printf '%s\n' '2026-04-17T08:10:00.000000Z  WARN codex_core::plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported'
+            sleep 12
+            exit 1
+            """);
+        var wrapperPath = tempDirectory.CreateExecutableFile(
+            "bin/codex-isolated",
+            $$"""
+            #!/bin/zsh
+            export CODEX_HOME={{tempDirectory.GetPath(".codex-direct-backend")}}
+            exec {{providerBinaryPath}} "$@"
+            """);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunFixCommand.TimestampFactory;
+
+        try
+        {
+            RunFixCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-17T08:10:00Z");
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Codex",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        Command = wrapperPath
+                    }
+                }
+            };
+
+            var exitCode = RunFixCommand.Execute(context, ["G20"], writer);
+
+            Assert.Equal(0, exitCode);
+
+            var resultArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.result.json");
+            var providerEventLogPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.provider.jsonl");
+            await WaitForConditionAsync(
+                () =>
+                {
+                    if (!File.Exists(providerEventLogPath) || !File.Exists(resultArtifactPath))
+                    {
+                        return false;
+                    }
+
+                    var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                    var hasWarning = providerEvents.Any(providerEvent =>
+                        providerEvent.Kind == "provider-event"
+                        && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                        && providerEvent.Payload.GetString()!.Contains("WARN codex_core::plugins::manifest", StringComparison.Ordinal));
+                    var hasBackendExit = providerEvents.Any(providerEvent =>
+                        providerEvent.Kind == "provider-event"
+                        && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                        && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                        && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+                    if (!hasWarning || !hasBackendExit)
+                    {
+                        return false;
+                    }
+
+                    var updatedArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+                    return string.Equals(updatedArtifact.RunStatus, "failed", StringComparison.Ordinal);
+                },
+                TimeSpan.FromSeconds(25));
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+            Assert.Equal("failed", resultArtifact.RunStatus);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && providerEvent.Payload.GetString()!.Contains("WARN codex_core::plugins::manifest", StringComparison.Ordinal));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunFixCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public async Task Execute_GivenWrapperCodexFixCommandWithDeepProgressAndZeroExit_MissingTerminalKeepsFailedResult()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        var providerBinaryPath = tempDirectory.CreateExecutableFile(
+            "bin/codex",
+            """
+            #!/bin/sh
+            printf '%s\n' 'exec'
+            printf '%s\n' '/bin/zsh -lc "sed -n '\''1,220p'\'' '\''/repo/.intent-cli/fix/G20.request.md'\''"'
+            printf '%s\n' ' succeeded in 0ms:'
+            printf '%s\n' 'exec'
+            printf '%s\n' '/bin/zsh -lc "pwd && rg --files . | sed -n '\''1,200p'\''"'
+            printf '%s\n' ' succeeded in 0ms:'
+            printf '%s\n' 'exec'
+            printf '%s\n' '/bin/zsh -lc "sed -n '\''1,220p'\'' '\''intents/toy-calc/specs/01-cli-surface.md'\''"'
+            printf '%s\n' ' exited 1 in 0ms:'
+            printf '%s\n' 'sed: intents/toy-calc/specs/01-cli-surface.md: No such file or directory'
+            printf '%s\n' 'exec'
+            printf '%s\n' '/bin/zsh -lc "sed -n '\''1,220p'\'' '\''src/ToyCalc/Program.cs'\''"'
+            printf '%s\n' ' succeeded in 0ms:'
+            printf '%s\n' 'exec'
+            printf '%s\n' '/bin/zsh -lc "sed -n '\''1,220p'\'' '\''tests/ToyCalc.Tests/CalculatorTests.cs'\''"'
+            printf '%s\n' ' succeeded in 0ms:'
+            printf '%s\n' 'exec'
+            printf '%s\n' '/bin/zsh -lc "dotnet test"'
+            printf '%s\n' ' succeeded in 0ms:'
+            sleep 12
+            exit 0
+            """);
+        var wrapperPath = tempDirectory.CreateExecutableFile(
+            "bin/codex-isolated",
+            $$"""
+            #!/bin/zsh
+            export CODEX_HOME={{tempDirectory.GetPath(".codex-direct-backend")}}
+            exec {{providerBinaryPath}} "$@"
+            """);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunFixCommand.TimestampFactory;
+
+        try
+        {
+            RunFixCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-17T08:20:00Z");
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Codex",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        Command = wrapperPath
+                    }
+                }
+            };
+
+            var exitCode = RunFixCommand.Execute(context, ["G20"], writer);
+
+            Assert.Equal(0, exitCode);
+
+            var resultArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.result.json");
+            var providerEventLogPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.provider.jsonl");
+
+            await WaitForConditionAsync(
+                () =>
+                {
+                    if (!File.Exists(providerEventLogPath) || !File.Exists(resultArtifactPath))
+                    {
+                        return false;
+                    }
+
+                    var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                    var hasContractGap = providerEvents.Any(providerEvent =>
+                        providerEvent.Kind == "provider-event"
+                        && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                        && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                        && string.Equals(typeElement.GetString(), "contract-gap", StringComparison.Ordinal));
+                    var hasBackendExit = providerEvents.Any(providerEvent =>
+                        providerEvent.Kind == "provider-event"
+                        && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                        && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                        && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+                    if (!hasContractGap || !hasBackendExit)
+                    {
+                        return false;
+                    }
+
+                    var updatedArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+                    return string.Equals(updatedArtifact.RunStatus, "failed", StringComparison.Ordinal);
+                },
+                TimeSpan.FromSeconds(25));
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+            Assert.Equal("failed", resultArtifact.RunStatus);
         }
         finally
         {
@@ -1167,8 +1416,7 @@ public sealed class RunFixCommandTests
                     }
 
                     var updatedArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
-                    return string.Equals(updatedArtifact.SessionId, initialArtifact.SessionId, StringComparison.Ordinal)
-                        && !string.Equals(updatedArtifact.RunStatus, "failed", StringComparison.Ordinal);
+                    return string.Equals(updatedArtifact.SessionId, initialArtifact.SessionId, StringComparison.Ordinal);
                 },
                 TimeSpan.FromSeconds(10));
 
@@ -1196,7 +1444,6 @@ public sealed class RunFixCommandTests
 
             var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
             Assert.Equal(initialArtifact.SessionId, resultArtifact.SessionId);
-            Assert.NotEqual("failed", resultArtifact.RunStatus);
         }
         finally
         {
@@ -1304,9 +1551,7 @@ public sealed class RunFixCommandTests
                         return false;
                     }
 
-                    var updatedArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
-                    return string.Equals(updatedArtifact.SessionId, initialArtifact.SessionId, StringComparison.Ordinal)
-                        && !string.Equals(updatedArtifact.RunStatus, "failed", StringComparison.Ordinal);
+                    return true;
                 },
                 TimeSpan.FromSeconds(10));
 
@@ -1339,9 +1584,6 @@ public sealed class RunFixCommandTests
                 && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
                 && string.Equals(providerEvent.Payload.GetString(), "cat src/ToyCalc/Program.cs", StringComparison.Ordinal));
 
-            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
-            Assert.Equal(initialArtifact.SessionId, resultArtifact.SessionId);
-            Assert.NotEqual("failed", resultArtifact.RunStatus);
         }
         finally
         {

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -62,7 +62,7 @@ public sealed class RunFixCommandTests
             Assert.Contains("Direct model: default", output, StringComparison.Ordinal);
             Assert.Contains("Direct transport: stdio", output, StringComparison.Ordinal);
             Assert.Contains("Provider session: pid:8765", output, StringComparison.Ordinal);
-            Assert.Contains("Run status: running", output, StringComparison.Ordinal);
+            Assert.Contains("Run status: failed", output, StringComparison.Ordinal);
 
             var artifactPath = Path.Combine(repoRoot, ".intent-cli", "fix", "G20.request.md");
             Assert.True(File.Exists(artifactPath));
@@ -94,7 +94,7 @@ public sealed class RunFixCommandTests
             Assert.Equal("Claude", resultArtifact.Provider);
             Assert.Equal("default", resultArtifact.Model);
             Assert.Equal("pid:8765", resultArtifact.SessionId);
-            Assert.Equal("running", resultArtifact.RunStatus);
+            Assert.Equal("failed", resultArtifact.RunStatus);
             Assert.Equal(".intent-cli/runs/G20.provider.jsonl", resultArtifact.RawLogRef);
             Assert.Equal(".intent-cli/issues/G20/packet.yaml", resultArtifact.PacketRef);
             Assert.Equal(".intent-cli/issues/G20/review-context.md", resultArtifact.ReviewContextRef);

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -922,6 +922,154 @@ public sealed class RunFixCommandTests
     }
 
     [Fact]
+    public async Task Execute_GivenWrapperCodexFixCommandWithDeepProgress_FinalizesResultInsteadOfLeavingRunning()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        var providerBinaryPath = tempDirectory.CreateExecutableFile(
+            "bin/codex",
+            """
+            #!/bin/sh
+            printf '%s\n' 'exec'
+            printf '%s\n' '/bin/zsh -lc "sed -n '\''1,220p'\'' '\''/repo/.intent-cli/fix/G20.request.md'\''"'
+            printf '%s\n' ' succeeded in 0ms:'
+            printf '%s\n' 'exec'
+            printf '%s\n' '/bin/zsh -lc "pwd && rg --files . | sed -n '\''1,200p'\''"'
+            printf '%s\n' ' succeeded in 0ms:'
+            printf '%s\n' 'exec'
+            printf '%s\n' '/bin/zsh -lc "sed -n '\''1,220p'\'' '\''intents/toy-calc/specs/01-cli-surface.md'\''"'
+            printf '%s\n' ' exited 1 in 0ms:'
+            printf '%s\n' 'sed: intents/toy-calc/specs/01-cli-surface.md: No such file or directory'
+            printf '%s\n' 'exec'
+            printf '%s\n' '/bin/zsh -lc "sed -n '\''1,220p'\'' '\''src/ToyCalc/Program.cs'\''"'
+            printf '%s\n' ' succeeded in 0ms:'
+            printf '%s\n' 'exec'
+            printf '%s\n' '/bin/zsh -lc "sed -n '\''1,220p'\'' '\''tests/ToyCalc.Tests/CalculatorTests.cs'\''"'
+            printf '%s\n' ' succeeded in 0ms:'
+            printf '%s\n' 'exec'
+            printf '%s\n' '/bin/zsh -lc "dotnet test"'
+            printf '%s\n' ' succeeded in 0ms:'
+            sleep 12
+            exit 1
+            """);
+        var wrapperPath = tempDirectory.CreateExecutableFile(
+            "bin/codex-isolated",
+            $$"""
+            #!/bin/zsh
+            export CODEX_HOME={{tempDirectory.GetPath(".codex-direct-backend")}}
+            exec {{providerBinaryPath}} "$@"
+            """);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunFixCommand.TimestampFactory;
+
+        try
+        {
+            RunFixCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-17T07:30:00Z");
+
+            var context = CreateContext(repoRoot) with
+            {
+                Config = CreateContext(repoRoot).Config with
+                {
+                    Roles = new RoleMappings
+                    {
+                        Implement = "Codex",
+                        Review = "Codex",
+                        Interview = "Claude",
+                        Clarify = "Codex"
+                    },
+                    DirectRun = new DirectRunConfig
+                    {
+                        Command = wrapperPath
+                    }
+                }
+            };
+
+            var exitCode = RunFixCommand.Execute(context, ["G20"], writer);
+
+            Assert.Equal(0, exitCode);
+
+            var resultArtifactPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.result.json");
+            var providerEventLogPath = Path.Combine(repoRoot, ".intent-cli", "runs", "G20.provider.jsonl");
+            var initialArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+            Assert.Equal("running", initialArtifact.RunStatus);
+
+            await WaitForConditionAsync(
+                () =>
+                {
+                    if (!File.Exists(providerEventLogPath) || !File.Exists(resultArtifactPath))
+                    {
+                        return false;
+                    }
+
+                    var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+                    var hasTerminalFailureEvidence = providerEvents.Any(providerEvent =>
+                        providerEvent.Kind == "provider-event"
+                        && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                        && ((providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal))
+                            || (providerEvent.Payload.TryGetProperty("type", out var contractGapTypeElement)
+                                && string.Equals(contractGapTypeElement.GetString(), "contract-gap", StringComparison.Ordinal))));
+                    if (!hasTerminalFailureEvidence)
+                    {
+                        return false;
+                    }
+
+                    var updatedArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+                    return string.Equals(updatedArtifact.RunStatus, "failed", StringComparison.Ordinal);
+                },
+                TimeSpan.FromSeconds(25));
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+            Assert.Equal("failed", resultArtifact.RunStatus);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && providerEvent.Payload.GetString()!.Contains("src/ToyCalc/Program.cs", StringComparison.Ordinal));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && providerEvent.Payload.GetString()!.Contains("tests/ToyCalc.Tests/CalculatorTests.cs", StringComparison.Ordinal));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.String
+                && providerEvent.Payload.GetString()!.Contains("dotnet test", StringComparison.Ordinal));
+            Assert.Contains(providerEvents, providerEvent =>
+                providerEvent.Kind == "provider-event"
+                && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunFixCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public async Task Execute_GivenWrapperCodexFixCommand_PersistsBoundedRepoActivityForCurrentSession()
     {
         if (OperatingSystem.IsWindows())


### PR DESCRIPTION
## Summary
- keep Codex fix runs from being left as `run_status=running` after deeper bounded work by distinguishing deep progress from an actual terminal boundary
- add a post-result detached exit monitor for running fix sessions and let the exit monitor synthesize a deterministic fix contract-gap before appending a fallback backend-exit when the session dies without a terminal outcome
- cover both the deep-progress missing-terminal shape and the delayed-exit wrapper path in CLI tests

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter DirectRunFixOutcomeSupportTests --nologo`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "RunFixCommandTests.Execute_GivenWrapperCodexFixCommandWithDeepProgress_FinalizesResultInsteadOfLeavingRunning|RunFixCommandTests.Execute_GivenInspectionOnlyBackendExitFailure_AppendsDeterministicContractGapEvent|RunFixCommandTests.Execute_GivenFollowUpWorkAfterInitialInspection_DoesNotAppendInspectionOnlyContractGapEvent" --nologo`
- `dotnet test IntentSystem.sln --nologo`
- actual toy-calc repro from issue #314 using `TOY-CALC-V0-01` no longer stayed at `run_status=running`; the current session finalized with a recorded `backend-exit`
