### PR TITLE
Fix evidence-only repair follow-up contract-gap classification

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -60,6 +60,31 @@ internal static class DirectRunFixOutcomeSupport
         "decide whether this is a repair or a contract-gap refusal",
         "decide whether this is a repair or a contract gap refusal"
     ];
+    private static readonly string[] EvidenceOnlyReviewFollowUpMarkers =
+    [
+        "stronger verification",
+        "real process-boundary test",
+        "real process boundary test",
+        "process-boundary test",
+        "process boundary test",
+        "invalid-usage assertions",
+        "invalid usage assertions",
+        "exact exit 1",
+        "exact exit code",
+        "exit code == 1",
+        "empty stdout",
+        "canonical stderr"
+    ];
+    private static readonly string[] EvidenceOnlyReviewFollowUpContextMarkers =
+    [
+        "review asks",
+        "review comment asks",
+        "comment asks",
+        "narrower contract detail",
+        "repo-local intent/spec artifacts lag implementation",
+        "repo-local intent/spec artifacts",
+        "repo-local spec artifacts lag implementation"
+    ];
     private static readonly string[] NoOpEditFreeMarkers =
     [
         "without requiring code changes",
@@ -696,6 +721,11 @@ internal static class DirectRunFixOutcomeSupport
             {
                 detail = $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' reported a deterministic contract gap.";
             }
+            else if (IsEvidenceOnlyReviewFollowUpContractGapReference(detail))
+            {
+                detail = string.Empty;
+                return false;
+            }
 
             return true;
         }
@@ -706,6 +736,11 @@ internal static class DirectRunFixOutcomeSupport
             if (!TryReadString(payload, "detail", out detail))
             {
                 detail = $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' reported a deterministic contract gap.";
+            }
+            else if (IsEvidenceOnlyReviewFollowUpContractGapReference(detail))
+            {
+                detail = string.Empty;
+                return false;
             }
 
             return true;
@@ -728,6 +763,11 @@ internal static class DirectRunFixOutcomeSupport
             return false;
         }
 
+        if (IsEvidenceOnlyReviewFollowUpContractGapReference(lower))
+        {
+            return false;
+        }
+
         if (lower.Contains("contract-gap refusal", StringComparison.Ordinal)
             || lower.Contains("contract gap refusal", StringComparison.Ordinal)
             || lower.Contains("stopped with a contract-gap explanation", StringComparison.Ordinal)
@@ -739,6 +779,17 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         return false;
+    }
+
+    private static bool IsEvidenceOnlyReviewFollowUpContractGapReference(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+
+        var normalized = value.Trim().ToLowerInvariant();
+        return EvidenceOnlyReviewFollowUpMarkers.Any(marker =>
+                normalized.Contains(marker, StringComparison.Ordinal))
+            && EvidenceOnlyReviewFollowUpContextMarkers.Any(marker =>
+                normalized.Contains(marker, StringComparison.Ordinal));
     }
 
     private static bool IsPlanningPreambleContractGapReference(string value)

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -10,6 +10,7 @@ internal static class DirectRunFixOutcomeSupport
     private const string ProviderBackendEndedBeforeSpecSourceReadReasonSuffix = "session-ended-before-spec-source-test-read";
     private const string MissingTerminalCaptureAfterRequestReadReasonSuffix = "session-terminal-boundary-missing-after-request-reread";
     private const string MissingTerminalCaptureAfterDeepProgressReasonSuffix = "session-terminal-boundary-missing-after-deep-progress";
