### PR TITLE
[G127] Reconcile externally completed child state before parent planning stop

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -28,6 +28,7 @@ internal static class RunCommand
     private const string ParentIntentUpdateRequiredStopReason = "parent-intent-update-required";
     private const string DeterministicContractGapStopReason = "deterministic-contract-gap";
     private const string NonRetryableFailureStopReason = "non-retryable-failure";
+    private const string TransitionActor = "intent-cli";
 
     public static Func<CliContext, string, QueueDispatchCommandResult> QueueDispatchExecutor { get; set; } =
         QueueDispatchCommand.ExecuteCore;
@@ -64,6 +65,9 @@ internal static class RunCommand
 
     public static Func<IGitCommandRunner> GitCommandRunnerFactory { get; set; } =
         () => new GitCommandRunner();
+
+    public static Func<IGitHubCommandRunner> GitHubCommandRunnerFactory { get; set; } =
+        () => new GhCommandRunner();
 
     public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
 
@@ -457,6 +461,16 @@ internal static class RunCommand
                 var blockedItem = queueState.Items.FirstOrDefault(item => item.State == QueueItemState.Blocked);
                 if (blockedItem is not null)
                 {
+                    if (TryReconcileExternallyCompletedBlockedItem(
+                            context,
+                            actions,
+                            queueState,
+                            blockedItem,
+                            out var externallyCompletedResult))
+                    {
+                        return externallyCompletedResult;
+                    }
+
                     if (TryHandlePostFixWorktreeProgressBoundary(context, actions, blockedItem, out var decisionResult))
                     {
                         if (decisionResult is not null)
@@ -621,6 +635,177 @@ internal static class RunCommand
             blockedItem.ExecutionUnit,
             session.LastInterruptionReason);
         return true;
+    }
+
+    private static bool TryReconcileExternallyCompletedBlockedItem(
+        CliContext context,
+        IReadOnlyList<RunCommandAction> actions,
+        QueueState queueState,
+        QueueItem blockedItem,
+        out RunCommandResult result)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(actions);
+        ArgumentNullException.ThrowIfNull(queueState);
+        ArgumentNullException.ThrowIfNull(blockedItem);
+
+        result = null!;
+        if (!TryResolveBlockedItemExternalCompletion(context, blockedItem, out var linkedIssue, out var linkedPr))
+        {
+            return false;
+        }
+
+        var timestamp = TimestampFactory();
+        var transition = QueueManager.TransitionNonBlocking(
+            queueState,
+            blockedItem.ExecutionUnit,
+            QueueItemState.Completed,
+            TransitionActor,
+            timestamp);
+        var reconciledState = transition.UpdatedState with
+        {
+            Items = transition.UpdatedState.Items.Select(item =>
+                string.Equals(item.ExecutionUnit, blockedItem.ExecutionUnit, StringComparison.Ordinal)
+                    ? item with { BlockedBy = [] }
+                    : item).ToArray()
+        };
+        File.WriteAllText(context.GetQueueStatePath(), QueueStateSerializer.Serialize(reconciledState));
+
+        AppendRunEvent(
+            context.GetRunLogPath(),
+            new RunEvent
+            {
+                Ts = timestamp,
+                ExecutionUnit = blockedItem.ExecutionUnit,
+                Event = "pr-merged",
+                By = TransitionActor,
+                LinkedPr = linkedPr
+            });
+        AppendRunEvent(
+            context.GetRunLogPath(),
+            new RunEvent
+            {
+                Ts = timestamp,
+                ExecutionUnit = blockedItem.ExecutionUnit,
+                Event = "issue-closed",
+                By = TransitionActor,
+                LinkedIssue = linkedIssue
+            });
+        AppendRunEvent(context.GetRunLogPath(), transition.Event);
+
+        result = CreateStopResult(
+            NoActionableItemStopReason,
+            actions,
+            blockedItem.ExecutionUnit,
+            $"Execution unit '{blockedItem.ExecutionUnit}' was reconciled from externally completed linked child state.");
+        return true;
+    }
+
+    private static bool TryResolveBlockedItemExternalCompletion(
+        CliContext context,
+        QueueItem blockedItem,
+        out string linkedIssue,
+        out string linkedPr)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(blockedItem);
+
+        linkedIssue = null!;
+        linkedPr = null!;
+
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            linkedIssue = blockedItem.LinkedIssue?.Url
+                ?? LatestLinkedIssueResolver.Resolve(runEvents, blockedItem.ExecutionUnit);
+            linkedPr = LatestLinkedPrResolver.TryResolve(runEvents, blockedItem.ExecutionUnit) ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(linkedIssue) || string.IsNullOrWhiteSpace(linkedPr))
+            {
+                linkedIssue = null!;
+                linkedPr = null!;
+                return false;
+            }
+
+            var githubRunner = GitHubCommandRunnerFactory();
+            var issue = GitHubIssueRef.Parse(linkedIssue);
+            var issueResult = RunGitHub(
+                githubRunner,
+                [
+                    "issue",
+                    "view",
+                    issue.IssueNumber.ToString(),
+                    "--repo",
+                    $"{issue.Owner}/{issue.Repo}",
+                    "--json",
+                    "state"
+                ],
+                "gh issue view failed.");
+            using var issueDocument = JsonDocument.Parse(issueResult.StdOut);
+            var issueState = issueDocument.RootElement.GetProperty("state").GetString();
+            if (!string.Equals(issueState, "CLOSED", StringComparison.OrdinalIgnoreCase))
+            {
+                linkedIssue = null!;
+                linkedPr = null!;
+                return false;
+            }
+
+            var pullRequest = GitHubPullRequestRef.Parse(linkedPr);
+            var pullRequestResult = RunGitHub(
+                githubRunner,
+                [
+                    "pr",
+                    "view",
+                    pullRequest.PullNumber.ToString(),
+                    "--repo",
+                    $"{pullRequest.Owner}/{pullRequest.Repo}",
+                    "--json",
+                    "state,mergeCommit"
+                ],
+                "gh pr view failed.");
+            using var pullRequestDocument = JsonDocument.Parse(pullRequestResult.StdOut);
+            var isMerged = pullRequestDocument.RootElement.TryGetProperty("mergeCommit", out var mergeCommitElement)
+                && mergeCommitElement.ValueKind != JsonValueKind.Null;
+            if (!isMerged)
+            {
+                linkedIssue = null!;
+                linkedPr = null!;
+                return false;
+            }
+
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            linkedIssue = null!;
+            linkedPr = null!;
+            return false;
+        }
+    }
+
+    private static GitHubCommandResult RunGitHub(
+        IGitHubCommandRunner runner,
+        IReadOnlyList<string> arguments,
+        string defaultError)
+    {
+        ArgumentNullException.ThrowIfNull(runner);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var result = runner.Run(arguments);
+        if (result.ExitCode != 0)
+        {
+            var error = string.IsNullOrWhiteSpace(result.StdErr)
+                ? defaultError
+                : result.StdErr.Trim();
+            throw new InvalidOperationException(error);
+        }
+
+        return result;
     }
 
     private static bool TryReconcileBlockedFixSupervisionState(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -6613,6 +6613,119 @@ public sealed class RunCommandTests
         Assert.Empty(result.Actions);
     }
 
