### PR TITLE
[G129] Preserve detached implement bounded progress after inventory

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -194,7 +194,7 @@ internal static class DirectRunCommandSupport
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(command);
 
-        return entryKind == DirectRunEntryKind.Fix
+        return (entryKind == DirectRunEntryKind.Fix || entryKind == DirectRunEntryKind.Implement)
             && launcher is DirectRunLauncher
             && IsCodexLikeCommand(command);
     }
@@ -492,7 +492,8 @@ internal static class DirectRunCommandSupport
         ArgumentException.ThrowIfNullOrWhiteSpace(runStatus);
 
         if (OperatingSystem.IsWindows()
-            || !string.Equals(entryKind, "fix", StringComparison.Ordinal)
+            || (!string.Equals(entryKind, "fix", StringComparison.Ordinal)
+                && !string.Equals(entryKind, "implement", StringComparison.Ordinal))
             || !string.Equals(runStatus, "running", StringComparison.Ordinal)
             || !TryParseSessionProcessId(providerSessionId, out var processId))
         {

--- a/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunExitMonitorCommand.cs
@@ -212,7 +212,8 @@ internal static class DirectRunExitMonitorCommand
 
     private static void AppendDeterministicFixBoundaryIfNeeded(DirectRunExitMonitorOptions options)
     {
-        if (!string.Equals(options.EntryKind, "fix", StringComparison.Ordinal)
+        if ((!string.Equals(options.EntryKind, "fix", StringComparison.Ordinal)
+                && !string.Equals(options.EntryKind, "implement", StringComparison.Ordinal))
             || !TryReadCurrentProviderEvents(
                 options.ProviderEventLogPath,
                 options.ProviderSessionId,

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -6,10 +6,10 @@ internal static class DirectRunFixOutcomeSupport
 {
     private const string DeterministicContractGapStopReason = "deterministic-contract-gap";
     private const string ExplicitContractGapRefusalReason = "provider-explicit-contract-gap-refusal";
-    private const string InspectionOnlyExitReason = "fix-session-ended-after-initial-inspection";
-    private const string ProviderBackendEndedBeforeSpecSourceReadReason = "fix-session-ended-before-spec-source-test-read";
-    private const string MissingTerminalCaptureAfterRequestReadReason = "fix-session-terminal-boundary-missing-after-request-reread";
-    private const string MissingTerminalCaptureAfterDeepProgressReason = "fix-session-terminal-boundary-missing-after-deep-progress";
+    private const string InspectionOnlyExitReasonSuffix = "session-ended-after-initial-inspection";
+    private const string ProviderBackendEndedBeforeSpecSourceReadReasonSuffix = "session-ended-before-spec-source-test-read";
+    private const string MissingTerminalCaptureAfterRequestReadReasonSuffix = "session-terminal-boundary-missing-after-request-reread";
+    private const string MissingTerminalCaptureAfterDeepProgressReasonSuffix = "session-terminal-boundary-missing-after-deep-progress";
     private static readonly string[] StartupWarningMarkers =
     [
         "warn",
@@ -87,14 +87,16 @@ internal static class DirectRunFixOutcomeSupport
         ArgumentException.ThrowIfNullOrWhiteSpace(provider);
         ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
 
-        if (!string.Equals(entryKind, "fix", StringComparison.Ordinal)
+        if (!SupportsEntryKind(entryKind)
             || HasCanonicalContractGap(providerEvents))
         {
             return null;
         }
 
+        var orderedProviderEvents = OrderEventsForAnalysis(providerEvents);
+
         if (TryCreateExplicitContractGapEvent(
-                providerEvents,
+                orderedProviderEvents,
                 timestamp,
                 executionUnit,
                 entryKind,
@@ -106,8 +108,9 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         if (!TryResolveCanonicalFailureDetail(
-                providerEvents,
+                orderedProviderEvents,
                 executionUnit,
+                entryKind,
                 providerSessionAlive,
                 out var reason,
                 out var detail))
@@ -137,14 +140,18 @@ internal static class DirectRunFixOutcomeSupport
     public static bool TryResolveContractGapDetail(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string executionUnit,
+        string entryKind,
         out string detail)
     {
         ArgumentNullException.ThrowIfNull(providerEvents);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
 
-        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        var orderedProviderEvents = OrderEventsForAnalysis(providerEvents);
+
+        for (var index = orderedProviderEvents.Count - 1; index >= 0; index--)
         {
-            if (!TryResolveExplicitContractGapDetail(providerEvents[index].Payload, executionUnit, out detail))
+            if (!TryResolveExplicitContractGapDetail(orderedProviderEvents[index].Payload, executionUnit, entryKind, out detail))
             {
                 continue;
             }
@@ -152,19 +159,23 @@ internal static class DirectRunFixOutcomeSupport
             return true;
         }
 
-        return TryResolveInspectionOnlyFailureDetail(providerEvents, executionUnit, out detail);
+        return TryResolveInspectionOnlyFailureDetail(orderedProviderEvents, executionUnit, entryKind, out detail);
     }
 
     public static bool TryResolveStartupOnlyFailureDetail(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string executionUnit,
+        string entryKind,
         out string detail)
     {
         ArgumentNullException.ThrowIfNull(providerEvents);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
+
+        var orderedProviderEvents = OrderEventsForAnalysis(providerEvents);
 
         detail = string.Empty;
-        var failingBackendExitIndex = FindFailingBackendExitIndex(providerEvents);
+        var failingBackendExitIndex = FindFailingBackendExitIndex(orderedProviderEvents);
         if (failingBackendExitIndex < 0)
         {
             return false;
@@ -173,34 +184,29 @@ internal static class DirectRunFixOutcomeSupport
         var sawStartupNoise = false;
         for (var index = 0; index < failingBackendExitIndex; index++)
         {
-            var providerEvent = providerEvents[index];
+            var providerEvent = orderedProviderEvents[index];
             if (providerEvent.Kind == "session-metadata"
-                || IsIgnorableReadyEvent(providerEvent.Payload))
+                || IsIgnorableReadyEvent(providerEvent.Payload)
+                || IsIgnorableStartupPreamble(providerEvent.Payload))
             {
                 continue;
-            }
-
-            if (TryResolveExplicitContractGapDetail(providerEvent.Payload, executionUnit, out _)
-                || ContainsSuccessfulInitialRepoInspection(providerEvent.Payload))
-            {
-                return false;
-            }
-
-            if (!sawStartupNoise
-                && IsIgnorableStartupPreamble(providerEvent.Payload))
-            {
-                continue;
-            }
-
-            if (ContainsBoundedFixProgressSignal(providerEvent.Payload))
-            {
-                return false;
             }
 
             if (IsIgnorableStartupNoise(providerEvent.Payload))
             {
                 sawStartupNoise = true;
                 continue;
+            }
+
+            if (TryResolveExplicitContractGapDetail(providerEvent.Payload, executionUnit, entryKind, out _)
+                || ContainsSuccessfulInitialRepoInspection(providerEvent.Payload))
+            {
+                return false;
+            }
+
+            if (ContainsBoundedFixProgressSignal(providerEvent.Payload))
+            {
+                return false;
             }
 
             return false;
@@ -212,7 +218,7 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         detail =
-            $"Fix direct run for '{executionUnit}' exited during provider startup before any bounded repo inspection, edit, test, refusal, or contract-gap output was emitted. Current-session provider output only contained startup warnings or noise before the backend exit.";
+            $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' exited during provider startup before any bounded repo inspection, edit, test, refusal, or contract-gap output was emitted. Current-session provider output only contained startup warnings or noise before the backend exit.";
         return true;
     }
 
@@ -238,15 +244,17 @@ internal static class DirectRunFixOutcomeSupport
         ArgumentNullException.ThrowIfNull(providerEvents);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
 
+        var orderedProviderEvents = OrderEventsForAnalysis(providerEvents);
+
         detail = string.Empty;
-        if (!HasSuccessfulBackendExit(providerEvents))
+        if (!HasSuccessfulBackendExit(orderedProviderEvents))
         {
             return false;
         }
 
-        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        for (var index = orderedProviderEvents.Count - 1; index >= 0; index--)
         {
-            if (!TryResolveNoOpSuccessDetail(providerEvents[index].Payload, out detail))
+            if (!TryResolveNoOpSuccessDetail(orderedProviderEvents[index].Payload, out detail))
             {
                 continue;
             }
@@ -295,6 +303,7 @@ internal static class DirectRunFixOutcomeSupport
     private static bool TryResolveCanonicalFailureDetail(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string executionUnit,
+        string entryKind,
         bool providerSessionAlive,
         out string reason,
         out string detail)
@@ -302,6 +311,7 @@ internal static class DirectRunFixOutcomeSupport
         if (TryResolveMissingTerminalAfterDeepProgressDetail(
                 providerEvents,
                 executionUnit,
+                entryKind,
                 providerSessionAlive,
                 out reason,
                 out detail))
@@ -312,6 +322,7 @@ internal static class DirectRunFixOutcomeSupport
         if (TryResolvePostRequestParityBoundaryDetail(
                 providerEvents,
                 executionUnit,
+                entryKind,
                 providerSessionAlive,
                 out reason,
                 out detail))
@@ -319,13 +330,14 @@ internal static class DirectRunFixOutcomeSupport
             return true;
         }
 
-        reason = InspectionOnlyExitReason;
-        return TryResolveInspectionOnlyFailureDetail(providerEvents, executionUnit, out detail);
+        reason = ResolveReason(entryKind, InspectionOnlyExitReasonSuffix);
+        return TryResolveInspectionOnlyFailureDetail(providerEvents, executionUnit, entryKind, out detail);
     }
 
     private static bool TryResolveMissingTerminalAfterDeepProgressDetail(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string executionUnit,
+        string entryKind,
         bool providerSessionAlive,
         out string reason,
         out string detail)
@@ -347,15 +359,16 @@ internal static class DirectRunFixOutcomeSupport
         var observedProductRead = providerEvents.Any(providerEvent => ContainsProductSourceOrTestReadAttempt(providerEvent.Payload));
         var observedDotNetTest = providerEvents.Any(providerEvent => ContainsDotNetTestAttempt(providerEvent.Payload));
 
-        reason = MissingTerminalCaptureAfterDeepProgressReason;
+        reason = ResolveReason(entryKind, MissingTerminalCaptureAfterDeepProgressReasonSuffix);
         detail =
-            $"Fix direct run for '{executionUnit}' reached deeper bounded work before the provider session died, but no same-session terminal outcome was captured. Current-session evidence observed request_reread={observedRequestReread}, repo_inventory={observedInventory}, repo_local_spec_read={observedSpecRead}, product_source_or_test_read={observedProductRead}, dotnet_test={observedDotNetTest}. The provider session is no longer alive, but neither backend-exit nor an explicit contract-gap was persisted for that same session, so the child runtime must synthesize a deterministic missing-terminal boundary instead of leaving run_status=running.";
+            $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' reached deeper bounded work before the provider session died, but no same-session terminal outcome was captured. Current-session evidence observed request_reread={observedRequestReread}, repo_inventory={observedInventory}, repo_local_spec_read={observedSpecRead}, product_source_or_test_read={observedProductRead}, dotnet_test={observedDotNetTest}. The provider session is no longer alive, but neither backend-exit nor an explicit contract-gap was persisted for that same session, so the child runtime must synthesize a deterministic missing-terminal boundary instead of leaving run_status=running.";
         return true;
     }
 
     private static bool TryResolvePostRequestParityBoundaryDetail(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string executionUnit,
+        string entryKind,
         bool providerSessionAlive,
         out string reason,
         out string detail)
@@ -377,9 +390,9 @@ internal static class DirectRunFixOutcomeSupport
         var failingBackendExitIndex = FindFailingBackendExitIndex(providerEvents);
         if (failingBackendExitIndex >= 0)
         {
-            reason = ProviderBackendEndedBeforeSpecSourceReadReason;
+            reason = ResolveReason(entryKind, ProviderBackendEndedBeforeSpecSourceReadReasonSuffix);
             detail =
-                $"Fix direct run for '{executionUnit}' stopped before repo-local spec/source/test planning reads. Current-session evidence observed request_reread={observedRequestReread}, repo_inventory={observedInventory}, repo_local_spec_read={observedSpecRead}, product_source_or_test_read={observedProductRead}. A failing backend-exit was captured before any repo-local spec or product source/test read, which indicates the provider backend itself exited before the next bounded read.";
+                $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' stopped before repo-local spec/source/test planning reads. Current-session evidence observed request_reread={observedRequestReread}, repo_inventory={observedInventory}, repo_local_spec_read={observedSpecRead}, product_source_or_test_read={observedProductRead}. A failing backend-exit was captured before any repo-local spec or product source/test read, which indicates the provider backend itself exited before the next bounded read.";
             return true;
         }
 
@@ -388,15 +401,16 @@ internal static class DirectRunFixOutcomeSupport
             return false;
         }
 
-        reason = MissingTerminalCaptureAfterRequestReadReason;
+        reason = ResolveReason(entryKind, MissingTerminalCaptureAfterRequestReadReasonSuffix);
         detail =
-            $"Fix direct run for '{executionUnit}' stopped before repo-local spec/source/test planning reads. Current-session evidence observed request_reread={observedRequestReread}, repo_inventory={observedInventory}, repo_local_spec_read={observedSpecRead}, product_source_or_test_read={observedProductRead}. The provider session is no longer alive, but no backend-exit or later bounded-read event was captured for the current session. This indicates the detached helper/current-session synthesis event capture dropped after the request reread layer rather than a completed repair attempt.";
+            $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' stopped before repo-local spec/source/test planning reads. Current-session evidence observed request_reread={observedRequestReread}, repo_inventory={observedInventory}, repo_local_spec_read={observedSpecRead}, product_source_or_test_read={observedProductRead}. The provider session is no longer alive, but no backend-exit or later bounded-read event was captured for the current session. This indicates the detached helper/current-session synthesis event capture dropped after the request reread layer rather than a completed repair attempt.";
         return true;
     }
 
     private static bool TryResolveInspectionOnlyFailureDetail(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string executionUnit,
+        string entryKind,
         out string detail)
     {
         detail = string.Empty;
@@ -412,12 +426,14 @@ internal static class DirectRunFixOutcomeSupport
         {
             var providerEvent = providerEvents[index];
             if (providerEvent.Kind == "session-metadata"
-                || IsIgnorableReadyEvent(providerEvent.Payload))
+                || IsIgnorableReadyEvent(providerEvent.Payload)
+                || IsIgnorableStartupPreamble(providerEvent.Payload)
+                || IsIgnorableStartupNoise(providerEvent.Payload))
             {
                 continue;
             }
 
-            if (TryResolveExplicitContractGapDetail(providerEvent.Payload, executionUnit, out _))
+            if (TryResolveExplicitContractGapDetail(providerEvent.Payload, executionUnit, entryKind, out _))
             {
                 return false;
             }
@@ -442,8 +458,34 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         detail =
-            $"Fix direct run for '{executionUnit}' exited after the initial repo-inspection command completed without any repair, test, refusal, or contract-gap outcome.";
+            $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' exited after the initial repo-inspection command completed without any repair, test, refusal, or contract-gap outcome.";
         return true;
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> OrderEventsForAnalysis(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        return providerEvents
+            .Select(
+                (providerEvent, index) => new
+                {
+                    Event = providerEvent,
+                    Index = index,
+                    ParsedTimestamp = DateTimeOffset.TryParse(
+                        providerEvent.Timestamp,
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        System.Globalization.DateTimeStyles.RoundtripKind,
+                        out var parsedTimestamp)
+                        ? parsedTimestamp
+                        : (DateTimeOffset?)null
+                })
+            .OrderBy(item => item.ParsedTimestamp is null ? 1 : 0)
+            .ThenBy(item => item.ParsedTimestamp)
+            .ThenBy(item => item.Index)
+            .Select(item => item.Event)
+            .ToArray();
     }
 
     private static int FindFailingBackendExitIndex(IReadOnlyList<DirectRunProviderEvent> providerEvents)
@@ -560,7 +602,7 @@ internal static class DirectRunFixOutcomeSupport
         out DirectRunProviderEvent? providerEvent)
     {
         providerEvent = null;
-        if (!TryResolveExplicitContractGapDetail(providerEvents, executionUnit, out var detail))
+        if (!TryResolveExplicitContractGapDetail(providerEvents, executionUnit, entryKind, out var detail))
         {
             return false;
         }
@@ -589,7 +631,11 @@ internal static class DirectRunFixOutcomeSupport
     private static bool HasExplicitContractGap(IReadOnlyList<DirectRunProviderEvent> providerEvents)
     {
         return providerEvents.Any(providerEvent =>
-            TryResolveExplicitContractGapDetail(providerEvent.Payload, providerEvent.ExecutionUnit ?? "fix", out _));
+            TryResolveExplicitContractGapDetail(
+                providerEvent.Payload,
+                providerEvent.ExecutionUnit ?? "fix",
+                providerEvent.EntryKind ?? "fix",
+                out _));
     }
 
     private static bool HasCanonicalContractGap(IReadOnlyList<DirectRunProviderEvent> providerEvents)
@@ -605,14 +651,16 @@ internal static class DirectRunFixOutcomeSupport
     private static bool TryResolveExplicitContractGapDetail(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string executionUnit,
+        string entryKind,
         out string detail)
     {
         ArgumentNullException.ThrowIfNull(providerEvents);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
 
         for (var index = providerEvents.Count - 1; index >= 0; index--)
         {
-            if (TryResolveExplicitContractGapDetail(providerEvents[index].Payload, executionUnit, out detail))
+            if (TryResolveExplicitContractGapDetail(providerEvents[index].Payload, executionUnit, entryKind, out detail))
             {
                 return true;
             }
@@ -625,6 +673,7 @@ internal static class DirectRunFixOutcomeSupport
     private static bool TryResolveExplicitContractGapDetail(
         JsonElement payload,
         string executionUnit,
+        string entryKind,
         out string detail)
     {
         detail = string.Empty;
@@ -645,7 +694,7 @@ internal static class DirectRunFixOutcomeSupport
         {
             if (!TryReadString(payload, "detail", out detail))
             {
-                detail = $"Fix direct run for '{executionUnit}' reported a deterministic contract gap.";
+                detail = $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' reported a deterministic contract gap.";
             }
 
             return true;
@@ -656,7 +705,7 @@ internal static class DirectRunFixOutcomeSupport
         {
             if (!TryReadString(payload, "detail", out detail))
             {
-                detail = $"Fix direct run for '{executionUnit}' reported a deterministic contract gap.";
+                detail = $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' reported a deterministic contract gap.";
             }
 
             return true;
@@ -707,6 +756,35 @@ internal static class DirectRunFixOutcomeSupport
                 normalized.StartsWith(prefix, StringComparison.Ordinal))
             || PlanningPreambleContractGapMarkers.Any(marker =>
                 normalized.Contains(marker, StringComparison.Ordinal));
+    }
+
+    private static bool SupportsEntryKind(string entryKind)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
+
+        return string.Equals(entryKind, "fix", StringComparison.Ordinal)
+            || string.Equals(entryKind, "implement", StringComparison.Ordinal);
+    }
+
+    private static string ResolveEntryLabel(string entryKind)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
+
+        return string.Equals(entryKind, "implement", StringComparison.Ordinal)
+            ? "Implement"
+            : "Fix";
+    }
+
+    private static string ResolveReason(string entryKind, string suffix)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(suffix);
+
+        var prefix = string.Equals(entryKind, "implement", StringComparison.Ordinal)
+            ? "implement"
+            : "fix";
+
+        return $"{prefix}-{suffix}";
     }
 
     private static bool ContainsSuccessfulInitialRepoInspection(JsonElement payload)

--- a/src/IntentSystem.Cli/Commands/DirectRunTerminalArtifactUpdater.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunTerminalArtifactUpdater.cs
@@ -162,7 +162,8 @@ internal static class DirectRunTerminalArtifactUpdater
         ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
         ArgumentException.ThrowIfNullOrWhiteSpace(currentRunStatus);
 
-        if (!string.Equals(entryKind, "fix", StringComparison.Ordinal)
+        if ((!string.Equals(entryKind, "fix", StringComparison.Ordinal)
+                && !string.Equals(entryKind, "implement", StringComparison.Ordinal))
             || !string.Equals(currentRunStatus, "running", StringComparison.Ordinal)
             || IsProviderSessionAlive(providerSessionId))
         {

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1949,7 +1949,7 @@ internal static class RunCommand
             requestArtifact.ProviderSessionId,
             requestArtifact.LaunchedAt);
 
-        return DirectRunFixOutcomeSupport.TryResolveContractGapDetail(providerEvents, executionUnit, out var detail)
+        return DirectRunFixOutcomeSupport.TryResolveContractGapDetail(providerEvents, executionUnit, "fix", out var detail)
             ? detail
             : null;
     }

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -159,15 +159,6 @@ internal static class RunCommand
                             continue;
                         }
 
-                        if (string.Equals(implementRunStatus, "failed", StringComparison.Ordinal))
-                        {
-                            return CreateStopResult(
-                                NonRetryableFailureStopReason,
-                                actions,
-                                inProgressItem.ExecutionUnit,
-                                $"Implement direct run failed for '{inProgressItem.ExecutionUnit}'.");
-                        }
-
                         if (!ArtifactExists(context, RunImplementArtifactPathResolver.Resolve(inProgressItem.ExecutionUnit)))
                         {
                             ExecuteAction(

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -419,6 +419,34 @@ internal static class RunSuperviseCommand
             };
 
             PersistSession(sessionArtifactPath, resumedSession);
+
+            if (resumedSession.WorkerEntry == RunSupervisionWorkerEntry.Implement
+                && HasCurrentImplementBoundedProgressSignal(context, executionUnit)
+                && TryCaptureDeadWorkerSessionFailure(
+                    context,
+                    executionUnit,
+                    resumedSession.WorkerEntry,
+                    out var deadWorkerFailure)
+                && deadWorkerFailure.ReportAsNonRetryableFailure)
+            {
+                return BlockForTerminalFailure(
+                    context,
+                    queueState,
+                    executionUnit,
+                    sessionArtifactPath,
+                    sessionArtifactRef,
+                    runLogPath,
+                    resumedSession,
+                    now,
+                    deadWorkerFailure.Reason,
+                    incrementRetryCount: false,
+                    emitRetryExhaustedEvent: false,
+                    emitRetryAttemptedEvent: true,
+                    retryAttemptReason: session.LastInterruptionReason,
+                    reportAsNonRetryableFailure: true,
+                    requiresPostFixWorktreeProgressDecision: deadWorkerFailure.RequiresPostFixWorktreeProgressDecision);
+            }
+
             AppendRunEvents(
                 runLogPath,
                 [
@@ -917,6 +945,33 @@ internal static class RunSuperviseCommand
             requestArtifact.ProviderSessionId);
 
         return true;
+    }
+
+    private static bool HasCurrentImplementBoundedProgressSignal(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var requestArtifactPath = ResolveDirectRunRequestArtifactPath(context, executionUnit);
+        var providerLogPath = ResolveDirectRunProviderLogPath(context, executionUnit);
+        if (!File.Exists(requestArtifactPath) || !File.Exists(providerLogPath))
+        {
+            return false;
+        }
+
+        var requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+        if (!string.Equals(requestArtifact.EntryKind, "implement", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerLogPath));
+        var currentProviderEvents = SelectCurrentSessionEvents(
+            providerEvents,
+            requestArtifact.ProviderSessionId,
+            requestArtifact.LaunchedAt);
+
+        return DirectRunFixOutcomeSupport.HasBoundedProgressSignal(currentProviderEvents);
     }
 
     private static void AppendDeterministicContractGapBoundaryIfNeeded(

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -821,6 +821,14 @@ internal static class RunSuperviseCommand
                 expectedEntryKind,
                 out failure))
         {
+            AppendDeterministicContractGapBoundaryIfNeeded(
+                providerLogPath,
+                currentProviderEvents,
+                executionUnit,
+                expectedEntryKind,
+                requestArtifact.Provider,
+                requestArtifact.ProviderSessionId);
+
             File.WriteAllText(
                 resultArtifactPath,
                 DirectRunResultArtifactJson.Serialize(resultArtifact with
@@ -880,21 +888,13 @@ internal static class RunSuperviseCommand
             {
                 return true;
             }
-
-            if (DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
-                    providerEventsWithSyntheticExit,
-                    executionUnit,
-                    out var startupOnlyDetail))
-            {
-                    failure = new WorkerSessionFailure(
-                        $"Worker session '{requestArtifact.ProviderSessionId}' for '{executionUnit}' exited with backend exit code 1. {startupOnlyDetail}",
-                        ReportAsNonRetryableFailure: true);
-                return true;
-            }
         }
 
+        var syntheticProviderEvents = new List<DirectRunProviderEvent>(currentProviderEvents.Count + 1);
+        syntheticProviderEvents.AddRange(currentProviderEvents);
+        syntheticProviderEvents.Add(backendExitEvent);
         if (!TryResolveTerminalFailureReason(
-                [backendExitEvent],
+                syntheticProviderEvents,
                 executionUnit,
                 requestArtifact.ProviderSessionId,
                 expectedEntryKind,
@@ -904,7 +904,46 @@ internal static class RunSuperviseCommand
                 $"Synthetic backend-exit for '{executionUnit}' did not resolve to a terminal failure reason.");
         }
 
+        AppendDeterministicContractGapBoundaryIfNeeded(
+            providerLogPath,
+            syntheticProviderEvents,
+            executionUnit,
+            expectedEntryKind,
+            requestArtifact.Provider,
+            requestArtifact.ProviderSessionId);
+
         return true;
+    }
+
+    private static void AppendDeterministicContractGapBoundaryIfNeeded(
+        string providerLogPath,
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerLogPath);
+        ArgumentNullException.ThrowIfNull(providerEvents);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(provider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+
+        var boundaryEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.UtcNow,
+            executionUnit,
+            entryKind,
+            provider,
+            providerSessionId,
+            providerSessionAlive: false);
+        if (boundaryEvent is null)
+        {
+            return;
+        }
+
+        new DirectRunProviderEventWriter(providerLogPath).Append(boundaryEvent);
     }
 
     private static bool TryAwaitTerminalFailureReason(
@@ -1030,6 +1069,34 @@ internal static class RunSuperviseCommand
         ArgumentException.ThrowIfNullOrWhiteSpace(expectedEntryKind);
 
         failure = null!;
+        if ((string.Equals(expectedEntryKind, "fix", StringComparison.Ordinal)
+                || string.Equals(expectedEntryKind, "implement", StringComparison.Ordinal))
+            && DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
+                providerEvents,
+                executionUnit,
+                expectedEntryKind,
+                out var startupOnlyDetail))
+        {
+            failure = new WorkerSessionFailure(
+                startupOnlyDetail,
+                ReportAsNonRetryableFailure: true);
+            return true;
+        }
+
+        if ((string.Equals(expectedEntryKind, "fix", StringComparison.Ordinal)
+                || string.Equals(expectedEntryKind, "implement", StringComparison.Ordinal))
+            && DirectRunFixOutcomeSupport.TryResolveContractGapDetail(
+                providerEvents,
+                executionUnit,
+                expectedEntryKind,
+                out var contractGapDetail))
+        {
+            failure = new WorkerSessionFailure(
+                contractGapDetail,
+                ReportAsNonRetryableFailure: true);
+            return true;
+        }
+
         for (var index = providerEvents.Count - 1; index >= 0; index--)
         {
             var providerEvent = providerEvents[index];
@@ -1041,18 +1108,6 @@ internal static class RunSuperviseCommand
             if (providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
                 && exitCodeElement.TryGetInt32(out var exitCode))
             {
-                if (string.Equals(expectedEntryKind, "fix", StringComparison.Ordinal)
-                    && DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
-                        providerEvents,
-                        executionUnit,
-                        out var startupOnlyDetail))
-                {
-                    failure = new WorkerSessionFailure(
-                        $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode}. {startupOnlyDetail}",
-                        ReportAsNonRetryableFailure: true);
-                    return true;
-                }
-
                 failure = new WorkerSessionFailure(
                     $"Worker session '{providerSessionId}' for '{executionUnit}' exited with backend exit code {exitCode}.",
                     ReportAsNonRetryableFailure: false);
@@ -1386,6 +1441,7 @@ internal static class RunSuperviseCommand
         if (DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
                 currentSessionEvents,
                 executionUnit,
+                "fix",
                 out var startupOnlyDetail))
         {
             return startupOnlyDetail;

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -761,10 +761,14 @@ internal static class RunSuperviseCommand
 
         var requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
         var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        var canReclassifyStaleFailedImplementResult =
+            string.Equals(expectedEntryKind, "implement", StringComparison.Ordinal)
+            && string.Equals(resultArtifact.RunStatus, "failed", StringComparison.Ordinal);
         if (!string.Equals(requestArtifact.EntryKind, expectedEntryKind, StringComparison.Ordinal)
             || !string.Equals(resultArtifact.EntryKind, expectedEntryKind, StringComparison.Ordinal)
             || !string.Equals(resultArtifact.SessionId, requestArtifact.ProviderSessionId, StringComparison.Ordinal)
-            || !string.Equals(resultArtifact.RunStatus, "running", StringComparison.Ordinal)
+            || (!string.Equals(resultArtifact.RunStatus, "running", StringComparison.Ordinal)
+                && !canReclassifyStaleFailedImplementResult)
             || !TryParseSessionProcessId(requestArtifact.ProviderSessionId, out var processId)
             || IsProcessAlive(processId))
         {

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -14,6 +14,7 @@ public sealed class DirectRunFixOutcomeSupportTests
         var resolved = DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
             providerEvents,
             "TOY-CALC-V0-01",
+            "fix",
             out var detail);
 
         Assert.True(resolved);
@@ -31,6 +32,7 @@ public sealed class DirectRunFixOutcomeSupportTests
         var resolved = DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
             providerEvents,
             "TOY-CALC-V0-01",
+            "fix",
             out var detail);
 
         Assert.True(resolved);
@@ -185,6 +187,32 @@ public sealed class DirectRunFixOutcomeSupportTests
         Assert.Equal("fix-session-ended-before-spec-source-test-read", contractGapEvent.Payload.GetProperty("reason").GetString());
         Assert.Contains(
             "provider backend itself exited before the next bounded read",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenImplementInventoryThenBackendExit_UsesInspectionOnlyReason()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("Use the request artifact at '/tmp/TOY-CALC-V0-02.request.md' as the bounded source of truth for this direct run.", entryKind: "implement"),
+            CreateProviderEvent("exec /bin/zsh -lc 'rg --files' succeeded in 0ms", entryKind: "implement"),
+            CreateBackendExitEvent(entryKind: "implement")
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-19T21:00:00Z"),
+            "TOY-CALC-V0-02",
+            "implement",
+            "Codex",
+            "pid:45803");
+
+        Assert.NotNull(contractGapEvent);
+        Assert.Equal("implement-session-ended-after-initial-inspection", contractGapEvent!.Payload.GetProperty("reason").GetString());
+        Assert.Contains(
+            "Implement direct run for 'TOY-CALC-V0-02' exited after the initial repo-inspection command completed",
             contractGapEvent.Payload.GetProperty("detail").GetString(),
             StringComparison.Ordinal);
     }
@@ -454,28 +482,28 @@ public sealed class DirectRunFixOutcomeSupportTests
         ];
     }
 
-    private static DirectRunProviderEvent CreateProviderEvent(string payload)
+    private static DirectRunProviderEvent CreateProviderEvent(string payload, string entryKind = "fix")
     {
         return new DirectRunProviderEvent
         {
             Timestamp = "2026-04-16T08:08:23.2829410+00:00",
             ExecutionUnit = "TOY-CALC-V0-01",
             Provider = "Codex",
-            EntryKind = "fix",
+            EntryKind = entryKind,
             SessionId = "pid:97771",
             Kind = "provider-event",
             Payload = JsonSerializer.SerializeToElement(payload)
         };
     }
 
-    private static DirectRunProviderEvent CreateBackendExitEvent()
+    private static DirectRunProviderEvent CreateBackendExitEvent(string entryKind = "fix")
     {
         return new DirectRunProviderEvent
         {
             Timestamp = "2026-04-17T05:58:47.0000000+00:00",
             ExecutionUnit = "TOY-CALC-V0-01",
             Provider = "Codex",
-            EntryKind = "fix",
+            EntryKind = entryKind,
             SessionId = "pid:97771",
             Kind = "provider-event",
             Payload = JsonSerializer.SerializeToElement(new

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -4259,6 +4259,98 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenImplementSessionThatDiesAfterInitialInventory_StopsWithNonRetryableFailureDetail()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Active))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G226.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "active",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                HandoffArtifactRef = ".intent-cli/implement/G226.request.md",
+                RetryCount = 0,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "implement", "pid:45803", provider: "Codex");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "implement",
+            "running",
+            providerEvents: CreateInitialInventoryImplementProviderEvents("G226", "pid:45803"),
+            sessionId: "pid:45803",
+            provider: "Codex");
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("non-retryable-failure", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        var action = Assert.Single(result.Actions);
+        Assert.Equal("run supervise", action.Name);
+        Assert.Contains("initial repo-inspection command completed", result.Detail, StringComparison.Ordinal);
+
+        var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+        Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+        Assert.Contains("initial repo-inspection command completed", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+        var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "supervision", "G226.session.json")));
+        Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+        Assert.Equal(0, session.RetryCount);
+        Assert.Contains("initial repo-inspection command completed", session.LastInterruptionReason, StringComparison.Ordinal);
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        Assert.Equal("blocked", runEvents[^1].Event);
+        Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+        Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task ExecuteCore_GivenStartupOnlyDeadFixWorkerSessionWhenBackendExitLandsDuringRaceWindow_StopsWithNonRetryableFailureDetail()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -7340,6 +7432,74 @@ public sealed class RunCommandTests
         }
 
         return providerEvents;
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateInitialInventoryImplementProviderEvents(
+        string executionUnit,
+        string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "session-metadata",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    model = "gpt-5.4-mini",
+                    transport = "sdk",
+                    command = "codex"
+                })
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.3000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("Use the request artifact at '/repo/.intent-cli/implement/G226.request.md' as the bounded source of truth for this direct run.")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.6000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'rg --files' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:00.8000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("warn plugin manifest falling_back after state db discrepancy on slow path")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    type = "backend-exit",
+                    exit_code = 1
+                })
+            }
+        ];
     }
 
     private static IReadOnlyList<DirectRunProviderEvent> CreateMeaningfulFixWorktreeProgressProviderEvents(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -3521,6 +3521,150 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenAutoResumedImplementSessionThatDiesAfterInitialInventory_StopsWithNonRetryableFailure()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            queueStatePath,
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Active))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            runLogPath,
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G226.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                Status = RunSupervisionSessionStatus.Monitoring,
+                QueueState = "active",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = null,
+                CommentRef = null,
+                HandoffArtifactRef = ".intent-cli/implement/G226.request.md",
+                RetryCount = 0,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z")
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "implement", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "implement",
+            "running",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Claude",
+                    EntryKind = "implement",
+                    SessionId = "pid:999999",
+                    Kind = "session-metadata",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        model = "sonnet",
+                        transport = "sdk",
+                        command = "claude"
+                    })
+                }
+            ],
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var originalRunImplementExecutor = RunSuperviseCommand.RunImplementExecutor;
+        var originalRaceWindow = RunSuperviseCommand.TerminalFailureRaceWindow;
+
+        try
+        {
+            RunSuperviseCommand.TerminalFailureRaceWindow = TimeSpan.Zero;
+            RunSuperviseCommand.RunImplementExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunRequest(repoRoot, executionUnit, "implement", "pid:4242", provider: "Claude");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "running",
+                    providerEvents: CreateInitialInventoryImplementProviderEvents(executionUnit, "pid:4242", includeBackendExit: false),
+                    sessionId: "pid:4242",
+                    provider: "Claude");
+
+                return new RunImplementResult
+                {
+                    Request = CreateRunImplementRequest(repoRoot, executionUnit) with
+                    {
+                        ImplementRole = "Claude"
+                    },
+                    ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("non-retryable-failure", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("run supervise", action.Name);
+            Assert.Contains("initial repo-inspection command completed", result.Detail, StringComparison.Ordinal);
+            Assert.DoesNotContain("auto-resumed", result.Detail, StringComparison.OrdinalIgnoreCase);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("initial repo-inspection command completed", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("failed", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("retry-attempted", runEvents[^2].Event);
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "auto-resumed", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.RunImplementExecutor = originalRunImplementExecutor;
+            RunSuperviseCommand.TerminalFailureRaceWindow = originalRaceWindow;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenDeadImplementWorkerSessionWithCapturedBackendExit_DoesNotReportMissingTerminalEvent()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -7546,10 +7690,11 @@ public sealed class RunCommandTests
 
     private static IReadOnlyList<DirectRunProviderEvent> CreateInitialInventoryImplementProviderEvents(
         string executionUnit,
-        string sessionId)
+        string sessionId,
+        bool includeBackendExit = true)
     {
-        return
-        [
+        var providerEvents = new List<DirectRunProviderEvent>
+        {
             new DirectRunProviderEvent
             {
                 Timestamp = "2026-04-10T12:00:00.0000000+00:00",
@@ -7594,8 +7739,12 @@ public sealed class RunCommandTests
                 SessionId = sessionId,
                 Kind = "provider-event",
                 Payload = System.Text.Json.JsonSerializer.SerializeToElement("warn plugin manifest falling_back after state db discrepancy on slow path")
-            },
-            new DirectRunProviderEvent
+            }
+        };
+
+        if (includeBackendExit)
+        {
+            providerEvents.Add(new DirectRunProviderEvent
             {
                 Timestamp = "2026-04-10T12:00:01.0000000+00:00",
                 ExecutionUnit = executionUnit,
@@ -7608,8 +7757,10 @@ public sealed class RunCommandTests
                     type = "backend-exit",
                     exit_code = 1
                 })
-            }
-        ];
+            });
+        }
+
+        return providerEvents;
     }
 
     private static IReadOnlyList<DirectRunProviderEvent> CreateMeaningfulFixWorktreeProgressProviderEvents(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -4351,6 +4351,116 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenReactivatedImplementWithStaleFailedResult_ReclassifiesToInspectionBoundary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "TOY-CALC-V0-02"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            queueStatePath,
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Active, executionUnit: "TOY-CALC-V0-02"))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            runLogPath,
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"TOY-CALC-V0-02","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"TOY-CALC-V0-02","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T11:55:00Z","execution_unit":"TOY-CALC-V0-02","event":"blocked","by":"intent-cli","reason":"Worker session 'pid:45803' for 'TOY-CALC-V0-02' exited with backend exit code 1."}
+            {"ts":"2026-04-10T12:15:00Z","execution_unit":"TOY-CALC-V0-02","event":"activated","by":"intent-cli"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "TOY-CALC-V0-02", "packet.yaml"),
+            """
+            execution_unit: "TOY-CALC-V0-02"
+
+            implementation_issue:
+              issue_title: "[G129] Preserve Detached Implement Bounded Progress After Initial Inventory"
+              goal: "Preserve detached implement progress boundaries."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/TOY-CALC-V0-02/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "TOY-CALC-V0-02.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "TOY-CALC-V0-02.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "TOY-CALC-V0-02",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                Status = RunSupervisionSessionStatus.Blocked,
+                QueueState = "blocked",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "TOY-CALC-V0-02"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-129-toy-calc-v0-02",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                HandoffArtifactRef = ".intent-cli/implement/TOY-CALC-V0-02.request.md",
+                RetryCount = 0,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T11:55:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T11:55:00Z"),
+                LastInterruptionReason = "Worker session 'pid:45803' for 'TOY-CALC-V0-02' exited with backend exit code 1."
+            }));
+        WriteDirectRunRequest(
+            repoRoot,
+            "TOY-CALC-V0-02",
+            "implement",
+            "pid:45803",
+            provider: "Codex",
+            launchedAt: "2026-04-10T12:20:00.0000000+00:00");
+        WriteDirectRunResult(
+            repoRoot,
+            "TOY-CALC-V0-02",
+            "implement",
+            "failed",
+            providerEvents: CreateInitialInventoryImplementProviderEvents("TOY-CALC-V0-02", "pid:45803"),
+            sessionId: "pid:45803",
+            provider: "Codex");
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("non-retryable-failure", result.StopReason);
+        Assert.Equal("TOY-CALC-V0-02", result.ExecutionUnit);
+        var action = Assert.Single(result.Actions);
+        Assert.Equal("run supervise", action.Name);
+        Assert.Contains("initial repo-inspection command completed", result.Detail, StringComparison.Ordinal);
+        Assert.DoesNotContain("Implement direct run failed for 'TOY-CALC-V0-02'.", result.Detail, StringComparison.Ordinal);
+
+        var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "TOY-CALC-V0-02");
+        Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+        Assert.Contains("initial repo-inspection command completed", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+        var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "supervision", "TOY-CALC-V0-02.session.json")));
+        Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+        Assert.Contains("initial repo-inspection command completed", session.LastInterruptionReason, StringComparison.Ordinal);
+
+        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "TOY-CALC-V0-02.provider.jsonl")));
+        Assert.Contains(
+            providerEvents,
+            providerEvent => providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "contract-gap", StringComparison.Ordinal)
+                && providerEvent.Payload.TryGetProperty("reason", out var reasonElement)
+                && string.Equals(reasonElement.GetString(), "implement-session-ended-after-initial-inspection", StringComparison.Ordinal));
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        Assert.Equal("blocked", runEvents[^1].Event);
+        Assert.Contains("initial repo-inspection command completed", runEvents[^1].Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ExecuteCore_GivenStartupOnlyDeadFixWorkerSessionWhenBackendExitLandsDuringRaceWindow_StopsWithNonRetryableFailureDetail()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -58,7 +58,7 @@ public sealed class RunImplementCommandTests
             Assert.Contains("Direct model: default", output, StringComparison.Ordinal);
             Assert.Contains("Direct transport: stdio", output, StringComparison.Ordinal);
             Assert.Contains("Provider session: pid:4321", output, StringComparison.Ordinal);
-            Assert.Contains("Run status: running", output, StringComparison.Ordinal);
+            Assert.Contains("Run status: failed", output, StringComparison.Ordinal);
 
             var artifactPath = Path.Combine(repoRoot, ".intent-cli", "implement", "G19.request.md");
             Assert.True(File.Exists(artifactPath));
@@ -88,7 +88,7 @@ public sealed class RunImplementCommandTests
             Assert.Equal("Claude", resultArtifact.Provider);
             Assert.Equal("default", resultArtifact.Model);
             Assert.Equal("pid:4321", resultArtifact.SessionId);
-            Assert.Equal("running", resultArtifact.RunStatus);
+            Assert.Equal("failed", resultArtifact.RunStatus);
             Assert.Equal(".intent-cli/runs/G19.provider.jsonl", resultArtifact.RawLogRef);
             Assert.Equal(".intent-cli/issues/G19/packet.yaml", resultArtifact.PacketRef);
             Assert.Equal(".intent-cli/issues/G19/review-context.md", resultArtifact.ReviewContextRef);

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -617,6 +617,81 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenDeadImplementWorkerSessionAfterInitialInventory_BlocksWithoutAutoResume()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Active)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateActiveRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G25.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession()));
+        WriteDeadImplementDirectRunArtifacts(repoRoot, "pid:999999", includeBackendExit: true);
+        File.AppendAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                CreateInitialInventoryImplementProviderEvents("G25", "pid:999999")
+                    .Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("initial repo-inspection command completed", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(0, session.RetryCount);
+            Assert.Contains("initial repo-inspection command completed", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl")));
+            Assert.Contains(
+                providerEvents,
+                providerEvent => providerEvent.Payload.ValueKind == JsonValueKind.Object
+                    && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                    && string.Equals(typeElement.GetString(), "contract-gap", StringComparison.Ordinal)
+                    && providerEvent.Payload.TryGetProperty("reason", out var reasonElement)
+                    && string.Equals(reasonElement.GetString(), "implement-session-ended-after-initial-inspection", StringComparison.Ordinal));
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("initial repo-inspection command completed", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public async Task Execute_GivenDeadImplementWorkerSessionAtRetryExhaustionWhenBackendExitLandsAfterPreviousRaceWindow_BlocksUsingBackendExitReason()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -2662,6 +2737,43 @@ public sealed class RunSuperviseCommandTests
             }) + Environment.NewLine);
         File.WriteAllText(Path.Combine(repoRoot, ".intent-cli", "runs", $"{executionUnit}.request.json"), DirectRunRequestArtifactJson.Serialize(requestArtifact));
         File.WriteAllText(Path.Combine(repoRoot, ".intent-cli", "runs", $"{executionUnit}.result.json"), DirectRunResultArtifactJson.Serialize(resultArtifact));
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateInitialInventoryImplementProviderEvents(string executionUnit, string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.2500000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("Use the request artifact at '/repo/.intent-cli/implement/G25.request.md' as the bounded source of truth for this direct run.")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.5000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'rg --files' succeeded in 0ms")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-08T10:20:00.7500000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Claude",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement("warn plugin manifest falling_back after state db discrepancy on slow path")
+            }
+        ];
     }
 
     private static IReadOnlyList<DirectRunProviderEvent> CreateMeaningfulFixWorktreeProgressEvents(string executionUnit, string sessionId)

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -617,6 +617,145 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenAutoResumedImplementSessionThatDiesAfterInitialInventory_BlocksInsteadOfMonitoring()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Active)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateActiveRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G25.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession()));
+        WriteDeadImplementDirectRunArtifacts(repoRoot, "pid:999999");
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalRunImplementExecutor = RunSuperviseCommand.RunImplementExecutor;
+        var originalRaceWindow = RunSuperviseCommand.TerminalFailureRaceWindow;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+            RunSuperviseCommand.TerminalFailureRaceWindow = TimeSpan.Zero;
+            RunSuperviseCommand.RunImplementExecutor = (_, executionUnit) =>
+            {
+                WriteLiveImplementDirectRunArtifacts(repoRoot, executionUnit, "pid:4242");
+                File.AppendAllText(
+                    Path.Combine(repoRoot, ".intent-cli", "runs", $"{executionUnit}.provider.jsonl"),
+                    string.Join(
+                        Environment.NewLine,
+                        new[]
+                        {
+                            new DirectRunProviderEvent
+                            {
+                                Timestamp = "2026-04-08T10:30:00.2500000+00:00",
+                                ExecutionUnit = executionUnit,
+                                Provider = "Claude",
+                                EntryKind = "implement",
+                                SessionId = "pid:4242",
+                                Kind = "provider-event",
+                                Payload = JsonSerializer.SerializeToElement("Use the request artifact at '/repo/.intent-cli/implement/G25.request.md' as the bounded source of truth for this direct run.")
+                            },
+                            new DirectRunProviderEvent
+                            {
+                                Timestamp = "2026-04-08T10:30:00.5000000+00:00",
+                                ExecutionUnit = executionUnit,
+                                Provider = "Claude",
+                                EntryKind = "implement",
+                                SessionId = "pid:4242",
+                                Kind = "provider-event",
+                                Payload = JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'rg --files' succeeded in 0ms")
+                            },
+                            new DirectRunProviderEvent
+                            {
+                                Timestamp = "2026-04-08T10:30:00.7500000+00:00",
+                                ExecutionUnit = executionUnit,
+                                Provider = "Claude",
+                                EntryKind = "implement",
+                                SessionId = "pid:4242",
+                                Kind = "provider-event",
+                                Payload = JsonSerializer.SerializeToElement("warn plugin manifest falling_back after state db discrepancy on slow path")
+                            }
+                        }
+                            .Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+
+                return new RunImplementResult
+                {
+                    Request = new RunImplementRequest
+                    {
+                        ExecutionUnit = executionUnit,
+                        State = "active",
+                        ImplementRole = "Claude",
+                        QueueWorkerRole = "coder",
+                        QueueReviewRole = "reviewer",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = "issue-178-g25",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/178",
+                        LatestLinkedPr = null,
+                        PacketRef = ".intent-cli/issues/G25/packet.yaml",
+                        ReviewContextRef = ".intent-cli/issues/G25/review-context.md",
+                        IssueTitle = "[G25] Run Supervise Command",
+                        Goal = "Supervise retryable run interruptions.",
+                        TargetPart = "cli run supervise command",
+                        TargetRepo = "submodules/intent-system",
+                        TargetPath = ".",
+                        InScope = [],
+                        OutOfScope = [],
+                        AcceptanceCriteria = [],
+                        DeterministicReviewChecks = [],
+                        ExpectedEvidence = []
+                    },
+                    ArtifactPath = ".intent-cli/implement/G25.request.md"
+                };
+            };
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.DoesNotContain("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("initial repo-inspection command completed", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(1, session.RetryCount);
+            Assert.Contains("initial repo-inspection command completed", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.result.json")));
+            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("failed", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("retry-attempted", runEvents[^2].Event);
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "auto-resumed", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.RunImplementExecutor = originalRunImplementExecutor;
+            RunSuperviseCommand.TerminalFailureRaceWindow = originalRaceWindow;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenDeadImplementWorkerSessionAfterInitialInventory_BlocksWithoutAutoResume()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- extend deterministic direct-run boundary classification from fix to implement sessions
- preserve initial-inventory progress by ordering same-session provider events by timestamp before boundary analysis
- block dead implement sessions with a canonical contract-gap boundary instead of generic retry exhaustion

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter DirectRunFixOutcomeSupportTests --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter RunSuperviseCommandTests --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter RunCommandTests --nologo
- dotnet test IntentSystem.sln --nologo

## Notes
- live toy-calc verification was not run from this worktree because reproducing the detached child flow would mutate parent intent/runtime state outside this repo; coverage is provided by the new implement-session regression tests.

Relates to #348