### PR TITLE
Fix blocked implement fallback rehydration

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -348,6 +348,20 @@ internal static class DirectRunFixOutcomeSupport
         return sawSpecRead && sawProductRead;
     }
 
+    internal static bool HasRecoveredSpecWithoutProductReadSignal(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        var orderedProviderEvents = OrderEventsForAnalysis(providerEvents);
+        var sawRequestReread = orderedProviderEvents.Any(providerEvent => ContainsRequestArtifactRead(providerEvent.Payload));
+        var sawSpecRead = HasSuccessfulRepoLocalSpecRead(orderedProviderEvents);
+        var sawProductRead = orderedProviderEvents.Any(providerEvent =>
+            !IsIgnorableStartupPreamble(providerEvent.Payload)
+            && ContainsProductSourceOrTestReadAttempt(providerEvent.Payload));
+
+        return sawRequestReread && sawSpecRead && !sawProductRead;
+    }
+
     internal static bool HasDeepExecutionProgressSignal(IReadOnlyList<DirectRunProviderEvent> providerEvents)
     {
         ArgumentNullException.ThrowIfNull(providerEvents);

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -501,6 +501,11 @@ internal static class RunCommand
                         continue;
                     }
 
+                    if (TryResolveBlockedImplementSessionFailureResult(context, actions, blockedItem, out var blockedImplementResult))
+                    {
+                        return blockedImplementResult;
+                    }
+
                     if (TryResolveBlockedFixRetryExhaustionResult(context, actions, blockedItem, out var blockedFixResult))
                     {
                         return blockedFixResult;
@@ -817,6 +822,49 @@ internal static class RunCommand
             actions,
             blockedItem.ExecutionUnit,
             session.LastInterruptionReason);
+        return true;
+    }
+
+    private static bool TryResolveBlockedImplementSessionFailureResult(
+        CliContext context,
+        IReadOnlyList<RunCommandAction> actions,
+        QueueItem blockedItem,
+        out RunCommandResult result)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(actions);
+        ArgumentNullException.ThrowIfNull(blockedItem);
+
+        result = null!;
+        var sessionArtifactRef = RunSupervisionSessionArtifactPathResolver.Resolve(
+            context.Config.Supervision.ArtifactRoot,
+            blockedItem.ExecutionUnit);
+        var sessionArtifactPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            sessionArtifactRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(sessionArtifactPath))
+        {
+            return false;
+        }
+
+        var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(sessionArtifactPath));
+        if (session.WorkerEntry != RunSupervisionWorkerEntry.Implement
+            || session.Status != RunSupervisionSessionStatus.Blocked)
+        {
+            return false;
+        }
+
+        var detail = TryResolveCurrentImplementSessionFailureDetail(context, blockedItem.ExecutionUnit);
+        if (string.IsNullOrWhiteSpace(detail))
+        {
+            return false;
+        }
+
+        result = CreateStopResult(
+            NonRetryableFailureStopReason,
+            actions,
+            blockedItem.ExecutionUnit,
+            detail);
         return true;
     }
 
@@ -2050,6 +2098,84 @@ internal static class RunCommand
 
         return DirectRunFixOutcomeSupport.TryResolveContractGapDetail(providerEvents, executionUnit, "fix", out var detail)
             ? detail
+            : null;
+    }
+
+    private static string? TryResolveCurrentImplementSessionFailureDetail(
+        CliContext context,
+        string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var requestArtifact = TryReadDirectRunRequestArtifact(context, executionUnit);
+        var resultArtifact = TryReadDirectRunResultArtifact(context, executionUnit, "implement");
+        if (requestArtifact is null
+            || resultArtifact is null
+            || !string.Equals(requestArtifact.EntryKind, "implement", StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.EntryKind, "implement", StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.RunStatus, "failed", StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.SessionId, requestArtifact.ProviderSessionId, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var providerEvents = TryReadDirectRunProviderEvents(context, executionUnit);
+        if (providerEvents.Count == 0)
+        {
+            return null;
+        }
+
+        providerEvents = SelectCurrentSessionEvents(
+            providerEvents,
+            requestArtifact.ProviderSessionId,
+            requestArtifact.LaunchedAt);
+
+        if (DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
+                providerEvents,
+                executionUnit,
+                "implement",
+                out var startupOnlyDetail))
+        {
+            return startupOnlyDetail;
+        }
+
+        if (DirectRunFixOutcomeSupport.TryResolveContractGapDetail(
+                providerEvents,
+                executionUnit,
+                "implement",
+                out var contractGapDetail))
+        {
+            return contractGapDetail;
+        }
+
+        var canonicalBoundaryEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.UtcNow,
+            executionUnit,
+            "implement",
+            requestArtifact.Provider,
+            requestArtifact.ProviderSessionId,
+            providerSessionAlive: false);
+        if (canonicalBoundaryEvent is null)
+        {
+            return null;
+        }
+
+        var providerLogRef = ResolveDirectRunProviderLogRef(context, executionUnit);
+        var providerLogPath = Path.GetFullPath(Path.Combine(
+            context.RepoRoot,
+            providerLogRef.Replace('/', Path.DirectorySeparatorChar)));
+        var writer = new DirectRunProviderEventWriter(providerLogPath);
+        writer.Append(canonicalBoundaryEvent);
+        providerEvents = [.. providerEvents, canonicalBoundaryEvent];
+
+        return DirectRunFixOutcomeSupport.TryResolveContractGapDetail(
+            providerEvents,
+            executionUnit,
+            "implement",
+            out var synthesizedContractGapDetail)
+            ? synthesizedContractGapDetail
             : null;
     }
 

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -120,6 +120,7 @@ internal static class RunCommand
         ArgumentNullException.ThrowIfNull(context);
 
         var actions = new List<RunCommandAction>();