+    [Fact]
+    public void ExecuteCore_GivenBlockedItemWithExternallyCompletedLinkedChildState_ReconcilesCompletedWithoutParentPlanning()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(
+                CreateQueueItem(QueueItemState.Blocked) with
+                {
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "tomohisa/toy-calc-sample",
+                        Number = 3,
+                        Url = "https://github.com/tomohisa/toy-calc-sample/issues/3"
+                    }
+                })));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/tomohisa/toy-calc-sample/issues/3"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/tomohisa/toy-calc-sample/pull/4"}
+            """ + Environment.NewLine);
+        var originalGitHubCommandRunnerFactory = RunCommand.GitHubCommandRunnerFactory;
+        var originalTimestampFactory = RunCommand.TimestampFactory;
+
+        try
+        {
+            RunCommand.GitHubCommandRunnerFactory = () => new ScriptedGitHubCommandRunner(
+            [
+                new ExpectedGitHubCommand(
+                    ["issue", "view", "3", "--repo", "tomohisa/toy-calc-sample", "--json", "state"],
+                    Success("""{"state":"CLOSED"}""")),
+                new ExpectedGitHubCommand(
+                    ["pr", "view", "4", "--repo", "tomohisa/toy-calc-sample", "--json", "state,mergeCommit"],
+                    Success("""{"state":"MERGED","mergeCommit":{"oid":"ccfef2c122b39f37ca5fe70744b72403b9e24234"}}"""))
+            ]);
+            RunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-19T08:00:00Z");
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("externally completed linked child state", result.Detail, StringComparison.Ordinal);
+            Assert.Empty(result.Actions);
+
+            var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            var selectedItem = queueState.Items.Single(item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Completed, selectedItem.State);
+            Assert.Empty(selectedItem.BlockedBy);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal("pr-merged", runEvents[^3].Event);
+            Assert.Equal("issue-closed", runEvents[^2].Event);
+            Assert.Equal("completed", runEvents[^1].Event);
+        }
+        finally
+        {
+            RunCommand.GitHubCommandRunnerFactory = originalGitHubCommandRunnerFactory;
+            RunCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenBlockedItemWithClosedIssueButUnmergedPullRequest_StopsWithParentIntentUpdateRequired()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(
+                CreateQueueItem(QueueItemState.Blocked) with
+                {
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "tomohisa/toy-calc-sample",
+                        Number = 3,
+                        Url = "https://github.com/tomohisa/toy-calc-sample/issues/3"
+                    }
+                })));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/tomohisa/toy-calc-sample/issues/3"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/tomohisa/toy-calc-sample/pull/4"}
+            """ + Environment.NewLine);
+        var originalGitHubCommandRunnerFactory = RunCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            RunCommand.GitHubCommandRunnerFactory = () => new ScriptedGitHubCommandRunner(
+            [
+                new ExpectedGitHubCommand(
+                    ["issue", "view", "3", "--repo", "tomohisa/toy-calc-sample", "--json", "state"],
+                    Success("""{"state":"CLOSED"}""")),
+                new ExpectedGitHubCommand(
+                    ["pr", "view", "4", "--repo", "tomohisa/toy-calc-sample", "--json", "state,mergeCommit"],
+                    Success("""{"state":"OPEN","mergeCommit":null}"""))
+            ]);
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("parent-intent-update-required", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("requires parent-side planning", result.Detail, StringComparison.Ordinal);
+            Assert.Empty(result.Actions);
+        }
+        finally
+        {
+            RunCommand.GitHubCommandRunnerFactory = originalGitHubCommandRunnerFactory;
+        }
+    }
+
     private static CliContext CreateContext(
         string repoRoot,
         string postFixWorktreeProgressPolicy = CliRuntimeContracts.DefaultPostFixWorktreeProgressPolicy)
