### PR TITLE
[G130] Re-Enter Fresh Implement Launch Instead Of Reusing Stale Failed Result

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -170,6 +170,27 @@ internal static class RunCommand
                             continue;
                         }
 
+                        var implementRequestArtifact = TryReadDirectRunRequestArtifact(context, inProgressItem.ExecutionUnit);
+                        var implementResultArtifact = TryReadDirectRunResultArtifact(
+                            context,
+                            inProgressItem.ExecutionUnit,
+                            "implement");
+                        if (ShouldLaunchFreshImplementAttempt(
+                                context,
+                                inProgressItem.ExecutionUnit,
+                                implementRequestArtifact,
+                                implementResultArtifact))
+                        {
+                            ClearActiveQueueBlockedBy(context, inProgressItem.ExecutionUnit);
+                            ExecuteAction(
+                                context,
+                                actions,
+                                "run implement",
+                                inProgressItem.ExecutionUnit,
+                                () => RunImplementExecutor(context, inProgressItem.ExecutionUnit));
+                            continue;
+                        }
+
                         var superviseResult = ExecuteAction(
                             context,
                             actions,
@@ -1542,6 +1563,66 @@ internal static class RunCommand
             DescribeSupervisionResult(superviseResult));
     }
 
+    internal static bool ShouldLaunchFreshImplementAttempt(
+        CliContext context,
+        string executionUnit,
+        DirectRunRequestArtifact? requestArtifact,
+        DirectRunResultArtifact? resultArtifact)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var latestActivatedAt = TryResolveLatestActivatedTimestamp(context, executionUnit);
+        if (HasBlockingImplementSupervisionSession(context, executionUnit, latestActivatedAt))
+        {
+            return false;
+        }
+
+        if (requestArtifact is null
+            || resultArtifact is null
+            || !string.Equals(requestArtifact.EntryKind, "implement", StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.RunStatus, "failed", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (DirectRunSessionBoundary.TryParseLaunchedAt(requestArtifact.LaunchedAt, out var launchedAt)
+            && latestActivatedAt is not null
+            && latestActivatedAt <= launchedAt)
+        {
+            return false;
+        }
+
+        if (!MatchesCurrentDirectRunRequestBoundary(requestArtifact, resultArtifact))
+        {
+            return false;
+        }
+
+        if (string.Equals(resultArtifact.RunStatus, "running", StringComparison.Ordinal)
+            || string.Equals(resultArtifact.RunStatus, "succeeded", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (latestActivatedAt is null)
+        {
+            return false;
+        }
+
+        var latestActivityAt = TryResolveCurrentImplementSessionLatestActivityAt(context, executionUnit, requestArtifact);
+        if (latestActivityAt is not null && latestActivatedAt > latestActivityAt)
+        {
+            return true;
+        }
+
+        if (!DirectRunSessionBoundary.TryParseLaunchedAt(requestArtifact.LaunchedAt, out launchedAt))
+        {
+            return false;
+        }
+
+        return latestActivatedAt > launchedAt;
+    }
+
     internal static bool ShouldLaunchFreshFixAttempt(
         CliContext context,
         string executionUnit,
@@ -1761,6 +1842,32 @@ internal static class RunCommand
         }
 
         return true;
+    }
+
+    private static bool HasBlockingImplementSupervisionSession(
+        CliContext context,
+        string executionUnit,
+        DateTimeOffset? latestActivatedAt)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        if (!TryReadSupervisionSession(context, executionUnit, out var session))
+        {
+            return false;
+        }
+
+        if (session.WorkerEntry != RunSupervisionWorkerEntry.Implement)
+        {
+            return true;
+        }
+
+        if (session.Status == RunSupervisionSessionStatus.Blocked)
+        {
+            return latestActivatedAt is null || latestActivatedAt <= session.UpdatedAt;
+        }
+
+        return latestActivatedAt is null || latestActivatedAt <= session.UpdatedAt;
     }
 
     private static bool TryReadSupervisionSession(
@@ -1987,6 +2094,48 @@ internal static class RunCommand
         return latestActivityAt;
     }
 
+    private static DateTimeOffset? TryResolveCurrentImplementSessionLatestActivityAt(
+        CliContext context,
+        string executionUnit,
+        DirectRunRequestArtifact? requestArtifact)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        if (requestArtifact is null
+            || !string.Equals(requestArtifact.EntryKind, "implement", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var providerEvents = TryReadDirectRunProviderEvents(context, executionUnit);
+        if (providerEvents.Count == 0)
+        {
+            return null;
+        }
+
+        providerEvents = SelectCurrentSessionEvents(
+            providerEvents,
+            requestArtifact.ProviderSessionId,
+            requestArtifact.LaunchedAt);
+
+        DateTimeOffset? latestActivityAt = null;
+        foreach (var providerEvent in providerEvents)
+        {
+            if (!DateTimeOffset.TryParse(providerEvent.Timestamp, out var parsedTimestamp))
+            {
+                continue;
+            }
+
+            if (latestActivityAt is null || parsedTimestamp > latestActivityAt.Value)
+            {
+                latestActivityAt = parsedTimestamp;
+            }
+        }
+
+        return latestActivityAt;
+    }
+
     private static IReadOnlyList<DirectRunProviderEvent> TryReadDirectRunProviderEvents(CliContext context, string executionUnit)
     {
         var providerLogRef = ResolveDirectRunProviderLogRef(context, executionUnit);
@@ -2050,6 +2199,31 @@ internal static class RunCommand
             var runEvent = runEvents[index];
             if (string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
                 && string.Equals(runEvent.Event, "fix-requested", StringComparison.Ordinal))
+            {
+                return runEvent.Ts;
+            }
+        }
+
+        return null;
+    }
+
+    private static DateTimeOffset? TryResolveLatestActivatedTimestamp(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            return null;
+        }
+
+        var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        for (var index = runEvents.Count - 1; index >= 0; index--)
+        {
+            var runEvent = runEvents[index];
+            if (string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                && string.Equals(runEvent.Event, "activated", StringComparison.Ordinal))
             {
                 return runEvent.Ts;
             }
@@ -2485,6 +2659,32 @@ internal static class RunCommand
             && string.Equals(resultArtifact.Provider, requestArtifact.Provider, StringComparison.Ordinal)
             && string.Equals(resultArtifact.Model, requestArtifact.Model, StringComparison.Ordinal)
             && string.Equals(resultArtifact.SessionId, requestArtifact.ProviderSessionId, StringComparison.Ordinal);
+    }
+
+    private static void ClearActiveQueueBlockedBy(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var queueState = LoadQueueStateOrThrow(context);
+        var selectedItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+        if (selectedItem is null
+            || selectedItem.State != QueueItemState.Active
+            || selectedItem.BlockedBy.Count == 0)
+        {
+            return;
+        }
+
+        var updatedState = queueState with
+        {
+            UpdatedAt = TimestampFactory(),
+            Items = queueState.Items.Select(item =>
+                string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                    ? item with { BlockedBy = [] }
+                    : item).ToArray()
+        };
+        File.WriteAllText(context.GetQueueStatePath(), QueueStateSerializer.Serialize(updatedState));
     }
 
 

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -4605,6 +4605,214 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenReactivatedImplementWithStaleFailedResultFromOlderSession_LaunchesFreshImplement()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "TOY-CALC-V0-02"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            queueStatePath,
+            QueueStateSerializer.Serialize(CreateQueueState(
+                CreateQueueItem(QueueItemState.Active, executionUnit: "TOY-CALC-V0-02") with
+                {
+                    BlockedBy = ["Worker session 'pid:45803' for 'TOY-CALC-V0-02' exited with backend exit code 1."]
+                })));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            runLogPath,
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"TOY-CALC-V0-02","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"TOY-CALC-V0-02","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T12:05:00Z","execution_unit":"TOY-CALC-V0-02","event":"blocked","by":"intent-cli","reason":"Worker session 'pid:45803' for 'TOY-CALC-V0-02' exited with backend exit code 1."}
+            {"ts":"2026-04-10T12:15:00Z","execution_unit":"TOY-CALC-V0-02","event":"activated","by":"intent-cli"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "TOY-CALC-V0-02", "packet.yaml"),
+            """
+            execution_unit: "TOY-CALC-V0-02"
+
+            implementation_issue:
+              issue_title: "[G130] Re-Enter Fresh Implement Launch Instead Of Reusing Stale Failed Result"
+              goal: "Launch a fresh implement session after active re-entry."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/TOY-CALC-V0-02/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "TOY-CALC-V0-02.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "TOY-CALC-V0-02.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "TOY-CALC-V0-02",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                Status = RunSupervisionSessionStatus.Blocked,
+                QueueState = "blocked",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "TOY-CALC-V0-02"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-130-toy-calc-v0-02",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                HandoffArtifactRef = ".intent-cli/implement/TOY-CALC-V0-02.request.md",
+                RetryCount = 0,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:05:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T12:05:00Z"),
+                LastInterruptionReason = "Worker session 'pid:45803' for 'TOY-CALC-V0-02' exited with backend exit code 1."
+            }));
+        WriteDirectRunRequest(
+            repoRoot,
+            "TOY-CALC-V0-02",
+            "implement",
+            "pid:45803",
+            provider: "Codex",
+            launchedAt: "2026-04-10T12:00:00.0000000+00:00");
+        WriteDirectRunResult(
+            repoRoot,
+            "TOY-CALC-V0-02",
+            "implement",
+            "failed",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:05:00.0000000+00:00",
+                    ExecutionUnit = "TOY-CALC-V0-02",
+                    Provider = "Codex",
+                    EntryKind = "implement",
+                    SessionId = "pid:45803",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                }
+            ],
+            sessionId: "pid:45803",
+            provider: "Codex");
+        var originalRunImplementExecutor = RunCommand.RunImplementExecutor;
+        var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
+
+        try
+        {
+            RunCommand.RunImplementExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunRequest(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "pid:4242",
+                    provider: "Codex",
+                    launchedAt: "2026-04-10T12:21:00.0000000+00:00");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "running",
+                    providerEvents:
+                    [
+                        new DirectRunProviderEvent
+                        {
+                            Timestamp = "2026-04-10T12:21:00.0000000+00:00",
+                            ExecutionUnit = executionUnit,
+                            Provider = "Codex",
+                            EntryKind = "implement",
+                            SessionId = "pid:4242",
+                            Kind = "session-metadata",
+                            Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                            {
+                                model = "gpt-5.4-mini",
+                                transport = "responses",
+                                command = "codex"
+                            })
+                        }
+                    ],
+                    sessionId: "pid:4242",
+                    provider: "Codex");
+                File.AppendAllText(
+                    runLogPath,
+                    RunLogSerializer.SerializeLine(new RunEvent
+                    {
+                        Ts = DateTimeOffset.Parse("2026-04-10T12:21:00Z"),
+                        ExecutionUnit = executionUnit,
+                        Event = "provider-lifecycle",
+                        By = "intent-cli",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        EntryKind = "implement",
+                        Provider = "Codex",
+                        Model = "gpt-5.4-mini",
+                        SessionId = "pid:4242",
+                        RunStatus = "running",
+                        RawLogRef = $".intent-cli/runs/{executionUnit}.provider.jsonl",
+                        ResultRef = $".intent-cli/runs/{executionUnit}.result.json",
+                        PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit)
+                    }) + Environment.NewLine);
+
+                return new RunImplementResult
+                {
+                    Request = CreateRunImplementRequest(repoRoot, executionUnit),
+                    ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md",
+                    DirectRun = CreateDirectRunLaunchResult(executionUnit, "pid:4242")
+                };
+            };
+            RunCommand.RunSuperviseExecutor = (_, executionUnit) => new RunSuperviseResult
+            {
+                ExecutionUnit = executionUnit,
+                SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                RetryCount = 0,
+                RetryBudget = 3,
+                HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md"
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("TOY-CALC-V0-02", result.ExecutionUnit);
+            Assert.Equal(2, result.Actions.Count);
+            Assert.Equal("run implement", result.Actions[0].Name);
+            Assert.Equal("run supervise", result.Actions[1].Name);
+            Assert.Contains("under supervision", result.Detail, StringComparison.Ordinal);
+
+            var requestArtifact = DirectRunRequestArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "TOY-CALC-V0-02.request.json")));
+            Assert.Equal("pid:4242", requestArtifact.ProviderSessionId);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "TOY-CALC-V0-02.result.json")));
+            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "TOY-CALC-V0-02");
+            Assert.Equal(QueueItemState.Active, selectedItem.State);
+            Assert.Empty(selectedItem.BlockedBy);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Contains(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "provider-lifecycle", StringComparison.Ordinal)
+                && string.Equals(runEvent.SessionId, "pid:4242", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunCommand.RunImplementExecutor = originalRunImplementExecutor;
+            RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
+        }
+    }
+
+    [Fact]
     public async Task ExecuteCore_GivenStartupOnlyDeadFixWorkerSessionWhenBackendExitLandsDuringRaceWindow_StopsWithNonRetryableFailureDetail()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- relaunch active implement work when a reactivated item still points at a stale failed implement session from before the latest `activated` event
- clear stale `blocked_by` on the active queue item before relaunching so queue/result artifacts stay aligned
- add focused `RunCommand` regression coverage for stale failed implement re-entry and preserve the existing inspection-boundary reconciliation path

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests.ExecuteCore_GivenReactivatedImplement" --nologo`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests" --nologo`
- `dotnet test IntentSystem.sln --nologo` (other test projects passed; the run did not finish because `IntentSystem.Cli.Tests` stayed open in a child-process monitor case)

## Live Verification
- The current `/Users/tomohisa/dev/GitHub/MyIntentHost` workspace no longer contains the exact `TOY-CALC-V0-02` stale runtime artifacts described in issue 350, so a true live-state repro could not be rerun as written.
- I attempted an isolated toy-calc repro against a temp copy of the parent repo; it cleared stale active `blocked_by`, but the hand-built packet shape hit a packet contract gap before a real implement launch, so I am not counting that as acceptance-grade live verification.

Closes #350
