### PR TITLE
Fix #320 classify runtime-artifact-only fix drift

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -946,12 +946,13 @@ internal static class RunSuperviseCommand
 
         failure = null!;
         if (!TryFindFailingBackendExitCode(providerEvents, out var exitCode)
-            || DirectRunFixOutcomeSupport.TryResolveContractGapDetail(providerEvents, executionUnit, out _)
             || !DirectRunFixOutcomeSupport.HasBoundedProgressSignal(providerEvents)
             )
         {
             return false;
         }
+
+        var hasExplicitContractGapSignal = DirectRunFixOutcomeSupport.HasExplicitContractGapSignal(providerEvents);
 
         var gitCommandRunner = GitCommandRunnerFactory();
         if (RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths(
@@ -971,6 +972,11 @@ internal static class RunSuperviseCommand
                 worktreePath,
                 out var runtimeArtifactPaths))
         {
+            if (hasExplicitContractGapSignal)
+            {
+                return false;
+            }
+
             return false;
         }
 

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -948,18 +948,36 @@ internal static class RunSuperviseCommand
         if (!TryFindFailingBackendExitCode(providerEvents, out var exitCode)
             || DirectRunFixOutcomeSupport.TryResolveContractGapDetail(providerEvents, executionUnit, out _)
             || !DirectRunFixOutcomeSupport.HasBoundedProgressSignal(providerEvents)
-            || !RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths(
-                GitCommandRunnerFactory(),
+            )
+        {
+            return false;
+        }
+
+        var gitCommandRunner = GitCommandRunnerFactory();
+        if (RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths(
+                gitCommandRunner,
                 worktreePath,
                 out var changedPaths))
+        {
+            failure = new WorkerSessionFailure(
+                $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode} after bounded fix progress and left meaningful execution-unit worktree changes. Changed paths: {RunWorktreeProgressSupport.SummarizePaths(changedPaths)}.",
+                ReportAsNonRetryableFailure: true,
+                RequiresPostFixWorktreeProgressDecision: true);
+            return true;
+        }
+
+        if (!DirectRunFixOutcomeSupport.HasDeepExecutionProgressSignal(providerEvents)
+            || !RunWorktreeProgressSupport.TryResolveOutOfScopeRuntimeArtifactDiffPaths(
+                gitCommandRunner,
+                worktreePath,
+                out var runtimeArtifactPaths))
         {
             return false;
         }
 
         failure = new WorkerSessionFailure(
-            $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode} after bounded fix progress and left meaningful execution-unit worktree changes. Changed paths: {RunWorktreeProgressSupport.SummarizePaths(changedPaths)}.",
-            ReportAsNonRetryableFailure: true,
-            RequiresPostFixWorktreeProgressDecision: true);
+            $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode} after bounded deep fix progress but left only out-of-scope runtime-artifact drift under '.intent-cli/**' and no product changes under 'src/**' or 'tests/**'. Changed paths: {RunWorktreeProgressSupport.SummarizePaths(runtimeArtifactPaths)}.",
+            ReportAsNonRetryableFailure: true);
         return true;
     }
 

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -966,8 +966,7 @@ internal static class RunSuperviseCommand
             return true;
         }
 
-        if (!DirectRunFixOutcomeSupport.HasDeepExecutionProgressSignal(providerEvents)
-            || !RunWorktreeProgressSupport.TryResolveOutOfScopeRuntimeArtifactDiffPaths(
+        if (!RunWorktreeProgressSupport.TryResolveOutOfScopeRuntimeArtifactDiffPaths(
                 gitCommandRunner,
                 worktreePath,
                 out var runtimeArtifactPaths))
@@ -976,7 +975,7 @@ internal static class RunSuperviseCommand
         }
 
         failure = new WorkerSessionFailure(
-            $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode} after bounded deep fix progress but left only out-of-scope runtime-artifact drift under '.intent-cli/**' and no product changes under 'src/**' or 'tests/**'. Changed paths: {RunWorktreeProgressSupport.SummarizePaths(runtimeArtifactPaths)}.",
+            $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode} after bounded fix progress but left only out-of-scope runtime-artifact drift under '.intent-cli/**' and no product changes under 'src/**' or 'tests/**'. Changed paths: {RunWorktreeProgressSupport.SummarizePaths(runtimeArtifactPaths)}.",
             ReportAsNonRetryableFailure: true);
         return true;
     }

