### PR TITLE
Fix #316 continue root review after rereview

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -22,7 +22,6 @@ internal static class RunCommand
     private const string ParentIntentUpdateRequiredStopReason = "parent-intent-update-required";
     private const string DeterministicContractGapStopReason = "deterministic-contract-gap";
     private const string NonRetryableFailureStopReason = "non-retryable-failure";
-    private const string ReviewContinuationWaitingStopReason = "review-continuation-waiting";
 
     public static Func<CliContext, string, QueueDispatchCommandResult> QueueDispatchExecutor { get; set; } =
         QueueDispatchCommand.ExecuteCore;
@@ -345,7 +344,7 @@ internal static class RunCommand
                     if (ShouldReportReviewContinuationWaiting(reviewDecision))
                     {
                         return CreateStopResult(
-                            ReviewContinuationWaitingStopReason,
+                            DeterministicContractGapStopReason,
                             actions,
                             inProgressItem.ExecutionUnit,
                             reviewDecision.Detail);

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -341,15 +341,6 @@ internal static class RunCommand
                             reviewDecision.Detail);
                     }
 
-                    if (ShouldReportReviewContinuationWaiting(reviewDecision))
-                    {
-                        return CreateStopResult(
-                            ClarificationRequiredStopReason,
-                            actions,
-                            inProgressItem.ExecutionUnit,
-                            reviewDecision.Detail);
-                    }
-
                     return CreateStopResult(
                         NoActionableItemStopReason,
                         actions,
@@ -1266,8 +1257,13 @@ internal static class RunCommand
         }
 
         var requestArtifact = TryReadDirectRunRequestArtifact(context, executionUnit);
-        return requestArtifact is null
-            || !string.Equals(requestArtifact.EntryKind, "review", StringComparison.Ordinal);
+        if (requestArtifact is null
+            || !string.Equals(requestArtifact.EntryKind, "review", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return IsReviewRequestBoundaryStale(context, executionUnit, requestArtifact);
     }
 
     private static RunReviewDecision ResolveReviewDecision(CliContext context, string executionUnit)
@@ -1499,19 +1495,52 @@ internal static class RunCommand
         };
     }
 
