### PR TITLE
[G121] Repair stale failed fix result reuse

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -252,6 +252,16 @@ internal static class RunCommand
                         }
 
                         var fixRunStatus = fixResultArtifact?.RunStatus;
+                        if (TryReconcileBlockedFixSupervisionState(
+                                context,
+                                actions,
+                                inProgressItem,
+                                out var blockedFixResult))
+                        {
+                            freshFixContinuationStates.Remove(inProgressItem.ExecutionUnit);
+                            return blockedFixResult;
+                        }
+
                         var currentFixSessionContractGap = TryResolveCurrentFixSessionContractGap(
                             context,
                             inProgressItem.ExecutionUnit,
@@ -599,6 +609,80 @@ internal static class RunCommand
             blockedItem.ExecutionUnit,
             session.LastInterruptionReason);
         return true;
+    }
+
+    private static bool TryReconcileBlockedFixSupervisionState(
+        CliContext context,
+        IReadOnlyList<RunCommandAction> actions,
+        QueueItem fixingItem,
+        out RunCommandResult result)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(actions);
+        ArgumentNullException.ThrowIfNull(fixingItem);
+
+        result = null!;
+        var latestFixRequestedAt = TryResolveLatestFixRequestedTimestamp(context, fixingItem.ExecutionUnit);
+        if (!TryResolveBlockedFixSupervisionSession(
+                context,
+                fixingItem.ExecutionUnit,
+                latestFixRequestedAt,
+                out var session))
+        {
+            return false;
+        }
+
+        var interruptionReason = string.IsNullOrWhiteSpace(session.LastInterruptionReason)
+            ? $"Supervisor blocked '{fixingItem.ExecutionUnit}' after non-retryable failure."
+            : session.LastInterruptionReason;
+        PersistBlockedFixQueueState(context, fixingItem, interruptionReason);
+        AppendRunEvent(
+            context.GetRunLogPath(),
+            new RunEvent
+            {
+                Ts = TimestampFactory(),
+                ExecutionUnit = fixingItem.ExecutionUnit,
+                Event = "blocked",
+                By = "intent-cli",
+                LinkedPr = session.LinkedPr,
+                CommentRef = session.CommentRef,
+                Reason = interruptionReason
+            });
+
+        result = CreateStopResult(
+            NonRetryableFailureStopReason,
+            actions,
+            fixingItem.ExecutionUnit,
+            interruptionReason);
+        return true;
+    }
+
+    private static void PersistBlockedFixQueueState(
+        CliContext context,
+        QueueItem queueItem,
+        string interruptionReason)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(queueItem);
+        ArgumentException.ThrowIfNullOrWhiteSpace(interruptionReason);
+
+        var queueState = LoadQueueStateOrThrow(context);
+        var queueStatePath = context.GetQueueStatePath();
+        var now = TimestampFactory();
+        var updatedState = queueState with
+        {
+            UpdatedAt = now,
+            Items = queueState.Items.Select(item =>
+                string.Equals(item.ExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal)
+                    ? item with
+                    {
+                        State = QueueItemState.Blocked,
+                        BlockedBy = [interruptionReason]
+                    }
+                    : item).ToArray()
+        };
+
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
     }
 
     private static bool TryResolvePostFixWorktreeProgressDecisionSession(
@@ -1237,6 +1321,15 @@ internal static class RunCommand
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
 
+        if (TryResolveBlockedFixSupervisionSession(
+                context,
+                executionUnit,
+                latestFixRequestedAt,
+                out _))
+        {
+            return true;
+        }
+
         var sessionArtifactRef = RunSupervisionSessionArtifactPathResolver.Resolve(
             context.Config.Supervision.ArtifactRoot,
             executionUnit);
@@ -1250,10 +1343,45 @@ internal static class RunCommand
 
         var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(sessionArtifactPath));
         if (session.WorkerEntry == RunSupervisionWorkerEntry.Fix
-            && session.Status == RunSupervisionSessionStatus.Blocked
-            && latestFixRequestedAt is not null
-            && latestFixRequestedAt > session.UpdatedAt)
+            && session.Status == RunSupervisionSessionStatus.Blocked)
         {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryResolveBlockedFixSupervisionSession(
+        CliContext context,
+        string executionUnit,
+        DateTimeOffset? latestFixRequestedAt,
+        out RunSupervisionSession session)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        session = null!;
+        var sessionArtifactRef = RunSupervisionSessionArtifactPathResolver.Resolve(
+            context.Config.Supervision.ArtifactRoot,
+            executionUnit);
+        var sessionArtifactPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            sessionArtifactRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(sessionArtifactPath))
+        {
+            return false;
+        }
+
+        session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(sessionArtifactPath));
+        if (session.WorkerEntry != RunSupervisionWorkerEntry.Fix
+            || session.Status != RunSupervisionSessionStatus.Blocked)
+        {
+            return false;
+        }
+
+        if (latestFixRequestedAt is not null && latestFixRequestedAt > session.UpdatedAt)
+        {
+            session = null!;
             return false;
         }
 

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -262,6 +262,18 @@ internal static class RunCommand
                             return blockedFixResult;
                         }
 
