### PR TITLE
[G128] Auto-continue root run into intake launch

### DIFF
--- a/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
@@ -71,12 +71,26 @@ internal static class IntakeIssueCommand
 
     internal static IntakeIssueResult ExecuteCore(string repoRoot, string domain)
     {
+        return ExecuteCore(repoRoot, domain, executionUnit: null);
+    }
+
+    internal static IntakeIssueResult ExecuteCore(string repoRoot, string domain, string? executionUnit)
+    {
         var baseline = LoadIssueBaseline(repoRoot);
         var units = LoadExecutionUnits(repoRoot, domain);
+        if (!string.IsNullOrWhiteSpace(executionUnit))
+        {
+            units = units
+                .Where(unit => string.Equals(unit.ExecutionUnitId, executionUnit, StringComparison.Ordinal))
+                .ToArray();
+        }
+
         if (units.Count == 0)
         {
             throw new InvalidOperationException(
-                $"No intake-origin issue-ready execution units were found for domain '{domain}'.");
+                string.IsNullOrWhiteSpace(executionUnit)
+                    ? $"No intake-origin issue-ready execution units were found for domain '{domain}'."
+                    : $"Execution unit '{executionUnit}' was not found in intake execution artifact for domain '{domain}'.");
         }
 
         return GenerateArtifacts(repoRoot, domain, units, baseline);

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -36,6 +36,12 @@ internal static class RunCommand
     public static Func<CliContext, string, RunStartResult> RunStartExecutor { get; set; } =
         RunStartCommand.ExecuteCore;
 
+    public static Func<string, string, IntakeIssueResult> IntakeIssueExecutor { get; set; } =
+        IntakeIssueCommand.ExecuteCore;
+
+    public static Func<CliContext, string, TextWriter, IntakeLaunchResult> IntakeLaunchExecutor { get; set; } =
+        IntakeLaunchCommand.ExecuteCore;
+
     public static Func<CliContext, string, RunImplementResult> RunImplementExecutor { get; set; } =
         RunImplementCommand.ExecuteCore;
 
@@ -493,6 +499,27 @@ internal static class RunCommand
                         $"Blocked item '{blockedItem.ExecutionUnit}' requires parent-side planning.");
                 }
 
+                if (TryResolveAutoContinueIntakeDomain(context, queueState, out var intakeDomain))
+                {
+                    ExecuteAction(
+                        context,
+                        actions,
+                        "intake issue",
+                        intakeDomain,
+                        () => IntakeIssueExecutor(context.RepoRoot, intakeDomain));
+                    ExecuteAction(
+                        context,
+                        actions,
+                        "intake launch",
+                        intakeDomain,
+                        () => IntakeLaunchExecutor(context, intakeDomain, TextWriter.Null));
+
+                    return CreateStopResult(
+                        NoActionableItemStopReason,
+                        actions,
+                        detail: $"Root run auto-continued into intake domain '{intakeDomain}'.");
+                }
+
                 return CreateStopResult(NoActionableItemStopReason, actions);
             }
             catch (RunDeterministicGapException exception)
@@ -509,6 +536,66 @@ internal static class RunCommand
             DeterministicContractGapStopReason,
             actions,
             detail: $"Run orchestration exceeded {IterationBudget} iterations.");
