### PR TITLE
[G119] Repair Review Accept Draft Ready Bridge HTTP 404

### DIFF
--- a/src/IntentSystem.Review/GhReviewAcceptClient.cs
+++ b/src/IntentSystem.Review/GhReviewAcceptClient.cs
@@ -29,13 +29,31 @@ public sealed class GhReviewAcceptClient : IReviewAcceptClient
                 "POST"
             ]);
 
-        if (result.ExitCode != 0)
+        if (result.ExitCode == 0)
         {
-            var error = string.IsNullOrWhiteSpace(result.StdErr)
-                ? "gh api pull request ready_for_review failed."
-                : result.StdErr.Trim();
-            throw new InvalidOperationException(error);
+            return;
         }
+
+        if (IsNotFound(result.StdErr))
+        {
+            var fallbackResult = commandRunner.Run(
+                [
+                    "pr",
+                    "ready",
+                    pullRequest.PullNumber.ToString(),
+                    "--repo",
+                    $"{pullRequest.Owner}/{pullRequest.Repo}"
+                ]);
+
+            if (fallbackResult.ExitCode == 0)
+            {
+                return;
+            }
+
+            throw new InvalidOperationException(GetErrorMessage(fallbackResult.StdErr, "gh pr ready failed."));
+        }
+
+        throw new InvalidOperationException(GetErrorMessage(result.StdErr, "gh api pull request ready_for_review failed."));
     }
 
     public string MergePullRequest(string linkedPr)
@@ -94,5 +112,18 @@ public sealed class GhReviewAcceptClient : IReviewAcceptClient
                 : result.StdErr.Trim();
             throw new InvalidOperationException(error);
         }
+    }
+
+    private static bool IsNotFound(string stdErr)
+    {
+        return !string.IsNullOrWhiteSpace(stdErr)
+            && stdErr.Contains("HTTP 404", StringComparison.Ordinal);
+    }
+
+    private static string GetErrorMessage(string stdErr, string fallbackMessage)
+    {
+        return string.IsNullOrWhiteSpace(stdErr)
+            ? fallbackMessage
+            : stdErr.Trim();
     }
 }

--- a/tests/IntentSystem.Cli.Tests/ReviewAcceptCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewAcceptCommandTests.cs
@@ -271,6 +271,130 @@ public sealed class ReviewAcceptCommandTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenDraftLinkedPrAndReadyApi404_FallsBackToPrReadyAndCompletesCloseout()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G12", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-03T10:00:00Z","execution_unit":"G12","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/tomohisa/toy-calc-sample/issues/3"}
+            {"ts":"2026-04-03T10:10:00Z","execution_unit":"G12","event":"review-started","by":"intent-cli","linked_pr":"https://github.com/tomohisa/toy-calc-sample/pull/4"}
+            """ + Environment.NewLine);
+        using var writer = new StringWriter();
+        var reviewRunner = new ScriptedReviewCommandRunner(
+        [
+            new ExpectedReviewCommand(
+                [
+                    "api",
+                    "repos/tomohisa/toy-calc-sample/pulls/4/merge",
+                    "--method",
+                    "PUT",
+                    "-f",
+                    "merge_method=merge"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr = "gh: Pull Request is still a draft (HTTP 405)"
+                }),
+            new ExpectedReviewCommand(
+                [
+                    "api",
+                    "repos/tomohisa/toy-calc-sample/pulls/4/ready_for_review",
+                    "--method",
+                    "POST"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr = "gh: Not Found (HTTP 404)"
+                }),
+            new ExpectedReviewCommand(
+                [
+                    "pr",
+                    "ready",
+                    "4",
+                    "--repo",
+                    "tomohisa/toy-calc-sample"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                }),
+            new ExpectedReviewCommand(
+                [
+                    "api",
+                    "repos/tomohisa/toy-calc-sample/pulls/4/merge",
+                    "--method",
+                    "PUT",
+                    "-f",
+                    "merge_method=merge"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = """{"sha":"abc123"}""",
+                    StdErr = string.Empty
+                }),
+            new ExpectedReviewCommand(
+                [
+                    "api",
+                    "repos/tomohisa/toy-calc-sample/issues/3",
+                    "--method",
+                    "PATCH",
+                    "-f",
+                    "state=closed"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = """{"state":"closed"}""",
+                    StdErr = string.Empty
+                })
+        ]);
+        var gitRunner = new FakeGitRunner(headCommit: "abc123");
+
+        var originalClientFactory = ReviewAcceptCommand.AcceptClientFactory;
+        var originalGitFactory = ReviewAcceptCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = ReviewAcceptCommand.TimestampFactory;
+
+        try
+        {
+            ReviewAcceptCommand.AcceptClientFactory = () => new GhReviewAcceptClient(reviewRunner);
+            ReviewAcceptCommand.GitCommandRunnerFactory = () => gitRunner;
+            ReviewAcceptCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T01:02:03Z");
+
+            var exitCode = ReviewAcceptCommand.Execute(CreateContext(repoRoot), ["G12"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Review accepted for G12", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(5, reviewRunner.Calls.Count);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Completed, queueState.Items.Single(item => item.ExecutionUnit == "G12").State);
+        }
+        finally
+        {
+            ReviewAcceptCommand.AcceptClientFactory = originalClientFactory;
+            ReviewAcceptCommand.GitCommandRunnerFactory = originalGitFactory;
+            ReviewAcceptCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext
@@ -443,6 +567,25 @@ public sealed class ReviewAcceptCommandTests
                     : string.Empty,
                 StdErr = string.Empty
             };
+        }
+    }
+
+    private sealed record ExpectedReviewCommand(IReadOnlyList<string> Arguments, ReviewCommandResult Result);
+
+    private sealed class ScriptedReviewCommandRunner(IReadOnlyList<ExpectedReviewCommand> expectedCalls) : IReviewCommandRunner
+    {
+        private readonly Queue<ExpectedReviewCommand> expectedCalls = new(expectedCalls);
+
+        public List<IReadOnlyList<string>> Calls { get; } = [];
+
+        public ReviewCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            Calls.Add(arguments.ToArray());
+
+            Assert.NotEmpty(expectedCalls);
+            var expected = expectedCalls.Dequeue();
+            Assert.Equal(expected.Arguments, arguments);
+            return expected.Result;
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -609,8 +609,8 @@ public sealed class RunCommandTests
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "runs.jsonl"),
             """