--- a/src/IntentSystem.Cli/Commands/RunWorktreeProgressSupport.cs
+++ b/src/IntentSystem.Cli/Commands/RunWorktreeProgressSupport.cs
@@ -13,62 +13,43 @@ internal static class RunWorktreeProgressSupport
         ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
 
         changedPaths = [];
-        GitCommandResult statusResult;
-        try
-        {
-            statusResult = gitCommandRunner.Run(
+        if (!TryClassifyWorktreeDiffPaths(
+                gitCommandRunner,
                 worktreePath,
-                ["status", "--short", "--untracked-files=all"]);
-        }
-        catch (Exception exception) when (
-            exception is InvalidOperationException
-            or IOException
-            or ArgumentException
-            or DirectoryNotFoundException
-            or System.ComponentModel.Win32Exception)
+                out var meaningfulPaths,
+                out _))
         {
             return false;
         }
 
-        if (statusResult.ExitCode != 0 || string.IsNullOrWhiteSpace(statusResult.StdOut))
+        if (meaningfulPaths.Count == 0)
         {
             return false;
         }
 
-        var paths = new List<string>();
-        foreach (var rawLine in statusResult.StdOut.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
-        {
-            var line = rawLine.TrimEnd();
-            if (string.IsNullOrWhiteSpace(line))
-            {
-                continue;
-            }
+        changedPaths = meaningfulPaths;
+        return true;
+    }
 
-            var pathText = line.Length > 3 ? line[3..].Trim() : line.Trim();
-            if (string.IsNullOrWhiteSpace(pathText))
-            {
-                continue;
-            }
+    public static bool TryResolveOutOfScopeRuntimeArtifactDiffPaths(
+        IGitCommandRunner gitCommandRunner,
+        string worktreePath,
+        out IReadOnlyList<string> changedPaths)
+    {
+        ArgumentNullException.ThrowIfNull(gitCommandRunner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
 
-            var normalizedPath = pathText.Contains(" -> ", StringComparison.Ordinal)
-                ? pathText[(pathText.LastIndexOf(" -> ", StringComparison.Ordinal) + 4)..].Trim()
-                : pathText;
-            normalizedPath = normalizedPath.Trim().Trim('"').Replace('\\', '/');
-            if (string.IsNullOrWhiteSpace(normalizedPath)
-                || IsIgnoredWorktreeArtifactPath(normalizedPath))
-            {
-                continue;
-            }
-
-            paths.Add(normalizedPath);
-        }
-
-        if (paths.Count == 0)
+        changedPaths = [];
+        if (!TryClassifyWorktreeDiffPaths(
+                gitCommandRunner,
+                worktreePath,
+                out _,
+                out var runtimeArtifactPaths))
         {
             return false;
         }
 
-        changedPaths = paths;
+        changedPaths = runtimeArtifactPaths;
         return true;
     }
 
@@ -108,5 +89,104 @@ internal static class RunWorktreeProgressSupport
             || string.Equals(segment, "obj", StringComparison.Ordinal)
             || string.Equals(segment, "TestResults", StringComparison.Ordinal)
             || string.Equals(segment, ".vs", StringComparison.Ordinal));
