### PR TITLE
Carry long-lived fix sessions to terminal root-run boundaries

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -16,7 +16,11 @@ internal static class RunCommand
         public string ExecutionUnit { get; } = executionUnit;
     }
 
-    private sealed record FreshFixContinuationState(DateTimeOffset Deadline, int RemainingPolls);
+    private sealed record FreshFixContinuationState(
+        DateTimeOffset TotalDeadline,
+        DateTimeOffset Deadline,
+        DateTimeOffset LastObservedActivityAt,
+        int RemainingPolls);
 
     private const int IterationBudget = 128;
     private const string NoActionableItemStopReason = "no-actionable-item";
@@ -65,7 +69,11 @@ internal static class RunCommand
 
     internal static TimeSpan FreshFixContinuationWindow { get; set; } = TimeSpan.FromSeconds(30);
 
-    internal static TimeSpan FreshFixContinuationPollInterval { get; set; } = TimeSpan.FromMilliseconds(200);
+    internal static TimeSpan FreshFixContinuationActivityWindow { get; set; } = TimeSpan.FromSeconds(45);
+
+    internal static TimeSpan FreshFixContinuationTotalWindow { get; set; } = TimeSpan.FromSeconds(90);
+
+    internal static TimeSpan FreshFixContinuationPollInterval { get; set; } = TimeSpan.FromMilliseconds(500);
 
     internal static int FreshFixContinuationMaxPolls { get; set; } = 120;
 
@@ -304,6 +312,7 @@ internal static class RunCommand
                             () => RunSuperviseExecutor(context, inProgressItem.ExecutionUnit));
 
                         if (ShouldContinueFreshFixSupervision(
+                                context,
                                 freshFixContinuationStates,
                                 inProgressItem.ExecutionUnit,
                                 superviseResult))
@@ -1091,7 +1100,9 @@ internal static class RunCommand
         ArgumentNullException.ThrowIfNull(continuationStates);
 
         continuationStates.Remove(executionUnit);
-        if (FreshFixContinuationWindow <= TimeSpan.Zero || FreshFixContinuationMaxPolls <= 0)
+        if (FreshFixContinuationWindow <= TimeSpan.Zero
+            || FreshFixContinuationTotalWindow <= TimeSpan.Zero
+            || FreshFixContinuationMaxPolls <= 0)
         {
             return;
         }
@@ -1103,22 +1114,32 @@ internal static class RunCommand
             && DirectRunSessionBoundary.TryParseLaunchedAt(requestArtifact.LaunchedAt, out var parsedLaunchedAt)
                 ? parsedLaunchedAt
                 : now;
+        var totalDeadline = launchedAt + FreshFixContinuationTotalWindow;
         var deadline = launchedAt + FreshFixContinuationWindow;
+        if (deadline > totalDeadline)
+        {
+            deadline = totalDeadline;
+        }
+
         if (deadline <= now)
         {
             return;
         }
 
         continuationStates[executionUnit] = new FreshFixContinuationState(
+            totalDeadline,
             deadline,
+            launchedAt,
             FreshFixContinuationMaxPolls);
     }
 
     private static bool ShouldContinueFreshFixSupervision(
+        CliContext context,
         IDictionary<string, FreshFixContinuationState> continuationStates,
         string executionUnit,
         RunSuperviseResult superviseResult)
     {
+        ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(continuationStates);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
         ArgumentNullException.ThrowIfNull(superviseResult);
@@ -1137,6 +1158,12 @@ internal static class RunCommand
             continuationStates.Remove(executionUnit);
             return false;
         }
+
+        continuationState = RefreshFreshFixContinuationActivity(
+            continuationStates,
+            executionUnit,
+            continuationState,
+            context);
 
         if (TimestampFactory() >= continuationState.Deadline || continuationState.RemainingPolls <= 0)
         {
@@ -1157,6 +1184,41 @@ internal static class RunCommand
         }
 
         return true;
+    }
+
+    private static FreshFixContinuationState RefreshFreshFixContinuationActivity(
+        IDictionary<string, FreshFixContinuationState> continuationStates,
+        string executionUnit,
+        FreshFixContinuationState continuationState,
+        CliContext? context)
+    {
+        if (context is null || FreshFixContinuationActivityWindow <= TimeSpan.Zero)
+        {
+            return continuationState;
+        }
+
+        var requestArtifact = TryReadDirectRunRequestArtifact(context, executionUnit);
+        var latestActivityAt = TryResolveCurrentFixSessionLatestActivityAt(context, executionUnit, requestArtifact);
+        if (latestActivityAt is null || latestActivityAt <= continuationState.LastObservedActivityAt)
+        {
+            return continuationState;
+        }
+
+        var extendedDeadline = latestActivityAt.Value + FreshFixContinuationActivityWindow;
+        if (extendedDeadline > continuationState.TotalDeadline)
+        {
+            extendedDeadline = continuationState.TotalDeadline;
+        }
+
+        continuationState = continuationState with
+        {
+            Deadline = extendedDeadline > continuationState.Deadline
+                ? extendedDeadline
+                : continuationState.Deadline,
+            LastObservedActivityAt = latestActivityAt.Value
+        };
+        continuationStates[executionUnit] = continuationState;
+        return continuationState;
     }
 
     private static void SleepFreshFixContinuationPollInterval()