-            {"ts":"2026-04-03T10:00:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
-            {"ts":"2026-04-03T10:10:00Z","execution_unit":"G226","event":"review-started","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-03T10:00:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/tomohisa/toy-calc-sample/issues/3"}
+            {"ts":"2026-04-03T10:10:00Z","execution_unit":"G226","event":"review-started","by":"intent-cli","linked_pr":"https://github.com/tomohisa/toy-calc-sample/pull/4"}
             """ + Environment.NewLine);
         WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
         WriteDirectRunResult(repoRoot, "G226", "review", "accepted");
@@ -670,7 +670,7 @@ public sealed class RunCommandTests
             Assert.Equal("G226", action.ExecutionUnit);
             Assert.DoesNotContain("Pull Request is still a draft", result.Detail ?? string.Empty, StringComparison.Ordinal);
             Assert.Equal(2, client.MergeAttempts);
-            Assert.Equal(["https://github.com/J-Tech-Japan/intent-system/pull/226"], client.ReadyMarkedPrs);
+            Assert.Equal(["https://github.com/tomohisa/toy-calc-sample/pull/4"], client.ReadyMarkedPrs);
 
             var queueState = QueueStateSerializer.Deserialize(
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
@@ -681,6 +681,219 @@ public sealed class RunCommandTests
             Assert.Equal("pr-merged", runEvents[^3].Event);
             Assert.Equal("issue-closed", runEvents[^2].Event);
             Assert.Equal("completed", runEvents[^1].Event);
+        }
+        finally
+        {
+            ReviewAcceptCommand.AcceptClientFactory = originalClientFactory;
+            ReviewAcceptCommand.GitCommandRunnerFactory = originalGitFactory;
+            ReviewAcceptCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenAcceptedReviewDecisionWithDraftLinkedPrAndReadyApi404_ClosesOutWithoutDeterministicContractGap()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            implementation_issue_packet:
+              issue_title: "[G226] Review Accept"
+              issue_kind: "feature"
+              source_execution_unit: "G226"
+              goal: "Close out accepted review."
+              in_scope:
+                - "review accept command"
+              out_of_scope:
+                - "review comment"
+              target_repo: "submodules/child-repo"
+              target_path: "."
+              target_part: "cli review accept command"
+              dependencies: []
+              technical_baseline:
+                - "C# / .NET"
+              project_local_guide:
+                - "AGENTS.md"
+              intent_baseline:
+                - "closeout stays thin"
+              intent_references:
+                - "ICL.P.PRODUCT_GOAL"
+              rules_and_specs:
+                - "intents/rules/issue-lifecycle-and-landing.md"
+              acceptance_criteria:
+                - "review accept merges and closes"
+              verification_evidence:
+                - "tests-passing"
+              review_mode: "deterministic-review"
+              completion_action: "wait-for-deterministic-review"
+              landing_policy: "merge-after-review"
+
+            review_context_packet:
+              source_execution_unit: "G226"
+              parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+              intent_references:
+                - "ICL.P.PRODUCT_GOAL"
+              rules_and_specs:
+                - "intents/rules/issue-lifecycle-and-landing.md"
+              acceptance_criteria:
+                - "review accept merges and closes"
+              deterministic_review_checks:
+                - "selected item only"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-03T10:00:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/tomohisa/toy-calc-sample/issues/3"}
+            {"ts":"2026-04-03T10:10:00Z","execution_unit":"G226","event":"review-started","by":"intent-cli","linked_pr":"https://github.com/tomohisa/toy-calc-sample/pull/4"}
+            """ + Environment.NewLine);
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
+        WriteDirectRunResult(repoRoot, "G226", "review", "accepted");
+        var originalClientFactory = ReviewAcceptCommand.AcceptClientFactory;
+        var originalGitFactory = ReviewAcceptCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = ReviewAcceptCommand.TimestampFactory;
+        var reviewRunner = new ScriptedReviewCommandRunner(
+        [
+            new ExpectedReviewCommand(
+                [
+                    "api",
+                    "repos/tomohisa/toy-calc-sample/pulls/4/merge",
+                    "--method",
+                    "PUT",
+                    "-f",
+                    "merge_method=merge"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr = "gh: Pull Request is still a draft (HTTP 405)"
+                }),
+            new ExpectedReviewCommand(
+                [
+                    "api",
+                    "repos/tomohisa/toy-calc-sample/pulls/4/ready_for_review",
+                    "--method",
+                    "POST"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr = "gh: Not Found (HTTP 404)"
+                }),
+            new ExpectedReviewCommand(
+                [
+                    "pr",
+                    "ready",
+                    "4",
+                    "--repo",
+                    "tomohisa/toy-calc-sample"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                }),
+            new ExpectedReviewCommand(
+                [
+                    "api",
+                    "repos/tomohisa/toy-calc-sample/pulls/4/merge",
+                    "--method",
+                    "PUT",
+                    "-f",
+                    "merge_method=merge"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = """{"sha":"abc123"}""",
+                    StdErr = string.Empty
+                }),
+            new ExpectedReviewCommand(
+                [
+                    "api",
+                    "repos/tomohisa/toy-calc-sample/issues/3",
+                    "--method",
+                    "PATCH",
+                    "-f",
+                    "state=closed"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = """{"state":"closed"}""",
+                    StdErr = string.Empty
+                })
+        ]);
+
+        try
+        {
+            ReviewAcceptCommand.AcceptClientFactory = () => new GhReviewAcceptClient(reviewRunner);
+            ReviewAcceptCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                new Dictionary<string, GitCommandResult>
+                {
+                    [FakeGitRunner.CreateCommandKey(["fetch", "origin", "main"])] = new GitCommandResult
+                    {
+                        ExitCode = 0,
+                        StdOut = string.Empty,
+                        StdErr = string.Empty
+                    },
+                    [FakeGitRunner.CreateCommandKey(["switch", "main"])] = new GitCommandResult
+                    {
+                        ExitCode = 0,
+                        StdOut = string.Empty,
+                        StdErr = string.Empty
+                    },
+                    [FakeGitRunner.CreateCommandKey(["merge", "--ff-only", "origin/main"])] = new GitCommandResult
+                    {
+                        ExitCode = 0,
+                        StdOut = string.Empty,
+                        StdErr = string.Empty
+                    },
+                    [FakeGitRunner.CreateCommandKey(["rev-parse", "HEAD"])] = new GitCommandResult
+                    {
+                        ExitCode = 0,
+                        StdOut = "abc123" + Environment.NewLine,
+                        StdErr = string.Empty
+                    },
+                    [FakeGitRunner.CreateCommandKey(["add", "submodules/child-repo"])] = new GitCommandResult
+                    {
+                        ExitCode = 0,
+                        StdOut = string.Empty,
+                        StdErr = string.Empty
+                    }
+                });
+            ReviewAcceptCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T01:02:03Z");
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Null(result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review accept", action.Name);
+            Assert.Equal("G226", action.ExecutionUnit);
+            Assert.DoesNotContain("Not Found", result.Detail ?? string.Empty, StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Completed, queueState.Items.Single(item => item.ExecutionUnit == "G226").State);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal("pr-merged", runEvents[^3].Event);
+            Assert.Equal("issue-closed", runEvents[^2].Event);
+            Assert.Equal("completed", runEvents[^1].Event);
+            Assert.Equal(5, reviewRunner.Calls.Count);
         }
         finally
         {
@@ -6782,6 +6995,25 @@ public sealed class RunCommandTests
 
         public void CloseIssue(string linkedIssue)
         {
+        }
+    }
+
+    private sealed record ExpectedReviewCommand(IReadOnlyList<string> Arguments, ReviewCommandResult Result);
+
+    private sealed class ScriptedReviewCommandRunner(IReadOnlyList<ExpectedReviewCommand> expectedCalls) : IReviewCommandRunner
+    {
+        private readonly Queue<ExpectedReviewCommand> expectedCalls = new(expectedCalls);
+
+        public List<IReadOnlyList<string>> Calls { get; } = [];
+
+        public ReviewCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            Calls.Add(arguments.ToArray());
+
+            Assert.NotEmpty(expectedCalls);
+            var expected = expectedCalls.Dequeue();
+            Assert.Equal(expected.Arguments, arguments);
+            return expected.Result;
         }
     }
 