+        var freshImplementContinuationStates = new Dictionary<string, FreshFixContinuationState>(StringComparer.Ordinal);
         var freshFixContinuationStates = new Dictionary<string, FreshFixContinuationState>(StringComparer.Ordinal);
 
         for (var iteration = 0; iteration < IterationBudget; iteration++)
@@ -150,6 +151,7 @@ internal static class RunCommand
                             "implement");
                         if (string.Equals(implementRunStatus, "succeeded", StringComparison.Ordinal))
                         {
+                            freshImplementContinuationStates.Remove(inProgressItem.ExecutionUnit);
                             ExecuteAction(
                                 context,
                                 actions,
@@ -188,6 +190,10 @@ internal static class RunCommand
                                 "run implement",
                                 inProgressItem.ExecutionUnit,
                                 () => RunImplementExecutor(context, inProgressItem.ExecutionUnit));
+                            TrackFreshImplementContinuation(
+                                context,
+                                inProgressItem.ExecutionUnit,
+                                freshImplementContinuationStates);
                             continue;
                         }
 
@@ -197,6 +203,18 @@ internal static class RunCommand
                             "run supervise",
                             inProgressItem.ExecutionUnit,
                             () => RunSuperviseExecutor(context, inProgressItem.ExecutionUnit));
+
+                        if (ShouldContinueFreshImplementSupervision(
+                                context,
+                                freshImplementContinuationStates,
+                                inProgressItem.ExecutionUnit,
+                                superviseResult))
+                        {
+                            SleepFreshFixContinuationPollInterval();
+                            continue;
+                        }
+
+                        freshImplementContinuationStates.Remove(inProgressItem.ExecutionUnit);
 
                         if (superviseResult.Blocked)
                         {
@@ -1814,6 +1832,49 @@ internal static class RunCommand
             FreshFixContinuationMaxPolls);
     }
 
+    private static void TrackFreshImplementContinuation(
+        CliContext context,
+        string executionUnit,
+        IDictionary<string, FreshFixContinuationState> continuationStates)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(continuationStates);
+
+        continuationStates.Remove(executionUnit);
+        if (FreshFixContinuationWindow <= TimeSpan.Zero
+            || FreshFixContinuationTotalWindow <= TimeSpan.Zero
+            || FreshFixContinuationMaxPolls <= 0)
+        {
+            return;
+        }
+
+        var now = TimestampFactory();
+        var requestArtifact = TryReadDirectRunRequestArtifact(context, executionUnit);
+        var launchedAt = requestArtifact is not null
+            && string.Equals(requestArtifact.EntryKind, "implement", StringComparison.Ordinal)
+            && DirectRunSessionBoundary.TryParseLaunchedAt(requestArtifact.LaunchedAt, out var parsedLaunchedAt)
+                ? parsedLaunchedAt
+                : now;
+        var totalDeadline = launchedAt + FreshFixContinuationTotalWindow;
+        var deadline = launchedAt + FreshFixContinuationWindow;
+        if (deadline > totalDeadline)
+        {
+            deadline = totalDeadline;
+        }
+
+        if (deadline <= now)
+        {
+            return;
+        }
+
+        continuationStates[executionUnit] = new FreshFixContinuationState(
+            totalDeadline,
+            deadline,
+            launchedAt,
+            FreshFixContinuationMaxPolls);
+    }
+
     private static bool ShouldContinueFreshFixSupervision(
         CliContext context,
         IDictionary<string, FreshFixContinuationState> continuationStates,
@@ -1867,6 +1928,59 @@ internal static class RunCommand
         return true;
     }
 
