### PR TITLE
Fix #369 stale fixing-state implement continuation

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -236,6 +236,14 @@ internal static class RunCommand
 
                     if (inProgressItem.State == QueueItemState.Fixing)
                     {
+                        if (TryAutoContinueFixingImplementRecoveredSpecBoundary(
+                                context,
+                                queueState,
+                                inProgressItem))
+                        {
+                            continue;
+                        }
+
                         if (!ArtifactExists(context, ReviewCommentArtifactPathResolver.Resolve(inProgressItem.ExecutionUnit)))
                         {
                             return CreateStopResult(
@@ -833,23 +841,66 @@ internal static class RunCommand
             return false;
         }
 
+        TransitionQueueItemToActive(context, queueState, blockedItem.ExecutionUnit);
+        return true;
+    }
+
+    private static bool TryAutoContinueFixingImplementRecoveredSpecBoundary(
+        CliContext context,
+        QueueState queueState,
+        QueueItem fixingItem)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(queueState);
+        ArgumentNullException.ThrowIfNull(fixingItem);
+
+        if (ArtifactExists(context, ReviewCommentArtifactPathResolver.Resolve(fixingItem.ExecutionUnit))
+            || ArtifactExists(context, RunFixArtifactPathResolver.Resolve(fixingItem.ExecutionUnit)))
+        {
+            return false;
+        }
+
+        if (!TryReadSupervisionSession(context, fixingItem.ExecutionUnit, out var session)
+            || session.WorkerEntry != RunSupervisionWorkerEntry.Implement
+            || session.Status != RunSupervisionSessionStatus.Blocked)
+        {
+            return false;
+        }
+
+        if (!HasCurrentBlockedImplementRecoveredSpecBoundary(context, fixingItem.ExecutionUnit))
+        {
+            return false;
+        }
+
+        TransitionQueueItemToActive(context, queueState, fixingItem.ExecutionUnit);
+        return true;
+    }
+
+    private static void TransitionQueueItemToActive(
+        CliContext context,
+        QueueState queueState,
+        string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(queueState);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
         var timestamp = TimestampFactory();
         var transition = QueueManager.TransitionNonBlocking(
             queueState,
-            blockedItem.ExecutionUnit,
+            executionUnit,
             QueueItemState.Active,
             TransitionActor,
             timestamp);
         var updatedState = transition.UpdatedState with
         {
             Items = transition.UpdatedState.Items.Select(item =>
-                string.Equals(item.ExecutionUnit, blockedItem.ExecutionUnit, StringComparison.Ordinal)
+                string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal)
                     ? item with { BlockedBy = [] }
                     : item).ToArray()
         };
         File.WriteAllText(context.GetQueueStatePath(), QueueStateSerializer.Serialize(updatedState));
         AppendRunEvent(context.GetRunLogPath(), transition.Event);
-        return true;
     }
 
     private static bool TryResolveBlockedFixRetryExhaustionResult(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -8384,6 +8384,315 @@ public sealed class RunCommandTests
         }
     }
 
