### PR TITLE
Fix #318 preserve explicit fix contract-gap outcome

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -952,7 +952,7 @@ internal static class DirectRunCommandSupport
             currentProviderEvents = [.. currentProviderEvents, fixContractGapEvent];
         }
 
-        var runStatus = ResolveRunStatus(currentProviderEvents);
+        var runStatus = ResolveRunStatus(entryKind, currentProviderEvents);
         if (string.Equals(entryKind, "review", StringComparison.Ordinal))
         {
             var capturedMessagePath = Path.GetFullPath(Path.Combine(
@@ -1159,8 +1159,14 @@ internal static class DirectRunCommandSupport
         return fallbackModel;
     }
 
-    private static string ResolveRunStatus(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    private static string ResolveRunStatus(string entryKind, IReadOnlyList<DirectRunProviderEvent> providerEvents)
     {
+        if (string.Equals(entryKind, "fix", StringComparison.Ordinal)
+            && DirectRunFixOutcomeSupport.HasExplicitContractGapSignal(providerEvents))
+        {
+            return "failed";
+        }
+
         for (var index = providerEvents.Count - 1; index >= 0; index--)
         {
             var payload = providerEvents[index].Payload;

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -5,6 +5,7 @@ namespace IntentSystem.Cli.Commands;
 internal static class DirectRunFixOutcomeSupport
 {
     private const string DeterministicContractGapStopReason = "deterministic-contract-gap";
+    private const string ExplicitContractGapRefusalReason = "provider-explicit-contract-gap-refusal";
     private const string InspectionOnlyExitReason = "fix-session-ended-after-initial-inspection";
     private const string ProviderBackendEndedBeforeSpecSourceReadReason = "fix-session-ended-before-spec-source-test-read";
     private const string MissingTerminalCaptureAfterRequestReadReason = "fix-session-terminal-boundary-missing-after-request-reread";
@@ -63,8 +64,24 @@ internal static class DirectRunFixOutcomeSupport
         ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
 
         if (!string.Equals(entryKind, "fix", StringComparison.Ordinal)
-            || HasExplicitContractGap(providerEvents)
-            || !TryResolveCanonicalFailureDetail(
+            || HasCanonicalContractGap(providerEvents))
+        {
+            return null;
+        }
+
+        if (TryCreateExplicitContractGapEvent(
+                providerEvents,
+                timestamp,
+                executionUnit,
+                entryKind,
+                provider,
+                providerSessionId,
+                out var explicitContractGapEvent))
+        {
+            return explicitContractGapEvent;
+        }
+
+        if (!TryResolveCanonicalFailureDetail(
                 providerEvents,
                 executionUnit,
                 providerSessionAlive,
@@ -456,10 +473,76 @@ internal static class DirectRunFixOutcomeSupport
         return true;
     }
 
+    private static bool TryCreateExplicitContractGapEvent(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        DateTimeOffset timestamp,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        out DirectRunProviderEvent? providerEvent)
+    {
+        providerEvent = null;
+        if (!TryResolveExplicitContractGapDetail(providerEvents, executionUnit, out var detail))
+        {
+            return false;
+        }
+
+        providerEvent = new DirectRunProviderEvent
+        {
+            Timestamp = timestamp.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = provider,
+            EntryKind = entryKind,
+            SessionId = providerSessionId,
+            Kind = "provider-event",
+            Payload = JsonSerializer.SerializeToElement(new
+            {
+                type = "contract-gap",
+                stop_reason = DeterministicContractGapStopReason,
+                reason = ExplicitContractGapRefusalReason,
+                detail,
+                run_status = "failed"
+            })
+        };
+
+        return true;
+    }
+
     private static bool HasExplicitContractGap(IReadOnlyList<DirectRunProviderEvent> providerEvents)
     {
         return providerEvents.Any(providerEvent =>
             TryResolveExplicitContractGapDetail(providerEvent.Payload, providerEvent.ExecutionUnit ?? "fix", out _));
+    }
+
+    private static bool HasCanonicalContractGap(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        return providerEvents.Any(providerEvent =>
+            providerEvent.Payload.ValueKind == JsonValueKind.Object
+            && ((TryReadString(providerEvent.Payload, "stop_reason", out var stopReason)
+                    && string.Equals(stopReason, DeterministicContractGapStopReason, StringComparison.Ordinal))
+                || (TryReadString(providerEvent.Payload, "type", out var type)
+                    && string.Equals(type, "contract-gap", StringComparison.Ordinal))));
+    }
+
+    private static bool TryResolveExplicitContractGapDetail(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        out string detail)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            if (TryResolveExplicitContractGapDetail(providerEvents[index].Payload, executionUnit, out detail))
+            {
+                return true;
+            }
+        }
+
+        detail = string.Empty;
+        return false;
     }
 
     private static bool TryResolveExplicitContractGapDetail(
@@ -468,6 +551,13 @@ internal static class DirectRunFixOutcomeSupport
         out string detail)
     {
         detail = string.Empty;
+        if (payload.ValueKind == JsonValueKind.String
+            && IsExplicitContractGapRefusalText(payload.GetString(), out var explicitDetail))
+        {
+            detail = explicitDetail;
+            return true;
+        }
+
         if (payload.ValueKind != JsonValueKind.Object)
         {
             return false;
@@ -492,6 +582,28 @@ internal static class DirectRunFixOutcomeSupport
                 detail = $"Fix direct run for '{executionUnit}' reported a deterministic contract gap.";
             }
 
+            return true;
+        }
+        return false;
+    }
+
+    private static bool IsExplicitContractGapRefusalText(string? value, out string detail)
+    {
+        detail = string.Empty;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var normalized = value.Trim();
+        var lower = normalized.ToLowerInvariant();
+        if (lower.Contains("contract-gap refusal", StringComparison.Ordinal)
+            || lower.Contains("contract gap refusal", StringComparison.Ordinal)
+            || lower.Contains("stopped with a contract-gap explanation", StringComparison.Ordinal)
+            || lower.Contains("stopped with a contract gap explanation", StringComparison.Ordinal)
+            || lower.Contains("reported a deterministic contract gap", StringComparison.Ordinal))
+        {
+            detail = normalized;
             return true;
         }
 

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -232,6 +232,16 @@ internal static class RunCommand
                             fixRequestArtifact);
                         if (!string.IsNullOrWhiteSpace(currentFixSessionContractGap))
                         {
+                            if (fixResultArtifact is not null
+                                && !string.Equals(fixResultArtifact.RunStatus, "failed", StringComparison.Ordinal))
+                            {
+                                fixResultArtifact = fixResultArtifact with
+                                {
+                                    RunStatus = "failed"
+                                };
+                                PersistDirectRunResultArtifact(context, inProgressItem.ExecutionUnit, fixResultArtifact);
+                            }
+
                             return CreateStopResult(
                                 DeterministicContractGapStopReason,
                                 actions,

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -289,6 +289,39 @@ public sealed class DirectRunFixOutcomeSupportTests
         Assert.Null(contractGapEvent);
     }
 
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenExplicitContractGapRefusalTextAndSuccessfulBackendExit_CreatesFailureBoundary()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-01.request.md' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' intents/toy-calc/specs/01-cli-surface.md'"),
+            CreateProviderEvent(" exited 1 in 0ms:"),
+            CreateProviderEvent("sed: intents/toy-calc/specs/01-cli-surface.md: No such file or directory"),
+            CreateProviderEvent("I stopped with a contract-gap explanation rather than inventing a repair target because the deterministic review contract points at `intents/toy-calc/specs/01-cli-surface.md`, and that spec file does not exist in this worktree."),
+            CreateProviderEvent("2. Close this run as a completed contract-gap refusal."),
+            CreateSuccessfulBackendExitEvent()
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-17T07:40:00Z"),
+            "TOY-CALC-V0-01",
+            "fix",
+            "Codex",
+            "pid:6210",
+            providerSessionAlive: false);
+
+        Assert.NotNull(contractGapEvent);
+        Assert.Equal("failed", contractGapEvent!.Payload.GetProperty("run_status").GetString());
+        Assert.Equal("provider-explicit-contract-gap-refusal", contractGapEvent.Payload.GetProperty("reason").GetString());
+        Assert.Contains(
+            "contract-gap refusal",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
     private static IReadOnlyList<DirectRunProviderEvent> CreateIssue295CurrentSessionRawEvents(string? echoedRequest = null)
     {
         return

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -2044,6 +2044,107 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFixingItemWithSucceededFixResultAndExplicitContractGapRefusal_DoesNotAdvanceIntoReview()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Codex");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "succeeded",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:999999",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                        "I stopped with a contract-gap explanation rather than inventing a repair target because the deterministic review contract points at `intents/toy-calc/specs/01-cli-surface.md`, and that spec file does not exist in this worktree.")
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:999999",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                        "2. Close this run as a completed contract-gap refusal.")
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:02.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:999999",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 0
+                    })
+                }
+            ],
+            sessionId: "pid:999999",
+            provider: "Codex");
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("deterministic-contract-gap", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("contract-gap refusal", result.Detail, StringComparison.OrdinalIgnoreCase);
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+        Assert.Equal("failed", resultArtifact.RunStatus);
+    }
+
+    [Fact]
     public void ExecuteCore_GivenFixingItemWithFollowUpWorkAfterInitialInspection_DoesNotClassifyInspectionOnlyContractGap()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- treat explicit fix-session contract-gap refusals as failed direct-run outcomes even when the backend exits with code 0
- persist that non-success boundary into the current fix result so root run stops on deterministic-contract-gap before resubmit/rereview
- add regression coverage for canonical contract-gap synthesis and root-run orchestration behavior

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~CreateCanonicalContractGapEventIfNeeded_GivenExplicitContractGapRefusalTextAndSuccessfulBackendExit_CreatesFailureBoundary|FullyQualifiedName~ExecuteCore_GivenFixingItemWithSucceededFixResultAndExplicitContractGapRefusal_DoesNotAdvanceIntoReview" --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IntentSystem.Cli.Tests.RunCommandTests.|FullyQualifiedName~IntentSystem.Cli.Tests.DirectRunFixOutcomeSupportTests.|FullyQualifiedName~IntentSystem.Cli.Tests.RunFixCommandTests.Execute_GivenWrapperCodexFixCommandWithDeepProgressAndSuccessfulBackendExit_FinalizesResultAsContractGapFailure" --nologo
- dotnet test IntentSystem.sln --nologo (hangs in IntentSystem.Cli.Tests testhost in this environment; stopped after confirming no progress)

Closes #318