### PR TITLE
[G123] Surface No-Op Fix Success Instead Of Retrying After Backend Exit 0

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -219,6 +219,33 @@ internal static class DirectRunFixOutcomeSupport
         return HasSpecAndProductReadProgressSignal(providerEvents);
     }
 
+    public static bool TryResolveNoOpSuccessDetail(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        out string detail)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        detail = string.Empty;
+        if (!HasSuccessfulBackendExit(providerEvents))
+        {
+            return false;
+        }
+
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            if (!TryResolveNoOpSuccessDetail(providerEvents[index].Payload, out detail))
+            {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
     internal static bool HasExplicitContractGapSignal(IReadOnlyList<DirectRunProviderEvent> providerEvents)
     {
         ArgumentNullException.ThrowIfNull(providerEvents);
@@ -483,6 +510,32 @@ internal static class DirectRunFixOutcomeSupport
             return false;
         }
 
+        return true;
+    }
+
+    private static bool TryResolveNoOpSuccessDetail(JsonElement payload, out string detail)
+    {
+        detail = string.Empty;
+        if (payload.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        var value = payload.GetString();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var normalized = value.Trim();
+        var lower = normalized.ToLowerInvariant();
+        if (!lower.Contains("without requiring code changes", StringComparison.Ordinal)
+            || !lower.Contains("already matches", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        detail = normalized;
         return true;
     }
 

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -218,6 +218,21 @@ internal static class RunSuperviseCommand
                 now);
         }
 
+        if (HasDeadWorkerSessionSucceeded(context, executionUnit, session.WorkerEntry))
+        {
+            var completedSession = session with
+            {
+                Status = RunSupervisionSessionStatus.Monitoring,
+                UpdatedAt = now,
+                LastHeartbeatAt = now,
+                NextRetryAt = null,
+                LastInterruptionReason = null
+            };
+
+            PersistSession(sessionArtifactPath, completedSession);
+            return CreateResult(sessionArtifactRef, completedSession);
+        }
+
         if (session.Status == RunSupervisionSessionStatus.RetryScheduled)
         {
             if (session.NextRetryAt is null)
@@ -766,6 +781,22 @@ internal static class RunSuperviseCommand
         var currentProviderEvents = SelectCurrentSessionEvents(providerEvents, requestArtifact.ProviderSessionId, requestArtifact.LaunchedAt);
 
         if (string.Equals(expectedEntryKind, "fix", StringComparison.Ordinal)
+            && DirectRunFixOutcomeSupport.TryResolveNoOpSuccessDetail(
+                currentProviderEvents,
+                executionUnit,
+                out _))
+        {
+            File.WriteAllText(
+                resultArtifactPath,
+                DirectRunResultArtifactJson.Serialize(resultArtifact with
+                {
+                    RunStatus = "succeeded"
+                }));
+
+            return false;
+        }
+
+        if (string.Equals(expectedEntryKind, "fix", StringComparison.Ordinal)
             && TryResolveFixWorktreeProgressFailure(
                 currentProviderEvents,
                 executionUnit,
@@ -1061,6 +1092,37 @@ internal static class RunSuperviseCommand
 
         exitCode = default;
         return false;
+    }
+
+    private static bool HasDeadWorkerSessionSucceeded(
+        CliContext context,
+        string executionUnit,
+        RunSupervisionWorkerEntry workerEntry)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var expectedEntryKind = ResolveDirectRunEntryKind(workerEntry);
+        var requestArtifactPath = ResolveDirectRunRequestArtifactPath(context, executionUnit);
+        var resultArtifactPath = ResolveDirectRunResultArtifactPath(context, executionUnit);
+        if (!File.Exists(requestArtifactPath) || !File.Exists(resultArtifactPath))
+        {
+            return false;
+        }
+
+        var requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        if (!string.Equals(requestArtifact.EntryKind, expectedEntryKind, StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.EntryKind, expectedEntryKind, StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.SessionId, requestArtifact.ProviderSessionId, StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.RunStatus, "succeeded", StringComparison.Ordinal)
+            || !TryParseSessionProcessId(requestArtifact.ProviderSessionId, out var processId)
+            || IsProcessAlive(processId))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     private static string ResolveDirectRunRequestArtifactPath(CliContext context, string executionUnit)

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -921,6 +921,92 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenDeadFixWorkerSessionWithNoOpSuccessAndBackendExitZero_MarksSucceededWithoutAutoResume()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateFixingRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Fixing)));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G25.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession(workerEntry: RunSupervisionWorkerEntry.Fix)));
+        WriteDeadFixDirectRunArtifacts(repoRoot, "pid:999999");
+        File.AppendAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                new[]
+                {
+                    CreateProviderEvent(
+                        "2026-04-08T10:20:00.5000000+00:00",
+                        "G25",
+                        "fix",
+                        "pid:999999",
+                        "provider-event",
+                        "The bounded repair attempt completed without requiring code changes: the current tree already matches the canonical v0 CLI contract and passes verification."),
+                    CreateProviderEvent(
+                        "2026-04-08T10:20:01.0000000+00:00",
+                        "G25",
+                        "fix",
+                        "pid:999999",
+                        "provider-event",
+                        new
+                        {
+                            type = "backend-exit",
+                            exit_code = 0
+                        })
+                }
+                .Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalRunFixExecutor = RunSuperviseCommand.RunFixExecutor;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+            RunSuperviseCommand.RunFixExecutor = (_, _) =>
+                throw new InvalidOperationException("unexpected extra fix worker launch");
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.DoesNotContain("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Monitoring, session.Status);
+            Assert.Equal(0, session.RetryCount);
+            Assert.Null(session.NextRetryAt);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.result.json")));
+            Assert.Equal("pid:999999", resultArtifact.SessionId);
+            Assert.Equal("succeeded", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "auto-resumed", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.RunFixExecutor = originalRunFixExecutor;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenStartupOnlyDeadFixWorkerSession_BlocksWithoutConsumingRetryBudget()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- treat fix-session no-op success narratives followed by backend exit 0 as a terminal success boundary
- suppress retry scheduling for dead worker sessions whose direct-run result is already marked succeeded
- add supervise regression coverage proving no retry-attempted or second fix launch occurs for the no-op path

Closes #336

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunSuperviseCommandTests.Execute_GivenDeadFixWorkerSessionWithNoOpSuccessAndBackendExitZero_MarksSucceededWithoutAutoResume|FullyQualifiedName~RunSuperviseCommandTests.Execute_GivenDeadFixWorkerSession_CapturesFailureAndAutoResumesFixLoop|FullyQualifiedName~RunSuperviseCommandTests.Execute_GivenDeadFixWorkerSessionWithToyCalcMixedReplayShapeAndOnlyRuntimeArtifactDiff_BlocksWithoutConsumingRetryBudget" --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunSuperviseCommandTests" --nologo