### PR TITLE
[G126] Let fresh fix retry supersede stale monitoring supervision

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1196,7 +1196,7 @@ internal static class RunCommand
             DescribeSupervisionResult(superviseResult));
     }
 
-    private static bool ShouldLaunchFreshFixAttempt(
+    internal static bool ShouldLaunchFreshFixAttempt(
         CliContext context,
         string executionUnit,
         DirectRunRequestArtifact? requestArtifact,
@@ -1394,29 +1394,22 @@ internal static class RunCommand
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
 
-        if (TryResolveBlockedFixSupervisionSession(
-                context,
-                executionUnit,
-                latestFixRequestedAt,
-                out _))
-        {
-            return true;
-        }
-
-        var sessionArtifactRef = RunSupervisionSessionArtifactPathResolver.Resolve(
-            context.Config.Supervision.ArtifactRoot,
-            executionUnit);
-        var sessionArtifactPath = Path.GetFullPath(Path.Combine(
-            context.RepoRoot,
-            sessionArtifactRef.Replace('/', Path.DirectorySeparatorChar)));
-        if (!File.Exists(sessionArtifactPath))
+        if (!TryReadSupervisionSession(context, executionUnit, out var session))
         {
             return false;
         }
 
-        var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(sessionArtifactPath));
-        if (session.WorkerEntry == RunSupervisionWorkerEntry.Fix
-            && session.Status == RunSupervisionSessionStatus.Blocked)
+        if (session.WorkerEntry != RunSupervisionWorkerEntry.Fix)
+        {
+            return true;
+        }
+
+        if (session.Status == RunSupervisionSessionStatus.Blocked)
+        {
+            return latestFixRequestedAt is null || latestFixRequestedAt <= session.UpdatedAt;
+        }
+
+        if (IsStaleMonitoringFixSupervisionSession(session, latestFixRequestedAt))
         {
             return false;
         }
@@ -1424,7 +1417,7 @@ internal static class RunCommand
         return true;
     }
 
-    private static bool TryReadBlockedFixSupervisionSession(
+    private static bool TryReadSupervisionSession(
         CliContext context,
         string executionUnit,
         out RunSupervisionSession session)
@@ -1445,10 +1438,21 @@ internal static class RunCommand
         }
 
         session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(sessionArtifactPath));
-        if (session.WorkerEntry != RunSupervisionWorkerEntry.Fix
+        return true;
+    }
+
+    private static bool TryReadBlockedFixSupervisionSession(
+        CliContext context,
+        string executionUnit,
+        out RunSupervisionSession session)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        if (!TryReadSupervisionSession(context, executionUnit, out session)
+            || session.WorkerEntry != RunSupervisionWorkerEntry.Fix
             || session.Status != RunSupervisionSessionStatus.Blocked)
         {
-            session = null!;
             return false;
         }
 
@@ -1476,6 +1480,18 @@ internal static class RunCommand
         }
 
         return true;
+    }
+
+    private static bool IsStaleMonitoringFixSupervisionSession(
+        RunSupervisionSession session,
+        DateTimeOffset? latestFixRequestedAt)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        return session.WorkerEntry == RunSupervisionWorkerEntry.Fix
+            && session.Status == RunSupervisionSessionStatus.Monitoring
+            && latestFixRequestedAt is not null
+            && latestFixRequestedAt > session.UpdatedAt;
     }
 
     private static string? TryReadDirectRunStatus(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -5938,6 +5938,92 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ShouldLaunchFreshFixAttempt_GivenStaleMonitoringFixSupervisionSessionWithNewerFixRequested_ReturnsTrue()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            {"ts":"2026-04-10T12:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"manual retry after preserved failure"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 0,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T12:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:14:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T12:14:00Z")
+            }));
+        WriteDirectRunRequest(
+            repoRoot,
+            "G226",
+            "fix",
+            "pid:29569",
+            provider: "Codex",
+            launchedAt: "2026-04-10T12:20:00.0000000+00:00");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "failed",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:14:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:29569",
+                    Kind = "assistant-message",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        role = "assistant",
+                        content = "I’m reading the request artifact first, then I’ll trace the relevant code path and either make the bounded repair or give a concrete contract-gap refusal."
+                    })
+                }
+            ],
+            sessionId: "pid:29569",
+            provider: "Codex");
+
+        var requestArtifact = DirectRunRequestArtifactJson.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.request.json")));
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+
+        var shouldLaunch = RunCommand.ShouldLaunchFreshFixAttempt(
+            CreateContext(repoRoot),
+            "G226",
+            requestArtifact,
+            resultArtifact);
+
+        Assert.True(shouldLaunch);
+    }
+
+    [Fact]
     public void ExecuteCore_GivenFixingItemWithStaleFailedFixResultWhoseLatestActivityPredatesManualFixRequest_LaunchesFreshFix()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -5980,6 +6066,246 @@ public sealed class RunCommandTests
         tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
             "# Repair Worker Handoff");
