### PR TITLE
Repair review accept closeout against accepted worktree changes

### DIFF
--- a/src/IntentSystem.Review/ChildRepoMainSynchronizer.cs
+++ b/src/IntentSystem.Review/ChildRepoMainSynchronizer.cs
@@ -17,7 +17,15 @@ public static class ChildRepoMainSynchronizer
 
         Run(commandRunner, childRepoPath, ["fetch", "origin", "main"], "child repo fetch failed.");
         Run(commandRunner, childRepoPath, ["switch", "main"], "child repo switch to main failed.");
-        Run(commandRunner, childRepoPath, ["merge", "--ff-only", "origin/main"], "child repo main fast-forward failed.");
+        var mergeResult = commandRunner.Run(childRepoPath, ["merge", "--ff-only", "origin/main"]);
+        if (mergeResult.ExitCode != 0
+            && !TryReconcileAcceptedWorktreeState(commandRunner, childRepoPath, mergedCommitSha, mergeResult))
+        {
+            var error = string.IsNullOrWhiteSpace(mergeResult.StdErr)
+                ? "child repo main fast-forward failed."
+                : mergeResult.StdErr.Trim();
+            throw new InvalidOperationException(error);
+        }
 
         var headResult = Run(commandRunner, childRepoPath, ["rev-parse", "HEAD"], "child repo HEAD resolve failed.");
         var headCommit = headResult.StdOut.Trim();
@@ -51,5 +59,142 @@ public static class ChildRepoMainSynchronizer
         }
 
         return result;