+    [Fact]
+    public void ExecuteCore_GivenFixingItemWithoutReviewCommentButWithBlockedImplementRecovery_ReactivatesImplementContinuation()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "TOY-CALC-V0-04"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            queueStatePath,
+            QueueStateSerializer.Serialize(CreateQueueState(
+                CreateQueueItem(QueueItemState.Fixing, executionUnit: "TOY-CALC-V0-04"))));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            runLogPath,
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"TOY-CALC-V0-04","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"TOY-CALC-V0-04","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T12:30:00Z","execution_unit":"TOY-CALC-V0-04","event":"blocked","by":"intent-cli","reason":"Worker session 'pid:27654' for 'TOY-CALC-V0-04' exited with backend exit code 1."}
+            {"ts":"2026-04-10T12:31:00Z","execution_unit":"TOY-CALC-V0-04","event":"fix-requested","by":"intent-cli","reason":"manual retry after preserved failure"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "TOY-CALC-V0-04", "packet.yaml"),
+            """
+            execution_unit: "TOY-CALC-V0-04"
+
+            implementation_issue:
+              issue_title: "[G136] Repair Implement Progress After Nested-Worktree Handoff Fallback"
+              goal: "Repair implement progression after nested-worktree handoff fallback."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/TOY-CALC-V0-04/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "TOY-CALC-V0-04.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "TOY-CALC-V0-04.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "TOY-CALC-V0-04",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                Status = RunSupervisionSessionStatus.Blocked,
+                QueueState = "blocked",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "TOY-CALC-V0-04"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-136-toy-calc-v0-04",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                HandoffArtifactRef = ".intent-cli/implement/TOY-CALC-V0-04.request.md",
+                RetryCount = 3,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:30:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T12:30:00Z"),
+                LastInterruptionReason = "Worker session 'pid:27654' for 'TOY-CALC-V0-04' exited with backend exit code 1."
+            }));
+        WriteDirectRunRequest(
+            repoRoot,
+            "TOY-CALC-V0-04",
+            "implement",
+            "pid:27654",
+            provider: "Codex",
+            launchedAt: "2026-04-10T12:20:00.0000000+00:00");
+        WriteDirectRunResult(
+            repoRoot,
+            "TOY-CALC-V0-04",
+            "implement",
+            "failed",
+            providerEvents: CreateFallbackSpecRecoveryImplementProviderEvents("TOY-CALC-V0-04", "pid:27654"),
+            sessionId: "pid:27654",
+            provider: "Codex");
+        var originalRunImplementExecutor = RunCommand.RunImplementExecutor;
+        var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
+        var originalTimestampFactory = RunCommand.TimestampFactory;
+        var originalFreshFixContinuationPollInterval = RunCommand.FreshFixContinuationPollInterval;
+        var superviseCallCount = 0;
+
+        try
+        {
+            RunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-10T12:31:00.5000000+00:00");
+            RunCommand.FreshFixContinuationPollInterval = TimeSpan.Zero;
+            RunCommand.RunImplementExecutor = (_, executionUnit) =>
+            {
+                const string sessionId = "pid:17682";
+                const string launchedAt = "2026-04-10T12:31:00.0000000+00:00";
+                WriteDirectRunRequest(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    sessionId,
+                    provider: "Codex",
+                    launchedAt: launchedAt);
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "running",
+                    providerEvents: CreateSingleSearchImplementProviderEvents(executionUnit, sessionId),
+                    sessionId: sessionId,
+                    provider: "Codex");
+                File.WriteAllText(
+                    Path.Combine(repoRoot, ".intent-cli", "supervision", $"{executionUnit}.session.json"),
+                    RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+                    {
+                        ExecutionUnit = executionUnit,
+                        WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                        Status = RunSupervisionSessionStatus.Monitoring,
+                        QueueState = "active",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = "issue-136-toy-calc-v0-04",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md",
+                        RetryCount = 0,
+                        RetryBudget = 3,
+                        CreatedAt = DateTimeOffset.Parse(launchedAt),
+                        UpdatedAt = DateTimeOffset.Parse(launchedAt),
+                        LastHeartbeatAt = DateTimeOffset.Parse(launchedAt)
+                    }));
+                File.AppendAllText(
+                    runLogPath,
+                    RunLogSerializer.SerializeLine(new RunEvent
+                    {
+                        Ts = DateTimeOffset.Parse(launchedAt),
+                        ExecutionUnit = executionUnit,
+                        Event = "provider-lifecycle",
+                        By = "intent-cli",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        EntryKind = "implement",
+                        Provider = "Codex",
+                        Model = "gpt-5.4-mini",
+                        SessionId = sessionId,
+                        RunStatus = "running",
+                        RawLogRef = $".intent-cli/runs/{executionUnit}.provider.jsonl",
+                        ResultRef = $".intent-cli/runs/{executionUnit}.result.json",
+                        PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit)
+                    }) + Environment.NewLine);
+
+                return new RunImplementResult
+                {
+                    Request = CreateRunImplementRequest(repoRoot, executionUnit),
+                    ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md",
+                    DirectRun = CreateDirectRunLaunchResult(executionUnit, sessionId)
+                };
+            };
+            RunCommand.RunSuperviseExecutor = (context, executionUnit) =>
+            {
+                superviseCallCount++;
+                if (superviseCallCount == 1)
+                {
+                    return new RunSuperviseResult
+                    {
+                        ExecutionUnit = executionUnit,
+                        SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                        WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                        SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                        RetryCount = 0,
+                        RetryBudget = 3,
+                        HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md"
+                    };
+                }
+
+                WriteDirectRunRequest(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "pid:17683",
+                    provider: "Codex",
+                    launchedAt: "2026-04-10T12:31:01.0000000+00:00");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "running",
+                    providerEvents: CreateImplementResumedSessionProviderEvents(executionUnit, "pid:17683"),
+                    sessionId: "pid:17683",
+                    provider: "Codex");
+                File.WriteAllText(
+                    Path.Combine(repoRoot, ".intent-cli", "supervision", $"{executionUnit}.session.json"),
+                    RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+                    {
+                        ExecutionUnit = executionUnit,
+                        WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                        Status = RunSupervisionSessionStatus.Monitoring,
+                        QueueState = "active",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit),
+                        ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                        Branch = "issue-136-toy-calc-v0-04",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md",
+                        RetryCount = 0,
+                        RetryBudget = 3,
+                        CreatedAt = DateTimeOffset.Parse("2026-04-10T12:31:01.0000000+00:00"),
+                        UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:31:01.0000000+00:00"),
+                        LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T12:31:01.0000000+00:00")
+                    }));
+                File.AppendAllText(
+                    runLogPath,
+                    RunLogSerializer.SerializeLine(new RunEvent
+                    {
+                        Ts = DateTimeOffset.Parse("2026-04-10T12:31:01Z"),
+                        ExecutionUnit = executionUnit,
+                        Event = "retry-attempted",
+                        By = "intent-cli",
+                        Reason = "Worker session 'pid:17682' for 'TOY-CALC-V0-04' exited with backend exit code 1."
+                    }) + Environment.NewLine);
+                File.AppendAllText(
+                    runLogPath,
+                    RunLogSerializer.SerializeLine(new RunEvent
+                    {
+                        Ts = DateTimeOffset.Parse("2026-04-10T12:31:01Z"),
+                        ExecutionUnit = executionUnit,
+                        Event = "auto-resumed",
+                        By = "intent-cli",
+                        Reason = "run implement"
+                    }) + Environment.NewLine);
+                File.AppendAllText(
+                    runLogPath,
+                    RunLogSerializer.SerializeLine(new RunEvent
+                    {
+                        Ts = DateTimeOffset.Parse("2026-04-10T12:31:01Z"),
+                        ExecutionUnit = executionUnit,
+                        Event = "provider-lifecycle",
+                        By = "intent-cli",
+                        LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                        EntryKind = "implement",
+                        Provider = "Codex",
+                        Model = "gpt-5.4-mini",
+                        SessionId = "pid:17683",
+                        RunStatus = "running",
+                        RawLogRef = $".intent-cli/runs/{executionUnit}.provider.jsonl",
+                        ResultRef = $".intent-cli/runs/{executionUnit}.result.json",
+                        PacketRef = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        ReviewContextRef = $".intent-cli/issues/{executionUnit}/review-context.md",
+                        WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", executionUnit)
+                    }) + Environment.NewLine);
+
+                return new RunSuperviseResult
+                {
+                    ExecutionUnit = executionUnit,
+                    SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                    WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                    SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                    RetryCount = 0,
+                    RetryBudget = 3,
+                    HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md",
+                    AutoResumed = true
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("TOY-CALC-V0-04", result.ExecutionUnit);
+            Assert.Equal(3, result.Actions.Count);
+            Assert.Equal("run implement", result.Actions[0].Name);
+            Assert.Equal("run supervise", result.Actions[1].Name);
+            Assert.Equal("run supervise", result.Actions[2].Name);
+            Assert.Contains("auto-resumed", result.Detail, StringComparison.Ordinal);
+
+            var requestArtifact = DirectRunRequestArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "TOY-CALC-V0-04.request.json")));
+            Assert.Equal("pid:17683", requestArtifact.ProviderSessionId);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs", "TOY-CALC-V0-04.result.json")));
+            Assert.Equal("pid:17683", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "TOY-CALC-V0-04");
+            Assert.Equal(QueueItemState.Active, selectedItem.State);
+            Assert.Empty(selectedItem.BlockedBy);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal(
+                2,
+                runEvents.Count(runEvent =>
+                    string.Equals(runEvent.Event, "activated", StringComparison.Ordinal)
+                    && string.Equals(runEvent.ExecutionUnit, "TOY-CALC-V0-04", StringComparison.Ordinal)));
+            Assert.Contains(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "fix-requested", StringComparison.Ordinal)
+                && string.Equals(runEvent.ExecutionUnit, "TOY-CALC-V0-04", StringComparison.Ordinal));
+            Assert.Contains(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal)
+                && string.Equals(runEvent.ExecutionUnit, "TOY-CALC-V0-04", StringComparison.Ordinal));
+            Assert.Contains(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "auto-resumed", StringComparison.Ordinal)
+                && string.Equals(runEvent.ExecutionUnit, "TOY-CALC-V0-04", StringComparison.Ordinal));
+            Assert.Contains(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "provider-lifecycle", StringComparison.Ordinal)
+                && string.Equals(runEvent.SessionId, "pid:17683", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunCommand.RunImplementExecutor = originalRunImplementExecutor;
+            RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
+            RunCommand.TimestampFactory = originalTimestampFactory;
+            RunCommand.FreshFixContinuationPollInterval = originalFreshFixContinuationPollInterval;
+        }
+    }
+
     private static CliContext CreateContext(
         string repoRoot,
         string postFixWorktreeProgressPolicy = CliRuntimeContracts.DefaultPostFixWorktreeProgressPolicy)


### PR DESCRIPTION
## Summary
- reactivate fixing items back to active when they still carry the blocked implement recovery shape from G136 and no review/fix artifacts exist yet
- keep the existing blocked-item recovery path but reuse the active-transition helper for both blocked and fixing stale states
- add a focused regression for the persisted TOY-CALC-V0-04 live repro shape with fixing state plus a stale implement session

## Verification
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~ExecuteCore_GivenBlockedImplementSessionWithFallbackSpecRecovery_LaunchesFreshImplementContinuation|FullyQualifiedName~ExecuteCore_GivenFixingItemWithoutReviewCommentButWithBlockedImplementRecovery_ReactivatesImplementContinuation" --nologo
- dotnet test IntentSystem.sln --nologo
- live repro from toy-calc-sample root using current worktree CLI confirmed TOY-CALC-V0-04 advanced to active, appended a fresh provider-lifecycle event (pid:39549), and progressed to review / PR https://github.com/tomohisa/toy-calc-sample/pull/11