+        WriteDirectRunRequest(
+            repoRoot,
+            "G226",
+            "fix",
+            "pid:29569",
+            provider: "Codex",
+            launchedAt: "2026-04-10T12:20:00.0000000+00:00");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "failed",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:14:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:29569",
+                    Kind = "assistant-message",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        role = "assistant",
+                        content = "I’m reading the request artifact first, then I’ll trace the relevant code path and either make the bounded repair or give a concrete contract-gap refusal."
+                    })
+                }
+            ],
+            sessionId: "pid:29569",
+            provider: "Codex");
+        var originalRunFixExecutor = RunCommand.RunFixExecutor;
+        var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
+        var originalFreshFixContinuationWindow = RunCommand.FreshFixContinuationWindow;
+        var originalFreshFixContinuationTotalWindow = RunCommand.FreshFixContinuationTotalWindow;
+
+        try
+        {
+            RunCommand.FreshFixContinuationWindow = TimeSpan.Zero;
+            RunCommand.FreshFixContinuationTotalWindow = TimeSpan.Zero;
+            RunCommand.RunFixExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunRequest(
+                    repoRoot,
+                    executionUnit,
+                    "fix",
+                    "pid:4242",
+                    provider: "Codex",
+                    launchedAt: "2026-04-10T12:21:00.0000000+00:00");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "fix",
+                    "running",
+                    providerEvents:
+                    [
+                        new DirectRunProviderEvent
+                        {
+                            Timestamp = "2026-04-10T12:21:00.0000000+00:00",
+                            ExecutionUnit = executionUnit,
+                            Provider = "Codex",
+                            EntryKind = "fix",
+                            SessionId = "pid:4242",
+                            Kind = "session-metadata",
+                            Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                            {
+                                model = "gpt-5.4-mini",
+                                transport = "responses",
+                                command = "codex"
+                            })
+                        }
+                    ],
+                    sessionId: "pid:4242",
+                    provider: "Codex");
+                File.AppendAllText(
+                    runLogPath,
+                    RunLogSerializer.SerializeLine(new RunEvent
+                    {
+                        Ts = DateTimeOffset.Parse("2026-04-10T12:21:00Z"),
+                        ExecutionUnit = executionUnit,
+                        Event = "provider-lifecycle",
+                        By = "intent-cli",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                        CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                        EntryKind = "fix",
+                        Provider = "Codex",
+                        Model = "gpt-5.4-mini",
+                        SessionId = "pid:4242",
+                        RunStatus = "running",
+                        RawLogRef = $".intent-cli/runs/{executionUnit}.provider.jsonl",
+                        ResultRef = $".intent-cli/runs/{executionUnit}.result.json",
+                        PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit)
+                    }) + Environment.NewLine);
+
+                return new RunFixResult
+                {
+                    Request = new RunFixRequest
+                    {
+                        ExecutionUnit = executionUnit,
+                        State = "fixing",
+                        ImplementRole = "Codex",
+                        QueueWorkerRole = "coder",
+                        QueueReviewRole = "reviewer",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = $"issue-226-{executionUnit.ToLowerInvariant()}",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        LatestLinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                        LatestCommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                        PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                        ReviewCommentArtifactRef = $".intent-cli/reviews/{executionUnit}.comment.json",
+                        ReviewRequestRef = $".intent-cli/reviews/{executionUnit}.request.json",
+                        ReviewCommentBodyPath = $".intent-cli/reviews/{executionUnit}.comment.md",
+                        IssueTitle = "[G226] Root Run Orchestration Command",
+                        Goal = "Coordinate the root run loop.",
+                        TargetPart = "run command",
+                        TargetRepo = "submodules/intent-system",
+                        TargetPath = ".",
+                        InScope = [],
+                        OutOfScope = [],
+                        AcceptanceCriteria = [],
+                        DeterministicReviewChecks = [],
+                        ExpectedEvidence = []
+                    },
+                    ArtifactPath = $".intent-cli/fix/{executionUnit}.request.md",
+                    DirectRun = CreateDirectRunLaunchResult(executionUnit, "pid:4242")
+                };
+            };
+            RunCommand.RunSuperviseExecutor = (_, executionUnit) => new RunSuperviseResult
+            {
+                ExecutionUnit = executionUnit,
+                SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                RetryCount = 0,
+                RetryBudget = 3,
+                HandoffArtifactRef = $".intent-cli/fix/{executionUnit}.request.md"
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Equal(2, result.Actions.Count);
+            Assert.Equal("run fix", result.Actions[0].Name);
+            Assert.Equal("run supervise", result.Actions[1].Name);
+            Assert.Contains("under supervision", result.Detail, StringComparison.Ordinal);
+            Assert.DoesNotContain("I’m reading the request artifact first", result.Detail, StringComparison.Ordinal);
+
+            var requestArtifact = DirectRunRequestArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.request.json")));
+            Assert.Equal("pid:4242", requestArtifact.ProviderSessionId);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Contains(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "provider-lifecycle", StringComparison.Ordinal)
+                && string.Equals(runEvent.SessionId, "pid:4242", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunCommand.RunFixExecutor = originalRunFixExecutor;
+            RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
+            RunCommand.FreshFixContinuationWindow = originalFreshFixContinuationWindow;
+            RunCommand.FreshFixContinuationTotalWindow = originalFreshFixContinuationTotalWindow;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenFixingItemWithStaleMonitoringFixSessionAndFailedFixResultWhoseLatestActivityPredatesManualFixRequest_LaunchesFreshFix()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        tempDirectory.CreateFile(
+            runLogPath,
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            {"ts":"2026-04-10T12:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"manual retry after preserved failure"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Fix,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "fixing",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                CommentRef = "https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2",
+                HandoffArtifactRef = ".intent-cli/fix/G226.request.md",
+                RetryCount = 0,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T12:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:14:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T12:14:00Z")
+            }));
         WriteDirectRunRequest(
             repoRoot,
             "G226",


### PR DESCRIPTION
## Summary
- bypass stale fix monitoring supervision when a newer fix-requested event postdates the stale session update
- keep non-fix supervision and current blocked fix supervision as blocking states
- add focused tests for direct fresh-retry gating and ExecuteCore stale monitoring retry recovery

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests.ShouldLaunchFreshFixAttempt_GivenStaleMonitoringFixSupervisionSessionWithNewerFixRequested_ReturnsTrue|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenFixingItemWithStaleFailedFixResultWhoseLatestActivityPredatesManualFixRequest_LaunchesFreshFix|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenFixingItemWithStaleMonitoringFixSessionAndFailedFixResultWhoseLatestActivityPredatesManualFixRequest_LaunchesFreshFix" --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests" --nologo
- dotnet test IntentSystem.sln --nologo
- live repro in /Users/tomohisa/dev/GitHub/MyIntentHost/submodules/toy-calc-sample using this branch's CLI project: queue transition TOY-CALC-V0-01 fixing; run

## Live Repro Result
- stale failed result pid:86808 was superseded by a new provider-lifecycle event for pid:51137
- root run returned no-actionable-item with actions: run fix, run supervise
- current result artifact is now running for the fresh fix session