+                        if (TryReconcileStaleFailedFixResultState(
+                                context,
+                                actions,
+                                inProgressItem,
+                                fixRequestArtifact,
+                                fixResultArtifact,
+                                out var staleFailedFixResult))
+                        {
+                            freshFixContinuationStates.Remove(inProgressItem.ExecutionUnit);
+                            return staleFailedFixResult;
+                        }
+
                         var currentFixSessionContractGap = TryResolveCurrentFixSessionContractGap(
                             context,
                             inProgressItem.ExecutionUnit,
@@ -654,6 +666,54 @@ internal static class RunCommand
             actions,
             fixingItem.ExecutionUnit,
             interruptionReason);
+        return true;
+    }
+
+    private static bool TryReconcileStaleFailedFixResultState(
+        CliContext context,
+        IReadOnlyList<RunCommandAction> actions,
+        QueueItem fixingItem,
+        DirectRunRequestArtifact? requestArtifact,
+        DirectRunResultArtifact? resultArtifact,
+        out RunCommandResult result)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(actions);
+        ArgumentNullException.ThrowIfNull(fixingItem);
+
+        result = null!;
+        if (requestArtifact is null
+            || resultArtifact is null
+            || !string.Equals(requestArtifact.EntryKind, "fix", StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.RunStatus, "failed", StringComparison.Ordinal)
+            || !MatchesCurrentDirectRunRequestBoundary(requestArtifact, resultArtifact)
+            || !DirectRunSessionBoundary.TryParseLaunchedAt(requestArtifact.LaunchedAt, out var launchedAt)
+            || !TryReadBlockedFixSupervisionSession(context, fixingItem.ExecutionUnit, out var session)
+            || session.UpdatedAt >= launchedAt)
+        {
+            return false;
+        }
+
+        var failureReason = $"Fix direct run failed for '{fixingItem.ExecutionUnit}'.";
+        PersistBlockedFixQueueState(context, fixingItem, failureReason);
+        AppendRunEvent(
+            context.GetRunLogPath(),
+            new RunEvent
+            {
+                Ts = TimestampFactory(),
+                ExecutionUnit = fixingItem.ExecutionUnit,
+                Event = "blocked",
+                By = "intent-cli",
+                LinkedPr = session.LinkedPr,
+                CommentRef = session.CommentRef,
+                Reason = failureReason
+            });
+
+        result = CreateStopResult(
+            NonRetryableFailureStopReason,
+            actions,
+            fixingItem.ExecutionUnit,
+            failureReason);
         return true;
     }
 
@@ -1351,10 +1411,9 @@ internal static class RunCommand
         return true;
     }
 
-    private static bool TryResolveBlockedFixSupervisionSession(
+    private static bool TryReadBlockedFixSupervisionSession(
         CliContext context,
         string executionUnit,
-        DateTimeOffset? latestFixRequestedAt,
         out RunSupervisionSession session)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -1375,6 +1434,24 @@ internal static class RunCommand
         session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(sessionArtifactPath));
         if (session.WorkerEntry != RunSupervisionWorkerEntry.Fix
             || session.Status != RunSupervisionSessionStatus.Blocked)