--- a/tests/IntentSystem.Review.Tests/GhReviewAcceptClientTests.cs
+++ b/tests/IntentSystem.Review.Tests/GhReviewAcceptClientTests.cs
@@ -6,17 +6,32 @@ public sealed class GhReviewAcceptClientTests
     public void MergePullRequest_GivenLinkedPr_MergesViaGhApiAndReturnsMergedSha()
     {
         var runner = new FakeRunner(
-            """{"sha":"abc123"}""",
-            string.Empty);
+        [
+            new ExpectedCall(
+                [
+                    "api",
+                    "repos/tomohisa/toy-calc-sample/pulls/4/merge",
+                    "--method",
+                    "PUT",
+                    "-f",
+                    "merge_method=merge"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = """{"sha":"abc123"}""",
+                    StdErr = string.Empty
+                })
+        ]);
         var client = new GhReviewAcceptClient(runner);
 
-        var mergedSha = client.MergePullRequest("https://github.com/J-Tech-Japan/intent-system/pull/46");
+        var mergedSha = client.MergePullRequest("https://github.com/tomohisa/toy-calc-sample/pull/4");
 
         Assert.Equal("abc123", mergedSha);
         Assert.Equal(
             [
                 "api",
-                "repos/J-Tech-Japan/intent-system/pulls/46/merge",
+                "repos/tomohisa/toy-calc-sample/pulls/4/merge",
                 "--method",
                 "PUT",
                 "-f",
@@ -26,17 +41,100 @@ public sealed class GhReviewAcceptClientTests
     }
 
     [Fact]
-    public void CloseIssue_GivenLinkedIssue_ClosesViaGhApi()
+    public void MarkPullRequestReady_GivenLinkedPr_MarksReadyViaGhApi()
     {
-        var runner = new FakeRunner("""{"state":"closed"}""", string.Empty);
+        var runner = new FakeRunner(
+        [
+            new ExpectedCall(
+                [
+                    "api",
+                    "repos/tomohisa/toy-calc-sample/pulls/4/ready_for_review",
+                    "--method",
+                    "POST"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "{}",
+                    StdErr = string.Empty
+                })
+        ]);
         var client = new GhReviewAcceptClient(runner);
 
-        client.CloseIssue("https://github.com/J-Tech-Japan/intent-system/issues/51");
+        client.MarkPullRequestReady("https://github.com/tomohisa/toy-calc-sample/pull/4");
+
+        Assert.Single(runner.Calls);
+    }
+
+    [Fact]
+    public void MarkPullRequestReady_GivenReadyForReviewApi404_FallsBackToGhPrReady()
+    {
+        var runner = new FakeRunner(
+        [
+            new ExpectedCall(
+                [
+                    "api",
+                    "repos/tomohisa/toy-calc-sample/pulls/4/ready_for_review",
+                    "--method",
+                    "POST"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr = "gh: Not Found (HTTP 404)"
+                }),
+            new ExpectedCall(
+                [
+                    "pr",
+                    "ready",
+                    "4",
+                    "--repo",
+                    "tomohisa/toy-calc-sample"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                })
+        ]);
+        var client = new GhReviewAcceptClient(runner);
+
+        client.MarkPullRequestReady("https://github.com/tomohisa/toy-calc-sample/pull/4");
+
+        Assert.Equal(2, runner.Calls.Count);
+    }
+
+    [Fact]
+    public void CloseIssue_GivenLinkedIssue_ClosesViaGhApi()
+    {
+        var runner = new FakeRunner(
+        [
+            new ExpectedCall(
+                [
+                    "api",
+                    "repos/tomohisa/toy-calc-sample/issues/3",
+                    "--method",
+                    "PATCH",
+                    "-f",
+                    "state=closed"
+                ],
+                new ReviewCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = """{"state":"closed"}""",
+                    StdErr = string.Empty
+                })
+        ]);
+        var client = new GhReviewAcceptClient(runner);
+
+        client.CloseIssue("https://github.com/tomohisa/toy-calc-sample/issues/3");
 
         Assert.Equal(
             [
                 "api",
-                "repos/J-Tech-Japan/intent-system/issues/51",
+                "repos/tomohisa/toy-calc-sample/issues/3",
                 "--method",
                 "PATCH",
                 "-f",
@@ -54,20 +152,25 @@ public sealed class GhReviewAcceptClientTests
         Assert.Contains("issue URL shape", exception.Message, StringComparison.Ordinal);
     }
 
-    private sealed class FakeRunner(string stdOut, string stdErr, int exitCode = 0) : IReviewCommandRunner
+    private sealed record ExpectedCall(IReadOnlyList<string> Arguments, ReviewCommandResult Result);
+
+    private sealed class FakeRunner(IReadOnlyList<ExpectedCall> expectedCalls) : IReviewCommandRunner
     {
-        public IReadOnlyList<string> Arguments { get; private set; } = [];
+        private readonly Queue<ExpectedCall> expectedCalls = new(expectedCalls);
+
+        public List<IReadOnlyList<string>> Calls { get; } = [];
+
+        public IReadOnlyList<string> Arguments => Calls.LastOrDefault() ?? [];
 
         public ReviewCommandResult Run(IReadOnlyList<string> arguments)
         {
-            Arguments = arguments.ToArray();
+            Calls.Add(arguments.ToArray());
 
-            return new ReviewCommandResult
-            {
-                ExitCode = exitCode,
-                StdOut = stdOut,
-                StdErr = stdErr
-            };
+            Assert.NotEmpty(expectedCalls);
+            var expected = expectedCalls.Dequeue();
+            Assert.Equal(expected.Arguments, arguments);
+
+            return expected.Result;
         }
     }
 }


### PR DESCRIPTION
## Summary
- fall back from `gh api .../ready_for_review` to `gh pr ready --repo <owner/repo> <number>` when GitHub returns `HTTP 404` for a draft PR ready transition
- cover the fallback in `GhReviewAcceptClient` tests and in `review accept` / root `intent-cli run` closeout tests using the real child repo URL shape from the toy-calc repro
- preserve the existing accepted-review closeout path when the draft bridge only needs the earlier `HTTP 405` retry

## Validation
- `dotnet test tests/IntentSystem.Review.Tests/IntentSystem.Review.Tests.csproj --nologo --filter "FullyQualifiedName~GhReviewAcceptClientTests"`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo --filter "FullyQualifiedName~Execute_GivenDraftLinkedPrAndReadyApi404_FallsBackToPrReadyAndCompletesCloseout|FullyQualifiedName~ExecuteCore_GivenAcceptedReviewDecisionWithDraftLinkedPrAndReadyApi404_ClosesOutWithoutDeterministicContractGap|FullyQualifiedName~Execute_GivenDraftLinkedPr_MarksReadyBeforeMergeAndCompletesCloseout|FullyQualifiedName~ExecuteCore_GivenAcceptedReviewDecisionWithDraftLinkedPr_ClosesOutWithoutDeterministicContractGap"`
- `dotnet test IntentSystem.sln --nologo` started and all non-CLI test projects passed, but the run again remained open waiting on `IntentSystem.Cli.Tests`
- attempted the toy-calc verification with `/Users/tomohisa/dev/GitHub/MyIntentHost/submodules/toy-calc-sample`, but the current local state stayed on the earlier `fixing` path (`Worker remains under supervision.`) and did not reach the review-accept boundary described in the issue

Closes #328