### PR TITLE
Fix #371 standalone bug implementation issue body

### DIFF
--- a/src/IntentSystem.Cli/Commands/BugImplementationIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugImplementationIssueCommand.cs
@@ -2,6 +2,27 @@ namespace IntentSystem.Cli.Commands;
 
 internal static class BugImplementationIssueCommand
 {
+    private sealed record StandaloneIssuePacketContract(
+        string PacketRef,
+        string ExecutionUnit,
+        string IssueTitle,
+        string Goal,
+        string TargetRepo,
+        string TargetPath,
+        string TargetPart,
+        IReadOnlyList<string> InScope,
+        IReadOnlyList<string> OutOfScope,
+        IReadOnlyList<string> AcceptanceCriteria,
+        IReadOnlyList<string> VerificationEvidence,
+        string ClarificationReturnPath);
+
+    private sealed record StandaloneIssueBodyContext(
+        BugImplementationRepairArtifact Repair,
+        BugExecutionArtifact? Execution,
+        BugTriageArtifact? Triage,
+        BugReportArtifact? Report,
+        IReadOnlyList<StandaloneIssuePacketContract> Targets);
+
     public static Func<IQueueDispatchPublisher> PublisherFactory { get; set; } = () => new GhQueueDispatchPublisher();
 
     public static Func<IGitRemoteCommandRunner> GitCommandRunnerFactory { get; set; } = () => new GitRemoteCommandRunner();
@@ -55,7 +76,7 @@ internal static class BugImplementationIssueCommand
         if (repair.ReadyToIssueCut)
         {
             var targetRepo = ResolveSingleGitHubTargetRepo(context.RepoRoot, repair.ImplementationRepairTargets);
-            var body = BuildIssueBody(repair);
+            var body = BuildIssueBody(BuildIssueBodyContext(context.RepoRoot, repair));
             var linkedIssue = PublisherFactory().CreateIssue(targetRepo, repair.SuggestedIssueTitle, body);
             createdIssueUrl = linkedIssue.Url;
             createdIssueNumber = linkedIssue.Number;
@@ -129,18 +150,458 @@ internal static class BugImplementationIssueCommand
         return distinctRepos[0];
     }
 
-    private static string BuildIssueBody(BugImplementationRepairArtifact repair)
+    private static StandaloneIssueBodyContext BuildIssueBodyContext(string repoRoot, BugImplementationRepairArtifact repair)
     {
-        return string.Join(
-            Environment.NewLine,
-            [
-                $"# {repair.SuggestedIssueTitle}",
-                string.Empty,
-                repair.SuggestedGoal,
-                string.Empty,
-                "## Implementation Repair Targets",
-                ..repair.ImplementationRepairTargets.Select(target => $"- {target}")
-            ]);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentNullException.ThrowIfNull(repair);
+
+        var execution = TryReadExecutionArtifact(repoRoot, repair.ExecutionRef);
+        var triage = execution is null ? null : TryReadTriageArtifact(repoRoot, execution.TriageRef);
+        var reportRef = execution?.ReportRef ?? triage?.ReportRef;
+        var report = string.IsNullOrWhiteSpace(reportRef) ? null : TryReadReportArtifact(repoRoot, reportRef);
+        var targets = repair.ImplementationRepairTargets
+            .Select(target => ReadStandaloneIssuePacketContract(repoRoot, target))
+            .ToArray();
+
+        return new StandaloneIssueBodyContext(repair, execution, triage, report, targets);
+    }
+
+    private static string BuildIssueBody(StandaloneIssueBodyContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var lines = new List<string>
+        {
+            $"# {context.Repair.SuggestedIssueTitle}",
+            string.Empty,
+            "## Goal"
+        };
+        AppendListOrFallback(lines, ResolveGoalLines(context), "Repair the selected implementation slice.");
+
+        lines.Add(string.Empty);
+        lines.Add("## Background");
+        AppendListOrFallback(lines, ResolveBackgroundLines(context), $"This child issue was cut from bug '{context.Repair.BugId}'.");
+
+        lines.Add(string.Empty);
+        lines.Add("## Reproduction or Current Observed State");
+        AppendListOrFallback(lines, ResolveObservedStateLines(context), "Current observed bug state was captured in the bug flow artifacts.");
+
+        lines.Add(string.Empty);
+        lines.Add("## Actual Result");
+        AppendListOrFallback(lines, ResolveActualResultLines(context), "The current implementation does not satisfy the bug-repair contract yet.");
+
+        lines.Add(string.Empty);
+        lines.Add("## Expected Repaired Result");
+        AppendListOrFallback(lines, ResolveExpectedResultLines(context), "The repaired implementation satisfies the selected packet goal and acceptance criteria.");
+
+        lines.Add(string.Empty);
+        lines.Add("## Narrowest Acceptable Repair Direction");
+        AppendListOrFallback(lines, ResolveRepairDirectionLines(context), "Limit the change to the selected implementation target and preserve current issue creation behavior.");
+
+        lines.Add(string.Empty);
+        lines.Add("## Target Repo / Path / Part");
+        AppendListOrFallback(lines, ResolveTargetLines(context), "Target packet data was not available.");
+
+        lines.Add(string.Empty);
+        lines.Add("## In Scope");
+        AppendListOrFallback(lines, DistinctPreserveOrder(context.Targets.SelectMany(target => target.InScope)), "The selected implementation target listed above.");
+
+        lines.Add(string.Empty);
+        lines.Add("## Out Of Scope");
+        AppendListOrFallback(lines, DistinctPreserveOrder(context.Targets.SelectMany(target => target.OutOfScope)), "Behavior outside the selected bug-repair slice.");
+
+        lines.Add(string.Empty);
+        lines.Add("## Acceptance Criteria");
+        AppendListOrFallback(lines, DistinctPreserveOrder(context.Targets.SelectMany(target => target.AcceptanceCriteria)), "The repaired implementation resolves the reported bug without widening scope.");
+
+        lines.Add(string.Empty);
+        lines.Add("## Verification");
+        AppendListOrFallback(lines, DistinctPreserveOrder(context.Targets.SelectMany(target => target.VerificationEvidence)), "Run the most relevant tests for the selected target slice.");
+
+        lines.Add(string.Empty);
+        lines.Add("## Relevant Links");
+        AppendListOrFallback(lines, ResolveRelevantLinkLines(context), $"Implementation repair artifact: {context.Repair.ExecutionRef}");
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static IEnumerable<string> ResolveGoalLines(StandaloneIssueBodyContext context)
+    {
+        if (context.Targets.Count == 1)
+        {
+            return [context.Targets[0].Goal];
+        }
+
+        var goalLines = context.Targets
+            .Select(target => $"{target.ExecutionUnit}: {target.Goal}")
+            .ToArray();
+        if (goalLines.Length != 0)
+        {
+            return goalLines;
+        }
+
+        return [context.Repair.SuggestedGoal];
+    }
+
+    private static IEnumerable<string> ResolveBackgroundLines(StandaloneIssueBodyContext context)
+    {
+        var lines = new List<string>();
+        if (context.Report is not null)
+        {
+            lines.Add($"Bug title: {context.Report.Title} ({context.Report.BugId}).");
+        }
+
+        if (context.Triage is not null)
+        {
+            lines.Add(
+                $"Triage classified the bug as '{context.Triage.TriageClassification}' and selected downstream action '{context.Triage.DownstreamAction}'.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(context.Repair.SuggestedGoal))
+        {
+            lines.Add($"Current repair goal from bug planning: {context.Repair.SuggestedGoal}");
+        }
+
+        return lines;
+    }
+
+    private static IEnumerable<string> ResolveObservedStateLines(StandaloneIssueBodyContext context)
+    {
+        var lines = new List<string>();
+        if (context.Report is not null)
+        {
+            lines.Add($"Problem statement: {context.Report.ProblemStatement}");
+            lines.Add($"Suspected failure locus: {context.Report.SuspectedFailureLocus}");
+        }
+
+        if (context.Triage is not null && context.Triage.ResolvedExecutionUnits.Count != 0)
+        {
+            lines.Add($"Resolved execution units: {string.Join(", ", context.Triage.ResolvedExecutionUnits)}");
+        }
+
+        return lines;
+    }
+
+    private static IEnumerable<string> ResolveActualResultLines(StandaloneIssueBodyContext context)
+    {
+        var lines = new List<string>();
+        if (context.Report is not null)
+        {
+            lines.Add(context.Report.ProblemStatement);
+        }
+
+        if (context.Triage is not null && context.Triage.LinkedReviewRefs.Count != 0)
+        {
+            lines.Add($"Review evidence: {string.Join(", ", context.Triage.LinkedReviewRefs)}");
+        }
+
+        return lines;
+    }
+
+    private static IEnumerable<string> ResolveExpectedResultLines(StandaloneIssueBodyContext context)
+    {
+        var lines = new List<string>();
+        lines.AddRange(DistinctPreserveOrder(context.Targets.Select(target => target.Goal)));
+        lines.AddRange(DistinctPreserveOrder(context.Targets.SelectMany(target => target.AcceptanceCriteria)));
+        return lines;
+    }
+
+    private static IEnumerable<string> ResolveRepairDirectionLines(StandaloneIssueBodyContext context)
+    {
+        var lines = new List<string>
+        {
+            "Repair only the bug-driven implementation slice selected by triage and packet targets below.",
+            "Preserve existing issue creation and target repo resolution behavior while fixing the underlying implementation mismatch."
+        };
+
+        lines.AddRange(context.Targets.Select(target =>
+            $"{target.ExecutionUnit}: repo '{target.TargetRepo}', path '{target.TargetPath}', part '{target.TargetPart}'."));
+
+        return lines;
+    }
+
+    private static IEnumerable<string> ResolveTargetLines(StandaloneIssueBodyContext context)
+    {
+        return context.Targets.Select(target =>
+            $"{target.ExecutionUnit}: repo '{target.TargetRepo}', path '{target.TargetPath}', part '{target.TargetPart}'.");
+    }
+
+    private static IEnumerable<string> ResolveRelevantLinkLines(StandaloneIssueBodyContext context)
+    {
+        var links = new List<string>
+        {
+            $"Bug report artifact: {context.Execution?.ReportRef ?? context.Triage?.ReportRef ?? $".intent-cli/bugs/{context.Repair.BugId}.report.yaml"}",
+            $"Bug triage artifact: {context.Execution?.TriageRef ?? $".intent-cli/bugs/{context.Repair.BugId}.triage.yaml"}",
+            $"Bug plan artifact: {context.Repair.ExecutionRef}",
+            $"Implementation repair artifact: {BugImplementationRepairArtifactPathResolver.Resolve(context.Repair.BugId)}"
+        };
+
+        links.AddRange(context.Repair.ImplementationRepairTargets.Select(target => $"Packet target: {target}"));
+
+        if (context.Report is not null)
+        {
+            links.AddRange(context.Report.LinkedIssueRefs.Select(link => $"Linked issue: {link}"));
+            links.AddRange(context.Report.LinkedPrRefs.Select(link => $"Linked PR: {link}"));
+            links.AddRange(context.Report.LinkedReviewRefs.Select(link => $"Linked review: {link}"));
+        }
+
+        links.AddRange(context.Targets.Select(target =>
+            $"Clarification return path for {target.ExecutionUnit}: {target.ClarificationReturnPath}"));
+
+        return DistinctPreserveOrder(links);
+    }
+
+    private static StandaloneIssuePacketContract ReadStandaloneIssuePacketContract(string repoRoot, string packetRef)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(packetRef);
+
+        var packetPath = ResolveExistingArtifactPath(repoRoot, packetRef, "Implementation repair target packet");
+        var yaml = File.ReadAllText(packetPath);
+
+        try
+        {
+            var packet = IntentSystem.Projection.Serialization.ProjectionPacketSerializer.Deserialize(yaml);
+            return new StandaloneIssuePacketContract(
+                packetRef,
+                packet.ImplementationIssuePacket.SourceExecutionUnit,
+                packet.ImplementationIssuePacket.IssueTitle,
+                packet.ImplementationIssuePacket.Goal,
+                packet.ImplementationIssuePacket.TargetRepo,
+                packet.ImplementationIssuePacket.TargetPath,
+                packet.ImplementationIssuePacket.TargetPart,
+                packet.ImplementationIssuePacket.InScope,
+                packet.ImplementationIssuePacket.OutOfScope,
+                packet.ImplementationIssuePacket.AcceptanceCriteria,
+                packet.ImplementationIssuePacket.VerificationEvidence,
+                packet.ReviewContextPacket.ClarificationReturnPath);
+        }
+        catch (InvalidOperationException)
+        {
+            return ReadLegacyStandaloneIssuePacketContract(packetRef, yaml);
+        }
+    }
+
+    private static StandaloneIssuePacketContract ReadLegacyStandaloneIssuePacketContract(string packetRef, string yaml)
+    {
+        var rootValues = new Dictionary<string, object>(StringComparer.Ordinal);
+        var sections = new Dictionary<string, Dictionary<string, object>>(StringComparer.Ordinal);
+        Dictionary<string, object>? currentSection = null;
+        string? currentListKey = null;
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (!char.IsWhiteSpace(line[0]))
+            {
+                if (line.EndsWith(":", StringComparison.Ordinal))
+                {
+                    var sectionName = line[..^1];
+                    currentSection = new Dictionary<string, object>(StringComparer.Ordinal);
+                    sections[sectionName] = currentSection;
+                    currentListKey = null;
+                    continue;
+                }
+
+                var separatorIndex = line.IndexOf(':');
+                if (separatorIndex < 0)
+                {
+                    throw new InvalidOperationException($"Projection packet YAML contains invalid root field '{line}'.");
+                }
+
+                var key = line[..separatorIndex].Trim();
+                var value = line[(separatorIndex + 1)..].TrimStart();
+                rootValues[key] = ParseLegacyScalar(value);
+                currentSection = null;
+                currentListKey = null;
+                continue;
+            }
+
+            if (currentSection is null)
+            {
+                throw new InvalidOperationException("Projection packet YAML must declare a section before nested fields.");
+            }
+
+            if (line.StartsWith("    - ", StringComparison.Ordinal))
+            {
+                if (currentListKey is null
+                    || !currentSection.TryGetValue(currentListKey, out var listValue)
+                    || listValue is not List<string> list)
+                {
+                    throw new InvalidOperationException(
+                        $"Projection packet YAML contains list item without a list field: '{line.Trim()}'.");
+                }
+
+                list.Add(ParseLegacyScalar(line[6..]));
+                continue;
+            }
+
+            var trimmed = line[2..];
+            var separatorIndex2 = trimmed.IndexOf(':');
+            if (separatorIndex2 < 0)
+            {
+                throw new InvalidOperationException($"Projection packet YAML field line is missing ':': '{trimmed}'.");
+            }
+
+            var key2 = trimmed[..separatorIndex2];
+            var value2 = trimmed[(separatorIndex2 + 1)..].TrimStart();
+            if (value2.Length == 0)
+            {
+                currentSection[key2] = new List<string>();
+                currentListKey = key2;
+                continue;
+            }
+
+            currentListKey = null;
+            currentSection[key2] = value2 == "[]"
+                ? Array.Empty<string>()
+                : ParseLegacyScalar(value2);
+        }
+
+        if (!rootValues.TryGetValue("execution_unit", out var executionUnitValue)
+            || executionUnitValue is not string executionUnit
+            || string.IsNullOrWhiteSpace(executionUnit))
+        {
+            throw new InvalidOperationException("Projection packet YAML must contain root field 'execution_unit'.");
+        }
+
+        if (!sections.TryGetValue("implementation_issue", out var implementationIssue))
+        {
+            throw new InvalidOperationException("Projection packet YAML must contain required section 'implementation_issue'.");
+        }
+
+        var reviewContext = sections.TryGetValue("review", out var reviewSection)
+            ? reviewSection
+            : new Dictionary<string, object>(StringComparer.Ordinal);
+
+        return new StandaloneIssuePacketContract(
+            packetRef,
+            executionUnit,
+            GetRequiredLegacyScalar(implementationIssue, "issue_title"),
+            GetRequiredLegacyScalar(implementationIssue, "goal"),
+            GetRequiredLegacyScalar(implementationIssue, "target_repo"),
+            GetLegacyScalarOrDefault(implementationIssue, "target_path", "."),
+            GetLegacyScalarOrDefault(implementationIssue, "target_part", GetRequiredLegacyScalar(implementationIssue, "issue_title")),
+            GetLegacyList(implementationIssue, "in_scope"),
+            GetLegacyList(implementationIssue, "out_of_scope"),
+            GetLegacyList(implementationIssue, "acceptance_criteria"),
+            GetLegacyList(implementationIssue, "verification_evidence"),
+            GetLegacyScalarOrDefault(reviewContext, "clarification_return_path", "intents/intent-cli/clarifications/open.md"));
+    }
+
+    private static BugExecutionArtifact? TryReadExecutionArtifact(string repoRoot, string artifactRef)
+    {
+        var artifactPath = Path.GetFullPath(Path.Combine(repoRoot, artifactRef.Replace('/', Path.DirectorySeparatorChar)));
+        return File.Exists(artifactPath)
+            ? BugExecutionArtifactYaml.Deserialize(File.ReadAllText(artifactPath))
+            : null;
+    }
+
+    private static BugTriageArtifact? TryReadTriageArtifact(string repoRoot, string artifactRef)
+    {
+        var artifactPath = Path.GetFullPath(Path.Combine(repoRoot, artifactRef.Replace('/', Path.DirectorySeparatorChar)));
+        return File.Exists(artifactPath)
+            ? BugTriageArtifactYaml.Deserialize(File.ReadAllText(artifactPath))
+            : null;
+    }
+
+    private static BugReportArtifact? TryReadReportArtifact(string repoRoot, string artifactRef)
+    {
+        var artifactPath = Path.GetFullPath(Path.Combine(repoRoot, artifactRef.Replace('/', Path.DirectorySeparatorChar)));
+        return File.Exists(artifactPath)
+            ? BugReportArtifactYaml.Deserialize(File.ReadAllText(artifactPath))
+            : null;
+    }
+
+    private static void AppendListOrFallback(List<string> lines, IEnumerable<string> values, string fallback)
+    {
+        ArgumentNullException.ThrowIfNull(lines);
+        ArgumentNullException.ThrowIfNull(values);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fallback);
+
+        var materialized = values
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .ToArray();
+        if (materialized.Length == 0)
+        {
+            lines.Add($"- {fallback}");
+            return;
+        }
+
+        lines.AddRange(materialized.Select(value => $"- {value}"));
+    }
+
+    private static IReadOnlyList<string> DistinctPreserveOrder(IEnumerable<string> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var result = new List<string>();
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value) || !seen.Add(value))
+            {
+                continue;
+            }
+
+            result.Add(value);
+        }
+
+        return result;
+    }
+
+    private static string GetRequiredLegacyScalar(IReadOnlyDictionary<string, object> values, string key)
+    {
+        return values.TryGetValue(key, out var value) && value is string text && !string.IsNullOrWhiteSpace(text)
+            ? text
+            : throw new InvalidOperationException($"Projection packet YAML must contain required field '{key}'.");
+    }
+
+    private static string GetLegacyScalarOrDefault(IReadOnlyDictionary<string, object> values, string key, string defaultValue)
+    {
+        if (values.TryGetValue(key, out var value) && value is string text && !string.IsNullOrWhiteSpace(text))
+        {
+            return text;
+        }
+
+        return defaultValue;
+    }
+
+    private static IReadOnlyList<string> GetLegacyList(IReadOnlyDictionary<string, object> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            return [];
+        }
+
+        return value switch
+        {
+            string[] arrayValue => arrayValue,
+            List<string> listValue => listValue,
+            _ => throw new InvalidOperationException($"Projection packet YAML field '{key}' must be a list.")
+        };
+    }
+
+    private static string ParseLegacyScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
     }
 
     private static string WriteArtifact(string repoRoot, BugImplementationIssueArtifact artifact)