+    }
+
+    private static bool TryClassifyWorktreeDiffPaths(
+        IGitCommandRunner gitCommandRunner,
+        string worktreePath,
+        out IReadOnlyList<string> meaningfulPaths,
+        out IReadOnlyList<string> runtimeArtifactPaths)
+    {
+        meaningfulPaths = [];
+        runtimeArtifactPaths = [];
+
+        GitCommandResult statusResult;
+        try
+        {
+            statusResult = gitCommandRunner.Run(
+                worktreePath,
+                ["status", "--short", "--untracked-files=all"]);
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException
+            or ArgumentException
+            or DirectoryNotFoundException
+            or System.ComponentModel.Win32Exception)
+        {
+            return false;
+        }
+
+        if (statusResult.ExitCode != 0 || string.IsNullOrWhiteSpace(statusResult.StdOut))
+        {
+            return false;
+        }
+
+        var meaningful = new List<string>();
+        var runtimeArtifacts = new List<string>();
+        foreach (var rawLine in statusResult.StdOut.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            var normalizedPath = TryNormalizeStatusPath(rawLine);
+            if (string.IsNullOrWhiteSpace(normalizedPath))
+            {
+                continue;
+            }
+
+            if (IsOutOfScopeRuntimeArtifactPath(normalizedPath))
+            {
+                runtimeArtifacts.Add(normalizedPath);
+                continue;
+            }
+
+            if (IsIgnoredWorktreeArtifactPath(normalizedPath))
+            {
+                continue;
+            }
+
+            meaningful.Add(normalizedPath);
+        }
+
+        if (meaningful.Count > 0)
+        {
+            meaningfulPaths = meaningful;
+            return true;
+        }
+
+        if (runtimeArtifacts.Count > 0)
+        {
+            runtimeArtifactPaths = runtimeArtifacts;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string? TryNormalizeStatusPath(string rawLine)
+    {
+        var line = rawLine.TrimEnd();
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return null;
+        }
+
+        var pathText = line.Length > 3 ? line[3..].Trim() : line.Trim();
+        if (string.IsNullOrWhiteSpace(pathText))
+        {
+            return null;
+        }
+
+        var normalizedPath = pathText.Contains(" -> ", StringComparison.Ordinal)
+            ? pathText[(pathText.LastIndexOf(" -> ", StringComparison.Ordinal) + 4)..].Trim()
+            : pathText;
+        normalizedPath = normalizedPath.Trim().Trim('"').Replace('\\', '/');
+        return string.IsNullOrWhiteSpace(normalizedPath) ? null : normalizedPath;
+    }
+
+    private static bool IsOutOfScopeRuntimeArtifactPath(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        return path.Replace('\\', '/').TrimStart('/')
+            .StartsWith(".intent-cli/", StringComparison.Ordinal);
     }
 }

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -302,6 +302,9 @@ public sealed class RunCommandTests
             Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
             "{}");
         tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
             "# Repair Worker Handoff");
         WriteDirectRunRequest(repoRoot, "G226", "review", "stale-review-session");