+    private static bool ShouldContinueFreshImplementSupervision(
+        CliContext context,
+        IDictionary<string, FreshFixContinuationState> continuationStates,
+        string executionUnit,
+        RunSuperviseResult superviseResult)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(continuationStates);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(superviseResult);
+
+        if (!continuationStates.TryGetValue(executionUnit, out var continuationState))
+        {
+            return false;
+        }
+
+        if (superviseResult.Blocked
+            || superviseResult.WorkerEntry != RunSupervisionWorkerEntry.Implement
+            || superviseResult.SessionStatus != RunSupervisionSessionStatus.Monitoring
+            || superviseResult.RetryScheduled
+            || superviseResult.AutoResumed)
+        {
+            continuationStates.Remove(executionUnit);
+            return false;
+        }
+
+        continuationState = RefreshFreshImplementContinuationActivity(
+            continuationStates,
+            executionUnit,
+            continuationState,
+            context);
+
+        if (TimestampFactory() >= continuationState.Deadline || continuationState.RemainingPolls <= 0)
+        {
+            continuationStates.Remove(executionUnit);
+            return false;
+        }
+
+        if (continuationState.RemainingPolls == 1)
+        {
+            continuationStates.Remove(executionUnit);
+        }
+        else
+        {
+            continuationStates[executionUnit] = continuationState with
+            {
+                RemainingPolls = continuationState.RemainingPolls - 1
+            };
+        }
+
+        return true;
+    }
+
     private static FreshFixContinuationState RefreshFreshFixContinuationActivity(
         IDictionary<string, FreshFixContinuationState> continuationStates,
         string executionUnit,
@@ -1880,6 +1994,41 @@ internal static class RunCommand
 
         var requestArtifact = TryReadDirectRunRequestArtifact(context, executionUnit);
         var latestActivityAt = TryResolveCurrentFixSessionLatestActivityAt(context, executionUnit, requestArtifact);
+        if (latestActivityAt is null || latestActivityAt <= continuationState.LastObservedActivityAt)
+        {
+            return continuationState;
+        }
+
+        var extendedDeadline = latestActivityAt.Value + FreshFixContinuationActivityWindow;
+        if (extendedDeadline > continuationState.TotalDeadline)
+        {
+            extendedDeadline = continuationState.TotalDeadline;
+        }
+
+        continuationState = continuationState with
+        {
+            Deadline = extendedDeadline > continuationState.Deadline
+                ? extendedDeadline
+                : continuationState.Deadline,
+            LastObservedActivityAt = latestActivityAt.Value
+        };
+        continuationStates[executionUnit] = continuationState;
+        return continuationState;
+    }
+
+    private static FreshFixContinuationState RefreshFreshImplementContinuationActivity(
+        IDictionary<string, FreshFixContinuationState> continuationStates,
+        string executionUnit,
+        FreshFixContinuationState continuationState,
+        CliContext? context)
+    {
+        if (context is null || FreshFixContinuationActivityWindow <= TimeSpan.Zero)
+        {
+            return continuationState;
+        }
+
+        var requestArtifact = TryReadDirectRunRequestArtifact(context, executionUnit);
+        var latestActivityAt = TryResolveCurrentImplementSessionLatestActivityAt(context, executionUnit, requestArtifact);
         if (latestActivityAt is null || latestActivityAt <= continuationState.LastObservedActivityAt)
         {
             return continuationState;

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -501,6 +501,14 @@ internal static class RunCommand
                         continue;
                     }
 
+                    if (TryAutoContinueBlockedImplementRecoveredSpecBoundary(
+                            context,
+                            queueState,
+                            blockedItem))
+                    {
+                        continue;
+                    }
+
                     if (TryResolveBlockedImplementSessionFailureResult(context, actions, blockedItem, out var blockedImplementResult))
                     {
                         return blockedImplementResult;
@@ -783,6 +791,46 @@ internal static class RunCommand
         }
 
         ExecuteAutoContinuePostFixWorktreeProgress(context, actions, blockedItem, session);
+        return true;
+    }
+
+    private static bool TryAutoContinueBlockedImplementRecoveredSpecBoundary(
+        CliContext context,
+        QueueState queueState,
+        QueueItem blockedItem)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(queueState);
+        ArgumentNullException.ThrowIfNull(blockedItem);
+
+        if (!TryReadSupervisionSession(context, blockedItem.ExecutionUnit, out var session)
+            || session.WorkerEntry != RunSupervisionWorkerEntry.Implement
+            || session.Status != RunSupervisionSessionStatus.Blocked)
+        {
+            return false;
+        }
+
+        if (!HasCurrentBlockedImplementRecoveredSpecBoundary(context, blockedItem.ExecutionUnit))
+        {
+            return false;
+        }
+
+        var timestamp = TimestampFactory();
+        var transition = QueueManager.TransitionNonBlocking(
+            queueState,
+            blockedItem.ExecutionUnit,
+            QueueItemState.Active,
+            TransitionActor,
+            timestamp);
+        var updatedState = transition.UpdatedState with
+        {
+            Items = transition.UpdatedState.Items.Select(item =>
+                string.Equals(item.ExecutionUnit, blockedItem.ExecutionUnit, StringComparison.Ordinal)
+                    ? item with { BlockedBy = [] }
+                    : item).ToArray()
+        };
+        File.WriteAllText(context.GetQueueStatePath(), QueueStateSerializer.Serialize(updatedState));
+        AppendRunEvent(context.GetRunLogPath(), transition.Event);
         return true;
     }
 