--- a/src/IntentSystem.Cli/Commands/BugImplementationIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/BugImplementationIssueCommand.cs
@@ -10,6 +10,12 @@ internal static class BugImplementationIssueCommand
         string TargetRepo,
         string TargetPath,
         string TargetPart,
+        IReadOnlyList<string> Dependencies,
+        IReadOnlyList<string> TechnicalBaseline,
+        IReadOnlyList<string> ProjectLocalGuide,
+        IReadOnlyList<string> IntentBaseline,
+        IReadOnlyList<string> IntentReferences,
+        IReadOnlyList<string> RulesAndSpecs,
         IReadOnlyList<string> InScope,
         IReadOnlyList<string> OutOfScope,
         IReadOnlyList<string> AcceptanceCriteria,
@@ -199,6 +205,14 @@ internal static class BugImplementationIssueCommand
         AppendListOrFallback(lines, ResolveRepairDirectionLines(context), "Limit the change to the selected implementation target and preserve current issue creation behavior.");
 
         lines.Add(string.Empty);
+        lines.Add("## Accepted Baseline You May Assume");
+        AppendListOrFallback(lines, ResolveAcceptedBaselineLines(context), "No additional packet baseline assumptions were provided.");
+
+        lines.Add(string.Empty);
+        lines.Add("## Dependencies");
+        AppendListOrFallback(lines, ResolveDependencyLines(context), "No execution-unit dependencies were declared for the selected repair target.");
+
+        lines.Add(string.Empty);
         lines.Add("## Target Repo / Path / Part");
         AppendListOrFallback(lines, ResolveTargetLines(context), "Target packet data was not available.");
 
