### PR TITLE
[G122] Isolate stale fix worktree runtime artifacts

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunFixCommand.cs
@@ -107,6 +107,13 @@ internal static class RunFixCommand
             throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
         }
 
+        PrepareWorktreeRuntimeContext(
+            context,
+            queueItem,
+            packetPath,
+            reviewContextPath,
+            worktreePath);
+
         ChildWorkTargetGuard.EnsureTargetAllowed(
             executionUnit,
             context.RepoRoot,
@@ -165,6 +172,77 @@ internal static class RunFixCommand
             ArtifactPath = relativeArtifactPath,
             DirectRun = directRun
         };
+    }
+
+    private static void PrepareWorktreeRuntimeContext(
+        CliContext context,
+        QueueItem queueItem,
+        string packetPath,
+        string reviewContextPath,
+        string worktreePath)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(queueItem);
+        ArgumentException.ThrowIfNullOrWhiteSpace(packetPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reviewContextPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
+
+        SyncCurrentIssueArtifactsToWorktree(queueItem.ExecutionUnit, packetPath, worktreePath);
+        SyncCurrentIssueArtifactsToWorktree(queueItem.ExecutionUnit, reviewContextPath, worktreePath);
+        RemoveStaleWorktreeRootResultArtifact(context, queueItem.ExecutionUnit, worktreePath);
+    }
+
+    private static void SyncCurrentIssueArtifactsToWorktree(
+        string executionUnit,
+        string sourceArtifactPath,
+        string worktreePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceArtifactPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
+
+        var sourceIssueDirectory = Path.GetDirectoryName(sourceArtifactPath)
+            ?? throw new InvalidOperationException("Issue artifact path did not contain a directory.");
+        if (!Directory.Exists(sourceIssueDirectory))
+        {
+            throw new InvalidOperationException($"Issue artifact directory was not found at {sourceIssueDirectory}");
+        }
+
+        var targetIssueDirectory = Path.Combine(worktreePath, ".intent-cli", "issues", executionUnit);
+        Directory.CreateDirectory(targetIssueDirectory);
+
+        foreach (var sourceFilePath in Directory.GetFiles(sourceIssueDirectory))
+        {
+            var targetFilePath = Path.Combine(targetIssueDirectory, Path.GetFileName(sourceFilePath));
+            File.Copy(sourceFilePath, targetFilePath, overwrite: true);
+        }
+    }
+
+    private static void RemoveStaleWorktreeRootResultArtifact(
+        CliContext context,
+        string executionUnit,
+        string worktreePath)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
+
+        var worktreeRunResultPath = Path.Combine(
+            worktreePath,
+            RunRootResultArtifactPathResolver.Resolve(context).Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(worktreeRunResultPath))
+        {
+            return;
+        }
+
+        var artifact = RunRootResultArtifactJson.Deserialize(File.ReadAllText(worktreeRunResultPath));
+        if (string.IsNullOrWhiteSpace(artifact.ExecutionUnit)
+            || string.Equals(artifact.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        File.Delete(worktreeRunResultPath);
     }
 
     private static RunFixRequest BuildRequest(

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -132,6 +132,85 @@ public sealed class RunFixCommandTests
     }
 
     [Fact]
+    public void Execute_GivenStaleWorktreeRuntimeArtifacts_SyncsCurrentIssueArtifactsAndRemovesSupersededRunResult()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var worktreePath = tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G20"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "implementation.md"),
+            "# Current implementation");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G20", "github-body.md"),
+            "# Current github body");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G20.comment.json"),
+            CreateReviewCommentArtifactJson());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "worktrees", "G20", ".intent-cli", "issues", "OLD-01", "packet.yaml"),
+            "stale-packet");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "worktrees", "G20", ".intent-cli", "run.result.json"),
+            RunRootResultArtifactJson.Serialize(new RunRootResultArtifact
+            {
+                SchemaVersion = "1",
+                StopReason = "deterministic-contract-gap",
+                TouchedExecutionUnits = ["OLD-01"],
+                ReusedChildCommandRefs = [],
+                ExecutionUnit = "OLD-01",
+                Detail = "stale worktree result"
+            }));
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunFixCommand.TimestampFactory;
+        var originalLauncherFactory = RunFixCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            RunFixCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:25:00Z");
+            RunFixCommand.DirectRunLauncherFactory = () => new FakeDirectRunLauncher(
+                "pid:8765",
+                "Claude",
+                "default",
+                "stdio",
+                "stdio transport launched via 'claude' in '/repo/.intent-cli/worktrees/G20' for provider 'Claude'.");
+
+            var exitCode = RunFixCommand.Execute(CreateContext(repoRoot), ["G20"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.True(File.Exists(Path.Combine(worktreePath, ".intent-cli", "issues", "G20", "packet.yaml")));
+            Assert.True(File.Exists(Path.Combine(worktreePath, ".intent-cli", "issues", "G20", "review-context.md")));
+            Assert.True(File.Exists(Path.Combine(worktreePath, ".intent-cli", "issues", "G20", "implementation.md")));
+            Assert.True(File.Exists(Path.Combine(worktreePath, ".intent-cli", "issues", "G20", "github-body.md")));
+            Assert.Equal(
+                CreatePacketYaml(),
+                File.ReadAllText(Path.Combine(worktreePath, ".intent-cli", "issues", "G20", "packet.yaml")));
+            Assert.Equal(
+                CreateReviewContextMarkdown(),
+                File.ReadAllText(Path.Combine(worktreePath, ".intent-cli", "issues", "G20", "review-context.md")));
+            Assert.False(File.Exists(Path.Combine(worktreePath, ".intent-cli", "run.result.json")));
+            Assert.True(File.Exists(Path.Combine(worktreePath, ".intent-cli", "issues", "OLD-01", "packet.yaml")));
+        }
+        finally
+        {
+            RunFixCommand.TimestampFactory = originalTimestampFactory;
+            RunFixCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenMissingExecutionUnit_ReturnsExitCodeOne()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
Closes #334

## Summary
- sync the current execution unit's `.intent-cli/issues/<execution-unit>/` packet artifacts into the fix worktree before launching a fresh fix session
- remove a worktree-local `.intent-cli/run.result.json` only when it belongs to a superseded execution unit so stale root runtime history does not hijack the current fix session
- add focused coverage for stale worktree runtime contamination during `run fix`

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo --filter "FullyQualifiedName~RunFixCommandTests.Execute_GivenStaleWorktreeRuntimeArtifacts_SyncsCurrentIssueArtifactsAndRemovesSupersededRunResult|FullyQualifiedName~RunFixCommandTests.Execute_GivenFixingItemWithInputs_GeneratesRepairHandoffArtifactAndNormalizedRunResult|FullyQualifiedName~RunFixCommandTests.Execute_GivenFollowUpWorkAfterInitialInspection_DoesNotAppendInspectionOnlyContractGapEvent|FullyQualifiedName~RunFixCommandTests.Execute_GivenRuntimeOnlyTargetPart_ReturnsExitCodeOneWithoutWritingRepairArtifact"`
- `dotnet test IntentSystem.sln --nologo` *(aborted in `IntentSystem.Cli.Tests`: test host crashed after 403 passing tests with `System.IO.IOException: The file .../.intent-cli/runs already exists` from `DirectRunProviderEventWriter.AppendWithDirectoryRecovery`)*