+    private const string EvidenceOnlyReviewFollowUpMissingOutcomeReasonSuffix = "evidence-only-review-follow-up-ended-without-bounded-repair-outcome";
     private static readonly string[] StartupWarningMarkers =
     [
         "warn",
@@ -130,6 +131,18 @@ internal static class DirectRunFixOutcomeSupport
                 out var explicitContractGapEvent))
         {
             return explicitContractGapEvent;
+        }
+
+        if (TryCreateEvidenceOnlyReviewFollowUpFailureEvent(
+                orderedProviderEvents,
+                timestamp,
+                executionUnit,
+                entryKind,
+                provider,
+                providerSessionId,
+                out var evidenceOnlyReviewFollowUpFailureEvent))
+        {
+            return evidenceOnlyReviewFollowUpFailureEvent;
         }
 
         if (!TryResolveCanonicalFailureDetail(
@@ -653,6 +666,53 @@ internal static class DirectRunFixOutcomeSupport
         return true;
     }
 
+    private static bool TryCreateEvidenceOnlyReviewFollowUpFailureEvent(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        DateTimeOffset timestamp,
+        string executionUnit,
+        string entryKind,
+        string provider,
+        string providerSessionId,
+        out DirectRunProviderEvent? providerEvent)
+    {
+        providerEvent = null;
+        if (!string.Equals(entryKind, "fix", StringComparison.Ordinal)
+            || !HasSuccessfulBackendExit(providerEvents)
+            || !HasEvidenceOnlyReviewFollowUpContractGapReference(providerEvents)
+            || TryResolveNoOpSuccessDetail(providerEvents, executionUnit, out _)
+            || HasBoundedRepairOutcomeSignal(providerEvents))
+        {
+            return false;
+        }
+
+        var observedRequestReread = providerEvents.Any(providerEvent => ContainsRequestArtifactRead(providerEvent.Payload));
+        var observedInventory = providerEvents.Any(providerEvent => ContainsInitialRepoInventory(providerEvent.Payload));
+        var observedRepoLocalSpecRead = HasSuccessfulRepoLocalSpecRead(providerEvents);
+        var observedProductSourceOrTestRead = providerEvents.Any(providerEvent => ContainsProductSourceOrTestReadAttempt(providerEvent.Payload));
+        var observedBoundedRepairOutcome = HasBoundedRepairOutcomeSignal(providerEvents);
+
+        providerEvent = new DirectRunProviderEvent
+        {
+            Timestamp = timestamp.ToString("O"),
+            ExecutionUnit = executionUnit,
+            Provider = provider,
+            EntryKind = entryKind,
+            SessionId = providerSessionId,
+            Kind = "provider-event",
+            Payload = JsonSerializer.SerializeToElement(new
+            {
+                type = "contract-gap",
+                stop_reason = DeterministicContractGapStopReason,
+                reason = ResolveReason(entryKind, EvidenceOnlyReviewFollowUpMissingOutcomeReasonSuffix),
+                detail =
+                    $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' ended after evidence-only review-follow-up ambiguity without a bounded repair outcome. Current-session evidence observed request_reread={observedRequestReread}, repo_inventory={observedInventory}, repo_local_spec_read={observedRepoLocalSpecRead}, product_source_or_test_read={observedProductSourceOrTestRead}, bounded_repair_outcome={observedBoundedRepairOutcome}. The session emitted evidence-only uncertainty about whether repo-local intent/spec artifacts lag implementation or whether the review asks for a narrower contract detail, then exited successfully without a same-session repair, verification command, no-op success boundary, or explicit refusal. Root runtime handling must preserve this as a bounded repair failure instead of silently treating exit_code=0 as success.",
+                run_status = "failed"
+            })
+        };
+
+        return true;
+    }
+
     private static bool HasExplicitContractGap(IReadOnlyList<DirectRunProviderEvent> providerEvents)
     {
         return providerEvents.Any(providerEvent =>
@@ -790,6 +850,31 @@ internal static class DirectRunFixOutcomeSupport
                 normalized.Contains(marker, StringComparison.Ordinal))
             && EvidenceOnlyReviewFollowUpContextMarkers.Any(marker =>
                 normalized.Contains(marker, StringComparison.Ordinal));
+    }
+
+    private static bool HasEvidenceOnlyReviewFollowUpContractGapReference(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        foreach (var providerEvent in providerEvents)
+        {
+            foreach (var value in EnumeratePayloadStrings(providerEvent.Payload))
+            {
+                if (IsEvidenceOnlyReviewFollowUpContractGapReference(value))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasBoundedRepairOutcomeSignal(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        return providerEvents.Any(providerEvent => ContainsBoundedRepairOutcomeSignal(providerEvent.Payload));
     }
 
     private static bool IsPlanningPreambleContractGapReference(string value)
@@ -1067,12 +1152,49 @@ internal static class DirectRunFixOutcomeSupport
         return false;
     }
 
+    private static bool ContainsBoundedRepairOutcomeSignal(JsonElement payload)
+    {
+        foreach (var value in EnumeratePayloadStrings(payload))
+        {
+            var normalized = value.Trim().ToLowerInvariant();
+            if (normalized.Contains("apply_patch", StringComparison.Ordinal)
+                || normalized.Contains("dotnet test", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            if (!LooksLikeCommandInvocation(normalized)
+                || ContainsReadCommand(normalized)
+                || normalized.Contains("rg --files", StringComparison.Ordinal)
+                || normalized.Contains("git status", StringComparison.Ordinal)
+                || normalized.Contains("git diff", StringComparison.Ordinal)
+                || normalized.Contains("pwd", StringComparison.Ordinal)
+                || normalized.Contains("ls ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
     private static bool ContainsReadCommand(string normalized)
     {
         return normalized.Contains("cat ", StringComparison.Ordinal)
             || normalized.Contains("sed -n", StringComparison.Ordinal)
             || normalized.Contains("head ", StringComparison.Ordinal)
             || normalized.Contains("tail ", StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeCommandInvocation(string normalized)
+    {
+        return normalized.StartsWith("/bin/", StringComparison.Ordinal)
+            || normalized.StartsWith("exec /bin/", StringComparison.Ordinal)
+            || normalized.Contains(" -lc ", StringComparison.Ordinal)
+            || normalized.Contains("dotnet ", StringComparison.Ordinal)
+            || normalized.Contains("dnx ", StringComparison.Ordinal);
     }
 
     private static bool TryResolveCommandOutcome(

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -61,6 +61,16 @@ internal static class DirectRunFixOutcomeSupport
         "decide whether this is a repair or a contract-gap refusal",
         "decide whether this is a repair or a contract gap refusal"
     ];
+    private static readonly string[] StartupPlanningContractGapReadMarkers =
+    [
+        "i’m reading the request artifact first",
+        "i'm reading the request artifact first"
+    ];
+    private static readonly string[] StartupPlanningContractGapDecisionMarkers =
+    [
+        "either patch it or give a concrete contract-gap refusal",
+        "either patch it or give a concrete contract gap refusal"
+    ];
     private static readonly string[] EvidenceOnlyReviewFollowUpMarkers =
     [
         "stronger verification",
@@ -891,7 +901,11 @@ internal static class DirectRunFixOutcomeSupport
         return PlanningPreambleContractGapPrefixes.Any(prefix =>
                 normalized.StartsWith(prefix, StringComparison.Ordinal))
             || PlanningPreambleContractGapMarkers.Any(marker =>
-                normalized.Contains(marker, StringComparison.Ordinal));
+                normalized.Contains(marker, StringComparison.Ordinal))
+            || (StartupPlanningContractGapReadMarkers.Any(marker =>
+                    normalized.Contains(marker, StringComparison.Ordinal))
+                && StartupPlanningContractGapDecisionMarkers.Any(marker =>
+                    normalized.Contains(marker, StringComparison.Ordinal)));
     }
 
     private static bool SupportsEntryKind(string entryKind)

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -66,10 +66,26 @@ internal static class DirectRunFixOutcomeSupport
         "i’m reading the request artifact first",
         "i'm reading the request artifact first"
     ];
+    private static readonly string[] StartupPlanningContractGapActionMarkers =
+    [
+        "i’ll inspect",
+        "i'll inspect",
+        "after that i’ll either",
+        "after that i'll either",
+        "either patch it",
+        "either implement the fix and verify it",
+        "pin down the bounded scope",
+        "reproduce and repair it",
+        "validate the bounded fix"
+    ];
     private static readonly string[] StartupPlanningContractGapDecisionMarkers =
     [
         "either patch it or give a concrete contract-gap refusal",
-        "either patch it or give a concrete contract gap refusal"
+        "either patch it or give a concrete contract gap refusal",
+        "give a deterministic contract-gap refusal if",
+        "give a deterministic contract gap refusal if",
+        "give a concrete contract-gap refusal if",
+        "give a concrete contract gap refusal if"
     ];
     private static readonly string[] EvidenceOnlyReviewFollowUpMarkers =
     [
@@ -903,6 +919,8 @@ internal static class DirectRunFixOutcomeSupport
             || PlanningPreambleContractGapMarkers.Any(marker =>
                 normalized.Contains(marker, StringComparison.Ordinal))
             || (StartupPlanningContractGapReadMarkers.Any(marker =>
+                    normalized.Contains(marker, StringComparison.Ordinal))
+                && StartupPlanningContractGapActionMarkers.Any(marker =>
                     normalized.Contains(marker, StringComparison.Ordinal))
                 && StartupPlanningContractGapDecisionMarkers.Any(marker =>
                     normalized.Contains(marker, StringComparison.Ordinal)));

--- a/src/IntentSystem.Cli/Commands/DirectRunTerminalArtifactUpdater.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunTerminalArtifactUpdater.cs
@@ -119,10 +119,33 @@ internal static class DirectRunTerminalArtifactUpdater
             return;
         }
 
+        IReadOnlyList<DirectRunProviderEvent> currentProviderEvents = [];
+        if (TryReadCurrentProviderEvents(
+                providerEventLogPath,
+                providerSessionId,
+                launchedAt,
+                out var resolvedCurrentProviderEvents))
+        {
+            currentProviderEvents = resolvedCurrentProviderEvents;
+            if ((string.Equals(resultArtifact.EntryKind, "fix", StringComparison.Ordinal)
+                    || string.Equals(resultArtifact.EntryKind, "implement", StringComparison.Ordinal))
+                && DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+                    currentProviderEvents,
+                    DateTimeOffset.UtcNow,
+                    resultArtifact.ExecutionUnit,
+                    resultArtifact.EntryKind,
+                    resultArtifact.Provider,
+                    providerSessionId,
+                    providerSessionAlive: true) is { } boundaryEvent)
+            {
+                var writer = new DirectRunProviderEventWriter(providerEventLogPath);
+                writer.Append(boundaryEvent);
+                currentProviderEvents = [.. currentProviderEvents, boundaryEvent];
+            }
+        }
+
         var terminalStatus = ResolveEffectiveTerminalRunStatus(
-            providerEventLogPath,
-            providerSessionId,
-            launchedAt,
+            currentProviderEvents,
             exitCode);
         if (string.Equals(resultArtifact.RunStatus, terminalStatus, StringComparison.Ordinal))
         {
@@ -224,29 +247,12 @@ internal static class DirectRunTerminalArtifactUpdater
     }
 
     private static string ResolveEffectiveTerminalRunStatus(
-        string providerEventLogPath,
-        string providerSessionId,
-        DateTimeOffset launchedAt,
+        IReadOnlyList<DirectRunProviderEvent> currentProviderEvents,
         int exitCode)
     {
-        try
+        if (currentProviderEvents.Any(providerEvent => IsExplicitFailureBoundary(providerEvent.Payload)))
         {
-            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
-            var currentProviderEvents = DirectRunSessionBoundary.SelectEvents(
-                providerEvents,
-                providerSessionId,
-                launchedAt);
-            if (currentProviderEvents.Any(providerEvent => IsExplicitFailureBoundary(providerEvent.Payload)))
-            {
-                return "failed";
-            }
-        }
-        catch (Exception exception) when (
-            exception is IOException
-            or InvalidOperationException
-            or ArgumentException
-            or JsonException)
-        {
+            return "failed";
         }
 
         return exitCode == 0 ? "succeeded" : "failed";

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -428,6 +428,73 @@ public sealed class DirectRunFixOutcomeSupportTests
         Assert.Null(contractGapEvent);
     }
 
+    [Fact]
+    public void HasExplicitContractGapSignal_GivenEvidenceOnlyReviewFollowUpContractGapUncertainty_ReturnsFalse()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("I cannot tell whether repo-local intent/spec artifacts lag implementation or whether the review comment asks for a narrower contract detail, but the comment asks for stronger verification: add a real process-boundary test and tighten invalid-usage assertions to exact exit code == 1, empty stdout, and canonical stderr."),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' tests/ToyCalc.Tests/CalculatorTests.cs' succeeded in 0ms")
+        ];
+
+        var resolved = DirectRunFixOutcomeSupport.HasExplicitContractGapSignal(providerEvents);
+
+        Assert.False(resolved);
+    }
+
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenEvidenceOnlyReviewFollowUpContractGapUncertaintyAndSuccessfulBackendExit_DoesNotCreateFailureBoundary()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-02.request.md' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' tests/ToyCalc.Tests/ProgramBoundaryTests.cs' succeeded in 0ms"),
+            CreateProviderEvent("I cannot tell whether repo-local intent/spec artifacts lag implementation or whether the review asks for a narrower contract detail, but the comment asks for stronger verification: add a real process-boundary test and tighten invalid-usage assertions to exact exit code == 1, empty stdout, and canonical stderr."),
+            CreateProviderEvent("Verified direct process boundary evidence: invalid usage exits 1 with empty stdout and canonical stderr; success exits 0 with stdout 5."),
+            CreateSuccessfulBackendExitEvent()
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-20T04:10:00Z"),
+            "TOY-CALC-V0-02",
+            "fix",
+            "Codex",
+            "pid:11911",
+            providerSessionAlive: false);
+
+        Assert.Null(contractGapEvent);
+    }
+
+    [Fact]
+    public void HasExplicitContractGapSignal_GivenContractGapPayloadForEvidenceOnlyReviewFollowUp_ReturnsFalse()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-02.request.md' succeeded in 0ms"),
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-20T04:09:59.0000000+00:00",
+                ExecutionUnit = "TOY-CALC-V0-02",
+                Provider = "Codex",
+                EntryKind = "fix",
+                SessionId = "pid:11911",
+                Kind = "provider-event",
+                Payload = JsonSerializer.SerializeToElement(new
+                {
+                    type = "contract-gap",
+                    stop_reason = "deterministic-contract-gap",
+                    detail = "Worker cannot tell whether repo-local intent/spec artifacts lag implementation or whether the review comment asks for a narrower contract detail, but the comment asks for stronger verification: add a real process-boundary test and tighten invalid-usage assertions to exact exit code == 1, empty stdout, and canonical stderr."
+                })
+            }
+        ];
+
+        var resolved = DirectRunFixOutcomeSupport.HasExplicitContractGapSignal(providerEvents);
+
+        Assert.False(resolved);
+    }
+
     private static IReadOnlyList<DirectRunProviderEvent> CreateIssue295CurrentSessionRawEvents(string? echoedRequest = null)
     {
         return

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -443,7 +443,7 @@ public sealed class DirectRunFixOutcomeSupportTests
     }
 
     [Fact]
-    public void CreateCanonicalContractGapEventIfNeeded_GivenEvidenceOnlyReviewFollowUpContractGapUncertaintyAndSuccessfulBackendExit_DoesNotCreateFailureBoundary()
+    public void CreateCanonicalContractGapEventIfNeeded_GivenEvidenceOnlyReviewFollowUpContractGapUncertaintyAndSuccessfulBackendExitWithoutBoundedOutcome_CreatesFailureBoundary()
     {
         IReadOnlyList<DirectRunProviderEvent> providerEvents =
         [
@@ -451,7 +451,42 @@ public sealed class DirectRunFixOutcomeSupportTests
             CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
             CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' tests/ToyCalc.Tests/ProgramBoundaryTests.cs' succeeded in 0ms"),
             CreateProviderEvent("I cannot tell whether repo-local intent/spec artifacts lag implementation or whether the review asks for a narrower contract detail, but the comment asks for stronger verification: add a real process-boundary test and tighten invalid-usage assertions to exact exit code == 1, empty stdout, and canonical stderr."),
-            CreateProviderEvent("Verified direct process boundary evidence: invalid usage exits 1 with empty stdout and canonical stderr; success exits 0 with stdout 5."),
+            CreateSuccessfulBackendExitEvent()
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-20T04:10:00Z"),
+            "TOY-CALC-V0-02",
+            "fix",
+            "Codex",
+            "pid:11911",
+            providerSessionAlive: false);
+
+        Assert.NotNull(contractGapEvent);
+        Assert.Equal(
+            "fix-evidence-only-review-follow-up-ended-without-bounded-repair-outcome",
+            contractGapEvent!.Payload.GetProperty("reason").GetString());
+        Assert.Contains(
+            "bounded repair outcome",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenEvidenceOnlyReviewFollowUpContractGapUncertaintyAndSuccessfulBackendExitWithVerificationCommand_DoesNotCreateFailureBoundary()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-02.request.md' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' tests/ToyCalc.Tests/ProgramBoundaryTests.cs' succeeded in 0ms"),
+            CreateProviderEvent("I cannot tell whether repo-local intent/spec artifacts lag implementation or whether the review asks for a narrower contract detail, but the comment asks for stronger verification: add a real process-boundary test and tighten invalid-usage assertions to exact exit code == 1, empty stdout, and canonical stderr."),
+            CreateProviderEvent("/bin/zsh -lc './bin/Debug/net10.0/toycalc --bad-args' in /repo/.intent-cli/worktrees/TOY-CALC-V0-02"),
+            CreateProviderEvent(" exited 1 in 0ms:"),
+            CreateProviderEvent("Usage: toycalc <left> <op> <right>"),
+            CreateProviderEvent("/bin/zsh -lc './bin/Debug/net10.0/toycalc 2 + 3' in /repo/.intent-cli/worktrees/TOY-CALC-V0-02"),
+            CreateProviderEvent(" succeeded in 0ms:"),
             CreateSuccessfulBackendExitEvent()
         ];
 

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -464,6 +464,41 @@ public sealed class DirectRunFixOutcomeSupportTests
     }
 
     [Fact]
+    public void HasExplicitContractGapSignal_GivenStartupPlanningSentenceWithDeterministicContractGapRefusalIfUnderspecified_ReturnsFalse()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("I’m reading the request artifact first to pin down the bounded scope, then I’ll inspect the minimum repo surface needed to reproduce and repair it. After that I’ll either implement the fix and verify it, or give a deterministic contract-gap refusal if the artifact is underspecified."),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-02.request.md' succeeded in 0ms")
+        ];
+
+        var resolved = DirectRunFixOutcomeSupport.HasExplicitContractGapSignal(providerEvents);
+
+        Assert.False(resolved);
+    }
+
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenStartupPlanningSentenceWithDeterministicContractGapRefusalIfUnderspecifiedWhileSessionIsAlive_DoesNotCreateFailureBoundary()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-02.request.md' succeeded in 0ms"),
+            CreateProviderEvent("I’m reading the request artifact first to pin down the bounded scope, then I’ll inspect the minimum repo surface needed to reproduce and repair it. After that I’ll either implement the fix and verify it, or give a deterministic contract-gap refusal if the artifact is underspecified.")
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-21T02:15:00Z"),
+            "TOY-CALC-V0-02",
+            "fix",
+            "Codex",
+            "pid:8054",
+            providerSessionAlive: true);
+
+        Assert.Null(contractGapEvent);
+    }
+
+    [Fact]
     public void HasExplicitContractGapSignal_GivenEvidenceOnlyReviewFollowUpContractGapUncertainty_ReturnsFalse()
     {
         IReadOnlyList<DirectRunProviderEvent> providerEvents =

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -429,6 +429,41 @@ public sealed class DirectRunFixOutcomeSupportTests
     }
 
     [Fact]