@@ -320,6 +334,22 @@ internal static class BugImplementationIssueCommand
         return lines;
     }
 
+    private static IEnumerable<string> ResolveAcceptedBaselineLines(StandaloneIssueBodyContext context)
+    {
+        var lines = new List<string>();
+        lines.AddRange(DistinctPreserveOrder(context.Targets.SelectMany(target => target.TechnicalBaseline)));
+        lines.AddRange(DistinctPreserveOrder(context.Targets.SelectMany(target => target.ProjectLocalGuide)));
+        lines.AddRange(DistinctPreserveOrder(context.Targets.SelectMany(target => target.IntentBaseline)));
+        lines.AddRange(DistinctPreserveOrder(context.Targets.SelectMany(target => target.IntentReferences)));
+        lines.AddRange(DistinctPreserveOrder(context.Targets.SelectMany(target => target.RulesAndSpecs)));
+        return lines;
+    }
+
+    private static IEnumerable<string> ResolveDependencyLines(StandaloneIssueBodyContext context)
+    {
+        return DistinctPreserveOrder(context.Targets.SelectMany(target => target.Dependencies));
+    }
+
     private static IEnumerable<string> ResolveTargetLines(StandaloneIssueBodyContext context)
     {
         return context.Targets.Select(target =>
@@ -370,6 +400,12 @@ internal static class BugImplementationIssueCommand
                 packet.ImplementationIssuePacket.TargetRepo,
                 packet.ImplementationIssuePacket.TargetPath,
                 packet.ImplementationIssuePacket.TargetPart,
+                packet.ImplementationIssuePacket.Dependencies,
+                packet.ImplementationIssuePacket.TechnicalBaseline,
+                packet.ImplementationIssuePacket.ProjectLocalGuide,
+                packet.ImplementationIssuePacket.IntentBaseline,
+                packet.ImplementationIssuePacket.IntentReferences,
+                packet.ImplementationIssuePacket.RulesAndSpecs,
                 packet.ImplementationIssuePacket.InScope,
                 packet.ImplementationIssuePacket.OutOfScope,
                 packet.ImplementationIssuePacket.AcceptanceCriteria,
@@ -488,6 +524,12 @@ internal static class BugImplementationIssueCommand
             GetRequiredLegacyScalar(implementationIssue, "target_repo"),
             GetLegacyScalarOrDefault(implementationIssue, "target_path", "."),
             GetLegacyScalarOrDefault(implementationIssue, "target_part", GetRequiredLegacyScalar(implementationIssue, "issue_title")),
+            GetLegacyList(implementationIssue, "dependencies"),
+            GetLegacyList(implementationIssue, "technical_baseline"),
+            GetLegacyList(implementationIssue, "project_local_guide"),
+            GetLegacyList(implementationIssue, "intent_baseline"),
+            GetLegacyList(implementationIssue, "intent_references"),
+            GetLegacyList(implementationIssue, "rules_and_specs"),
             GetLegacyList(implementationIssue, "in_scope"),
             GetLegacyList(implementationIssue, "out_of_scope"),
             GetLegacyList(implementationIssue, "acceptance_criteria"),

--- a/tests/IntentSystem.Cli.Tests/BugImplementationIssueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugImplementationIssueCommandTests.cs
@@ -12,6 +12,15 @@ public sealed class BugImplementationIssueCommandTests
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
         tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.report.yaml"),
+            BugReportArtifactYaml.Serialize(CreateBugReportArtifact()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.triage.yaml"),
+            BugTriageArtifactYaml.Serialize(CreateBugTriageArtifact()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.plan.yaml"),
+            BugExecutionArtifactYaml.Serialize(CreateBugExecutionArtifact()));
+        tempDirectory.CreateFile(
             Path.Combine("repo", ".intent-cli", "bugs", "BUG-123.implementation-repair.yaml"),
             BugImplementationRepairArtifactYaml.Serialize(CreateRepairArtifact(readyToIssueCut: true)));
         tempDirectory.CreateFile(
@@ -21,10 +30,11 @@ public sealed class BugImplementationIssueCommandTests
         using var writer = new StringWriter();
         var originalPublisherFactory = BugImplementationIssueCommand.PublisherFactory;
         var originalGitRunnerFactory = BugImplementationIssueCommand.GitCommandRunnerFactory;
+        var publisher = new CapturingPublisher();
 
         try
         {
-            BugImplementationIssueCommand.PublisherFactory = () => new FakePublisher();
+            BugImplementationIssueCommand.PublisherFactory = () => publisher;
             BugImplementationIssueCommand.GitCommandRunnerFactory = () => new FakeGitCommandRunner();
 
             var exitCode = BugImplementationIssueCommand.Execute(CreateContext(repoRoot), ["BUG-123"], writer);
@@ -39,6 +49,28 @@ public sealed class BugImplementationIssueCommandTests
             Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/53", artifact.CreatedIssueUrl);
             Assert.Equal(53, artifact.CreatedIssueNumber);
             Assert.Equal([".intent-cli/issues/G25/packet.yaml"], artifact.ImplementationRepairTargets);
+
+            Assert.Equal("J-Tech-Japan/intent-system", publisher.TargetRepo);
+            Assert.Equal("Implementation repair: OAuth callback loop (BUG-123)", publisher.Title);
+            Assert.NotNull(publisher.Body);
+            Assert.Contains("## Goal", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("## Background", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("## Reproduction or Current Observed State", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("## Actual Result", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("## Expected Repaired Result", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("## Narrowest Acceptable Repair Direction", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("## Target Repo / Path / Part", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("## In Scope", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("## Out Of Scope", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("## Acceptance Criteria", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("## Verification", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("## Relevant Links", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("Problem statement: Observed callback loop after login.", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("Suspected failure locus: OAuth callback state is not reset after the redirect.", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("Repair callback flow so the OAuth redirect completes exactly once without looping.", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("repo 'submodules/intent-system', path '.', part 'auth callback'.", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("accept callback responses without looping", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("dotnet test IntentSystem.sln --nologo", publisher.Body, StringComparison.Ordinal);
         }
         finally
         {
@@ -108,6 +140,67 @@ public sealed class BugImplementationIssueCommandTests
         };
     }
 
+    private static BugReportArtifact CreateBugReportArtifact(string bugId = "BUG-123")
+    {
+        return new BugReportArtifact
+        {
+            DomainSlug = "auth",
+            BugId = bugId,
+            Title = "OAuth callback loop",
+            ReportSource = "from-file",
+            ProblemStatement = "Observed callback loop after login.",
+            SuspectedFailureLocus = "OAuth callback state is not reset after the redirect.",
+            OriginalInstructionRefs = ["ICL.P.PRODUCT_GOAL"],
+            AffectedIntentRefs = ["intents/intent-cli/means/auth.md"],
+            AffectedRuleSpecRefs = ["intents/intent-cli/specs/12-bug-fix-and-intent-repair.md"],
+            ClarificationCandidates = ["Should the callback token be consumed on first successful redirect?"],
+            LinkedExecutionUnits = ["G25"],
+            LinkedIssueRefs = ["https://github.com/J-Tech-Japan/intent-system/issues/369"],
+            LinkedPrRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/370"],
+            LinkedReviewRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"]
+        };
+    }
+
+    private static BugTriageArtifact CreateBugTriageArtifact(string bugId = "BUG-123")
+    {
+        return new BugTriageArtifact
+        {
+            BugId = bugId,
+            ReportRef = $".intent-cli/bugs/{bugId}.report.yaml",
+            TriageClassification = "implementation-mismatch",
+            DownstreamAction = "dual-track",
+            ClarificationRequired = false,
+            ClarificationReasons = [],
+            OriginalInstructionRootRefs = ["ICL.P.PRODUCT_GOAL"],
+            LinkedReviewRefs = ["https://github.com/J-Tech-Japan/intent-system/pull/180#issuecomment-1"],
+            ResolvedExecutionUnits = ["G25"],
+            ResolvedImplementationRefs = [".intent-cli/issues/G25/implementation.md"],
+            ResolvedReviewContextRefs = [".intent-cli/issues/G25/review-context.md"],
+            ResolvedPacketRefs = [".intent-cli/issues/G25/packet.yaml"],
+            UnresolvedExecutionUnits = [],
+            ImplementationRepairCandidates = ["G25"],
+            IntentRepairCandidates = ["intents/intent-cli/means/auth.md"]
+        };
+    }
+
+    private static BugExecutionArtifact CreateBugExecutionArtifact(string bugId = "BUG-123")
+    {
+        return new BugExecutionArtifact
+        {
+            BugId = bugId,
+            ReportRef = $".intent-cli/bugs/{bugId}.report.yaml",
+            TriageRef = $".intent-cli/bugs/{bugId}.triage.yaml",
+            DownstreamAction = "dual-track",
+            ResolvedImplementationRefs = [".intent-cli/issues/G25/implementation.md"],
+            ResolvedReviewContextRefs = [".intent-cli/issues/G25/review-context.md"],
+            ResolvedPacketRefs = [".intent-cli/issues/G25/packet.yaml"],
+            ImplementationTaskCandidates = ["G25"],
+            IntentTaskCandidates = ["intents/intent-cli/means/auth.md"],
+            ClarificationRequired = false,
+            ReadyToLaunch = true
+        };
+    }
+
     private static string CreatePacketYaml()
     {
         return """
@@ -115,9 +208,10 @@ public sealed class BugImplementationIssueCommandTests
           issue_title: "[G25] Repair callback flow"
           issue_kind: "bugfix"
           source_execution_unit: "G25"
-          goal: "Repair callback flow."
+          goal: "Repair callback flow so the OAuth redirect completes exactly once without looping."
           in_scope:
             - "callback flow"
+            - "OAuth redirect state handling"
           out_of_scope:
             - "review flow"
           target_repo: "submodules/intent-system"
@@ -135,9 +229,9 @@ public sealed class BugImplementationIssueCommandTests
           rules_and_specs:
             - "intents/rules/issue-lifecycle-and-landing.md"
           acceptance_criteria:
-            - "repair issue created"
+            - "accept callback responses without looping"
           verification_evidence:
-            - "tests-passing"
+            - "dotnet test IntentSystem.sln --nologo"
           review_mode: "deterministic-review"
           completion_action: "wait-for-deterministic-review"
           landing_policy: "merge-after-review"
@@ -173,10 +267,19 @@ public sealed class BugImplementationIssueCommandTests
         };
     }
 
-    private sealed class FakePublisher : IQueueDispatchPublisher
+    private sealed class CapturingPublisher : IQueueDispatchPublisher
     {
+        public string? TargetRepo { get; private set; }
+
+        public string? Title { get; private set; }
+
+        public string? Body { get; private set; }
+
         public LinkedIssue CreateIssue(string targetRepo, string title, string body)
         {
+            TargetRepo = targetRepo;
+            Title = title;
+            Body = body;
             return new LinkedIssue
             {
                 Repo = targetRepo,

--- a/tests/IntentSystem.Cli.Tests/BugImplementationIssueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugImplementationIssueCommandTests.cs
@@ -59,6 +59,8 @@ public sealed class BugImplementationIssueCommandTests
             Assert.Contains("## Actual Result", publisher.Body, StringComparison.Ordinal);
             Assert.Contains("## Expected Repaired Result", publisher.Body, StringComparison.Ordinal);
             Assert.Contains("## Narrowest Acceptable Repair Direction", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("## Accepted Baseline You May Assume", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("## Dependencies", publisher.Body, StringComparison.Ordinal);
             Assert.Contains("## Target Repo / Path / Part", publisher.Body, StringComparison.Ordinal);
             Assert.Contains("## In Scope", publisher.Body, StringComparison.Ordinal);
             Assert.Contains("## Out Of Scope", publisher.Body, StringComparison.Ordinal);
@@ -69,6 +71,12 @@ public sealed class BugImplementationIssueCommandTests
             Assert.Contains("Suspected failure locus: OAuth callback state is not reset after the redirect.", publisher.Body, StringComparison.Ordinal);
             Assert.Contains("Repair callback flow so the OAuth redirect completes exactly once without looping.", publisher.Body, StringComparison.Ordinal);
             Assert.Contains("repo 'submodules/intent-system', path '.', part 'auth callback'.", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("- G24", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("- C# / .NET", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("- AGENTS.md", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("- keep repair deterministic", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("- ICL.P.PRODUCT_GOAL", publisher.Body, StringComparison.Ordinal);
+            Assert.Contains("- intents/rules/issue-lifecycle-and-landing.md", publisher.Body, StringComparison.Ordinal);
             Assert.Contains("accept callback responses without looping", publisher.Body, StringComparison.Ordinal);
             Assert.Contains("dotnet test IntentSystem.sln --nologo", publisher.Body, StringComparison.Ordinal);
         }
@@ -217,7 +225,8 @@ public sealed class BugImplementationIssueCommandTests
           target_repo: "submodules/intent-system"
           target_path: "."
           target_part: "auth callback"
-          dependencies: []
+          dependencies:
+            - "G24"
           technical_baseline:
             - "C# / .NET"
           project_local_guide:


### PR DESCRIPTION
## Summary
- replace the thin bug implementation-issue body with a standalone implementation contract built from bug report, triage, plan, implementation-repair, and packet data
- support both projected packet YAML and current parent packet YAML when extracting target repo/path/part, scope, acceptance, and verification
- add focused tests that capture the published issue body and assert the standalone sections expected by issue-only workers

## Verification
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~BugImplementationIssueCommandTests" --nologo
- dotnet test IntentSystem.sln --nologo