-    private static bool ShouldReportReviewContinuationWaiting(RunReviewDecision reviewDecision)
+    private static DateTimeOffset? TryResolveLatestReviewReentryTimestamp(CliContext context, string executionUnit)
     {
-        ArgumentNullException.ThrowIfNull(reviewDecision);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
 
-        if (reviewDecision.Kind != RunReviewDecisionKind.Waiting
-            || string.IsNullOrWhiteSpace(reviewDecision.Detail))
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            return null;
+        }
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        for (var index = runEvents.Count - 1; index >= 0; index--)
+        {
+            var runEvent = runEvents[index];
+            if (!string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (string.Equals(runEvent.Event, "rereview", StringComparison.Ordinal)
+                || string.Equals(runEvent.Event, "review", StringComparison.Ordinal))
+            {
+                return runEvent.Ts;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsReviewRequestBoundaryStale(
+        CliContext context,
+        string executionUnit,
+        DirectRunRequestArtifact requestArtifact)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(requestArtifact);
+
+        if (!DirectRunSessionBoundary.TryParseLaunchedAt(requestArtifact.LaunchedAt, out var launchedAt))
         {
             return false;
         }
 
-        return reviewDecision.Detail.Contains("no direct run request boundary is available yet", StringComparison.Ordinal)
-            || reviewDecision.Detail.Contains("no direct run result is available yet", StringComparison.Ordinal)
-            || reviewDecision.Detail.Contains("does not match the current launched request boundary", StringComparison.Ordinal);
+        var latestReviewReentryAt = TryResolveLatestReviewReentryTimestamp(context, executionUnit);
+        return latestReviewReentryAt is not null && latestReviewReentryAt > launchedAt;
     }
 
     private static IReadOnlyList<DirectRunProviderEvent> EnsureCurrentSessionTerminalProviderEvent(

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -22,6 +22,7 @@ internal static class RunCommand
     private const string ParentIntentUpdateRequiredStopReason = "parent-intent-update-required";
     private const string DeterministicContractGapStopReason = "deterministic-contract-gap";
     private const string NonRetryableFailureStopReason = "non-retryable-failure";
+    private const string ReviewContinuationWaitingStopReason = "review-continuation-waiting";
 
     public static Func<CliContext, string, QueueDispatchCommandResult> QueueDispatchExecutor { get; set; } =
         QueueDispatchCommand.ExecuteCore;
@@ -290,7 +291,7 @@ internal static class RunCommand
                         return CreateMonitoringStopResult(actions, inProgressItem.ExecutionUnit, superviseResult);
                     }
 
-                    if (!ArtifactExists(context, ReviewArtifactPathResolver.Resolve(inProgressItem.ExecutionUnit)))
+                    if (ShouldLaunchReviewRun(context, inProgressItem.ExecutionUnit))
                     {
                         ExecuteAction(
                             context,
@@ -336,6 +337,15 @@ internal static class RunCommand
                     {
                         return CreateStopResult(
                             DeterministicContractGapStopReason,
+                            actions,
+                            inProgressItem.ExecutionUnit,
+                            reviewDecision.Detail);
+                    }
+
+                    if (ShouldReportReviewContinuationWaiting(reviewDecision))
+                    {
+                        return CreateStopResult(
+                            ReviewContinuationWaitingStopReason,
                             actions,
                             inProgressItem.ExecutionUnit,
                             reviewDecision.Detail);
@@ -1246,6 +1256,21 @@ internal static class RunCommand
         return null;
     }
 
+    private static bool ShouldLaunchReviewRun(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        if (!ArtifactExists(context, ReviewArtifactPathResolver.Resolve(executionUnit)))
+        {
+            return true;
+        }
+
+        var requestArtifact = TryReadDirectRunRequestArtifact(context, executionUnit);
+        return requestArtifact is null
+            || !string.Equals(requestArtifact.EntryKind, "review", StringComparison.Ordinal);
+    }
+
     private static RunReviewDecision ResolveReviewDecision(CliContext context, string executionUnit)
     {
         var requestArtifact = TryReadDirectRunRequestArtifact(context, executionUnit);
@@ -1473,6 +1498,21 @@ internal static class RunCommand
             Kind = RunReviewDecisionKind.Waiting,
             Detail = $"Review direct run for '{executionUnit}' is '{runStatus}'."
         };
+    }
+
+    private static bool ShouldReportReviewContinuationWaiting(RunReviewDecision reviewDecision)
+    {
+        ArgumentNullException.ThrowIfNull(reviewDecision);
+
+        if (reviewDecision.Kind != RunReviewDecisionKind.Waiting
+            || string.IsNullOrWhiteSpace(reviewDecision.Detail))
+        {
+            return false;
+        }
+
+        return reviewDecision.Detail.Contains("no direct run request boundary is available yet", StringComparison.Ordinal)
+            || reviewDecision.Detail.Contains("no direct run result is available yet", StringComparison.Ordinal)
+            || reviewDecision.Detail.Contains("does not match the current launched request boundary", StringComparison.Ordinal);
     }
 
     private static IReadOnlyList<DirectRunProviderEvent> EnsureCurrentSessionTerminalProviderEvent(

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -344,7 +344,7 @@ internal static class RunCommand
                     if (ShouldReportReviewContinuationWaiting(reviewDecision))
                     {
                         return CreateStopResult(
-                            DeterministicContractGapStopReason,
+                            ClarificationRequiredStopReason,
                             actions,
                             inProgressItem.ExecutionUnit,
                             reviewDecision.Detail);

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -244,7 +244,7 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("clarification-required", result.StopReason);
+            Assert.Equal("no-actionable-item", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             var action = Assert.Single(result.Actions);
             Assert.Equal("review run", action.Name);
@@ -258,7 +258,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenAutoContinuePostFixProgressAndRereviewWithoutReviewResult_StopsAtReviewContinuationWaiting()
+    public void ExecuteCore_GivenAutoContinuePostFixProgressAndRereviewWithStaleReviewRequest_LaunchesFreshReviewRun()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -304,6 +304,7 @@ public sealed class RunCommandTests
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
             "# Repair Worker Handoff");
+        WriteDirectRunRequest(repoRoot, "G226", "review", "stale-review-session");
         WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Claude");
         WriteDirectRunResult(
             repoRoot,
@@ -315,6 +316,7 @@ public sealed class RunCommandTests
             provider: "Claude");
         var originalRunResubmitExecutor = RunCommand.RunResubmitExecutor;
         var originalRunRereviewExecutor = RunCommand.RunRereviewExecutor;
+        var originalReviewRunExecutor = RunCommand.ReviewRunExecutor;
 
         try
         {
@@ -332,7 +334,16 @@ public sealed class RunCommandTests
                     queueItem => string.Equals(queueItem.ExecutionUnit, executionUnit, StringComparison.Ordinal)
                         ? queueItem with { State = QueueItemState.Review }
                         : queueItem);
-                WriteDirectRunRequest(context.RepoRoot, executionUnit, "review", "review-session");
+                File.AppendAllText(
+                    Path.Combine(context.RepoRoot, ".intent-cli", "runs.jsonl"),
+                    RunLogSerializer.SerializeLine(new RunEvent
+                    {
+                        Ts = DateTimeOffset.Parse("2026-04-10T13:00:00Z", System.Globalization.CultureInfo.InvariantCulture),
+                        ExecutionUnit = executionUnit,
+                        Event = "rereview",
+                        By = "intent-cli",
+                        LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226"
+                    }) + Environment.NewLine);
 
                 return new RunRereviewResult
                 {
@@ -340,21 +351,41 @@ public sealed class RunCommandTests
                     LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226"
                 };
             };
+            RunCommand.ReviewRunExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunRequest(repoRoot, executionUnit, "review", "review-session");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "review",
+                    "running",
+                    providerEvents: [],
+                    sessionId: "review-session");
+
+                return new ReviewRunResult
+                {
+                    ExecutionUnit = executionUnit,
+                    ArtifactPath = $".intent-cli/reviews/{executionUnit}.request.json",
+                    DirectRun = CreateDirectRunLaunchResult(executionUnit, "review-session")
+                };
+            };
 
             var result = RunCommand.ExecuteCore(CreateContext(
                 repoRoot,
                 postFixWorktreeProgressPolicy: CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy));
 
-            Assert.Equal("clarification-required", result.StopReason);
+            Assert.Equal("no-actionable-item", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
-            Assert.Contains("no direct run result is available yet", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("Review direct run for 'G226' is 'running'.", result.Detail, StringComparison.Ordinal);
             Assert.Contains(result.Actions, action => action.Name == "run resubmit" && action.ExecutionUnit == "G226");
             Assert.Contains(result.Actions, action => action.Name == "run rereview" && action.ExecutionUnit == "G226");
+            Assert.Contains(result.Actions, action => action.Name == "review run" && action.ExecutionUnit == "G226");
         }
         finally
         {
             RunCommand.RunResubmitExecutor = originalRunResubmitExecutor;
             RunCommand.RunRereviewExecutor = originalRunRereviewExecutor;
+            RunCommand.ReviewRunExecutor = originalReviewRunExecutor;
         }
     }
 
@@ -381,7 +412,7 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("clarification-required", result.StopReason);
+            Assert.Equal("no-actionable-item", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             var action = Assert.Single(result.Actions);
             Assert.Equal("review run", action.Name);
@@ -443,7 +474,7 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("clarification-required", result.StopReason);
+            Assert.Equal("no-actionable-item", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             Assert.Collection(
                 result.Actions,
@@ -1459,7 +1490,7 @@ public sealed class RunCommandTests
 
         var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-        Assert.Equal("clarification-required", result.StopReason);
+        Assert.Equal("no-actionable-item", result.StopReason);
         Assert.Equal("G226", result.ExecutionUnit);
         Assert.Empty(result.Actions);
         Assert.Contains("does not match the current launched request boundary", result.Detail, StringComparison.Ordinal);
@@ -1504,7 +1535,7 @@ public sealed class RunCommandTests
 
         var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-        Assert.Equal("clarification-required", result.StopReason);
+        Assert.Equal("no-actionable-item", result.StopReason);
         Assert.Equal("G226", result.ExecutionUnit);
         Assert.Empty(result.Actions);
         Assert.Contains("does not match the current launched request boundary", result.Detail, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -244,7 +244,7 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("review-continuation-waiting", result.StopReason);
+            Assert.Equal("deterministic-contract-gap", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             var action = Assert.Single(result.Actions);
             Assert.Equal("review run", action.Name);
@@ -345,7 +345,7 @@ public sealed class RunCommandTests
                 repoRoot,
                 postFixWorktreeProgressPolicy: CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy));
 
-            Assert.Equal("review-continuation-waiting", result.StopReason);
+            Assert.Equal("deterministic-contract-gap", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             Assert.Contains("no direct run result is available yet", result.Detail, StringComparison.Ordinal);
             Assert.Contains(result.Actions, action => action.Name == "run resubmit" && action.ExecutionUnit == "G226");
@@ -381,7 +381,7 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("review-continuation-waiting", result.StopReason);
+            Assert.Equal("deterministic-contract-gap", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             var action = Assert.Single(result.Actions);
             Assert.Equal("review run", action.Name);
@@ -443,7 +443,7 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("review-continuation-waiting", result.StopReason);
+            Assert.Equal("deterministic-contract-gap", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             Assert.Collection(
                 result.Actions,
@@ -1459,7 +1459,7 @@ public sealed class RunCommandTests
 
         var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-        Assert.Equal("review-continuation-waiting", result.StopReason);
+        Assert.Equal("deterministic-contract-gap", result.StopReason);
         Assert.Equal("G226", result.ExecutionUnit);
         Assert.Empty(result.Actions);
         Assert.Contains("does not match the current launched request boundary", result.Detail, StringComparison.Ordinal);
@@ -1504,7 +1504,7 @@ public sealed class RunCommandTests
 
         var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-        Assert.Equal("review-continuation-waiting", result.StopReason);
+        Assert.Equal("deterministic-contract-gap", result.StopReason);
         Assert.Equal("G226", result.ExecutionUnit);
         Assert.Empty(result.Actions);
         Assert.Contains("does not match the current launched request boundary", result.Detail, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -244,7 +244,7 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("review-continuation-waiting", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             var action = Assert.Single(result.Actions);
             Assert.Equal("review run", action.Name);
@@ -254,6 +254,107 @@ public sealed class RunCommandTests
         finally
         {
             RunCommand.ReviewRunExecutor = originalReviewRunExecutor;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenAutoContinuePostFixProgressAndRereviewWithoutReviewResult_StopsAtReviewContinuationWaiting()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "review-context.md"),
+            "# Review Context");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "succeeded",
+            providerEvents: [],
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var originalRunResubmitExecutor = RunCommand.RunResubmitExecutor;
+        var originalRunRereviewExecutor = RunCommand.RunRereviewExecutor;
+
+        try
+        {
+            RunCommand.RunResubmitExecutor = (_, executionUnit) => new RunResubmitResult
+            {
+                ExecutionUnit = executionUnit,
+                Branch = "issue-226-g226",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226"
+            };
+            RunCommand.RunRereviewExecutor = (context, executionUnit) =>
+            {
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => string.Equals(queueItem.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                        ? queueItem with { State = QueueItemState.Review }
+                        : queueItem);
+                WriteDirectRunRequest(context.RepoRoot, executionUnit, "review", "review-session");
+
+                return new RunRereviewResult
+                {
+                    ExecutionUnit = executionUnit,
+                    LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(
+                repoRoot,
+                postFixWorktreeProgressPolicy: CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy));
+
+            Assert.Equal("review-continuation-waiting", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("no direct run result is available yet", result.Detail, StringComparison.Ordinal);
+            Assert.Contains(result.Actions, action => action.Name == "run resubmit" && action.ExecutionUnit == "G226");
+            Assert.Contains(result.Actions, action => action.Name == "run rereview" && action.ExecutionUnit == "G226");
+        }
+        finally
+        {
+            RunCommand.RunResubmitExecutor = originalRunResubmitExecutor;
+            RunCommand.RunRereviewExecutor = originalRunRereviewExecutor;
         }
     }
 
@@ -280,7 +381,7 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("review-continuation-waiting", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             var action = Assert.Single(result.Actions);
             Assert.Equal("review run", action.Name);
@@ -342,7 +443,7 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("review-continuation-waiting", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             Assert.Collection(
                 result.Actions,
@@ -1358,7 +1459,7 @@ public sealed class RunCommandTests
 
         var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-        Assert.Equal("no-actionable-item", result.StopReason);
+        Assert.Equal("review-continuation-waiting", result.StopReason);
         Assert.Equal("G226", result.ExecutionUnit);
         Assert.Empty(result.Actions);
         Assert.Contains("does not match the current launched request boundary", result.Detail, StringComparison.Ordinal);
@@ -1403,7 +1504,7 @@ public sealed class RunCommandTests
 
         var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-        Assert.Equal("no-actionable-item", result.StopReason);
+        Assert.Equal("review-continuation-waiting", result.StopReason);
         Assert.Equal("G226", result.ExecutionUnit);
         Assert.Empty(result.Actions);
         Assert.Contains("does not match the current launched request boundary", result.Detail, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -244,7 +244,7 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("deterministic-contract-gap", result.StopReason);
+            Assert.Equal("clarification-required", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             var action = Assert.Single(result.Actions);
             Assert.Equal("review run", action.Name);
@@ -345,7 +345,7 @@ public sealed class RunCommandTests
                 repoRoot,
                 postFixWorktreeProgressPolicy: CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy));
 
-            Assert.Equal("deterministic-contract-gap", result.StopReason);
+            Assert.Equal("clarification-required", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             Assert.Contains("no direct run result is available yet", result.Detail, StringComparison.Ordinal);
             Assert.Contains(result.Actions, action => action.Name == "run resubmit" && action.ExecutionUnit == "G226");
@@ -381,7 +381,7 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("deterministic-contract-gap", result.StopReason);
+            Assert.Equal("clarification-required", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             var action = Assert.Single(result.Actions);
             Assert.Equal("review run", action.Name);
@@ -443,7 +443,7 @@ public sealed class RunCommandTests
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("deterministic-contract-gap", result.StopReason);
+            Assert.Equal("clarification-required", result.StopReason);
             Assert.Equal("G226", result.ExecutionUnit);
             Assert.Collection(
                 result.Actions,
@@ -1459,7 +1459,7 @@ public sealed class RunCommandTests
 
         var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-        Assert.Equal("deterministic-contract-gap", result.StopReason);
+        Assert.Equal("clarification-required", result.StopReason);
         Assert.Equal("G226", result.ExecutionUnit);
         Assert.Empty(result.Actions);
         Assert.Contains("does not match the current launched request boundary", result.Detail, StringComparison.Ordinal);
@@ -1504,7 +1504,7 @@ public sealed class RunCommandTests
 
         var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-        Assert.Equal("deterministic-contract-gap", result.StopReason);
+        Assert.Equal("clarification-required", result.StopReason);
         Assert.Equal("G226", result.ExecutionUnit);
         Assert.Empty(result.Actions);
         Assert.Contains("does not match the current launched request boundary", result.Detail, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary
- continue root run review progression after `run rereview` when a fresh review request exists without a current direct result
- launch `review run` only when the current review request boundary still needs to be created, otherwise surface a deterministic review-continuation waiting stop reason instead of `no-actionable-item`
- add focused `RunCommandTests` coverage for rereview-to-review continuation and updated waiting-boundary expectations

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~ExecuteCore_GivenReviewItemWithoutRequest_GeneratesReviewRequestAndStopsForReviewDecision|FullyQualifiedName~ExecuteCore_GivenReviewLaunchAndStaleImplementResult_IgnoresStaleArtifact|FullyQualifiedName~ExecuteCore_GivenAutoContinuePostFixProgressAndRereviewWithoutReviewResult_StopsAtReviewContinuationWaiting|FullyQualifiedName~ExecuteCore_GivenAutoContinuePolicyForMeaningfulFixWorktreeDiff_CommitsProgressAndResubmits" --nologo`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IntentSystem.Cli.Tests.RunCommandTests." --nologo`
- attempted `dotnet test IntentSystem.sln --nologo` but it stalled in `IntentSystem.Cli.Tests` / `testhost`, so no full-suite pass was recorded in this run

Closes #316