+    public void HasExplicitContractGapSignal_GivenStartupPlanningSentenceMentionsConcreteContractGapRefusal_ReturnsFalse()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("I’m reading the request artifact first, then I’ll inspect the smallest set of repository files needed to validate the bounded fix and either patch it or give a concrete contract-gap refusal."),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-02.request.md' succeeded in 0ms")
+        ];
+
+        var resolved = DirectRunFixOutcomeSupport.HasExplicitContractGapSignal(providerEvents);
+
+        Assert.False(resolved);
+    }
+
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenStartupPlanningSentenceMentionsConcreteContractGapRefusalWhileSessionIsAlive_DoesNotCreateFailureBoundary()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/TOY-CALC-V0-02.request.md' succeeded in 0ms"),
+            CreateProviderEvent("I’m reading the request artifact first, then I’ll inspect the smallest set of repository files needed to validate the bounded fix and either patch it or give a concrete contract-gap refusal.")
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-21T01:10:00Z"),
+            "TOY-CALC-V0-02",
+            "fix",
+            "Codex",
+            "pid:8053",
+            providerSessionAlive: true);
+
+        Assert.Null(contractGapEvent);
+    }
+
+    [Fact]
     public void HasExplicitContractGapSignal_GivenEvidenceOnlyReviewFollowUpContractGapUncertainty_ReturnsFalse()
     {
         IReadOnlyList<DirectRunProviderEvent> providerEvents =

--- a/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunLauncherTests.cs
@@ -1921,6 +1921,122 @@ public sealed class DirectRunLauncherTests
     }
 
     [Fact]
