### PR TITLE
Fix nested worktree implement handoff artifact reachability

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
@@ -99,6 +99,8 @@ internal static class RunImplementCommand
             throw new InvalidOperationException($"Worktree path was not found at {worktreePath}");
         }
 
+        SyncCurrentIssueArtifactsToWorktree(packetPath, worktreePath);
+
         ChildWorkTargetGuard.EnsureTargetAllowed(
             executionUnit,
             context.RepoRoot,
@@ -194,6 +196,36 @@ internal static class RunImplementCommand
     private static string ResolveArtifactPath(string repoRoot, string artifactRef)
     {
         return Path.GetFullPath(Path.Combine(repoRoot, artifactRef.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static void SyncCurrentIssueArtifactsToWorktree(
+        string sourceArtifactPath,
+        string worktreePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceArtifactPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
+
+        var sourceIssueDirectory = Path.GetDirectoryName(sourceArtifactPath)
+            ?? throw new InvalidOperationException("Issue artifact path did not contain a directory.");
+        if (!Directory.Exists(sourceIssueDirectory))
+        {
+            throw new InvalidOperationException($"Issue artifact directory was not found at {sourceIssueDirectory}");
+        }
+
+        var executionUnit = Path.GetFileName(sourceIssueDirectory);
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            throw new InvalidOperationException("Issue artifact directory did not contain an execution unit name.");
+        }
+
+        var targetIssueDirectory = Path.Combine(worktreePath, ".intent-cli", "issues", executionUnit);
+        Directory.CreateDirectory(targetIssueDirectory);
+
+        foreach (var sourceFilePath in Directory.GetFiles(sourceIssueDirectory))
+        {
+            var targetFilePath = Path.Combine(targetIssueDirectory, Path.GetFileName(sourceFilePath));
+            File.Copy(sourceFilePath, targetFilePath, overwrite: true);
+        }
     }
 
     private static string ResolveChildRepoPath(string repoRoot, string childRepoRef)

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -153,6 +153,66 @@ public sealed class RunImplementCommandTests
         Assert.DoesNotContain("latest_linked_pr", File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "implement", "G19.request.md")), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Execute_GivenNestedWorktree_SyncsCurrentIssueArtifactsBeforeLaunch()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var worktreePath = tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G19"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "implementation.md"),
+            "# Current implementation");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "github-body.md"),
+            "# Current github body");
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunImplementCommand.TimestampFactory;
+        var originalLauncherFactory = RunImplementCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            RunImplementCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:15:00Z");
+            RunImplementCommand.DirectRunLauncherFactory = () => new FakeDirectRunLauncher(
+                "pid:4321",
+                "Claude",
+                "default",
+                "stdio",
+                "stdio transport launched via 'claude' in '/repo/.intent-cli/worktrees/G19' for provider 'Claude'.");
+
+            var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.True(File.Exists(Path.Combine(worktreePath, ".intent-cli", "issues", "G19", "packet.yaml")));
+            Assert.True(File.Exists(Path.Combine(worktreePath, ".intent-cli", "issues", "G19", "review-context.md")));
+            Assert.True(File.Exists(Path.Combine(worktreePath, ".intent-cli", "issues", "G19", "implementation.md")));
+            Assert.True(File.Exists(Path.Combine(worktreePath, ".intent-cli", "issues", "G19", "github-body.md")));
+            Assert.Equal(
+                CreatePacketYaml(),
+                File.ReadAllText(Path.Combine(worktreePath, ".intent-cli", "issues", "G19", "packet.yaml")));
+            Assert.Equal(
+                CreateReviewContextMarkdown(),
+                File.ReadAllText(Path.Combine(worktreePath, ".intent-cli", "issues", "G19", "review-context.md")));
+        }
+        finally
+        {
+            RunImplementCommand.TimestampFactory = originalTimestampFactory;
+            RunImplementCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
     private sealed class FakeDirectRunLauncher(
         string providerSessionId,
         string provider,


### PR DESCRIPTION
## Summary
- sync the current execution unit's issue artifacts into the nested worktree before launching implement
- keep implement handoff packet and review-context refs usable from the execution-unit worktree boundary
- add regression coverage for nested-worktree artifact projection before direct run launch

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunImplementCommandTests" --nologo

Refs #364