+    }
+
+    private static bool TryResolveAutoContinueIntakeDomain(
+        CliContext context,
+        QueueState queueState,
+        out string domain)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(queueState);
+
+        domain = string.Empty;
+
+        if (!queueState.Items.Any(item => item.State == QueueItemState.Completed))
+        {
+            return false;
+        }
+
+        var intakeDirectory = Path.Combine(context.RepoRoot, ".intent-cli", "intake");
+        if (!Directory.Exists(intakeDirectory))
+        {
+            return false;
+        }
+
+        foreach (var artifactPath in Directory
+                     .EnumerateFiles(intakeDirectory, "*.execution.md", SearchOption.TopDirectoryOnly)
+                     .OrderBy(path => path, StringComparer.Ordinal))
+        {
+            IntakeExecutionRequest request;
+            try
+            {
+                request = IntakeExecutionArtifactMarkdown.Deserialize(File.ReadAllText(artifactPath));
+            }
+            catch (InvalidOperationException exception)
+            {
+                throw new RunDeterministicGapException(
+                    Path.GetFileName(artifactPath),
+                    $"Intake auto-continue could not read '{artifactPath}': {exception.Message}");
+            }
+
+            if (!request.ProposedExecutionUnits.Any(unit => IsAutoContinueLaunchable(queueState, unit.ExecutionUnitId)))
+            {
+                continue;
+            }
+
+            domain = request.Domain;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsAutoContinueLaunchable(QueueState queueState, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(queueState);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var queueItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        return queueItem is null || queueItem.State == QueueItemState.Queued;
     }
 
     private static T ExecuteAction<T>(

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -10,6 +10,8 @@ namespace IntentSystem.Cli.Commands;
 
 internal static class RunCommand
 {
+    private sealed record AutoContinueIntakeCandidate(string Domain, string ExecutionUnit);
+
     private sealed class RunDeterministicGapException(string executionUnit, string message)
         : InvalidOperationException(message)
     {
@@ -36,11 +38,11 @@ internal static class RunCommand
     public static Func<CliContext, string, RunStartResult> RunStartExecutor { get; set; } =
         RunStartCommand.ExecuteCore;
 
-    public static Func<string, string, IntakeIssueResult> IntakeIssueExecutor { get; set; } =
+    public static Func<string, string, string, IntakeIssueResult> IntakeIssueExecutor { get; set; } =
         IntakeIssueCommand.ExecuteCore;
 
-    public static Func<CliContext, string, TextWriter, IntakeLaunchResult> IntakeLaunchExecutor { get; set; } =
-        IntakeLaunchCommand.ExecuteCore;
+    public static Func<CliContext, string, int> QueueEnqueueExecutor { get; set; } =
+        ExecuteQueueEnqueue;
 
     public static Func<CliContext, string, RunImplementResult> RunImplementExecutor { get; set; } =
         RunImplementCommand.ExecuteCore;
@@ -499,25 +501,57 @@ internal static class RunCommand
                         $"Blocked item '{blockedItem.ExecutionUnit}' requires parent-side planning.");
                 }
 
-                if (TryResolveAutoContinueIntakeDomain(context, queueState, out var intakeDomain))
+                if (TryResolveAutoContinueIntakeCandidate(context, queueState, out var intakeCandidate))
                 {
+                    var selectedIntakeCandidate = intakeCandidate
+                        ?? throw new InvalidOperationException("Auto-continue intake candidate was not resolved.");
+
                     ExecuteAction(
                         context,
                         actions,
                         "intake issue",
-                        intakeDomain,
-                        () => IntakeIssueExecutor(context.RepoRoot, intakeDomain));
+                        selectedIntakeCandidate.ExecutionUnit,
+                        () => IntakeIssueExecutor(
+                            context.RepoRoot,
+                            selectedIntakeCandidate.Domain,
+                            selectedIntakeCandidate.ExecutionUnit));
+
+                    var launchQueueItem = TryLoadQueueItem(context, selectedIntakeCandidate.ExecutionUnit);
+                    if (launchQueueItem is null)
+                    {
+                        ExecuteAction(
+                            context,
+                            actions,
+                            "queue enqueue",
+                            selectedIntakeCandidate.ExecutionUnit,
+                            () => QueueEnqueueExecutor(context, selectedIntakeCandidate.ExecutionUnit));
+                        launchQueueItem = LoadQueueItemOrThrow(context, selectedIntakeCandidate.ExecutionUnit);
+                    }
+
+                    if (launchQueueItem.State != QueueItemState.Queued)
+                    {
+                        throw new RunDeterministicGapException(
+                            selectedIntakeCandidate.ExecutionUnit,
+                            $"Auto-continue intake target '{selectedIntakeCandidate.ExecutionUnit}' is in state '{FormatQueueItemState(launchQueueItem.State)}'.");
+                    }
+
+                    if (launchQueueItem.LinkedIssue is null)
+                    {
+                        ExecuteAction(
+                            context,
+                            actions,
+                            "queue dispatch",
+                            selectedIntakeCandidate.ExecutionUnit,
+                            () => QueueDispatchExecutor(context, selectedIntakeCandidate.ExecutionUnit));
+                    }
+
                     ExecuteAction(
                         context,
                         actions,
-                        "intake launch",
-                        intakeDomain,
-                        () => IntakeLaunchExecutor(context, intakeDomain, TextWriter.Null));
-
-                    return CreateStopResult(
-                        NoActionableItemStopReason,
-                        actions,
-                        detail: $"Root run auto-continued into intake domain '{intakeDomain}'.");
+                        "run start",
+                        selectedIntakeCandidate.ExecutionUnit,
+                        () => RunStartExecutor(context, selectedIntakeCandidate.ExecutionUnit));
+                    continue;
                 }
 
                 return CreateStopResult(NoActionableItemStopReason, actions);