+        {
+            session = null!;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryResolveBlockedFixSupervisionSession(
+        CliContext context,
+        string executionUnit,
+        DateTimeOffset? latestFixRequestedAt,
+        out RunSupervisionSession session)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        if (!TryReadBlockedFixSupervisionSession(context, executionUnit, out session))
         {
             return false;
         }

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -5819,7 +5819,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenFixingItemWithBlockedSupervisionAndStaleFailedFixResult_ReconcilesBlockedStateWithoutReusingStaleFailureDetail()
+    public void ExecuteCore_GivenFixingItemWithStaleBlockedSupervisionAndTerminalFailedFixResult_ReconcilesGenericFailureWithoutReusingPlanningSentence()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -5837,6 +5837,8 @@ public sealed class RunCommandTests
             {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
             {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
             {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            {"ts":"2026-04-10T11:55:00Z","execution_unit":"G226","event":"blocked","by":"intent-cli","reason":"backend exit code 1"}
+            {"ts":"2026-04-10T12:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"retry after preserved failure"}
             """ + Environment.NewLine);
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
@@ -5879,10 +5881,9 @@ public sealed class RunCommandTests
                 RetryCount = 2,
                 RetryBudget = 3,
                 CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
-                UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:05:00Z"),
-                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T12:05:00Z"),
-                LastInterruptionReason =
-                    "Worker session 'pid:29569' for 'G226' exited with backend exit code 1 after bounded fix progress and left only out-of-scope runtime-artifact drift under '.intent-cli/**'. Changed paths: .intent-cli/intake/toy-calc.execution.md."
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T11:55:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T11:55:00Z"),
+                LastInterruptionReason = "Worker session 'pid:2750' for 'G226' exited with backend exit code 1."
             }));
         WriteDirectRunRequest(
             repoRoot,
@@ -5890,7 +5891,7 @@ public sealed class RunCommandTests
             "fix",
             "pid:29569",
             provider: "Codex",
-            launchedAt: "2026-04-10T12:00:00.0000000+00:00");
+            launchedAt: "2026-04-10T12:20:00.0000000+00:00");
         WriteDirectRunResult(
             repoRoot,
             "G226",
@@ -5921,19 +5922,18 @@ public sealed class RunCommandTests
         Assert.Equal("non-retryable-failure", result.StopReason);
         Assert.Equal("G226", result.ExecutionUnit);
         Assert.Empty(result.Actions);
-        Assert.Contains("out-of-scope runtime-artifact drift", result.Detail, StringComparison.Ordinal);
+        Assert.Contains("Fix direct run failed for 'G226'.", result.Detail, StringComparison.Ordinal);
         Assert.DoesNotContain("I’m opening the request artifact", result.Detail, StringComparison.Ordinal);
-        Assert.DoesNotContain("Fix direct run failed", result.Detail, StringComparison.Ordinal);
 
         var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
         var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
         Assert.Equal(QueueItemState.Blocked, selectedItem.State);
-        Assert.Contains("out-of-scope runtime-artifact drift", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+        Assert.Contains("Fix direct run failed for 'G226'.", selectedItem.BlockedBy[0], StringComparison.Ordinal);
 
         var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
         Assert.Equal("blocked", runEvents[^1].Event);
         var lastRunEventReason = Assert.IsType<string>(runEvents[^1].Reason);
-        Assert.Contains("out-of-scope runtime-artifact drift", lastRunEventReason, StringComparison.Ordinal);
+        Assert.Contains("Fix direct run failed for 'G226'.", lastRunEventReason, StringComparison.Ordinal);
         Assert.DoesNotContain("I’m opening the request artifact", lastRunEventReason, StringComparison.Ordinal);
     }
 

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -5819,6 +5819,125 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFixingItemWithBlockedSupervisionAndStaleFailedFixResult_ReconcilesBlockedStateWithoutReusingStaleFailureDetail()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            queueStatePath,
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            runLogPath,
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Blocked,
+                QueueState = "blocked",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 2,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:05:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T12:05:00Z"),
+                LastInterruptionReason =
+                    "Worker session 'pid:29569' for 'G226' exited with backend exit code 1 after bounded fix progress and left only out-of-scope runtime-artifact drift under '.intent-cli/**'. Changed paths: .intent-cli/intake/toy-calc.execution.md."
+            }));
+        WriteDirectRunRequest(
+            repoRoot,
+            "G226",
+            "fix",
+            "pid:29569",
+            provider: "Codex",
+            launchedAt: "2026-04-10T12:00:00.0000000+00:00");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "failed",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:01:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:29569",
+                    Kind = "assistant-message",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        role = "assistant",
+                        content = "I’m opening the request artifact and the review context to decide whether this is a repair or a contract-gap refusal."
+                    })
+                }
+            ],
+            sessionId: "pid:29569",
+            provider: "Codex");
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("non-retryable-failure", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("out-of-scope runtime-artifact drift", result.Detail, StringComparison.Ordinal);
+        Assert.DoesNotContain("I’m opening the request artifact", result.Detail, StringComparison.Ordinal);
+        Assert.DoesNotContain("Fix direct run failed", result.Detail, StringComparison.Ordinal);
+
+        var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+        Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+        Assert.Contains("out-of-scope runtime-artifact drift", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        Assert.Equal("blocked", runEvents[^1].Event);
+        var lastRunEventReason = Assert.IsType<string>(runEvents[^1].Reason);
+        Assert.Contains("out-of-scope runtime-artifact drift", lastRunEventReason, StringComparison.Ordinal);
+        Assert.DoesNotContain("I’m opening the request artifact", lastRunEventReason, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ExecuteCore_GivenClarifyBlockedItem_StopsWithClarificationRequired()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
Closes #332

## Summary
- reconcile `fixing` queue items against a terminal blocked fix supervision session before reusing stale failed fix output
- persist the canonical blocked queue boundary and run-log event instead of surfacing the old planning-sentence contract-gap detail
- add regression coverage for the stale `fixing` + `blocked` + `failed` artifact mismatch after G120

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo --filter "FullyQualifiedName~ExecuteCore_GivenFixingItemWithBlockedSupervisionAndStaleFailedFixResult_ReconcilesBlockedStateWithoutReusingStaleFailureDetail|FullyQualifiedName~ExecuteCore_GivenQueueTransitionRetryAfterBlockedFixSession_LaunchesFreshFixAttempt|FullyQualifiedName~ExecuteCore_GivenFreshFixWorkerProgressesPastInitialContinuationWindow_ContinuesSupervisionAndCapturesRuntimeArtifactBoundary"`
- `dotnet test IntentSystem.sln --nologo` *(hangs while `IntentSystem.Cli.Tests` is still running; other test projects completed and passed before the hang)*