@@ -1301,6 +1363,48 @@ internal static class RunCommand
         return DirectRunFixOutcomeSupport.TryResolveContractGapDetail(providerEvents, executionUnit, out var detail)
             ? detail
             : null;
+    }
+
+    private static DateTimeOffset? TryResolveCurrentFixSessionLatestActivityAt(
+        CliContext context,
+        string executionUnit,
+        DirectRunRequestArtifact? requestArtifact)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        if (requestArtifact is null
+            || !string.Equals(requestArtifact.EntryKind, "fix", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var providerEvents = TryReadDirectRunProviderEvents(context, executionUnit);
+        if (providerEvents.Count == 0)
+        {
+            return null;
+        }
+
+        providerEvents = SelectCurrentSessionEvents(
+            providerEvents,
+            requestArtifact.ProviderSessionId,
+            requestArtifact.LaunchedAt);
+
+        DateTimeOffset? latestActivityAt = null;
+        foreach (var providerEvent in providerEvents)
+        {
+            if (!DateTimeOffset.TryParse(providerEvent.Timestamp, out var parsedTimestamp))
+            {
+                continue;
+            }
+
+            if (latestActivityAt is null || parsedTimestamp > latestActivityAt.Value)
+            {
+                latestActivityAt = parsedTimestamp;
+            }
+        }
+
+        return latestActivityAt;
     }
 
     private static IReadOnlyList<DirectRunProviderEvent> TryReadDirectRunProviderEvents(CliContext context, string executionUnit)

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -2047,7 +2047,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenFreshFixWorkerDiesAfterLongerLivedMonitoring_ContinuesSupervisionAndCapturesRuntimeArtifactBoundary()
+    public void ExecuteCore_GivenFreshFixWorkerProgressesPastInitialContinuationWindow_ContinuesSupervisionAndCapturesRuntimeArtifactBoundary()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -2066,7 +2066,7 @@ public sealed class RunCommandTests
             {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
             {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
             {"ts":"2026-04-10T12:20:00Z","execution_unit":"G226","event":"blocked","by":"intent-cli","reason":"backend exit code 1"}
-            {"ts":"2026-04-18T04:24:37.3246270+00:00","execution_unit":"G226","event":"fix-requested","by":"intent-cli"}
+            {"ts":"2026-04-18T04:46:59.7953570+00:00","execution_unit":"G226","event":"fix-requested","by":"intent-cli"}
             """ + Environment.NewLine);
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
@@ -2153,10 +2153,17 @@ public sealed class RunCommandTests
         var originalFreshFixContinuationPollInterval = RunCommand.FreshFixContinuationPollInterval;
         var originalGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
         var superviseCallCount = 0;
+        var timestampCallCount = 0;
 
         try
         {
-            RunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-18T04:24:51.2000000+00:00");
+            RunCommand.TimestampFactory = () =>
+            {
+                timestampCallCount++;
+                return timestampCallCount == 1
+                    ? DateTimeOffset.Parse("2026-04-18T04:46:59.9000000+00:00")
+                    : DateTimeOffset.Parse("2026-04-18T04:47:31.2000000+00:00");
+            };
             RunCommand.FreshFixContinuationPollInterval = TimeSpan.Zero;
             RunSuperviseCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
                 """
@@ -2172,7 +2179,7 @@ public sealed class RunCommandTests
                     "fix",
                     "pid:999999",
                     provider: "Codex",
-                    launchedAt: "2026-04-18T04:24:37.3246270+00:00");
+                    launchedAt: "2026-04-18T04:46:59.7953570+00:00");
                 WriteDirectRunResult(
                     repoRoot,
                     executionUnit,
@@ -2182,7 +2189,7 @@ public sealed class RunCommandTests
                     [
                         new DirectRunProviderEvent
                         {
-                            Timestamp = "2026-04-18T04:24:37.3246270+00:00",
+                            Timestamp = "2026-04-18T04:46:59.7953570+00:00",
                             ExecutionUnit = executionUnit,
                             Provider = "Codex",
                             EntryKind = "fix",
@@ -2216,11 +2223,10 @@ public sealed class RunCommandTests
                         HandoffArtifactRef = $".intent-cli/fix/{executionUnit}.request.md",
                         RetryCount = 2,
                         RetryBudget = 3,
-                        CreatedAt = DateTimeOffset.Parse("2026-04-18T04:24:37.3246270+00:00"),
-                        UpdatedAt = DateTimeOffset.Parse("2026-04-18T04:24:37.3246270+00:00"),
-                        LastHeartbeatAt = DateTimeOffset.Parse("2026-04-18T04:24:37.3246270+00:00")
+                        CreatedAt = DateTimeOffset.Parse("2026-04-18T04:46:59.7953570+00:00"),
+                        UpdatedAt = DateTimeOffset.Parse("2026-04-18T04:46:59.7953570+00:00"),
+                        LastHeartbeatAt = DateTimeOffset.Parse("2026-04-18T04:46:59.7953570+00:00")
                     }));
-
                 return new RunFixResult
                 {
                     Request = new RunFixRequest
@@ -2277,9 +2283,10 @@ public sealed class RunCommandTests
                         executionUnit,
                         "fix",
                         "running",
-                        providerEvents: CreateToyCalcReplayRuntimeArtifactOnlyFixProgressProviderEvents(
+                        providerEvents: CreateToyCalcLongerLivedRuntimeArtifactOnlyFixProgressProviderEvents(
                             executionUnit,
-                            "pid:999999"),
+                            "pid:999999",
+                            includeBackendExit: false),
                         sessionId: "pid:999999",
                         provider: "Codex");
 
@@ -2295,6 +2302,17 @@ public sealed class RunCommandTests
                     };
                 }
 
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "fix",
+                    "running",
+                    providerEvents: CreateToyCalcLongerLivedRuntimeArtifactOnlyFixProgressProviderEvents(
+                        executionUnit,
+                        "pid:999999",
+                        includeBackendExit: true),
+                    sessionId: "pid:999999",
+                    provider: "Codex");
                 return RunSuperviseCommand.ExecuteCore(context, executionUnit);
             };
 