@@ -4750,6 +4753,122 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFixingItemWithOnlyOutOfScopeRuntimeArtifactDiff_StopsWithoutRetryExhaustion()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 2,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents: CreateRuntimeArtifactOnlyFixProgressProviderEvents("G226", "pid:999999"),
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var originalGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M .intent-cli/intake/toy-calc.concept.yaml
+                 M .intent-cli/intake/toy-calc.execution.md
+                 M .intent-cli/intake/toy-calc.patch.md
+                """);
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("non-retryable-failure", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("out-of-scope runtime-artifact drift", result.Detail, StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/intake/toy-calc.concept.yaml", result.Detail, StringComparison.Ordinal);
+            Assert.DoesNotContain("Fix retry budget exhausted", result.Detail, StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("out-of-scope runtime-artifact drift", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("Fix retry budget exhausted", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(2, session.RetryCount);
+            Assert.False(session.RequiresPostFixWorktreeProgressDecision);
+            Assert.Contains("out-of-scope runtime-artifact drift", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("out-of-scope runtime-artifact drift", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenFixingItemWithStaleFailedFixResultAndRuntimeOnlyTarget_StopsWithDeterministicContractGap()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -5363,6 +5482,110 @@ public sealed class RunCommandTests
                 SessionId = sessionId,
                 Kind = "provider-event",
                 Payload = System.Text.Json.JsonSerializer.SerializeToElement("git status --short")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    type = "backend-exit",
+                    exit_code = 1
+                })
+            }
+        ];
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateRuntimeArtifactOnlyFixProgressProviderEvents(
+        string executionUnit,
+        string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "session-metadata",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    model = "sonnet",
+                    transport = "sdk",
+                    command = "claude"
+                })
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.0500000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                    "exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/G226.request.md' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.1000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                    "exec /bin/zsh -lc 'sed -n ''1,220p'' .intent-cli/fix/G226.request.md' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.2000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                    "exec /bin/zsh -lc 'sed -n ''1,220p'' intents/toy-calc/README.md' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.3000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                    "exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Calculator.cs' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.4000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                    "exec /bin/zsh -lc 'dotnet test' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.5000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(
+                    "Passed!  - Failed:     0, Passed:     9, Skipped:     0, Total:     9")
             },
             new DirectRunProviderEvent
             {

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -4869,6 +4869,120 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFixingItemWithToyCalcReplayShapeAndOnlyRuntimeArtifactDiff_StopsWithoutRetryExhaustion()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 2,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Codex");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents: CreateToyCalcReplayRuntimeArtifactOnlyFixProgressProviderEvents("G226", "pid:999999"),
+            sessionId: "pid:999999",
+            provider: "Codex");
+        var originalGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M .intent-cli/intake/toy-calc.concept.yaml
+                 M .intent-cli/intake/toy-calc.execution.md
+                 M .intent-cli/intake/toy-calc.patch.md
+                """);
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("non-retryable-failure", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("out-of-scope runtime-artifact drift", result.Detail, StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/intake/toy-calc.concept.yaml", result.Detail, StringComparison.Ordinal);
+            Assert.DoesNotContain("Fix retry budget exhausted", result.Detail, StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("out-of-scope runtime-artifact drift", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(2, session.RetryCount);
+            Assert.Contains("out-of-scope runtime-artifact drift", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("out-of-scope runtime-artifact drift", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenFixingItemWithStaleFailedFixResultAndRuntimeOnlyTarget_StopsWithDeterministicContractGap()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -5592,6 +5706,129 @@ public sealed class RunCommandTests
                 Timestamp = "2026-04-10T12:00:01.0000000+00:00",
                 ExecutionUnit = executionUnit,
                 Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    type = "backend-exit",
+                    exit_code = 1
+                })
+            }
+        ];
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateToyCalcReplayRuntimeArtifactOnlyFixProgressProviderEvents(
+        string executionUnit,
+        string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2369770+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("## Execution Contract")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2370090+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("- Continue beyond initial repository inspection; do not stop after a single listing/read-only command.")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2427050+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2428840+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("/bin/zsh -lc \"pwd && rg --files -g '!node_modules*' -g '!dist*' -g '!build*' | sed -n '1,220p'\" in /repo/.intent-cli/worktrees/G226")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2429790+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(" succeeded in 0ms:")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2431360+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("src/ToyCalc/Program.cs")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2431740+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("src/ToyCalc/Calculator.cs")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2432870+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("intents/toy-calc/clarifications/open.md")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2434640+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("tests/ToyCalc.Tests/CalculatorTests.cs")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2463570+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("2026-04-17T05:29:47.246315Z  WARN codex_core::plugins::manifest: ignoring interface.defaultPrompt: prompt must be at most 128 characters")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:30:36.3739630+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -4983,6 +4983,121 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFixingItemWithToyCalcMixedReplayShapeAndOnlyRuntimeArtifactDiff_StopsWithoutRetryExhaustion()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 2,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "fix", "pid:999999", provider: "Codex");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents: CreateToyCalcMixedReplayRuntimeArtifactOnlyFixProgressProviderEvents("G226", "pid:999999"),
+            sessionId: "pid:999999",
+            provider: "Codex");
+        var originalGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M .intent-cli/intake/toy-calc.concept.yaml
+                 M .intent-cli/intake/toy-calc.execution.md
+                 M .intent-cli/intake/toy-calc.patch.md
+                """);
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("non-retryable-failure", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("out-of-scope runtime-artifact drift", result.Detail, StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/intake/toy-calc.concept.yaml", result.Detail, StringComparison.Ordinal);
+            Assert.DoesNotContain("retry-exhausted", result.Detail, StringComparison.OrdinalIgnoreCase);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("out-of-scope runtime-artifact drift", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(2, session.RetryCount);
+            Assert.Contains("out-of-scope runtime-artifact drift", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("out-of-scope runtime-artifact drift", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenFixingItemWithStaleFailedFixResultAndRuntimeOnlyTarget_StopsWithDeterministicContractGap()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -5827,6 +5942,179 @@ public sealed class RunCommandTests
             new DirectRunProviderEvent
             {
                 Timestamp = "2026-04-17T05:30:36.3739630+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    type = "backend-exit",
+                    exit_code = 1
+                })
+            }
+        ];
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateToyCalcMixedReplayRuntimeArtifactOnlyFixProgressProviderEvents(
+        string executionUnit,
+        string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:18.4211970+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("/bin/zsh -lc \"sed -n '1,220p' '/repo/.intent-cli/fix/G226.request.md'\" in /repo/.intent-cli/worktrees/G226")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:18.4212630+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(" succeeded in 0ms:")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:18.4213240+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("# Repair Worker Handoff")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9131420+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9134060+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("/bin/zsh -lc \"sed -n '1,220p' intents/toy-calc/specs/01-cli-surface.md\" in /repo/.intent-cli/worktrees/G226")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9135080+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(" exited 1 in 0ms:")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9135740+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("sed: intents/toy-calc/specs/01-cli-surface.md: No such file or directory")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9167470+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9168690+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("/bin/zsh -lc \"sed -n '1,220p' src/ToyCalc/Program.cs && printf '\\n---\\n' && sed -n '1,220p' src/ToyCalc/CommandLine.cs && printf '\\n---\\n' && sed -n '1,220p' src/ToyCalc/Calculator.cs\" in /repo/.intent-cli/worktrees/G226")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9169560+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9170390+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("/bin/zsh -lc \"sed -n '1,220p' tests/ToyCalc.Tests/CalculatorTests.cs && printf '\\n---\\n' && sed -n '1,220p' tests/ToyCalc.Tests/ToyCalc.Tests.csproj && printf '\\n---\\n' && sed -n '1,220p' src/ToyCalc/ToyCalc.csproj\" in /repo/.intent-cli/worktrees/G226")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9171110+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(" succeeded in 0ms:")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:35.4885360+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("I've found a likely contract-gap: the canonical spec file referenced by the artifact is not present in this worktree, but the actual code currently uses `int` parsing and arithmetic already, which matches the review comment's requested fix. I'm running the test suite now to distinguish \"already fixed\" from \"needs a small local repair.\"")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:36.0546370+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:36.0548610+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("/bin/zsh -lc 'dotnet test ToyCalc.sln' in /repo/.intent-cli/worktrees/G226")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:40.0000000+00:00",
                 ExecutionUnit = executionUnit,
                 Provider = "Codex",
                 EntryKind = "fix",

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -1584,6 +1584,77 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenDeadFixWorkerSessionWithToyCalcReplayShapeAndOnlyRuntimeArtifactDiff_BlocksWithoutConsumingRetryBudget()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateFixingRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G25.request.md"),
+            "# Repair Worker Handoff");
+        WriteDeadFixDirectRunArtifacts(repoRoot, "pid:999999");
+        File.AppendAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                CreateToyCalcReplayRuntimeArtifactOnlyFixProgressEvents("G25", "pid:999999")
+                    .Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+            RunSuperviseCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M .intent-cli/intake/toy-calc.concept.yaml
+                 M .intent-cli/intake/toy-calc.execution.md
+                 M .intent-cli/intake/toy-calc.patch.md
+                """);
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("out-of-scope runtime-artifact drift", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/intake/toy-calc.concept.yaml", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(0, session.RetryCount);
+            Assert.Contains("out-of-scope runtime-artifact drift", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("out-of-scope runtime-artifact drift", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenNonRetryableAutoResumeFailure_BlocksSelectedItemAndAppendsTerminalEvents()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -2417,6 +2488,127 @@ public sealed class RunSuperviseCommandTests
                 Timestamp = "2026-04-08T10:20:01.0000000+00:00",
                 ExecutionUnit = executionUnit,
                 Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    type = "backend-exit",
+                    exit_code = 1
+                })
+            }
+        ];
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateToyCalcReplayRuntimeArtifactOnlyFixProgressEvents(string executionUnit, string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2369770+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("## Execution Contract")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2370090+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("- Continue beyond initial repository inspection; do not stop after a single listing/read-only command.")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2427050+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2428840+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("/bin/zsh -lc \"pwd && rg --files -g '!node_modules*' -g '!dist*' -g '!build*' | sed -n '1,220p'\" in /repo/.intent-cli/worktrees/G25")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2429790+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(" succeeded in 0ms:")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2431360+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("src/ToyCalc/Program.cs")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2431740+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("src/ToyCalc/Calculator.cs")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2432870+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("intents/toy-calc/clarifications/open.md")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2434640+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("tests/ToyCalc.Tests/CalculatorTests.cs")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:29:47.2463570+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("2026-04-17T05:29:47.246315Z  WARN codex_core::plugins::manifest: ignoring interface.defaultPrompt: prompt must be at most 128 characters")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-17T05:30:36.3739630+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
                 EntryKind = "fix",
                 SessionId = sessionId,
                 Kind = "provider-event",

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -1655,6 +1655,78 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenDeadFixWorkerSessionWithToyCalcMixedReplayShapeAndOnlyRuntimeArtifactDiff_BlocksWithoutConsumingRetryBudget()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateFixingRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G25.request.md"),
+            "# Repair Worker Handoff");
+        WriteDeadFixDirectRunArtifacts(repoRoot, "pid:999999");
+        File.AppendAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                CreateToyCalcMixedReplayRuntimeArtifactOnlyFixProgressEvents("G25", "pid:999999")
+                    .Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+            RunSuperviseCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M .intent-cli/intake/toy-calc.concept.yaml
+                 M .intent-cli/intake/toy-calc.execution.md
+                 M .intent-cli/intake/toy-calc.patch.md
+                """);
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("out-of-scope runtime-artifact drift", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/intake/toy-calc.concept.yaml", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("backend exit code 1.", selectedItem.BlockedBy[0], StringComparison.OrdinalIgnoreCase);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(0, session.RetryCount);
+            Assert.Contains("out-of-scope runtime-artifact drift", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("out-of-scope runtime-artifact drift", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenNonRetryableAutoResumeFailure_BlocksSelectedItemAndAppendsTerminalEvents()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -2607,6 +2679,177 @@ public sealed class RunSuperviseCommandTests
             new DirectRunProviderEvent
             {
                 Timestamp = "2026-04-17T05:30:36.3739630+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    type = "backend-exit",
+                    exit_code = 1
+                })
+            }
+        ];
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateToyCalcMixedReplayRuntimeArtifactOnlyFixProgressEvents(string executionUnit, string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:18.4211970+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("/bin/zsh -lc \"sed -n '1,220p' '/repo/.intent-cli/fix/G25.request.md'\" in /repo/.intent-cli/worktrees/G25")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:18.4212630+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(" succeeded in 0ms:")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:18.4213240+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("# Repair Worker Handoff")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9131420+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9134060+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("/bin/zsh -lc \"sed -n '1,220p' intents/toy-calc/specs/01-cli-surface.md\" in /repo/.intent-cli/worktrees/G25")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9135080+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(" exited 1 in 0ms:")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9135740+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("sed: intents/toy-calc/specs/01-cli-surface.md: No such file or directory")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9167470+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9168690+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("/bin/zsh -lc \"sed -n '1,220p' src/ToyCalc/Program.cs && printf '\\n---\\n' && sed -n '1,220p' src/ToyCalc/CommandLine.cs && printf '\\n---\\n' && sed -n '1,220p' src/ToyCalc/Calculator.cs\" in /repo/.intent-cli/worktrees/G25")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9169560+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9170390+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("/bin/zsh -lc \"sed -n '1,220p' tests/ToyCalc.Tests/CalculatorTests.cs && printf '\\n---\\n' && sed -n '1,220p' tests/ToyCalc.Tests/ToyCalc.Tests.csproj && printf '\\n---\\n' && sed -n '1,220p' src/ToyCalc/ToyCalc.csproj\" in /repo/.intent-cli/worktrees/G25")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:25.9171110+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(" succeeded in 0ms:")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:35.4885360+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("I've found a likely contract-gap: the canonical spec file referenced by the artifact is not present in this worktree, but the actual code currently uses `int` parsing and arithmetic already, which matches the review comment's requested fix. I'm running the test suite now to distinguish \"already fixed\" from \"needs a small local repair.\"")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:36.0546370+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:36.0548610+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("/bin/zsh -lc 'dotnet test ToyCalc.sln' in /repo/.intent-cli/worktrees/G25")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-16T20:43:40.0000000+00:00",
                 ExecutionUnit = executionUnit,
                 Provider = "Codex",
                 EntryKind = "fix",

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -1507,6 +1507,83 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenDeadFixWorkerSessionWithOnlyOutOfScopeRuntimeArtifactDiff_BlocksWithoutConsumingRetryBudget()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateFixingRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G25.request.md"),
+            "# Repair Worker Handoff");
+        WriteDeadFixDirectRunArtifacts(repoRoot, "pid:999999");
+        File.AppendAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                CreateRuntimeArtifactOnlyFixProgressEvents("G25", "pid:999999")
+                    .Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+            RunSuperviseCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M .intent-cli/intake/toy-calc.concept.yaml
+                 M .intent-cli/intake/toy-calc.execution.md
+                 M .intent-cli/intake/toy-calc.patch.md
+                """);
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("out-of-scope runtime-artifact drift", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/intake/toy-calc.concept.yaml", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("Fix retry budget exhausted", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(0, session.RetryCount);
+            Assert.False(session.RequiresPostFixWorktreeProgressDecision);
+            Assert.Contains("out-of-scope runtime-artifact drift", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.result.json")));
+            Assert.Equal("failed", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("out-of-scope runtime-artifact drift", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenNonRetryableAutoResumeFailure_BlocksSelectedItemAndAppendsTerminalEvents()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -2236,6 +2313,16 @@ public sealed class RunSuperviseCommandTests
         [
             new DirectRunProviderEvent
             {
+                Timestamp = "2026-04-08T10:20:00.0500000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/G25.request.md' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
                 Timestamp = "2026-04-08T10:20:00.1000000+00:00",
                 ExecutionUnit = executionUnit,
                 Provider = "Claude",
@@ -2253,6 +2340,77 @@ public sealed class RunSuperviseCommandTests
                 SessionId = sessionId,
                 Kind = "provider-event",
                 Payload = JsonSerializer.SerializeToElement("git status --short")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:01.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    type = "backend-exit",
+                    exit_code = 1
+                })
+            }
+        ];
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateRuntimeArtifactOnlyFixProgressEvents(string executionUnit, string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.1000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'sed -n ''1,220p'' .intent-cli/fix/G25.request.md' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.2000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'sed -n ''1,220p'' intents/toy-calc/README.md' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.3000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Calculator.cs' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.4000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'dotnet test' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.5000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("Passed!  - Failed:     0, Passed:     9, Skipped:     0, Total:     9")
             },
             new DirectRunProviderEvent
             {


### PR DESCRIPTION
## Summary
- classify execution-unit worktree drift into meaningful product changes vs out-of-scope `.intent-cli/**` runtime-artifact-only changes
- stop fix supervision immediately when a dead fix session reached bounded deep progress, exited with backend-exit, and left only `.intent-cli/**` drift with no `src/**` or `tests/**` changes
- add regression coverage for both `run supervise` and root `run` so this boundary no longer burns retry budget generically

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~Execute_GivenDeadFixWorkerSessionWithOnlyOutOfScopeRuntimeArtifactDiff_BlocksWithoutConsumingRetryBudget|FullyQualifiedName~ExecuteCore_GivenFixingItemWithOnlyOutOfScopeRuntimeArtifactDiff_StopsWithoutRetryExhaustion|FullyQualifiedName~Execute_GivenDeadFixWorkerSessionWithMeaningfulWorktreeDiff_BlocksAsNonRetryableFailure|FullyQualifiedName~ExecuteCore_GivenRetryExhaustedFixingItemWithIgnoredBuildArtifactsOnly_StopsWithRetryExhaustionSummary" --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IntentSystem.Cli.Tests.RunSuperviseCommandTests.|FullyQualifiedName~IntentSystem.Cli.Tests.RunCommandTests.|FullyQualifiedName~IntentSystem.Cli.Tests.DirectRunFixOutcomeSupportTests.|FullyQualifiedName~IntentSystem.Cli.Tests.RunFixCommandTests.Execute_GivenWrapperCodexFixCommandWithDeepProgressAndSuccessfulBackendExit_FinalizesResultAsContractGapFailure" --nologo
- dotnet test IntentSystem.sln --nologo (other test projects completed, but this environment hung while waiting on `IntentSystem.Cli.Tests` testhost)

## Notes
- I did not rerun the live toy-calc dogfooding repro because `/Users/tomohisa/dev/GitHub/MyIntentHost` is already heavily dirty in user-owned `.intent-cli/**` state and submodule state, so exercising it here would risk corrupting that ongoing environment.

Closes #320