### PR TITLE
Fix root run continuation for short-lived fix workers

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -16,6 +16,8 @@ internal static class RunCommand
         public string ExecutionUnit { get; } = executionUnit;
     }
 
+    private sealed record FreshFixContinuationState(DateTimeOffset Deadline, int RemainingPolls);
+
     private const int IterationBudget = 128;
     private const string NoActionableItemStopReason = "no-actionable-item";
     private const string ClarificationRequiredStopReason = "clarification-required";
@@ -61,6 +63,12 @@ internal static class RunCommand
 
     public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
 
+    internal static TimeSpan FreshFixContinuationWindow { get; set; } = TimeSpan.FromSeconds(3);
+
+    internal static TimeSpan FreshFixContinuationPollInterval { get; set; } = TimeSpan.FromMilliseconds(200);
+
+    internal static int FreshFixContinuationMaxPolls { get; set; } = 15;
+
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -92,6 +100,7 @@ internal static class RunCommand
         ArgumentNullException.ThrowIfNull(context);
 
         var actions = new List<RunCommandAction>();
+        var freshFixContinuationStates = new Dictionary<string, FreshFixContinuationState>(StringComparer.Ordinal);
 
         for (var iteration = 0; iteration < IterationBudget; iteration++)
         {
@@ -195,12 +204,17 @@ internal static class RunCommand
                                 "run fix",
                                 inProgressItem.ExecutionUnit,
                                 () => RunFixExecutor(context, inProgressItem.ExecutionUnit));
+                            TrackFreshFixContinuation(
+                                context,
+                                inProgressItem.ExecutionUnit,
+                                freshFixContinuationStates);
                             continue;
                         }
 
                         var currentFixTargetContractGap = TryResolveCurrentFixTargetContractGap(context, inProgressItem);
                         if (!string.IsNullOrWhiteSpace(currentFixTargetContractGap))
                         {
+                            freshFixContinuationStates.Remove(inProgressItem.ExecutionUnit);
                             return CreateStopResult(
                                 DeterministicContractGapStopReason,
                                 actions,
@@ -222,6 +236,10 @@ internal static class RunCommand
                                 "run fix",
                                 inProgressItem.ExecutionUnit,
                                 () => RunFixExecutor(context, inProgressItem.ExecutionUnit));
+                            TrackFreshFixContinuation(
+                                context,
+                                inProgressItem.ExecutionUnit,
+                                freshFixContinuationStates);
                             continue;
                         }
 