@@ -6249,6 +6267,105 @@ public sealed class RunCommandTests
                 })
             }
         ];
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateToyCalcLongerLivedRuntimeArtifactOnlyFixProgressProviderEvents(
+        string executionUnit,
+        string sessionId,
+        bool includeBackendExit)
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-18T04:46:59.7953570+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "session-metadata",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    model = "gpt-5.4-mini",
+                    transport = "responses",
+                    command = "codex"
+                })
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-18T04:47:29.8899000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-18T04:47:29.8901000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("/bin/zsh -lc \"sed -n '1,220p' tests/ToyCalc.Tests/CalculatorTests.cs && printf '\\n---\\n' && sed -n '1,220p' src/ToyCalc/Calculator.cs\" in /repo/.intent-cli/worktrees/G226")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-18T04:47:29.8903000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(" succeeded in 0ms:")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-18T04:47:29.8904000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("tests/ToyCalc.Tests/CalculatorTests.cs")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-18T04:47:29.8905140+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("src/ToyCalc/Calculator.cs")
+            }
+        ];
+
+        if (includeBackendExit)
+        {
+            providerEvents =
+            [
+                .. providerEvents,
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-18T04:48:05.0865860+00:00",
+                    ExecutionUnit = executionUnit,
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = sessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                }
+            ];
+        }
+
+        return providerEvents;
     }
 
     private static IReadOnlyList<DirectRunProviderEvent> CreateToyCalcMixedReplayRuntimeArtifactOnlyFixProgressProviderEvents(


### PR DESCRIPTION
## Summary
- extend fresh fix continuation from a single launch-time window into a bounded activity-aware policy for current fix sessions
- keep supervising longer-lived sessions while current-session provider activity continues, with a total cap and slower poll cadence to avoid premature root returns
- add a regression replay for the accepted G117 longer-lived toy-calc session path and preserve the accepted G115 blocked detail

Closes #324

## Testing
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo --filter "FullyQualifiedName~ExecuteCore_GivenFreshFixWorkerProgressesPastInitialContinuationWindow_ContinuesSupervisionAndCapturesRuntimeArtifactBoundary|FullyQualifiedName~ExecuteCore_GivenQueueTransitionRetryAfterBlockedFixSession_LaunchesFreshFixAttempt|FullyQualifiedName~ExecuteCore_GivenFixingItemWithToyCalcReplayShapeAndOnlyRuntimeArtifactDiff_StopsWithoutRetryExhaustion"
- attempted `dotnet test IntentSystem.sln --nologo`; multiple test projects completed, but the overall run stopped making progress after launching the remaining suite in this environment

## Notes
- I did not run the external `toy-calc-sample` dogfooding repro from `/Users/tomohisa/dev/GitHub/MyIntentHost` in this workspace run.