@@ -2177,6 +2225,37 @@ internal static class RunCommand
             out var synthesizedContractGapDetail)
             ? synthesizedContractGapDetail
             : null;
+    }
+
+    private static bool HasCurrentBlockedImplementRecoveredSpecBoundary(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var requestArtifact = TryReadDirectRunRequestArtifact(context, executionUnit);
+        var resultArtifact = TryReadDirectRunResultArtifact(context, executionUnit, "implement");
+        if (requestArtifact is null
+            || resultArtifact is null
+            || !string.Equals(requestArtifact.EntryKind, "implement", StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.EntryKind, "implement", StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.RunStatus, "failed", StringComparison.Ordinal)
+            || !MatchesCurrentDirectRunRequestBoundary(requestArtifact, resultArtifact))
+        {
+            return false;
+        }
+
+        var providerEvents = TryReadDirectRunProviderEvents(context, executionUnit);
+        if (providerEvents.Count == 0)
+        {
+            return false;
+        }
+
+        providerEvents = SelectCurrentSessionEvents(
+            providerEvents,
+            requestArtifact.ProviderSessionId,
+            requestArtifact.LaunchedAt);
+
+        return DirectRunFixOutcomeSupport.HasRecoveredSpecWithoutProductReadSignal(providerEvents);
     }
 
     private static DateTimeOffset? TryResolveCurrentFixSessionLatestActivityAt(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -8077,7 +8077,7 @@ public sealed class RunCommandTests
     }
 
     [Fact]
-    public void ExecuteCore_GivenBlockedImplementSessionWithFallbackSpecRecovery_RehydratesNonRetryableFailure()
+    public void ExecuteCore_GivenBlockedImplementSessionWithFallbackSpecRecovery_LaunchesFreshImplementContinuation()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -8154,35 +8154,105 @@ public sealed class RunCommandTests
             providerEvents: CreateFallbackSpecRecoveryImplementProviderEvents("TOY-CALC-V0-04", "pid:27654"),
             sessionId: "pid:27654",
             provider: "Codex");
+        var originalRunImplementExecutor = RunCommand.RunImplementExecutor;
+        var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
 
-        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+        try
+        {
+            RunCommand.RunImplementExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunRequest(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "pid:4242",
+                    provider: "Codex",
+                    launchedAt: "2026-04-10T12:31:00.0000000+00:00");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "running",
+                    providerEvents: CreateImplementProductReadProviderEvents(executionUnit, "pid:4242"),
+                    sessionId: "pid:4242",
+                    provider: "Codex");
+                File.AppendAllText(
+                    runLogPath,
+                    RunLogSerializer.SerializeLine(new RunEvent
+                    {
+                        Ts = DateTimeOffset.Parse("2026-04-10T12:31:00Z"),
+                        ExecutionUnit = executionUnit,
+                        Event = "provider-lifecycle",
+                        By = "intent-cli",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        EntryKind = "implement",
+                        Provider = "Codex",
+                        Model = "gpt-5.4-mini",
+                        SessionId = "pid:4242",
+                        RunStatus = "running",
+                        RawLogRef = $".intent-cli/runs/{executionUnit}.provider.jsonl",
+                        ResultRef = $".intent-cli/runs/{executionUnit}.result.json",
+                        PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit)
+                    }) + Environment.NewLine);
 
-        Assert.Equal("non-retryable-failure", result.StopReason);
-        Assert.Equal("TOY-CALC-V0-04", result.ExecutionUnit);
-        Assert.Empty(result.Actions);
-        Assert.Contains("repo_local_spec_read=True", result.Detail, StringComparison.Ordinal);
-        Assert.Contains("product_source_or_test_read=False", result.Detail, StringComparison.Ordinal);
-        Assert.DoesNotContain("requires parent-side planning", result.Detail, StringComparison.Ordinal);
+                return new RunImplementResult
+                {
+                    Request = CreateRunImplementRequest(repoRoot, executionUnit),
+                    ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md",
+                    DirectRun = CreateDirectRunLaunchResult(executionUnit, "pid:4242")
+                };
+            };
+            RunCommand.RunSuperviseExecutor = (_, executionUnit) => new RunSuperviseResult
+            {
+                ExecutionUnit = executionUnit,
+                SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                RetryCount = 0,
+                RetryBudget = 3,
+                HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md"
+            };
 