@@ -538,15 +572,15 @@ internal static class RunCommand
             detail: $"Run orchestration exceeded {IterationBudget} iterations.");
     }
 
-    private static bool TryResolveAutoContinueIntakeDomain(
+    private static bool TryResolveAutoContinueIntakeCandidate(
         CliContext context,
         QueueState queueState,
-        out string domain)
+        out AutoContinueIntakeCandidate? candidate)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(queueState);
 
-        domain = string.Empty;
+        candidate = null;
 
         if (!queueState.Items.Any(item => item.State == QueueItemState.Completed))
         {
@@ -575,13 +609,16 @@ internal static class RunCommand
                     $"Intake auto-continue could not read '{artifactPath}': {exception.Message}");
             }
 
-            if (!request.ProposedExecutionUnits.Any(unit => IsAutoContinueLaunchable(queueState, unit.ExecutionUnitId)))
+            foreach (var unit in request.ProposedExecutionUnits)
             {
-                continue;
-            }
+                if (!IsAutoContinueLaunchable(queueState, unit.ExecutionUnitId))
+                {
+                    continue;
+                }
 
-            domain = request.Domain;
-            return true;
+                candidate = new AutoContinueIntakeCandidate(request.Domain, unit.ExecutionUnitId);
+                return true;
+            }
         }
 
         return false;
@@ -596,6 +633,52 @@ internal static class RunCommand
             string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
 
         return queueItem is null || queueItem.State == QueueItemState.Queued;
+    }
+
+    private static QueueItem? TryLoadQueueItem(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var queueState = LoadQueueStateOrThrow(context);
+        return queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+    }
+
+    private static QueueItem LoadQueueItemOrThrow(CliContext context, string executionUnit)
+    {
+        return TryLoadQueueItem(context, executionUnit)
+               ?? throw new RunDeterministicGapException(
+                   executionUnit,
+                   $"Execution unit '{executionUnit}' was not found in queue state.");
+    }
+
+    private static int ExecuteQueueEnqueue(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        using var writer = new StringWriter();
+        var exitCode = QueueEnqueueCommand.Execute(context, [executionUnit], writer);
+        if (exitCode != 0)
+        {
+            var detail = writer.ToString().Trim();
+            throw new InvalidOperationException(
+                string.IsNullOrWhiteSpace(detail)
+                    ? $"Queue enqueue failed for '{executionUnit}'."
+                    : detail);
+        }
+
+        return exitCode;
+    }
+
+    private static string FormatQueueItemState(QueueItemState state)
+    {
+        return state switch
+        {
+            QueueItemState.ClarifyBlocked => "clarify-blocked",
+            _ => state.ToString().ToLowerInvariant()
+        };
     }
 
     private static T ExecuteAction<T>(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -223,6 +223,95 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenCompletedQueueAndLaunchableIntakeSlice_ReusesIntakeIssueAndLaunchBoundaries()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Completed))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateIntakeExecutionArtifactMarkdown("auth", "AUTH-01", "AUTH-02"));
