### PR TITLE
Fix implement pre-read contract-gap classification after product reads

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -8,6 +8,7 @@ internal static class DirectRunFixOutcomeSupport
     private const string ExplicitContractGapRefusalReason = "provider-explicit-contract-gap-refusal";
     private const string InspectionOnlyExitReasonSuffix = "session-ended-after-initial-inspection";
     private const string ProviderBackendEndedBeforeSpecSourceReadReasonSuffix = "session-ended-before-spec-source-test-read";
+    private const string ImplementBackendEndedAfterProductReadReasonSuffix = "session-ended-after-product-source-test-read";
     private const string MissingTerminalCaptureAfterRequestReadReasonSuffix = "session-terminal-boundary-missing-after-request-reread";
     private const string MissingTerminalCaptureAfterDeepProgressReasonSuffix = "session-terminal-boundary-missing-after-deep-progress";
     private const string EvidenceOnlyReviewFollowUpMissingOutcomeReasonSuffix = "evidence-only-review-follow-up-ended-without-bounded-repair-outcome";
@@ -397,6 +398,16 @@ internal static class DirectRunFixOutcomeSupport
             return true;
         }
 
+        if (TryResolveImplementBackendExitAfterProductReadDetail(
+                providerEvents,
+                executionUnit,
+                entryKind,
+                out reason,
+                out detail))
+        {
+            return true;
+        }
+
         if (TryResolvePostRequestParityBoundaryDetail(
                 providerEvents,
                 executionUnit,
@@ -482,6 +493,39 @@ internal static class DirectRunFixOutcomeSupport
         reason = ResolveReason(entryKind, MissingTerminalCaptureAfterRequestReadReasonSuffix);
         detail =
             $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' stopped before repo-local spec/source/test planning reads. Current-session evidence observed request_reread={observedRequestReread}, repo_inventory={observedInventory}, repo_local_spec_read={observedSpecRead}, product_source_or_test_read={observedProductRead}. The provider session is no longer alive, but no backend-exit or later bounded-read event was captured for the current session. This indicates the detached helper/current-session synthesis event capture dropped after the request reread layer rather than a completed repair attempt.";
+        return true;
+    }
+
+    private static bool TryResolveImplementBackendExitAfterProductReadDetail(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        string entryKind,
+        out string reason,
+        out string detail)
+    {
+        detail = string.Empty;
+        reason = string.Empty;
+
+        if (!string.Equals(entryKind, "implement", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var observedRequestReread = providerEvents.Any(providerEvent => ContainsRequestArtifactRead(providerEvent.Payload));
+        var observedInventory = providerEvents.Any(providerEvent => ContainsInitialRepoInventory(providerEvent.Payload));
+        var observedSpecRead = HasSuccessfulRepoLocalSpecRead(providerEvents);
+        var observedProductRead = providerEvents.Any(providerEvent => ContainsProductSourceOrTestReadAttempt(providerEvent.Payload));
+        if (!observedRequestReread
+            || !observedProductRead
+            || HasCapturedSuccessfulTerminalOutcome(providerEvents)
+            || FindFailingBackendExitIndex(providerEvents) < 0)
+        {
+            return false;
+        }
+
+        reason = ResolveReason(entryKind, ImplementBackendEndedAfterProductReadReasonSuffix);
+        detail =
+            $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' ended after current-session product source/test read activity but before a bounded repair outcome. Current-session evidence observed request_reread={observedRequestReread}, repo_inventory={observedInventory}, repo_local_spec_read={observedSpecRead}, product_source_or_test_read={observedProductRead}. A failing backend-exit was captured after product source/test read activity, so the normalized failure must preserve that later evidence rather than collapsing it into an earlier pre-read backend-exit boundary.";
         return true;
     }
 

--- a/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
+++ b/tests/IntentSystem.Cli.Tests/DirectRunFixOutcomeSupportTests.cs
@@ -218,6 +218,106 @@ public sealed class DirectRunFixOutcomeSupportTests
     }
 
     [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenImplementProductReadsAfterFailedSpecRead_DoesNotUsePreReadReason()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/implement/TOY-CALC-V0-05.request.md' succeeded in 0ms", entryKind: "implement"),
+            CreateProviderEvent("exec /bin/zsh -lc 'pwd && rg --files . | sed -n ''1,200p''' succeeded in 0ms", entryKind: "implement"),
+            CreateProviderEvent("src/ToyCalc/Program.cs", entryKind: "implement"),
+            CreateProviderEvent("src/ToyCalc/Calculator.cs", entryKind: "implement"),
+            CreateProviderEvent("src/ToyCalc/CommandLine.cs", entryKind: "implement"),
+            CreateProviderEvent("tests/ToyCalc.Tests/CalculatorTests.cs", entryKind: "implement"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' intents/toy-calc/specs/05-division-command.md'", entryKind: "implement"),
+            CreateProviderEvent(" failed in 0ms:", entryKind: "implement"),
+            CreateProviderEvent("sed: intents/toy-calc/specs/05-division-command.md: No such file or directory", entryKind: "implement"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' tests/ToyCalc.Tests/CalculatorTests.cs'", entryKind: "implement"),
+            CreateProviderEvent(" succeeded in 0ms:", entryKind: "implement"),
+            CreateProviderEvent("exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Program.cs && printf ''\\n---\\n'' && sed -n ''1,220p'' src/ToyCalc/CommandLine.cs && printf ''\\n---\\n'' && sed -n ''1,220p'' src/ToyCalc/Calculator.cs'", entryKind: "implement"),
+            CreateProviderEvent(" succeeded in 0ms:", entryKind: "implement"),
+            CreateBackendExitEvent(entryKind: "implement")
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-21T09:00:00Z"),
+            "TOY-CALC-V0-05",
+            "implement",
+            "Codex",
+            "pid:13345");
+
+        Assert.NotNull(contractGapEvent);
+        Assert.Equal(
+            "implement-session-ended-after-product-source-test-read",
+            contractGapEvent!.Payload.GetProperty("reason").GetString());
+        Assert.Contains(
+            "product_source_or_test_read=True",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            "after current-session product source/test read activity",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "before any repo-local spec or product source/test read",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateCanonicalContractGapEventIfNeeded_GivenIssue373LiveImplementShape_UsesAfterProductReadReason()
+    {
+        IReadOnlyList<DirectRunProviderEvent> providerEvents =
+        [
+            CreateProviderEvent(
+                "Use the request artifact at '/Users/tomohisa/dev/GitHub/MyIntentHost/submodules/toy-calc-sample/.intent-cli/implement/TOY-CALC-V0-05.request.md' as the bounded source of truth for this direct run.",
+                entryKind: "implement"),
+            CreateProviderEvent(
+                "/bin/zsh -lc \"pwd && ls -la && sed -n '1,220p' /Users/tomohisa/dev/GitHub/MyIntentHost/submodules/toy-calc-sample/.intent-cli/implement/TOY-CALC-V0-05.request.md\" in /Users/tomohisa/dev/GitHub/MyIntentHost/submodules/toy-calc-sample/.intent-cli/worktrees/TOY-CALC-V0-05",
+                entryKind: "implement"),
+            CreateProviderEvent(
+                "/bin/zsh -lc \"rg --files -g 'README*' -g 'package.json' -g 'pnpm-workspace.yaml' -g 'tsconfig*.json' -g 'src/**' -g 'app/**' -g 'tests/**' -g 'test/**' -g 'spec/**' -g '.intent-cli/**' | sed -n '1,220p'\" in /Users/tomohisa/dev/GitHub/MyIntentHost/submodules/toy-calc-sample/.intent-cli/worktrees/TOY-CALC-V0-05",
+                entryKind: "implement"),
+            CreateProviderEvent("src/ToyCalc/Program.cs", entryKind: "implement"),
+            CreateProviderEvent("src/ToyCalc/Calculator.cs", entryKind: "implement"),
+            CreateProviderEvent("src/ToyCalc/CommandLine.cs", entryKind: "implement"),
+            CreateProviderEvent("tests/ToyCalc.Tests/CalculatorTests.cs", entryKind: "implement"),
+            CreateProviderEvent(
+                "/bin/zsh -lc \"sed -n '1,220p' intents/toy-calc/specs/05-division-command.md\" in /Users/tomohisa/dev/GitHub/MyIntentHost/submodules/toy-calc-sample/.intent-cli/worktrees/TOY-CALC-V0-05",
+                entryKind: "implement"),
+            CreateProviderEvent("sed: intents/toy-calc/specs/05-division-command.md: No such file or directory", entryKind: "implement"),
+            CreateProviderEvent(
+                "/bin/zsh -lc \"sed -n '1,220p' tests/ToyCalc.Tests/CalculatorTests.cs\" in /Users/tomohisa/dev/GitHub/MyIntentHost/submodules/toy-calc-sample/.intent-cli/worktrees/TOY-CALC-V0-05",
+                entryKind: "implement"),
+            CreateProviderEvent(
+                "/bin/zsh -lc \"sed -n '1,220p' src/ToyCalc/Program.cs && printf '\\n---\\n' && sed -n '1,220p' src/ToyCalc/CommandLine.cs && printf '\\n---\\n' && sed -n '1,220p' src/ToyCalc/Calculator.cs\" in /Users/tomohisa/dev/GitHub/MyIntentHost/submodules/toy-calc-sample/.intent-cli/worktrees/TOY-CALC-V0-05",
+                entryKind: "implement"),
+            CreateBackendExitEvent(entryKind: "implement")
+        ];
+
+        var contractGapEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            providerEvents,
+            DateTimeOffset.Parse("2026-04-21T23:31:51Z"),
+            "TOY-CALC-V0-05",
+            "implement",
+            "Codex",
+            "pid:13345");
+
+        Assert.NotNull(contractGapEvent);
+        Assert.Equal(
+            "implement-session-ended-after-product-source-test-read",
+            contractGapEvent!.Payload.GetProperty("reason").GetString());
+        Assert.Contains(
+            "product_source_or_test_read=True",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            "before any repo-local spec or product source/test read",
+            contractGapEvent.Payload.GetProperty("detail").GetString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CreateCanonicalContractGapEventIfNeeded_GivenRequestRereadAndDeadSessionWithoutTerminalEvent_UsesMissingCaptureReason()
     {
         IReadOnlyList<DirectRunProviderEvent> providerEvents =


### PR DESCRIPTION
## Summary
- add an implement-only contract-gap classification for sessions that reached product source/test reads before backend exit
- preserve later product-read evidence instead of collapsing those failures into the pre-read backend-exit reason
- add regressions for both the simplified reproduction and the live toy-calc provider-event shape from issue #373

## Verification
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~DirectRunFixOutcomeSupportTests" --nologo
- dotnet test IntentSystem.sln --nologo

Closes #373