-        var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
-        var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "TOY-CALC-V0-04");
-        Assert.Equal(QueueItemState.Blocked, selectedItem.State);
-        Assert.Contains("requires parent-side planning", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-        var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
-            Path.Combine(repoRoot, ".intent-cli", "supervision", "TOY-CALC-V0-04.session.json")));
-        Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
-        Assert.Contains("requires parent-side planning", session.LastInterruptionReason, StringComparison.Ordinal);
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("TOY-CALC-V0-04", result.ExecutionUnit);
+            Assert.Equal(2, result.Actions.Count);
+            Assert.Equal("run implement", result.Actions[0].Name);
+            Assert.Equal("run supervise", result.Actions[1].Name);
+            Assert.Contains("under supervision", result.Detail, StringComparison.Ordinal);
 
-        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
-            Path.Combine(repoRoot, ".intent-cli", "runs", "TOY-CALC-V0-04.provider.jsonl")));
-        Assert.Contains(
-            providerEvents,
-            providerEvent => providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
-                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
-                && string.Equals(typeElement.GetString(), "contract-gap", StringComparison.Ordinal)
-                && providerEvent.Payload.TryGetProperty("reason", out var reasonElement)
-                && string.Equals(reasonElement.GetString(), "implement-session-ended-before-spec-source-test-read", StringComparison.Ordinal));
+            var requestArtifact = DirectRunRequestArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "TOY-CALC-V0-04.request.json")));
+            Assert.Equal("pid:4242", requestArtifact.ProviderSessionId);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "TOY-CALC-V0-04.result.json")));
+            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "TOY-CALC-V0-04");
+            Assert.Equal(QueueItemState.Active, selectedItem.State);
+            Assert.Empty(selectedItem.BlockedBy);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal(
+                2,
+                runEvents.Count(runEvent =>
+                    string.Equals(runEvent.Event, "activated", StringComparison.Ordinal)
+                    && string.Equals(runEvent.ExecutionUnit, "TOY-CALC-V0-04", StringComparison.Ordinal)));
+            Assert.Contains(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "provider-lifecycle", StringComparison.Ordinal)
+                && string.Equals(runEvent.SessionId, "pid:4242", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunCommand.RunImplementExecutor = originalRunImplementExecutor;
+            RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
+        }
     }
 
     private static CliContext CreateContext(
@@ -8892,6 +8962,40 @@ public sealed class RunCommandTests
                     type = "backend-exit",
                     exit_code = 1
                 })
+            }
+        ];
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateImplementProductReadProviderEvents(
+        string executionUnit,
+        string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:31:00.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "session-metadata",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    model = "gpt-5.4-mini",
+                    transport = "responses",
+                    command = "codex"
+                })
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:31:00.1000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'sed -n ''1,220p'' src/IntentSystem.Cli/Commands/RunCommand.cs' succeeded in 0ms")
             }
         ];
     }

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -8076,6 +8076,115 @@ public sealed class RunCommandTests
         }
     }
 