+        var originalIntakeIssueExecutor = RunCommand.IntakeIssueExecutor;
+        var originalIntakeLaunchExecutor = RunCommand.IntakeLaunchExecutor;
+        var invokedDomains = new List<string>();
+
+        try
+        {
+            RunCommand.IntakeIssueExecutor = (_, domain) =>
+            {
+                invokedDomains.Add($"issue:{domain}");
+                return new IntakeIssueResult
+                {
+                    Domain = domain,
+                    GeneratedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                    ArtifactPaths = [],
+                    SkippedUnits = []
+                };
+            };
+            RunCommand.IntakeLaunchExecutor = (_, domain, _) =>
+            {
+                invokedDomains.Add($"launch:{domain}");
+                return new IntakeLaunchResult
+                {
+                    Domain = domain,
+                    LaunchedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                    CreatedIssueRefs = [],
+                    WorktreePaths = [],
+                    SkippedUnits = []
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Null(result.ExecutionUnit);
+            Assert.Equal(["issue:auth", "launch:auth"], invokedDomains);
+            Assert.Collection(
+                result.Actions,
+                action =>
+                {
+                    Assert.Equal("intake issue", action.Name);
+                    Assert.Equal("auth", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("intake launch", action.Name);
+                    Assert.Equal("auth", action.ExecutionUnit);
+                });
+            Assert.Contains("auto-continued into intake domain 'auth'", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunCommand.IntakeIssueExecutor = originalIntakeIssueExecutor;
+            RunCommand.IntakeLaunchExecutor = originalIntakeLaunchExecutor;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenCompletedQueueAndOnlyCompletedIntakeUnits_DoesNotLoopBackIntoIntake()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(
+                CreateQueueState(
+                    CreateQueueItem(QueueItemState.Completed),
+                    CreateQueueItem(QueueItemState.Completed, executionUnit: "AUTH-01"))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
+            CreateIntakeExecutionArtifactMarkdown("auth", "AUTH-01"));
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("no-actionable-item", result.StopReason);
+        Assert.Empty(result.Actions);
+        Assert.Null(result.Detail);
+    }
+
+    [Fact]
     public void ExecuteCore_GivenReviewItemWithoutRequest_GeneratesReviewRequestAndStopsForReviewDecision()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -6824,6 +6913,32 @@ public sealed class RunCommandTests
             ReviewRole = "reviewer",
             Priority = "P1"
         };
+    }
+
+    private static string CreateIntakeExecutionArtifactMarkdown(string domain, params string[] executionUnits)
+    {
+        var sections = executionUnits.Select((executionUnit, index) => $$"""
+            ### `{{executionUnit}}`
+            source_file_path: intents/intent-cli/concepts/{{executionUnit.ToLowerInvariant()}}.md
+            target_part: concepts
+            dependencies:
+            - {{(index == 0 ? "none" : executionUnits[index - 1])}}
+            readiness_notes:
+            - Ready for issue cut
+            verification_hints:
+            - dotnet test IntentSystem.sln
+            """);
+
+        return $$"""
+            # Intake Execution Draft
+
+            ## Domain
+            `{{domain}}`
+
+            ## Proposed Execution Units
+
+            {{string.Join(Environment.NewLine + Environment.NewLine, sections)}}
+            """;
     }
 
     private static void PersistQueueState(string repoRoot, Func<QueueItem, QueueItem> update)

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -223,7 +223,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenCompletedQueueAndLaunchableIntakeSlice_ReusesIntakeIssueAndLaunchBoundaries()
+    public void ExecuteCore_GivenCompletedQueueAndLaunchableIntakeSlice_AutoContinuesSingleExecutionUnitOnly()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -234,58 +234,156 @@ public sealed class RunCommandTests
             Path.Combine("repo", ".intent-cli", "intake", "auth.execution.md"),
             CreateIntakeExecutionArtifactMarkdown("auth", "AUTH-01", "AUTH-02"));
         var originalIntakeIssueExecutor = RunCommand.IntakeIssueExecutor;
-        var originalIntakeLaunchExecutor = RunCommand.IntakeLaunchExecutor;
-        var invokedDomains = new List<string>();
+        var originalQueueEnqueueExecutor = RunCommand.QueueEnqueueExecutor;
+        var originalQueueDispatchExecutor = RunCommand.QueueDispatchExecutor;
+        var originalRunStartExecutor = RunCommand.RunStartExecutor;
+        var originalRunImplementExecutor = RunCommand.RunImplementExecutor;
+        var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
+        var invokedSteps = new List<string>();
 
         try
         {
-            RunCommand.IntakeIssueExecutor = (_, domain) =>
+            RunCommand.IntakeIssueExecutor = (_, domain, executionUnit) =>
             {
-                invokedDomains.Add($"issue:{domain}");
+                invokedSteps.Add($"issue:{domain}:{executionUnit}");
                 return new IntakeIssueResult
                 {
                     Domain = domain,
-                    GeneratedExecutionUnits = ["AUTH-01", "AUTH-02"],
+                    GeneratedExecutionUnits = [executionUnit],
                     ArtifactPaths = [],
                     SkippedUnits = []
                 };
             };
-            RunCommand.IntakeLaunchExecutor = (_, domain, _) =>
+            RunCommand.QueueEnqueueExecutor = (context, executionUnit) =>
             {
-                invokedDomains.Add($"launch:{domain}");
-                return new IntakeLaunchResult
+                invokedSteps.Add($"enqueue:{executionUnit}");
+                AppendQueueItem(context.RepoRoot, CreateQueueItem(QueueItemState.Queued, executionUnit: executionUnit, withLinkedIssue: false));
+                return 0;
+            };
+            RunCommand.QueueDispatchExecutor = (context, executionUnit) =>
+            {
+                invokedSteps.Add($"dispatch:{executionUnit}");
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => string.Equals(queueItem.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                        ? queueItem with
+                        {
+                            LinkedIssue = new LinkedIssue
+                            {
+                                Repo = "J-Tech-Japan/intent-system",
+                                Number = 401,
+                                Url = "https://github.com/J-Tech-Japan/intent-system/issues/401"
+                            }
+                        }
+                        : queueItem);
+
+                return new QueueDispatchCommandResult
                 {
-                    Domain = domain,
-                    LaunchedExecutionUnits = ["AUTH-01", "AUTH-02"],
-                    CreatedIssueRefs = [],
-                    WorktreePaths = [],
-                    SkippedUnits = []
+                    ExecutionUnit = executionUnit,
+                    LinkedIssueUrl = "https://github.com/J-Tech-Japan/intent-system/issues/401",
+                    ReusedExistingIssue = false
+                };
+            };
+            RunCommand.RunStartExecutor = (context, executionUnit) =>
+            {
+                invokedSteps.Add($"start:{executionUnit}");
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => string.Equals(queueItem.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                        ? queueItem with { State = QueueItemState.Active }
+                        : queueItem);
+
+                return new RunStartResult
+                {
+                    ExecutionUnit = executionUnit,
+                    WorktreePath = Path.Combine(context.RepoRoot, ".intent-cli", "worktrees", executionUnit),
+                    BranchName = $"issue-401-{executionUnit.ToLowerInvariant()}"
+                };
+            };
+            RunCommand.RunImplementExecutor = (context, executionUnit) =>
+            {
+                invokedSteps.Add($"implement:{executionUnit}");
+                tempDirectory.CreateFile(
+                    Path.Combine("repo", ".intent-cli", "implement", $"{executionUnit}.request.md"),
+                    "# Execution Worker Handoff");
+
+                return new RunImplementResult
+                {
+                    Request = CreateRunImplementRequest(repoRoot, executionUnit),
+                    ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md"
+                };
+            };
+            RunCommand.RunSuperviseExecutor = (_, executionUnit) =>
+            {
+                invokedSteps.Add($"supervise:{executionUnit}");
+                return new RunSuperviseResult
+                {
+                    ExecutionUnit = executionUnit,
+                    SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                    WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                    SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                    RetryCount = 0,
+                    RetryBudget = 3,
+                    HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md"
                 };
             };
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
             Assert.Equal("no-actionable-item", result.StopReason);
-            Assert.Null(result.ExecutionUnit);
-            Assert.Equal(["issue:auth", "launch:auth"], invokedDomains);
+            Assert.Equal("AUTH-01", result.ExecutionUnit);
+            Assert.Equal(
+                [
+                    "issue:auth:AUTH-01",
+                    "enqueue:AUTH-01",
+                    "dispatch:AUTH-01",
+                    "start:AUTH-01",
+                    "implement:AUTH-01",
+                    "supervise:AUTH-01"
+                ],
+                invokedSteps);
             Assert.Collection(
                 result.Actions,
                 action =>
                 {
                     Assert.Equal("intake issue", action.Name);
-                    Assert.Equal("auth", action.ExecutionUnit);
+                    Assert.Equal("AUTH-01", action.ExecutionUnit);
                 },
                 action =>
                 {
-                    Assert.Equal("intake launch", action.Name);
-                    Assert.Equal("auth", action.ExecutionUnit);
+                    Assert.Equal("queue enqueue", action.Name);
+                    Assert.Equal("AUTH-01", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("queue dispatch", action.Name);
+                    Assert.Equal("AUTH-01", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("run start", action.Name);
+                    Assert.Equal("AUTH-01", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("run implement", action.Name);
+                    Assert.Equal("AUTH-01", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("run supervise", action.Name);
+                    Assert.Equal("AUTH-01", action.ExecutionUnit);
                 });
-            Assert.Contains("auto-continued into intake domain 'auth'", result.Detail, StringComparison.Ordinal);
+            Assert.DoesNotContain(invokedSteps, step => step.Contains("AUTH-02", StringComparison.Ordinal));
         }
         finally
         {
             RunCommand.IntakeIssueExecutor = originalIntakeIssueExecutor;
-            RunCommand.IntakeLaunchExecutor = originalIntakeLaunchExecutor;
+            RunCommand.QueueEnqueueExecutor = originalQueueEnqueueExecutor;
+            RunCommand.QueueDispatchExecutor = originalQueueDispatchExecutor;
+            RunCommand.RunStartExecutor = originalRunStartExecutor;
+            RunCommand.RunImplementExecutor = originalRunImplementExecutor;
+            RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
         }
     }
 
@@ -6948,6 +7046,18 @@ public sealed class RunCommandTests
         var updatedState = queueState with
         {
             Items = queueState.Items.Select(update).ToArray()
+        };
+
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+    }
+
+    private static void AppendQueueItem(string repoRoot, QueueItem item)
+    {
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        var updatedState = queueState with
+        {
+            Items = [.. queueState.Items, item]
         };
 
         File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));


### PR DESCRIPTION
## Summary
- teach root `run` to auto-continue into intake when the current queue is fully closed out and an intake execution draft still has launchable units
- reuse the existing `intake issue` and `intake launch` command surfaces instead of introducing a new dispatch path
- add root-run regression coverage for launchable and already-completed intake slices

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter RunCommandTests --nologo`
- `dotnet test IntentSystem.sln --nologo`

Relates to #346