+    }
+
+    private static bool TryReconcileAcceptedWorktreeState(
+        IGitCommandRunner commandRunner,
+        string childRepoPath,
+        string mergedCommitSha,
+        GitCommandResult mergeResult)
+    {
+        if (!TryResolveMergeOverwritePaths(
+                mergeResult.StdErr + Environment.NewLine + mergeResult.StdOut,
+                out var conflictingPaths,
+                out var untrackedConflictingPaths))
+        {
+            return false;
+        }
+
+        var statusResult = Run(
+            commandRunner,
+            childRepoPath,
+            ["status", "--porcelain=v1", "--untracked-files=all"],
+            "child repo status resolve failed.");
+        var dirtyPaths = ParseStatusPaths(statusResult.StdOut);
+        if (dirtyPaths.Count == 0)
+        {
+            return false;
+        }
+
+        var outOfScopeDirtyPaths = dirtyPaths
+            .Where(path => !conflictingPaths.Contains(path))
+            .ToArray();
+        if (outOfScopeDirtyPaths.Length > 0)
+        {
+            throw new InvalidOperationException(
+                $"child repo accepted closeout reconciliation found additional dirty paths outside the merge-overwrite set: {string.Join(", ", outOfScopeDirtyPaths)}");
+        }
+
+        if (untrackedConflictingPaths.Count > 0)
+        {
+            Run(
+                commandRunner,
+                childRepoPath,
+                ["clean", "-fd", "--", .. untrackedConflictingPaths],
+                "child repo accepted closeout clean failed.");
+        }
+
+        Run(
+            commandRunner,
+            childRepoPath,
+            ["reset", "--hard", mergedCommitSha],
+            "child repo accepted closeout reset failed.");
+
+        var postResetStatusResult = Run(
+            commandRunner,
+            childRepoPath,
+            ["status", "--porcelain=v1", "--untracked-files=all"],
+            "child repo status resolve failed.");
+        if (!string.IsNullOrWhiteSpace(postResetStatusResult.StdOut))
+        {
+            throw new InvalidOperationException(
+                "child repo accepted closeout reconciliation left unexpected worktree drift after resetting to the merged commit.");
+        }
+
+        return true;
+    }
+
+    private static bool TryResolveMergeOverwritePaths(
+        string value,
+        out HashSet<string> conflictingPaths,
+        out HashSet<string> untrackedConflictingPaths)
+    {
+        conflictingPaths = [];
+        untrackedConflictingPaths = [];
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var lines = value
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Trim())
+            .ToArray();
+
+        for (var index = 0; index < lines.Length; index++)
+        {
+            var line = lines[index];
+            var isUntrackedSection =
+                line.Contains("The following untracked working tree files would be overwritten by merge:", StringComparison.Ordinal);
+            var isTrackedSection =
+                line.Contains("Your local changes to the following files would be overwritten by merge:", StringComparison.Ordinal);
+            if (!isUntrackedSection && !isTrackedSection)
+            {
+                continue;
+            }
+
+            for (var pathIndex = index + 1; pathIndex < lines.Length; pathIndex++)
+            {
+                var candidate = lines[pathIndex];
+                if (candidate.StartsWith("Please ", StringComparison.Ordinal)
+                    || candidate.StartsWith("Aborting", StringComparison.Ordinal)
+                    || candidate.Contains("would be overwritten by merge", StringComparison.Ordinal))
+                {
+                    break;
+                }
+
+                conflictingPaths.Add(candidate);
+                if (isUntrackedSection)
+                {
+                    untrackedConflictingPaths.Add(candidate);
+                }
+            }
+        }
+
+        return conflictingPaths.Count > 0;
+    }
+
+    private static IReadOnlyList<string> ParseStatusPaths(string stdOut)
+    {
+        if (string.IsNullOrWhiteSpace(stdOut))
+        {
+            return [];
+        }
+
+        return stdOut
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(
+                line =>
+                {
+                    var path = line.Length > 3
+                        ? line[3..].Trim()
+                        : line.Trim();
+                    var renameSeparatorIndex = path.IndexOf(" -> ", StringComparison.Ordinal);
+                    return renameSeparatorIndex >= 0
+                        ? path[(renameSeparatorIndex + 4)..].Trim()
+                        : path;
+                })
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .ToArray();
     }
 }

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -1015,6 +1015,181 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenAcceptedReviewDecisionWithAcceptedWorktreeChangesThatWouldBeOverwrittenByMerge_ClosesOutWithoutDeterministicContractGap()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Review))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "reviews", "G226.request.json"),
+            "{}");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            implementation_issue_packet:
+              issue_title: "[G226] Review Accept"
+              issue_kind: "feature"
+              source_execution_unit: "G226"
+              goal: "Close out accepted review."
+              in_scope:
+                - "review accept command"
+              out_of_scope:
+                - "review comment"
+              target_repo: "submodules/child-repo"
+              target_path: "."
+              target_part: "cli review accept command"
+              dependencies: []
+              technical_baseline:
+                - "C# / .NET"
+              project_local_guide:
+                - "AGENTS.md"
+              intent_baseline:
+                - "closeout stays thin"
+              intent_references:
+                - "ICL.P.PRODUCT_GOAL"
+              rules_and_specs:
+                - "intents/rules/issue-lifecycle-and-landing.md"
+              acceptance_criteria:
+                - "review accept merges and closes"
+              verification_evidence:
+                - "tests-passing"
+              review_mode: "deterministic-review"
+              completion_action: "wait-for-deterministic-review"
+              landing_policy: "merge-after-review"
+
+            review_context_packet:
+              source_execution_unit: "G226"
+              parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+              intent_references:
+                - "ICL.P.PRODUCT_GOAL"
+              rules_and_specs:
+                - "intents/rules/issue-lifecycle-and-landing.md"
+              acceptance_criteria:
+                - "review accept merges and closes"
+              deterministic_review_checks:
+                - "selected item only"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-03T10:00:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/tomohisa/toy-calc-sample/issues/5"}
+            {"ts":"2026-04-03T10:10:00Z","execution_unit":"G226","event":"review-started","by":"intent-cli","linked_pr":"https://github.com/tomohisa/toy-calc-sample/pull/6"}
+            """ + Environment.NewLine);
+        WriteDirectRunRequest(repoRoot, "G226", "review", "pid:226");
+        WriteDirectRunResult(repoRoot, "G226", "review", "accepted");
+        var originalClientFactory = ReviewAcceptCommand.AcceptClientFactory;
+        var originalGitFactory = ReviewAcceptCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = ReviewAcceptCommand.TimestampFactory;
+        var client = new FakeReviewAcceptClient();
+
+        try
+        {
+            ReviewAcceptCommand.AcceptClientFactory = () => client;
+            ReviewAcceptCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                new Dictionary<string, GitCommandResult>
+                {
+                    [FakeGitRunner.CreateCommandKey(["fetch", "origin", "main"])] = new GitCommandResult
+                    {
+                        ExitCode = 0,
+                        StdOut = string.Empty,
+                        StdErr = string.Empty
+                    },
+                    [FakeGitRunner.CreateCommandKey(["switch", "main"])] = new GitCommandResult
+                    {
+                        ExitCode = 0,
+                        StdOut = string.Empty,
+                        StdErr = string.Empty
+                    },
+                    [FakeGitRunner.CreateCommandKey(["merge", "--ff-only", "origin/main"])] = new GitCommandResult
+                    {
+                        ExitCode = 1,
+                        StdOut = string.Empty,
+                        StdErr =
+                            """
+                            error: Your local changes to the following files would be overwritten by merge:
+                              intents/toy-calc/specs/01-cli-surface.md
+                            error: The following untracked working tree files would be overwritten by merge:
+                              intents/toy-calc/specs/02-invalid-usage-contract.md
+                            Please move or remove them before you merge.
+                            Aborting
+                            """
+                    },
+                    [FakeGitRunner.CreateCommandKey(["status", "--porcelain=v1", "--untracked-files=all"])] = new GitCommandResult
+                    {
+                        ExitCode = 0,
+                        StdOut =
+                            """
+                             M intents/toy-calc/specs/01-cli-surface.md
+                            ?? intents/toy-calc/specs/02-invalid-usage-contract.md
+                            """,
+                        StdErr = string.Empty
+                    },
+                    [FakeGitRunner.CreateCommandKey(["clean", "-fd", "--", "intents/toy-calc/specs/02-invalid-usage-contract.md"])] = new GitCommandResult
+                    {
+                        ExitCode = 0,
+                        StdOut = string.Empty,
+                        StdErr = string.Empty
+                    },
+                    [FakeGitRunner.CreateCommandKey(["reset", "--hard", "abc123"])] = new GitCommandResult
+                    {
+                        ExitCode = 0,
+                        StdOut = "HEAD is now at abc123 closeout" + Environment.NewLine,
+                        StdErr = string.Empty
+                    },
+                    [FakeGitRunner.CreateCommandKey(["rev-parse", "HEAD"])] = new GitCommandResult
+                    {
+                        ExitCode = 0,
+                        StdOut = "abc123" + Environment.NewLine,
+                        StdErr = string.Empty
+                    },
+                    [FakeGitRunner.CreateCommandKey(["add", "submodules/child-repo"])] = new GitCommandResult
+                    {
+                        ExitCode = 0,
+                        StdOut = string.Empty,
+                        StdErr = string.Empty
+                    }
+                },
+                statusSequence:
+                [
+                    """
+                     M intents/toy-calc/specs/01-cli-surface.md
+                    ?? intents/toy-calc/specs/02-invalid-usage-contract.md
+                    """,
+                    string.Empty
+                ]);
+            ReviewAcceptCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-21T02:30:00Z");
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Null(result.ExecutionUnit);
+            var action = Assert.Single(result.Actions);
+            Assert.Equal("review accept", action.Name);
+            Assert.Equal("G226", action.ExecutionUnit);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Completed, queueState.Items.Single(item => item.ExecutionUnit == "G226").State);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal("pr-merged", runEvents[^3].Event);
+            Assert.Equal("issue-closed", runEvents[^2].Event);
+            Assert.Equal("completed", runEvents[^1].Event);
+        }
+        finally
+        {
+            ReviewAcceptCommand.AcceptClientFactory = originalClientFactory;
+            ReviewAcceptCommand.GitCommandRunnerFactory = originalGitFactory;
+            ReviewAcceptCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenAcceptedReviewDecisionWithDraftLinkedPrAndReadyApi404_ClosesOutWithoutDeterministicContractGap()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -9024,6 +9199,7 @@ public sealed class RunCommandTests
     {
         private readonly string? statusOutput;
         private readonly IReadOnlyDictionary<string, GitCommandResult>? scriptedResults;
+        private readonly Queue<string>? statusSequence;
 
         public FakeGitRunner(string statusOutput)
         {
@@ -9033,6 +9209,12 @@ public sealed class RunCommandTests
         public FakeGitRunner(IReadOnlyDictionary<string, GitCommandResult> scriptedResults)
         {
             this.scriptedResults = scriptedResults;
+        }
+
+        public FakeGitRunner(IReadOnlyDictionary<string, GitCommandResult> scriptedResults, IReadOnlyList<string> statusSequence)
+        {
+            this.scriptedResults = scriptedResults;
+            this.statusSequence = new Queue<string>(statusSequence);
         }
 
         public List<IReadOnlyList<string>> Commands { get; } = [];
@@ -9047,6 +9229,17 @@ public sealed class RunCommandTests
                 if (!scriptedResults.TryGetValue(key, out var result))
                 {
                     throw new Xunit.Sdk.XunitException($"Unexpected git command: {string.Join(" ", arguments)}");
+                }
+
+                if (arguments.SequenceEqual(["status", "--porcelain=v1", "--untracked-files=all"])
+                    && statusSequence is not null)
+                {
+                    return result with
+                    {
+                        StdOut = statusSequence.Count > 0
+                            ? statusSequence.Dequeue()
+                            : result.StdOut
+                    };
                 }
 
                 return result;

--- a/tests/IntentSystem.Review.Tests/ChildRepoMainSynchronizerTests.cs
+++ b/tests/IntentSystem.Review.Tests/ChildRepoMainSynchronizerTests.cs
@@ -38,6 +38,146 @@ public sealed class ChildRepoMainSynchronizerTests
     }
 
     [Fact]
+    public void Sync_GivenAcceptedWorktreePathsThatWouldBeOverwrittenByMerge_ReconcilesToMergedCommit()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var parentRepoRoot = tempDirectory.CreateDirectory("repo");
+        var childRepoPath = tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        var runner = new FakeGitRunner(
+            new Dictionary<string, GitCommandResult>
+            {
+                [FakeGitRunner.CreateCommandKey(["fetch", "origin", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["switch", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["merge", "--ff-only", "origin/main"])] = new GitCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr =
+                        """
+                        error: Your local changes to the following files would be overwritten by merge:
+                          intents/toy-calc/specs/01-cli-surface.md
+                        error: The following untracked working tree files would be overwritten by merge:
+                          intents/toy-calc/specs/02-invalid-usage-contract.md
+                        Please move or remove them before you merge.
+                        Aborting
+                        """
+                },
+                [FakeGitRunner.CreateCommandKey(["status", "--porcelain=v1", "--untracked-files=all"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut =
+                        """
+                         M intents/toy-calc/specs/01-cli-surface.md
+                        ?? intents/toy-calc/specs/02-invalid-usage-contract.md
+                        """,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["clean", "-fd", "--", "intents/toy-calc/specs/02-invalid-usage-contract.md"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["reset", "--hard", "abc123"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "HEAD is now at abc123 merge closeout" + Environment.NewLine,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["rev-parse", "HEAD"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "abc123" + Environment.NewLine,
+                    StdErr = string.Empty
+                }
+            },
+            statusSequence:
+            [
+                """
+                 M intents/toy-calc/specs/01-cli-surface.md
+                ?? intents/toy-calc/specs/02-invalid-usage-contract.md
+                """,
+                string.Empty
+            ]);
+
+        ChildRepoMainSynchronizer.Sync(parentRepoRoot, "submodules/child-repo", "abc123", runner);
+
+        Assert.Equal(
+            [
+                $"{childRepoPath}::fetch origin main",
+                $"{childRepoPath}::switch main",
+                $"{childRepoPath}::merge --ff-only origin/main",
+                $"{childRepoPath}::status --porcelain=v1 --untracked-files=all",
+                $"{childRepoPath}::clean -fd -- intents/toy-calc/specs/02-invalid-usage-contract.md",
+                $"{childRepoPath}::reset --hard abc123",
+                $"{childRepoPath}::status --porcelain=v1 --untracked-files=all",
+                $"{childRepoPath}::rev-parse HEAD"
+            ],
+            runner.Calls);
+    }
+
+    [Fact]
+    public void Sync_GivenMergeOverwriteAndAdditionalDirtyPaths_ThrowsInvalidOperationException()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var parentRepoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        var runner = new FakeGitRunner(
+            new Dictionary<string, GitCommandResult>
+            {
+                [FakeGitRunner.CreateCommandKey(["fetch", "origin", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["switch", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["merge", "--ff-only", "origin/main"])] = new GitCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr =
+                        """
+                        error: Your local changes to the following files would be overwritten by merge:
+                          intents/toy-calc/specs/01-cli-surface.md
+                        Please commit your changes or stash them before you merge.
+                        Aborting
+                        """
+                },
+                [FakeGitRunner.CreateCommandKey(["status", "--porcelain=v1", "--untracked-files=all"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut =
+                        """
+                         M intents/toy-calc/specs/01-cli-surface.md
+                         M src/ToyCalc/Program.cs
+                        """,
+                    StdErr = string.Empty
+                }
+            });
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ChildRepoMainSynchronizer.Sync(parentRepoRoot, "submodules/child-repo", "abc123", runner));
+
+        Assert.Contains("outside the merge-overwrite set", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Stage_GivenChildRepoRef_StagesParentSubmodulePointer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -52,13 +192,52 @@ public sealed class ChildRepoMainSynchronizerTests
             runner.Calls);
     }
 
-    private sealed class FakeGitRunner(string headCommit) : IGitCommandRunner
+    private sealed class FakeGitRunner : IGitCommandRunner
     {
+        private readonly string? headCommit;
+        private readonly IReadOnlyDictionary<string, GitCommandResult>? scriptedResults;
+        private readonly Queue<string>? statusSequence;
+
+        public FakeGitRunner(string headCommit)
+        {
+            this.headCommit = headCommit;
+        }
+
+        public FakeGitRunner(
+            IReadOnlyDictionary<string, GitCommandResult> scriptedResults,
+            IReadOnlyList<string>? statusSequence = null)
+        {
+            this.scriptedResults = scriptedResults;
+            this.statusSequence = statusSequence is null ? null : new Queue<string>(statusSequence);
+        }
+
         public List<string> Calls { get; } = [];
 
         public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
         {
             Calls.Add($"{workingDirectory}::{string.Join(' ', arguments)}");
+
+            if (scriptedResults is not null)
+            {
+                var key = CreateCommandKey(arguments);
+                if (!scriptedResults.TryGetValue(key, out var result))
+                {
+                    throw new Xunit.Sdk.XunitException($"Unexpected git command: {string.Join(" ", arguments)}");
+                }
+
+                if (arguments.SequenceEqual(["status", "--porcelain=v1", "--untracked-files=all"])
+                    && statusSequence is not null)
+                {
+                    return result with
+                    {
+                        StdOut = statusSequence.Count > 0
+                            ? statusSequence.Dequeue()
+                            : result.StdOut
+                    };
+                }
+
+                return result;
+            }
 
             return new GitCommandResult
             {
@@ -68,6 +247,11 @@ public sealed class ChildRepoMainSynchronizerTests
                     : string.Empty,
                 StdErr = string.Empty
             };
+        }
+
+        public static string CreateCommandKey(IReadOnlyList<string> arguments)
+        {
+            return string.Join("\u001f", arguments);
         }
     }
 


### PR DESCRIPTION
## Summary
- reconcile accepted child worktree files when `review accept` hits merge-overwrite errors during child `main` sync
- refuse reconciliation when additional dirty child-repo paths exist outside the merge-overwrite set
- add focused regressions for child sync and root approved-review -> `review accept` closeout

## Validation
- `dotnet test tests/IntentSystem.Review.Tests/IntentSystem.Review.Tests.csproj --filter "FullyQualifiedName~ChildRepoMainSynchronizerTests" --nologo`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommandTests.ExecuteCore_GivenAcceptedReviewDecisionWithAcceptedWorktreeChangesThatWouldBeOverwrittenByMerge_ClosesOutWithoutDeterministicContractGap" --nologo`

Closes #361