@@ -232,6 +250,7 @@ internal static class RunCommand
                             fixRequestArtifact);
                         if (!string.IsNullOrWhiteSpace(currentFixSessionContractGap))
                         {
+                            freshFixContinuationStates.Remove(inProgressItem.ExecutionUnit);
                             if (fixResultArtifact is not null
                                 && !string.Equals(fixResultArtifact.RunStatus, "failed", StringComparison.Ordinal))
                             {
@@ -251,6 +270,7 @@ internal static class RunCommand
 
                         if (string.Equals(fixRunStatus, "succeeded", StringComparison.Ordinal))
                         {
+                            freshFixContinuationStates.Remove(inProgressItem.ExecutionUnit);
                             ExecuteAction(
                                 context,
                                 actions,
@@ -268,6 +288,7 @@ internal static class RunCommand
 
                         if (string.Equals(fixRunStatus, "failed", StringComparison.Ordinal))
                         {
+                            freshFixContinuationStates.Remove(inProgressItem.ExecutionUnit);
                             return CreateStopResult(
                                 NonRetryableFailureStopReason,
                                 actions,
@@ -281,6 +302,17 @@ internal static class RunCommand
                             "run supervise",
                             inProgressItem.ExecutionUnit,
                             () => RunSuperviseExecutor(context, inProgressItem.ExecutionUnit));
+
+                        if (ShouldContinueFreshFixSupervision(
+                                freshFixContinuationStates,
+                                inProgressItem.ExecutionUnit,
+                                superviseResult))
+                        {
+                            SleepFreshFixContinuationPollInterval();
+                            continue;
+                        }
+
+                        freshFixContinuationStates.Remove(inProgressItem.ExecutionUnit);
 
                         if (superviseResult.Blocked)
                         {
@@ -1047,6 +1079,92 @@ internal static class RunCommand
         }
 
         return latestFixRequestedAt is not null && latestFixRequestedAt > launchedAt;
+    }
+
+    private static void TrackFreshFixContinuation(
+        CliContext context,
+        string executionUnit,
+        IDictionary<string, FreshFixContinuationState> continuationStates)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(continuationStates);
+
+        continuationStates.Remove(executionUnit);
+        if (FreshFixContinuationWindow <= TimeSpan.Zero || FreshFixContinuationMaxPolls <= 0)
+        {
+            return;
+        }
+
+        var now = TimestampFactory();
+        var requestArtifact = TryReadDirectRunRequestArtifact(context, executionUnit);
+        var launchedAt = requestArtifact is not null
+            && string.Equals(requestArtifact.EntryKind, "fix", StringComparison.Ordinal)
+            && DirectRunSessionBoundary.TryParseLaunchedAt(requestArtifact.LaunchedAt, out var parsedLaunchedAt)
+                ? parsedLaunchedAt
+                : now;
+        var deadline = launchedAt + FreshFixContinuationWindow;
+        if (deadline <= now)
+        {
+            return;
+        }
+
+        continuationStates[executionUnit] = new FreshFixContinuationState(
+            deadline,
+            FreshFixContinuationMaxPolls);
+    }
+
+    private static bool ShouldContinueFreshFixSupervision(
+        IDictionary<string, FreshFixContinuationState> continuationStates,
+        string executionUnit,
+        RunSuperviseResult superviseResult)
+    {
+        ArgumentNullException.ThrowIfNull(continuationStates);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(superviseResult);
+
+        if (!continuationStates.TryGetValue(executionUnit, out var continuationState))
+        {
+            return false;
+        }
+
+        if (superviseResult.Blocked
+            || superviseResult.WorkerEntry != RunSupervisionWorkerEntry.Fix
+            || superviseResult.SessionStatus != RunSupervisionSessionStatus.Monitoring
+            || superviseResult.RetryScheduled
+            || superviseResult.AutoResumed)
+        {
+            continuationStates.Remove(executionUnit);
+            return false;
+        }
+
+        if (TimestampFactory() >= continuationState.Deadline || continuationState.RemainingPolls <= 0)
+        {
+            continuationStates.Remove(executionUnit);
+            return false;
+        }
+
+        if (continuationState.RemainingPolls == 1)
+        {
+            continuationStates.Remove(executionUnit);
+        }
+        else
+        {
+            continuationStates[executionUnit] = continuationState with
+            {
+                RemainingPolls = continuationState.RemainingPolls - 1
+            };
+        }
+
+        return true;
+    }
+
+    private static void SleepFreshFixContinuationPollInterval()
+    {
+        if (FreshFixContinuationPollInterval > TimeSpan.Zero)
+        {
+            Thread.Sleep(FreshFixContinuationPollInterval);
+        }
     }
 
     private static bool HasBlockingFixSupervisionSession(

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -63,11 +63,11 @@ internal static class RunCommand
 
     public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
 
-    internal static TimeSpan FreshFixContinuationWindow { get; set; } = TimeSpan.FromSeconds(3);
+    internal static TimeSpan FreshFixContinuationWindow { get; set; } = TimeSpan.FromSeconds(30);
 
     internal static TimeSpan FreshFixContinuationPollInterval { get; set; } = TimeSpan.FromMilliseconds(200);
 
-    internal static int FreshFixContinuationMaxPolls { get; set; } = 15;
+    internal static int FreshFixContinuationMaxPolls { get; set; } = 120;
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -2047,7 +2047,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenFreshFixWorkerDiesAfterImmediateMonitoring_ContinuesSupervisionAndCapturesRuntimeArtifactBoundary()
+    public void ExecuteCore_GivenFreshFixWorkerDiesAfterLongerLivedMonitoring_ContinuesSupervisionAndCapturesRuntimeArtifactBoundary()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -2066,7 +2066,7 @@ public sealed class RunCommandTests
             {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
             {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
             {"ts":"2026-04-10T12:20:00Z","execution_unit":"G226","event":"blocked","by":"intent-cli","reason":"backend exit code 1"}
-            {"ts":"2026-04-17T05:29:47.0973580+00:00","execution_unit":"G226","event":"fix-requested","by":"intent-cli"}
+            {"ts":"2026-04-18T04:24:37.3246270+00:00","execution_unit":"G226","event":"fix-requested","by":"intent-cli"}
             """ + Environment.NewLine);
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
@@ -2150,18 +2150,14 @@ public sealed class RunCommandTests
         var originalRunFixExecutor = RunCommand.RunFixExecutor;
         var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
         var originalTimestampFactory = RunCommand.TimestampFactory;
-        var originalFreshFixContinuationWindow = RunCommand.FreshFixContinuationWindow;
         var originalFreshFixContinuationPollInterval = RunCommand.FreshFixContinuationPollInterval;
-        var originalFreshFixContinuationMaxPolls = RunCommand.FreshFixContinuationMaxPolls;
         var originalGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
         var superviseCallCount = 0;
 
         try
         {
-            RunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-17T05:29:47.3000000+00:00");
-            RunCommand.FreshFixContinuationWindow = TimeSpan.FromSeconds(5);
+            RunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-18T04:24:51.2000000+00:00");
             RunCommand.FreshFixContinuationPollInterval = TimeSpan.Zero;
-            RunCommand.FreshFixContinuationMaxPolls = 1;
             RunSuperviseCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
                 """
                  M .intent-cli/intake/toy-calc.concept.yaml
@@ -2176,7 +2172,7 @@ public sealed class RunCommandTests
                     "fix",
                     "pid:999999",
                     provider: "Codex",
-                    launchedAt: "2026-04-17T05:29:47.2369770+00:00");
+                    launchedAt: "2026-04-18T04:24:37.3246270+00:00");
                 WriteDirectRunResult(
                     repoRoot,
                     executionUnit,
@@ -2186,7 +2182,7 @@ public sealed class RunCommandTests
                     [
                         new DirectRunProviderEvent
                         {
-                            Timestamp = "2026-04-17T05:29:47.2369770+00:00",
+                            Timestamp = "2026-04-18T04:24:37.3246270+00:00",
                             ExecutionUnit = executionUnit,
                             Provider = "Codex",
                             EntryKind = "fix",
@@ -2220,9 +2216,9 @@ public sealed class RunCommandTests
                         HandoffArtifactRef = $".intent-cli/fix/{executionUnit}.request.md",
                         RetryCount = 2,
                         RetryBudget = 3,
-                        CreatedAt = DateTimeOffset.Parse("2026-04-17T05:29:47.2369770+00:00"),
-                        UpdatedAt = DateTimeOffset.Parse("2026-04-17T05:29:47.2369770+00:00"),
-                        LastHeartbeatAt = DateTimeOffset.Parse("2026-04-17T05:29:47.2369770+00:00")
+                        CreatedAt = DateTimeOffset.Parse("2026-04-18T04:24:37.3246270+00:00"),
+                        UpdatedAt = DateTimeOffset.Parse("2026-04-18T04:24:37.3246270+00:00"),
+                        LastHeartbeatAt = DateTimeOffset.Parse("2026-04-18T04:24:37.3246270+00:00")
                     }));
 
                 return new RunFixResult
@@ -2340,9 +2336,7 @@ public sealed class RunCommandTests
             RunCommand.RunFixExecutor = originalRunFixExecutor;
             RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
             RunCommand.TimestampFactory = originalTimestampFactory;
-            RunCommand.FreshFixContinuationWindow = originalFreshFixContinuationWindow;
             RunCommand.FreshFixContinuationPollInterval = originalFreshFixContinuationPollInterval;
-            RunCommand.FreshFixContinuationMaxPolls = originalFreshFixContinuationMaxPolls;
             RunSuperviseCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
         }
     }

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -2047,6 +2047,307 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFreshFixWorkerDiesAfterImmediateMonitoring_ContinuesSupervisionAndCapturesRuntimeArtifactBoundary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            {"ts":"2026-04-10T12:20:00Z","execution_unit":"G226","event":"blocked","by":"intent-cli","reason":"backend exit code 1"}
+            {"ts":"2026-04-17T05:29:47.0973580+00:00","execution_unit":"G226","event":"fix-requested","by":"intent-cli"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Blocked,
+                QueueState = "blocked",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 2,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:20:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T12:20:00Z"),
+                LastInterruptionReason = "backend exit code 1"
+            }));
+        WriteDirectRunRequest(
+            repoRoot,
+            "G226",
+            "fix",
+            "pid:57021",
+            provider: "Codex",
+            launchedAt: "2026-04-10T12:00:00.0000000+00:00");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "failed",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:57021",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                }
+            ],
+            sessionId: "pid:57021",
+            provider: "Codex");
+        var originalRunFixExecutor = RunCommand.RunFixExecutor;
+        var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
+        var originalTimestampFactory = RunCommand.TimestampFactory;
+        var originalFreshFixContinuationWindow = RunCommand.FreshFixContinuationWindow;
+        var originalFreshFixContinuationPollInterval = RunCommand.FreshFixContinuationPollInterval;
+        var originalFreshFixContinuationMaxPolls = RunCommand.FreshFixContinuationMaxPolls;
+        var originalGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+        var superviseCallCount = 0;
+
+        try
+        {
+            RunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-17T05:29:47.3000000+00:00");
+            RunCommand.FreshFixContinuationWindow = TimeSpan.FromSeconds(5);
+            RunCommand.FreshFixContinuationPollInterval = TimeSpan.Zero;
+            RunCommand.FreshFixContinuationMaxPolls = 1;
+            RunSuperviseCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M .intent-cli/intake/toy-calc.concept.yaml
+                 M .intent-cli/intake/toy-calc.execution.md
+                 M .intent-cli/intake/toy-calc.patch.md
+                """);
+            RunCommand.RunFixExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunRequest(
+                    repoRoot,
+                    executionUnit,
+                    "fix",
+                    "pid:999999",
+                    provider: "Codex",
+                    launchedAt: "2026-04-17T05:29:47.2369770+00:00");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "fix",
+                    "running",
+                    providerEvents:
+                    [
+                        new DirectRunProviderEvent
+                        {
+                            Timestamp = "2026-04-17T05:29:47.2369770+00:00",
+                            ExecutionUnit = executionUnit,
+                            Provider = "Codex",
+                            EntryKind = "fix",
+                            SessionId = "pid:999999",
+                            Kind = "session-metadata",
+                            Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                            {
+                                model = "gpt-5.4-mini",
+                                transport = "responses",
+                                command = "codex"
+                            })
+                        }
+                    ],
+                    sessionId: "pid:999999",
+                    provider: "Codex");
+
+                File.WriteAllText(
+                    Path.Combine(repoRoot, ".intent-cli", "supervision", $"{executionUnit}.session.json"),
+                    RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+                    {
+                        ExecutionUnit = executionUnit,
+                        WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                        Status = RunSupervisionSessionStatus.Monitoring,
+                        QueueState = "fixing",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = $"issue-226-{executionUnit.ToLowerInvariant()}",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                        CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                        HandoffArtifactRef = $".intent-cli/fix/{executionUnit}.request.md",
+                        RetryCount = 2,
+                        RetryBudget = 3,
+                        CreatedAt = DateTimeOffset.Parse("2026-04-17T05:29:47.2369770+00:00"),
+                        UpdatedAt = DateTimeOffset.Parse("2026-04-17T05:29:47.2369770+00:00"),
+                        LastHeartbeatAt = DateTimeOffset.Parse("2026-04-17T05:29:47.2369770+00:00")
+                    }));
+
+                return new RunFixResult
+                {
+                    Request = new RunFixRequest
+                    {
+                        ExecutionUnit = executionUnit,
+                        State = "fixing",
+                        ImplementRole = "Codex",
+                        QueueWorkerRole = "coder",
+                        QueueReviewRole = "reviewer",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = $"issue-226-{executionUnit.ToLowerInvariant()}",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        LatestLinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                        LatestCommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                        PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                        ReviewCommentArtifactRef = $".intent-cli/reviews/{executionUnit}.comment.json",
+                        ReviewRequestRef = $".intent-cli/reviews/{executionUnit}.request.json",
+                        ReviewCommentBodyPath = $".intent-cli/reviews/{executionUnit}.comment.md",
+                        IssueTitle = "[G226] Root Run Orchestration Command",
+                        Goal = "Coordinate the root run loop.",
+                        TargetPart = "run command",
+                        TargetRepo = "submodules/intent-system",
+                        TargetPath = ".",
+                        InScope = [],
+                        OutOfScope = [],
+                        AcceptanceCriteria = [],
+                        DeterministicReviewChecks = [],
+                        ExpectedEvidence = []
+                    },
+                    ArtifactPath = $".intent-cli/fix/{executionUnit}.request.md",
+                    DirectRun = new DirectRunLaunchResult
+                    {
+                        RequestArtifactPath = $".intent-cli/runs/{executionUnit}.request.json",
+                        ProviderEventLogPath = $".intent-cli/runs/{executionUnit}.provider.jsonl",
+                        ResultArtifactPath = $".intent-cli/runs/{executionUnit}.result.json",
+                        Provider = "Codex",
+                        Model = "gpt-5.4-mini",
+                        Transport = "responses",
+                        ProviderSessionId = "pid:999999",
+                        RunStatus = "running",
+                        TransportSummary = "launched"
+                    }
+                };
+            };
+            RunCommand.RunSuperviseExecutor = (context, executionUnit) =>
+            {
+                superviseCallCount++;
+                if (superviseCallCount == 1)
+                {
+                    WriteDirectRunResult(
+                        repoRoot,
+                        executionUnit,
+                        "fix",
+                        "running",
+                        providerEvents: CreateToyCalcReplayRuntimeArtifactOnlyFixProgressProviderEvents(
+                            executionUnit,
+                            "pid:999999"),
+                        sessionId: "pid:999999",
+                        provider: "Codex");
+
+                    return new RunSuperviseResult
+                    {
+                        ExecutionUnit = executionUnit,
+                        SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                        WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                        SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                        RetryCount = 2,
+                        RetryBudget = 3,
+                        HandoffArtifactRef = $".intent-cli/fix/{executionUnit}.request.md"
+                    };
+                }
+
+                return RunSuperviseCommand.ExecuteCore(context, executionUnit);
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("non-retryable-failure", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Equal(3, result.Actions.Count);
+            Assert.Equal("run fix", result.Actions[0].Name);
+            Assert.Equal("run supervise", result.Actions[1].Name);
+            Assert.Equal("run supervise", result.Actions[2].Name);
+            Assert.Contains("out-of-scope runtime-artifact drift", result.Detail, StringComparison.Ordinal);
+            Assert.DoesNotContain("Worker remains under supervision.", result.Detail, StringComparison.Ordinal);
+            Assert.Equal(2, superviseCallCount);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("out-of-scope runtime-artifact drift", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(2, session.RetryCount);
+            Assert.Contains("out-of-scope runtime-artifact drift", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("failed", resultArtifact.RunStatus);
+            Assert.Equal("pid:999999", resultArtifact.SessionId);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("out-of-scope runtime-artifact drift", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunCommand.RunFixExecutor = originalRunFixExecutor;
+            RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
+            RunCommand.TimestampFactory = originalTimestampFactory;
+            RunCommand.FreshFixContinuationWindow = originalFreshFixContinuationWindow;
+            RunCommand.FreshFixContinuationPollInterval = originalFreshFixContinuationPollInterval;
+            RunCommand.FreshFixContinuationMaxPolls = originalFreshFixContinuationMaxPolls;
+            RunSuperviseCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenFixingItemWithSucceededFixResultAndExplicitContractGapRefusal_DoesNotAdvanceIntoReview()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -6134,7 +6435,8 @@ public sealed class RunCommandTests
         string executionUnit,
         string entryKind,
         string providerSessionId,
-        string provider = "ReviewBot")
+        string provider = "ReviewBot",
+        string launchedAt = "2026-04-10T12:00:00.0000000+00:00")
     {
         var runsDirectory = Path.Combine(repoRoot, ".intent-cli", "runs");
         Directory.CreateDirectory(runsDirectory);
@@ -6151,7 +6453,7 @@ public sealed class RunCommandTests
                     Provider = provider,
                     Model = "gpt-5.4-mini",
                     Transport = "responses",
-                    LaunchedAt = "2026-04-10T12:00:00.0000000+00:00",
+                    LaunchedAt = launchedAt,
                     ProviderSessionId = providerSessionId,
                     TransportSummary = "launched"
                 }));


### PR DESCRIPTION
## Summary
- continue the root `run` loop across a freshly launched fix worker for a bounded supervision window
- preserve the existing monitoring stop behavior once that fresh-launch window expires
- add a regression test for the short-lived toy-calc runtime-artifact boundary capture path

Closes #322

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo --filter "FullyQualifiedName~ExecuteCore_GivenFreshFixWorkerDiesAfterImmediateMonitoring_ContinuesSupervisionAndCapturesRuntimeArtifactBoundary"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo --filter "FullyQualifiedName~ExecuteCore_GivenQueueTransitionRetryAfterBlockedFixSession_LaunchesFreshFixAttempt"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo --filter "FullyQualifiedName~ExecuteCore_GivenFixingItemWithToyCalcReplayShapeAndOnlyRuntimeArtifactDiff_StopsWithoutRetryExhaustion"
- attempted `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo` but it stalled after test discovery in this environment