@@ -7622,6 +7735,16 @@ public sealed class RunCommandTests
         return $"{executionUnit}.{DirectRunCommandSupport.CreateCapturedMessageSuffix(launchedAt)}.last-message.json";
     }
 
+    private static GitHubCommandResult Success(string stdOut)
+    {
+        return new GitHubCommandResult
+        {
+            ExitCode = 0,
+            StdOut = stdOut,
+            StdErr = string.Empty
+        };
+    }
+
     private sealed class FakeReviewCommentPublisher : IReviewCommentPublisher
     {
         public int CallCount { get; private set; }
@@ -7664,6 +7787,8 @@ public sealed class RunCommandTests
 
     private sealed record ExpectedReviewCommand(IReadOnlyList<string> Arguments, ReviewCommandResult Result);
 
+    private sealed record ExpectedGitHubCommand(IReadOnlyList<string> Arguments, GitHubCommandResult Result);
+
     private sealed class ScriptedReviewCommandRunner(IReadOnlyList<ExpectedReviewCommand> expectedCalls) : IReviewCommandRunner
     {
         private readonly Queue<ExpectedReviewCommand> expectedCalls = new(expectedCalls);
@@ -7674,6 +7799,19 @@ public sealed class RunCommandTests
         {
             Calls.Add(arguments.ToArray());
 
+            Assert.NotEmpty(expectedCalls);
+            var expected = expectedCalls.Dequeue();
+            Assert.Equal(expected.Arguments, arguments);
+            return expected.Result;
+        }
+    }
+
+    private sealed class ScriptedGitHubCommandRunner(IReadOnlyList<ExpectedGitHubCommand> expectedCalls) : IGitHubCommandRunner
+    {
+        private readonly Queue<ExpectedGitHubCommand> expectedCalls = new(expectedCalls);
+
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
             Assert.NotEmpty(expectedCalls);
             var expected = expectedCalls.Dequeue();
             Assert.Equal(expected.Arguments, arguments);


### PR DESCRIPTION
## Summary
- reconcile blocked queue items to completed when the linked child issue is already closed and the linked PR is already merged
- avoid falling through to parent-intent-update-required for this externally completed child-state shape
- add focused RunCommand coverage for merged child closeout and the still-unmerged fallback

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests.ExecuteCore_GivenBlockedItemWithExternallyCompletedLinkedChildState_ReconcilesCompletedWithoutParentPlanning|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenBlockedItemWithClosedIssueButUnmergedPullRequest_StopsWithParentIntentUpdateRequired" --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests" --nologo
- dotnet test IntentSystem.sln --nologo
- live repro in /Users/tomohisa/dev/GitHub/MyIntentHost/submodules/toy-calc-sample using this branch's CLI project

## Live Repro Result
- gh issue view 3 returned CLOSED
- gh pr view 4 returned MERGED with merge commit ccfef2c122b39f37ca5fe70744b72403b9e24234
- product verification still passed: ToyCalc tests passed and add 2 3 returned 5
- root run returned no-actionable-item with detail: Execution unit 'TOY-CALC-V0-01' was reconciled from externally completed linked child state
- queue state moved TOY-CALC-V0-01 to completed and runs.jsonl appended pr-merged, issue-closed, completed