+    [Fact]
+    public void ExecuteCore_GivenBlockedImplementSessionWithFallbackSpecRecovery_RehydratesNonRetryableFailure()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "TOY-CALC-V0-04"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            queueStatePath,
+            QueueStateSerializer.Serialize(CreateQueueState(
+                CreateQueueItem(QueueItemState.Blocked, executionUnit: "TOY-CALC-V0-04") with
+                {
+                    BlockedBy = ["Blocked item 'TOY-CALC-V0-04' requires parent-side planning."]
+                })));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            runLogPath,
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"TOY-CALC-V0-04","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"TOY-CALC-V0-04","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T12:30:00Z","execution_unit":"TOY-CALC-V0-04","event":"blocked","by":"intent-cli","reason":"Blocked item 'TOY-CALC-V0-04' requires parent-side planning."}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "TOY-CALC-V0-04", "packet.yaml"),
+            """
+            execution_unit: "TOY-CALC-V0-04"
+
+            implementation_issue:
+              issue_title: "[G136] Repair Implement Progress After Nested-Worktree Handoff Fallback"
+              goal: "Repair implement progression after nested-worktree handoff fallback."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/TOY-CALC-V0-04/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "TOY-CALC-V0-04.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "TOY-CALC-V0-04.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "TOY-CALC-V0-04",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                Status = RunSupervisionSessionStatus.Blocked,
+                QueueState = "blocked",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "TOY-CALC-V0-04"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-136-toy-calc-v0-04",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                HandoffArtifactRef = ".intent-cli/implement/TOY-CALC-V0-04.request.md",
+                RetryCount = 0,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:30:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T12:30:00Z"),
+                LastInterruptionReason = "Blocked item 'TOY-CALC-V0-04' requires parent-side planning."
+            }));
+        WriteDirectRunRequest(
+            repoRoot,
+            "TOY-CALC-V0-04",
+            "implement",
+            "pid:27654",
+            provider: "Codex",
+            launchedAt: "2026-04-10T12:20:00.0000000+00:00");
+        WriteDirectRunResult(
+            repoRoot,
+            "TOY-CALC-V0-04",
+            "implement",
+            "failed",
+            providerEvents: CreateFallbackSpecRecoveryImplementProviderEvents("TOY-CALC-V0-04", "pid:27654"),
+            sessionId: "pid:27654",
+            provider: "Codex");
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("non-retryable-failure", result.StopReason);
+        Assert.Equal("TOY-CALC-V0-04", result.ExecutionUnit);
+        Assert.Empty(result.Actions);
+        Assert.Contains("repo_local_spec_read=True", result.Detail, StringComparison.Ordinal);
+        Assert.Contains("product_source_or_test_read=False", result.Detail, StringComparison.Ordinal);
+        Assert.DoesNotContain("requires parent-side planning", result.Detail, StringComparison.Ordinal);
+
+        var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "TOY-CALC-V0-04");
+        Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+        Assert.Contains("requires parent-side planning", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+        var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "supervision", "TOY-CALC-V0-04.session.json")));
+        Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+        Assert.Contains("requires parent-side planning", session.LastInterruptionReason, StringComparison.Ordinal);
+
+        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "TOY-CALC-V0-04.provider.jsonl")));
+        Assert.Contains(
+            providerEvents,
+            providerEvent => providerEvent.Payload.ValueKind == System.Text.Json.JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "contract-gap", StringComparison.Ordinal)
+                && providerEvent.Payload.TryGetProperty("reason", out var reasonElement)
+                && string.Equals(reasonElement.GetString(), "implement-session-ended-before-spec-source-test-read", StringComparison.Ordinal));
+    }
+
     private static CliContext CreateContext(
         string repoRoot,
         string postFixWorktreeProgressPolicy = CliRuntimeContracts.DefaultPostFixWorktreeProgressPolicy)
@@ -8627,6 +8736,164 @@ public sealed class RunCommandTests
         }
 
         return providerEvents;
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateFallbackSpecRecoveryImplementProviderEvents(
+        string executionUnit,
+        string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:00.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "session-metadata",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    model = "gpt-5.4-mini",
+                    transport = "responses",
+                    command = "codex"
+                })
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:00.1000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:00.2000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("/bin/zsh -lc \"sed -n '1,220p' /repo/.intent-cli/implement/TOY-CALC-V0-04.request.md\" in /repo/.intent-cli/worktrees/TOY-CALC-V0-04")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:00.3000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(" succeeded in 0ms:")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:00.4000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("# Execution Worker Handoff")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:00.5000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:00.6000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("/bin/zsh -lc \"rg --files . | rg 'packet.yaml|04-max-command.md|intents/toy-calc|cli|max'\" in /repo/.intent-cli/worktrees/TOY-CALC-V0-04")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:00.7000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(" succeeded in 0ms:")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:00.8000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("intents/toy-calc/specs/04-max-command.md")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:00.9000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:01.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("/bin/zsh -lc \"sed -n '1,240p' /repo/intents/toy-calc/specs/04-max-command.md\" in /repo/.intent-cli/worktrees/TOY-CALC-V0-04")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:01.1000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(" succeeded in 0ms:")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:01.2000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("## Max command")
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:20:02.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    type = "backend-exit",
+                    exit_code = 1
+                })
+            }
+        ];
     }
 
     private static IReadOnlyList<DirectRunProviderEvent> CreateMeaningfulFixWorktreeProgressProviderEvents(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -8156,31 +8156,57 @@ public sealed class RunCommandTests
             provider: "Codex");
         var originalRunImplementExecutor = RunCommand.RunImplementExecutor;
         var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
+        var originalTimestampFactory = RunCommand.TimestampFactory;
+        var originalFreshFixContinuationPollInterval = RunCommand.FreshFixContinuationPollInterval;
+        var superviseCallCount = 0;
 
         try
         {
+            RunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-10T12:31:00.5000000+00:00");
+            RunCommand.FreshFixContinuationPollInterval = TimeSpan.Zero;
             RunCommand.RunImplementExecutor = (_, executionUnit) =>
             {
+                const string sessionId = "pid:17682";
+                const string launchedAt = "2026-04-10T12:31:00.0000000+00:00";
                 WriteDirectRunRequest(
                     repoRoot,
                     executionUnit,
                     "implement",
-                    "pid:4242",
+                    sessionId,
                     provider: "Codex",
-                    launchedAt: "2026-04-10T12:31:00.0000000+00:00");
+                    launchedAt: launchedAt);
                 WriteDirectRunResult(
                     repoRoot,
                     executionUnit,
                     "implement",
                     "running",
-                    providerEvents: CreateImplementProductReadProviderEvents(executionUnit, "pid:4242"),
-                    sessionId: "pid:4242",
+                    providerEvents: CreateSingleSearchImplementProviderEvents(executionUnit, sessionId),
+                    sessionId: sessionId,
                     provider: "Codex");
+                File.WriteAllText(
+                    Path.Combine(repoRoot, ".intent-cli", "supervision", $"{executionUnit}.session.json"),
+                    RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+                    {
+                        ExecutionUnit = executionUnit,
+                        WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                        Status = RunSupervisionSessionStatus.Monitoring,
+                        QueueState = "active",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = "issue-136-toy-calc-v0-04",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md",
+                        RetryCount = 0,
+                        RetryBudget = 3,
+                        CreatedAt = DateTimeOffset.Parse(launchedAt),
+                        UpdatedAt = DateTimeOffset.Parse(launchedAt),
+                        LastHeartbeatAt = DateTimeOffset.Parse(launchedAt)
+                    }));
                 File.AppendAllText(
                     runLogPath,
                     RunLogSerializer.SerializeLine(new RunEvent
                     {
-                        Ts = DateTimeOffset.Parse("2026-04-10T12:31:00Z"),
+                        Ts = DateTimeOffset.Parse(launchedAt),
                         ExecutionUnit = executionUnit,
                         Event = "provider-lifecycle",
                         By = "intent-cli",
@@ -8188,7 +8214,7 @@ public sealed class RunCommandTests
                         EntryKind = "implement",
                         Provider = "Codex",
                         Model = "gpt-5.4-mini",
-                        SessionId = "pid:4242",
+                        SessionId = sessionId,
                         RunStatus = "running",
                         RawLogRef = $".intent-cli/runs/{executionUnit}.provider.jsonl",
                         ResultRef = $".intent-cli/runs/{executionUnit}.result.json",
@@ -8201,36 +8227,131 @@ public sealed class RunCommandTests
                 {
                     Request = CreateRunImplementRequest(repoRoot, executionUnit),
                     ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md",
-                    DirectRun = CreateDirectRunLaunchResult(executionUnit, "pid:4242")
+                    DirectRun = CreateDirectRunLaunchResult(executionUnit, sessionId)
                 };
             };
-            RunCommand.RunSuperviseExecutor = (_, executionUnit) => new RunSuperviseResult
+            RunCommand.RunSuperviseExecutor = (context, executionUnit) =>
             {
-                ExecutionUnit = executionUnit,
-                SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
-                WorkerEntry = RunSupervisionWorkerEntry.Implement,
-                SessionStatus = RunSupervisionSessionStatus.Monitoring,
-                RetryCount = 0,
-                RetryBudget = 3,
-                HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md"
+                superviseCallCount++;
+                if (superviseCallCount == 1)
+                {
+                    return new RunSuperviseResult
+                    {
+                        ExecutionUnit = executionUnit,
+                        SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                        WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                        SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                        RetryCount = 0,
+                        RetryBudget = 3,
+                        HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md"
+                    };
+                }
+
+                WriteDirectRunRequest(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "pid:17683",
+                    provider: "Codex",
+                    launchedAt: "2026-04-10T12:31:01.0000000+00:00");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "running",
+                    providerEvents: CreateImplementResumedSessionProviderEvents(executionUnit, "pid:17683"),
+                    sessionId: "pid:17683",
+                    provider: "Codex");
+                File.WriteAllText(
+                    Path.Combine(repoRoot, ".intent-cli", "supervision", $"{executionUnit}.session.json"),
+                    RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+                    {
+                        ExecutionUnit = executionUnit,
+                        WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                        Status = RunSupervisionSessionStatus.Monitoring,
+                        QueueState = "active",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = "issue-136-toy-calc-v0-04",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md",
+                        RetryCount = 0,
+                        RetryBudget = 3,
+                        CreatedAt = DateTimeOffset.Parse("2026-04-10T12:31:01.0000000+00:00"),
+                        UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:31:01.0000000+00:00"),
+                        LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T12:31:01.0000000+00:00")
+                    }));
+                File.AppendAllText(
+                    runLogPath,
+                    RunLogSerializer.SerializeLine(new RunEvent
+                    {
+                        Ts = DateTimeOffset.Parse("2026-04-10T12:31:01Z"),
+                        ExecutionUnit = executionUnit,
+                        Event = "retry-attempted",
+                        By = "intent-cli",
+                        Reason = "Worker session 'pid:17682' for 'TOY-CALC-V0-04' exited with backend exit code 1."
+                    }) + Environment.NewLine);
+                File.AppendAllText(
+                    runLogPath,
+                    RunLogSerializer.SerializeLine(new RunEvent
+                    {
+                        Ts = DateTimeOffset.Parse("2026-04-10T12:31:01Z"),
+                        ExecutionUnit = executionUnit,
+                        Event = "auto-resumed",
+                        By = "intent-cli",
+                        Reason = "run implement"
+                    }) + Environment.NewLine);
+                File.AppendAllText(
+                    runLogPath,
+                    RunLogSerializer.SerializeLine(new RunEvent
+                    {
+                        Ts = DateTimeOffset.Parse("2026-04-10T12:31:01Z"),
+                        ExecutionUnit = executionUnit,
+                        Event = "provider-lifecycle",
+                        By = "intent-cli",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        EntryKind = "implement",
+                        Provider = "Codex",
+                        Model = "gpt-5.4-mini",
+                        SessionId = "pid:17683",
+                        RunStatus = "running",
+                        RawLogRef = $".intent-cli/runs/{executionUnit}.provider.jsonl",
+                        ResultRef = $".intent-cli/runs/{executionUnit}.result.json",
+                        PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit)
+                    }) + Environment.NewLine);
+
+                return new RunSuperviseResult
+                {
+                    ExecutionUnit = executionUnit,
+                    SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                    WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                    SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                    RetryCount = 0,
+                    RetryBudget = 3,
+                    HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md",
+                    AutoResumed = true
+                };
             };
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
             Assert.Equal("no-actionable-item", result.StopReason);
             Assert.Equal("TOY-CALC-V0-04", result.ExecutionUnit);
-            Assert.Equal(2, result.Actions.Count);
+            Assert.Equal(3, result.Actions.Count);
             Assert.Equal("run implement", result.Actions[0].Name);
             Assert.Equal("run supervise", result.Actions[1].Name);
-            Assert.Contains("under supervision", result.Detail, StringComparison.Ordinal);
+            Assert.Equal("run supervise", result.Actions[2].Name);
+            Assert.Contains("auto-resumed", result.Detail, StringComparison.Ordinal);
 
             var requestArtifact = DirectRunRequestArtifactJson.Deserialize(
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "TOY-CALC-V0-04.request.json")));
-            Assert.Equal("pid:4242", requestArtifact.ProviderSessionId);
+            Assert.Equal("pid:17683", requestArtifact.ProviderSessionId);
 
             var resultArtifact = DirectRunResultArtifactJson.Deserialize(
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "TOY-CALC-V0-04.result.json")));
-            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("pid:17683", resultArtifact.SessionId);
             Assert.Equal("running", resultArtifact.RunStatus);
 
             var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
@@ -8245,13 +8366,21 @@ public sealed class RunCommandTests
                     string.Equals(runEvent.Event, "activated", StringComparison.Ordinal)
                     && string.Equals(runEvent.ExecutionUnit, "TOY-CALC-V0-04", StringComparison.Ordinal)));
             Assert.Contains(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal)
+                && string.Equals(runEvent.ExecutionUnit, "TOY-CALC-V0-04", StringComparison.Ordinal));
+            Assert.Contains(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "auto-resumed", StringComparison.Ordinal)
+                && string.Equals(runEvent.ExecutionUnit, "TOY-CALC-V0-04", StringComparison.Ordinal));
+            Assert.Contains(runEvents, runEvent =>
                 string.Equals(runEvent.Event, "provider-lifecycle", StringComparison.Ordinal)
-                && string.Equals(runEvent.SessionId, "pid:4242", StringComparison.Ordinal));
+                && string.Equals(runEvent.SessionId, "pid:17683", StringComparison.Ordinal));
         }
         finally
         {
             RunCommand.RunImplementExecutor = originalRunImplementExecutor;
             RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
+            RunCommand.TimestampFactory = originalTimestampFactory;
+            RunCommand.FreshFixContinuationPollInterval = originalFreshFixContinuationPollInterval;
         }
     }
 
@@ -8966,7 +9095,7 @@ public sealed class RunCommandTests
         ];
     }
 
-    private static IReadOnlyList<DirectRunProviderEvent> CreateImplementProductReadProviderEvents(
+    private static IReadOnlyList<DirectRunProviderEvent> CreateSingleSearchImplementProviderEvents(
         string executionUnit,
         string sessionId)
     {
@@ -8990,6 +9119,40 @@ public sealed class RunCommandTests
             new DirectRunProviderEvent
             {
                 Timestamp = "2026-04-10T12:31:00.1000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "provider-event",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'rg -n \"max command|max|Max Command|maximum\" -S .' succeeded in 0ms")
+            }
+        ];
+    }
+
+    private static IReadOnlyList<DirectRunProviderEvent> CreateImplementResumedSessionProviderEvents(
+        string executionUnit,
+        string sessionId)
+    {
+        return
+        [
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:31:01.0000000+00:00",
+                ExecutionUnit = executionUnit,
+                Provider = "Codex",
+                EntryKind = "implement",
+                SessionId = sessionId,
+                Kind = "session-metadata",
+                Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                {
+                    model = "gpt-5.4-mini",
+                    transport = "responses",
+                    command = "codex"
+                })
+            },
+            new DirectRunProviderEvent
+            {
+                Timestamp = "2026-04-10T12:31:01.1000000+00:00",
                 ExecutionUnit = executionUnit,
                 Provider = "Codex",
                 EntryKind = "implement",


### PR DESCRIPTION
## Summary
- rehydrate blocked implement sessions to a non-retryable failure when current-session artifacts already show a bounded implement failure
- synthesize and persist a canonical implement contract-gap boundary when fallback/spec recovery stops before product source or test reads
- cover the blocked nested-worktree fallback path with a regression test and keep RunCommandTests green

Closes #367