+    public void PersistTerminalRunStatusIfCurrent_GivenEvidenceOnlyReviewFollowUpAmbiguityAndSuccessfulExit_AppendsFailureBoundaryAndFailsResult()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var providerEventLogPath = tempDirectory.GetPath(".intent-cli/runs/G14b-evidence.provider.jsonl");
+        var requestArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-evidence.request.json");
+        var resultArtifactPath = tempDirectory.GetPath(".intent-cli/runs/G14b-evidence.result.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(providerEventLogPath)!);
+
+        var launchedAt = DateTimeOffset.Parse("2026-04-20T23:40:00Z");
+        const string providerSessionId = "pid:11911";
+        File.WriteAllText(
+            requestArtifactPath,
+            DirectRunRequestArtifactJson.Serialize(new DirectRunRequestArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-evidence",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-evidence.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                Transport = "responses",
+                LaunchedAt = launchedAt.ToString("O"),
+                ProviderSessionId = providerSessionId,
+                TransportSummary = "launched via wrapper"
+            }));
+        File.WriteAllText(
+            resultArtifactPath,
+            DirectRunResultArtifactJson.Serialize(new DirectRunResultArtifact
+            {
+                SchemaVersion = "1",
+                ExecutionUnit = "G14b-evidence",
+                EntryKind = "fix",
+                UpstreamRequestRef = ".intent-cli/fix/G14b-evidence.request.md",
+                Provider = "Codex",
+                Model = "gpt-5.4-mini",
+                SessionId = providerSessionId,
+                RunStatus = "running",
+                RawLogRef = ".intent-cli/runs/G14b-evidence.provider.jsonl",
+                PacketRef = ".intent-cli/issues/G14b-evidence/packet.yaml",
+                ReviewContextRef = ".intent-cli/issues/G14b-evidence/review-context.md",
+                Worktree = new DirectRunWorktreeContext
+                {
+                    Path = "/repo/.intent-cli/worktrees/G14b-evidence"
+                }
+            }));
+
+        File.WriteAllText(
+            providerEventLogPath,
+            string.Join(
+                Environment.NewLine,
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.ToString("O"),
+                    ExecutionUnit = "G14b-evidence",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/G14b-evidence.request.md' succeeded in 0ms")
+                }),
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.AddMilliseconds(10).ToString("O"),
+                    ExecutionUnit = "G14b-evidence",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms")
+                }),
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.AddMilliseconds(20).ToString("O"),
+                    ExecutionUnit = "G14b-evidence",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("I cannot tell whether repo-local intent/spec artifacts lag implementation or whether the review comment asks for a narrower contract detail, but the comment asks for stronger verification: add a real process-boundary test and tighten invalid-usage assertions to exact exit code == 1, empty stdout, and canonical stderr.")
+                }),
+                DirectRunProviderEventJsonl.SerializeLine(new DirectRunProviderEvent
+                {
+                    Timestamp = launchedAt.AddMilliseconds(30).ToString("O"),
+                    ExecutionUnit = "G14b-evidence",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = providerSessionId,
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 0
+                    })
+                }),
+                string.Empty));
+
+        DirectRunTerminalArtifactUpdater.PersistTerminalRunStatusIfCurrent(
+            providerEventLogPath,
+            providerSessionId,
+            launchedAt,
+            exitCode: 0);
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(resultArtifactPath));
+        Assert.Equal("failed", resultArtifact.RunStatus);
+
+        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerEventLogPath));
+        Assert.Contains(providerEvents, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "contract-gap", StringComparison.Ordinal)
+            && providerEvent.Payload.TryGetProperty("reason", out var reasonElement)
+            && string.Equals(reasonElement.GetString(), "fix-evidence-only-review-follow-up-ended-without-bounded-repair-outcome", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void SynchronizeArtifactsToLatestSessionIfCurrent_GivenLaterCurrentSession_RewritesRequestAndResultArtifacts()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -3141,6 +3141,138 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenFixingItemWithEvidenceOnlyReviewFollowUpAmbiguityAfterSuccessfulExit_DoesNotSilentlyAdvanceIntoReview()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Fixing))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/226"}
+            {"ts":"2026-04-10T10:15:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/226#issuecomment-2","reason":"contract mismatch"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.comment.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "fix", "G226.request.md"),
+            "# Repair Worker Handoff");
+        WriteDirectRunRequest(
+            repoRoot,
+            "G226",
+            "fix",
+            "pid:11911",
+            provider: "Codex",
+            launchedAt: "2026-04-20T23:40:00.0000000+00:00");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "fix",
+            "running",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-20T23:40:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:11911",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/fix/G226.request.md' succeeded in 0ms")
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-20T23:40:00.0500000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:11911",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms")
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-20T23:40:00.1000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:11911",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("I cannot tell whether repo-local intent/spec artifacts lag implementation or whether the review comment asks for a narrower contract detail, but the comment asks for stronger verification: add a real process-boundary test and tighten invalid-usage assertions to exact exit code == 1, empty stdout, and canonical stderr.")
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-20T23:40:00.2000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Codex",
+                    EntryKind = "fix",
+                    SessionId = "pid:11911",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 0
+                    })
+                }
+            ],
+            sessionId: "pid:11911",
+            provider: "Codex");
+
+        DirectRunTerminalArtifactUpdater.PersistTerminalRunStatusIfCurrent(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl"),
+            "pid:11911",
+            DateTimeOffset.Parse("2026-04-20T23:40:00.0000000+00:00"),
+            exitCode: 0);
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("deterministic-contract-gap", result.StopReason);
+        Assert.Equal("G226", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("bounded repair outcome", result.Detail, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Fix direct run failed for 'G226'.", result.Detail, StringComparison.Ordinal);
+
+        var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+        Assert.Equal("failed", resultArtifact.RunStatus);
+
+        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G226.provider.jsonl")));
+        Assert.Contains(providerEvents, providerEvent =>
+            providerEvent.Kind == "provider-event"
+            && providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+            && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+            && string.Equals(typeElement.GetString(), "contract-gap", StringComparison.Ordinal)
+            && providerEvent.Payload.TryGetProperty("reason", out var reasonElement)
+            && string.Equals(reasonElement.GetString(), "fix-evidence-only-review-follow-up-ended-without-bounded-repair-outcome", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void ExecuteCore_GivenFixingItemWithFollowUpWorkAfterInitialInspection_DoesNotClassifyInspectionOnlyContractGap()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- suppress explicit contract-gap classification when a fix session is still handling evidence-only review follow-up work
- apply the same suppression to raw provider text and \`contract-gap\` payload details
- add regression tests covering the issue #359 wording and successful backend-exit follow-up path

## Validation
- \`dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~DirectRunFixOutcomeSupportTests" --nologo\`
- attempted \`dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo\` but the run stalled after test discovery in this environment

Closes #359