### PR TITLE
Fix explicit contract-gap refusal overmatch on planning preamble

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -47,6 +47,13 @@ internal static class DirectRunFixOutcomeSupport
         "continue beyond initial repository inspection",
         "do not stop after a single inspection command"
     ];
+    private static readonly string[] PlanningPreambleContractGapPrefixes =
+    [
+        "close this run as",
+        "close the run as",
+        "mark this run as",
+        "mark the run as"
+    ];
 
     public static DirectRunProviderEvent? CreateCanonicalContractGapEventIfNeeded(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
@@ -597,6 +604,11 @@ internal static class DirectRunFixOutcomeSupport
 
         var normalized = value.Trim();
         var lower = normalized.ToLowerInvariant();
+        if (IsPlanningPreambleContractGapReference(lower))
+        {
+            return false;
+        }
+
         if (lower.Contains("contract-gap refusal", StringComparison.Ordinal)
             || lower.Contains("contract gap refusal", StringComparison.Ordinal)
             || lower.Contains("stopped with a contract-gap explanation", StringComparison.Ordinal)
@@ -608,6 +620,21 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         return false;
+    }
+
+    private static bool IsPlanningPreambleContractGapReference(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+
+        var normalized = value.TrimStart();
+        while (normalized.Length > 0
+            && (char.IsDigit(normalized[0]) || normalized[0] is '.' or ')' or '-' or ':' || char.IsWhiteSpace(normalized[0])))
+        {
+            normalized = normalized[1..].TrimStart();
+        }
+
+        return PlanningPreambleContractGapPrefixes.Any(prefix =>
+            normalized.StartsWith(prefix, StringComparison.Ordinal));
     }
 
     private static bool ContainsSuccessfulInitialRepoInspection(JsonElement payload)

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -54,6 +54,12 @@ internal static class DirectRunFixOutcomeSupport
         "mark this run as",
         "mark the run as"
     ];
+    private static readonly string[] PlanningPreambleContractGapMarkers =
+    [
+        "opening the request artifact",
+        "decide whether this is a repair or a contract-gap refusal",
+        "decide whether this is a repair or a contract gap refusal"
+    ];
 
     public static DirectRunProviderEvent? CreateCanonicalContractGapEventIfNeeded(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
@@ -634,7 +640,9 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         return PlanningPreambleContractGapPrefixes.Any(prefix =>
-            normalized.StartsWith(prefix, StringComparison.Ordinal));
+                normalized.StartsWith(prefix, StringComparison.Ordinal))
+            || PlanningPreambleContractGapMarkers.Any(marker =>
+                normalized.Contains(marker, StringComparison.Ordinal));
     }
 
     private static bool ContainsSuccessfulInitialRepoInspection(JsonElement payload)

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -317,9 +317,47 @@ public sealed class DirectRunFixOutcomeSupportTests
         Assert.Equal("failed", contractGapEvent!.Payload.GetProperty("run_status").GetString());
         Assert.Equal("provider-explicit-contract-gap-refusal", contractGapEvent.Payload.GetProperty("reason").GetString());
         Assert.Contains(
-            "contract-gap refusal",
+            "contract-gap explanation",
             contractGapEvent.Payload.GetProperty("detail").GetString(),
             StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HasExplicitContractGapSignal_GivenPlanningPreambleMentionsCompletedContractGapRefusal_ReturnsFalse()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("1. Re-read the packet and confirm the bounded target."),
+            CreateProviderEvent("2. Close this run as a completed contract-gap refusal.")
+        ];
+
+        var resolved = DirectRunFixOutcomeSupport.HasExplicitContractGapSignal(providerEvents);
+
+        Assert.False(resolved);
+    }
+
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenPlanningPreambleMentionsCompletedContractGapRefusal_DoesNotCreateFailureBoundary()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-01.request.md' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("1. Re-read the packet and confirm the bounded target."),
+            CreateProviderEvent("2. Close this run as a completed contract-gap refusal."),
+            CreateSuccessfulBackendExitEvent()
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-18T06:00:00Z"),
+            "TOY-CALC-V0-01",
+            "fix",
+            "Codex",
+            "pid:3300",
+            providerSessionAlive: false);
+
+        Assert.Null(contractGapEvent);
     }
 
     private static IReadOnlyList<DirectRunProviderEvent> CreateIssue295CurrentSessionRawEvents(string? echoedRequest = null)

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -360,6 +360,46 @@ public sealed class DirectRunFixOutcomeSupportTests
         Assert.Null(contractGapEvent);
     }
 
+    [Fact]
+    public void HasExplicitContractGapSignal_GivenPlanningSentenceMentionsContractGapRefusalAndBoundedRepoActivity_ReturnsFalse()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("I’m opening the request artifact and the repo-local packet first so I can decide whether this is a repair or a contract-gap refusal."),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Program.cs' succeeded in 0ms")
+        ];
+
+        var resolved = DirectRunFixOutcomeSupport.HasExplicitContractGapSignal(providerEvents);
+
+        Assert.False(resolved);
+    }
+
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenPlanningSentenceMentionsContractGapRefusalAndBoundedRepoActivity_DoesNotCreateFailureBoundary()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-01.request.md' succeeded in 0ms"),
+            CreateProviderEvent("I’m opening the request artifact and the repo-local packet first so I can decide whether this is a repair or a contract-gap refusal."),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Program.cs' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' tests/ToyCalc.Tests/CalculatorTests.cs' succeeded in 0ms"),
+            CreateSuccessfulBackendExitEvent()
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-18T06:10:00Z"),
+            "TOY-CALC-V0-01",
+            "fix",
+            "Codex",
+            "pid:3301",
+            providerSessionAlive: false);
+
+        Assert.Null(contractGapEvent);
+    }
+
     private static IReadOnlyList<DirectRunProviderEvent> CreateIssue295CurrentSessionRawEvents(string? echoedRequest = null)
     {
         return

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -2809,7 +2809,7 @@ public sealed class RunCommandTests
         Assert.Equal("deterministic-contract-gap", result.StopReason);
         Assert.Equal("G226", result.ExecutionUnit);
         Assert.Empty(result.Actions);
-        Assert.Contains("contract-gap refusal", result.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("contract-gap explanation", result.Detail, StringComparison.OrdinalIgnoreCase);
 
         var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
             Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));


### PR DESCRIPTION
## Summary
- ignore imperative planning-preamble lines such as `Close this run as ...` when detecting explicit contract-gap refusals from fix provider output
- preserve real explicit refusal detection by continuing to accept the actual narrative explanation line as the canonical detail
- add focused support tests for planning-preamble false positives and keep the existing root `RunCommand` explicit-refusal path covered

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo --filter "FullyQualifiedName~DirectRunFixOutcomeSupportTests|FullyQualifiedName~ExecuteCore_GivenFixingItemWithSucceededFixResultAndExplicitContractGapRefusal_DoesNotAdvanceIntoReview"`

Closes #330