### PR TITLE
[G125] Re-Enter Fresh Fix Launch Instead Of Reusing Stale Deterministic Contract-Gap Result

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1226,12 +1226,25 @@ internal static class RunCommand
             return false;
         }
 
+        if (latestFixRequestedAt is null)
+        {
+            return false;
+        }
+
+        var latestActivityAt = TryResolveCurrentFixSessionLatestActivityAt(context, executionUnit, requestArtifact);
+        if (latestActivityAt is not null
+            && latestFixRequestedAt > latestActivityAt
+            && !TryReadBlockedFixSupervisionSession(context, executionUnit, out _))
+        {
+            return true;
+        }
+
         if (!DirectRunSessionBoundary.TryParseLaunchedAt(requestArtifact.LaunchedAt, out var launchedAt))
         {
             return false;
         }
 
-        return latestFixRequestedAt is not null && latestFixRequestedAt > launchedAt;
+        return latestFixRequestedAt > launchedAt;
     }
 
     private static void TrackFreshFixContinuation(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -5938,6 +5938,225 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFixingItemWithStaleFailedFixResultWhoseLatestActivityPredatesManualFixRequest_LaunchesFreshFix()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        tempDirectory.CreateFile(
+            runLogPath,
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            {"ts":"2026-04-10T12:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"manual retry after preserved failure"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        WriteDirectRunRequest(
+            repoRoot,
+            "G226",
+            "fix",
+            "pid:29569",
+            provider: "Codex",
+            launchedAt: "2026-04-10T12:20:00.0000000+00:00");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "failed",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:14:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:29569",
+                    Kind = "assistant-message",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        role = "assistant",
+                        content = "I’m reading the request artifact first, then I’ll trace the relevant code path and either make the bounded repair or give a concrete contract-gap refusal."
+                    })
+                }
+            ],
+            sessionId: "pid:29569",
+            provider: "Codex");
+        var originalRunFixExecutor = RunCommand.RunFixExecutor;
+        var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
+        var originalFreshFixContinuationWindow = RunCommand.FreshFixContinuationWindow;
+        var originalFreshFixContinuationTotalWindow = RunCommand.FreshFixContinuationTotalWindow;
+
+        try
+        {
+            RunCommand.FreshFixContinuationWindow = TimeSpan.Zero;
+            RunCommand.FreshFixContinuationTotalWindow = TimeSpan.Zero;
+            RunCommand.RunFixExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunRequest(
+                    repoRoot,
+                    executionUnit,
+                    "fix",
+                    "pid:4242",
+                    provider: "Codex",
+                    launchedAt: "2026-04-10T12:21:00.0000000+00:00");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "fix",
+                    "running",
+                    providerEvents:
+                    [
+                        new DirectRunProviderEvent
+                        {
+                            Timestamp = "2026-04-10T12:21:00.0000000+00:00",
+                            ExecutionUnit = executionUnit,
+                            Provider = "Codex",
+                            EntryKind = "fix",
+                            SessionId = "pid:4242",
+                            Kind = "session-metadata",
+                            Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                            {
+                                model = "gpt-5.4-mini",
+                                transport = "responses",
+                                command = "codex"
+                            })
+                        }
+                    ],
+                    sessionId: "pid:4242",
+                    provider: "Codex");
+                File.AppendAllText(
+                    runLogPath,
+                    RunLogSerializer.SerializeLine(new RunEvent
+                    {
+                        Ts = DateTimeOffset.Parse("2026-04-10T12:21:00Z"),
+                        ExecutionUnit = executionUnit,
+                        Event = "provider-lifecycle",
+                        By = "intent-cli",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                        CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                        EntryKind = "fix",
+                        Provider = "Codex",
+                        Model = "gpt-5.4-mini",
+                        SessionId = "pid:4242",
+                        RunStatus = "running",
+                        RawLogRef = $".intent-cli/runs/{executionUnit}.provider.jsonl",
+                        ResultRef = $".intent-cli/runs/{executionUnit}.result.json",
+                        PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit)
+                    }) + Environment.NewLine);
+
+                return new RunFixResult
+                {
+                    Request = new RunFixRequest
+                    {
+                        ExecutionUnit = executionUnit,
+                        State = "fixing",
+                        ImplementRole = "Codex",
+                        QueueWorkerRole = "coder",
+                        QueueReviewRole = "reviewer",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = $"issue-226-{executionUnit.ToLowerInvariant()}",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        LatestLinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                        LatestCommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                        PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                        ReviewCommentArtifactRef = $".intent-cli/reviews/{executionUnit}.comment.json",
+                        ReviewRequestRef = $".intent-cli/reviews/{executionUnit}.request.json",
+                        ReviewCommentBodyPath = $".intent-cli/reviews/{executionUnit}.comment.md",
+                        IssueTitle = "[G226] Root Run Orchestration Command",
+                        Goal = "Coordinate the root run loop.",
+                        TargetPart = "run command",
+                        TargetRepo = "submodules/intent-system",
+                        TargetPath = ".",
+                        InScope = [],
+                        OutOfScope = [],
+                        AcceptanceCriteria = [],
+                        DeterministicReviewChecks = [],
+                        ExpectedEvidence = []
+                    },
+                    ArtifactPath = $".intent-cli/fix/{executionUnit}.request.md",
+                    DirectRun = CreateDirectRunLaunchResult(executionUnit, "pid:4242")
+                };
+            };
+            RunCommand.RunSuperviseExecutor = (_, executionUnit) => new RunSuperviseResult
+            {
+                ExecutionUnit = executionUnit,
+                SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                RetryCount = 0,
+                RetryBudget = 3,
+                HandoffArtifactRef = $".intent-cli/fix/{executionUnit}.request.md"
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Equal(2, result.Actions.Count);
+            Assert.Equal("run fix", result.Actions[0].Name);
+            Assert.Equal("run supervise", result.Actions[1].Name);
+            Assert.Contains("under supervision", result.Detail, StringComparison.Ordinal);
+            Assert.DoesNotContain("I’m reading the request artifact first", result.Detail, StringComparison.Ordinal);
+
+            var requestArtifact = DirectRunRequestArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.request.json")));
+            Assert.Equal("pid:4242", requestArtifact.ProviderSessionId);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Contains(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "provider-lifecycle", StringComparison.Ordinal)
+                && string.Equals(runEvent.SessionId, "pid:4242", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunCommand.RunFixExecutor = originalRunFixExecutor;
+            RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
+            RunCommand.FreshFixContinuationWindow = originalFreshFixContinuationWindow;
+            RunCommand.FreshFixContinuationTotalWindow = originalFreshFixContinuationTotalWindow;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenClarifyBlockedItem_StopsWithClarificationRequired()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- relaunch fresh run fix when a manual fix-request is newer than the stale failed session's last provider activity, even if the stale request boundary's launched_at is newer
- keep blocked-supervision stale failure reconciliation intact so the accepted G121 generic-failure path does not regress
- add a RunCommand regression proving stale planning-sentence reuse is replaced by a fresh fix launch boundary and updated result artifact

Closes #340

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests.ExecuteCore_GivenFixingItemWithStaleFailedFixResultWhoseLatestActivityPredatesManualFixRequest_LaunchesFreshFix|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenFixingItemWithStaleBlockedSupervisionAndTerminalFailedFixResult_ReconcilesGenericFailureWithoutReusingPlanningSentence|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenFixingItemWithStaleFailedFixResultAndRuntimeOnlyTarget_StopsWithDeterministicContractGap" --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests" --nologo
- python3 wrapper for dotnet test IntentSystem.sln --nologo with 120s timeout; timed out after non-CLI suites passed and while waiting on IntentSystem.Cli.Tests