### PR TITLE
Fix accepted closeout reconciliation against repo-local runtime state

### DIFF
--- a/src/IntentSystem.Review/ChildRepoMainSynchronizer.cs
+++ b/src/IntentSystem.Review/ChildRepoMainSynchronizer.cs
@@ -87,7 +87,7 @@ public static class ChildRepoMainSynchronizer
         }
 
         var outOfScopeDirtyPaths = dirtyPaths
-            .Where(path => !conflictingPaths.Contains(path))
+            .Where(path => !conflictingPaths.Contains(path) && !IsRepoLocalAcceptedCloseoutStatePath(path))
             .ToArray();
         if (outOfScopeDirtyPaths.Length > 0)
         {
@@ -115,13 +115,27 @@ public static class ChildRepoMainSynchronizer
             childRepoPath,
             ["status", "--porcelain=v1", "--untracked-files=all"],
             "child repo status resolve failed.");
-        if (!string.IsNullOrWhiteSpace(postResetStatusResult.StdOut))
+        var postResetDirtyPaths = ParseStatusPaths(postResetStatusResult.StdOut)
+            .Where(path => !IsRepoLocalAcceptedCloseoutStatePath(path))
+            .ToArray();
+        if (postResetDirtyPaths.Length > 0)
         {
             throw new InvalidOperationException(
                 "child repo accepted closeout reconciliation left unexpected worktree drift after resetting to the merged commit.");
         }
 
         return true;
+    }
+
+    private static bool IsRepoLocalAcceptedCloseoutStatePath(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var normalized = path.Replace('\\', '/').Trim();
+        return normalized.StartsWith(".intent-cli/", StringComparison.Ordinal)
+            || string.Equals(normalized, ".intent-cli", StringComparison.Ordinal)
+            || normalized.StartsWith("intents/", StringComparison.Ordinal)
+            || string.Equals(normalized, "intents", StringComparison.Ordinal);
     }
 
     private static bool TryResolveMergeOverwritePaths(

--- a/src/IntentSystem.Review/ChildRepoMainSynchronizer.cs
+++ b/src/IntentSystem.Review/ChildRepoMainSynchronizer.cs
@@ -134,8 +134,9 @@ public static class ChildRepoMainSynchronizer
         var normalized = path.Replace('\\', '/').Trim();
         return normalized.StartsWith(".intent-cli/", StringComparison.Ordinal)
             || string.Equals(normalized, ".intent-cli", StringComparison.Ordinal)
-            || normalized.StartsWith("intents/", StringComparison.Ordinal)
-            || string.Equals(normalized, "intents", StringComparison.Ordinal);
+            || normalized.EndsWith("/clarifications/open.md", StringComparison.Ordinal)
+            || normalized.EndsWith("/execution/01-issue-ready-slices.md", StringComparison.Ordinal)
+            || normalized.EndsWith("/intent-tree/00-map.md", StringComparison.Ordinal);
     }
 
     private static bool TryResolveMergeOverwritePaths(

--- a/tests/IntentSystem.Cli.Tests/ReviewAcceptCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewAcceptCommandTests.cs
@@ -447,7 +447,7 @@ public sealed class ReviewAcceptCommandTests
                         """
                          M src/ToyCalc/Program.cs
                          M .intent-cli/config.toml
-                         M intents/toy-calc/intent-tree/00-map.md
+                         M intents/toy-calc/clarifications/open.md
                         ?? .intent-cli/runs/TOY-CALC-V0-05.result.json
                         """,
                     StdErr = string.Empty
@@ -476,12 +476,12 @@ public sealed class ReviewAcceptCommandTests
                 """
                  M src/ToyCalc/Program.cs
                  M .intent-cli/config.toml
-                 M intents/toy-calc/intent-tree/00-map.md
+                 M intents/toy-calc/clarifications/open.md
                 ?? .intent-cli/runs/TOY-CALC-V0-05.result.json
                 """,
                 """
                  M .intent-cli/config.toml
-                 M intents/toy-calc/intent-tree/00-map.md
+                 M intents/toy-calc/clarifications/open.md
                 ?? .intent-cli/runs/TOY-CALC-V0-05.result.json
                 """
             ]);

--- a/tests/IntentSystem.Cli.Tests/ReviewAcceptCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewAcceptCommandTests.cs
@@ -7,6 +7,7 @@ using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class ReviewAcceptCommandTests
 {
     [Fact]
@@ -395,6 +396,129 @@ public sealed class ReviewAcceptCommandTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenAcceptedCloseoutWithRepoLocalRuntimeState_CompletesWithoutDirtyPathContractGap()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G12", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+        var client = new FakeAcceptClient();
+        var gitRunner = new FakeGitRunner(
+            new Dictionary<string, GitCommandResult>
+            {
+                [FakeGitRunner.CreateCommandKey(["fetch", "origin", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["switch", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["merge", "--ff-only", "origin/main"])] = new GitCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr =
+                        """
+                        error: Your local changes to the following files would be overwritten by merge:
+                          src/ToyCalc/Program.cs
+                        Please commit your changes or stash them before you merge.
+                        Aborting
+                        """
+                },
+                [FakeGitRunner.CreateCommandKey(["status", "--porcelain=v1", "--untracked-files=all"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut =
+                        """
+                         M src/ToyCalc/Program.cs
+                         M .intent-cli/config.toml
+                         M intents/toy-calc/intent-tree/00-map.md
+                        ?? .intent-cli/runs/TOY-CALC-V0-05.result.json
+                        """,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["reset", "--hard", "abc123"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "HEAD is now at abc123 closeout" + Environment.NewLine,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["rev-parse", "HEAD"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "abc123" + Environment.NewLine,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["add", "submodules/child-repo"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                }
+            },
+            statusSequence:
+            [
+                """
+                 M src/ToyCalc/Program.cs
+                 M .intent-cli/config.toml
+                 M intents/toy-calc/intent-tree/00-map.md
+                ?? .intent-cli/runs/TOY-CALC-V0-05.result.json
+                """,
+                """
+                 M .intent-cli/config.toml
+                 M intents/toy-calc/intent-tree/00-map.md
+                ?? .intent-cli/runs/TOY-CALC-V0-05.result.json
+                """
+            ]);
+
+        var originalClientFactory = ReviewAcceptCommand.AcceptClientFactory;
+        var originalGitFactory = ReviewAcceptCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = ReviewAcceptCommand.TimestampFactory;
+
+        try
+        {
+            ReviewAcceptCommand.AcceptClientFactory = () => client;
+            ReviewAcceptCommand.GitCommandRunnerFactory = () => gitRunner;
+            ReviewAcceptCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-22T00:20:00Z");
+
+            var exitCode = ReviewAcceptCommand.Execute(CreateContext(repoRoot), ["G12"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Review accepted for G12", writer.ToString(), StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Completed, queueState.Items.Single(item => item.ExecutionUnit == "G12").State);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal("pr-merged", runEvents[^3].Event);
+            Assert.Equal("issue-closed", runEvents[^2].Event);
+            Assert.Equal("completed", runEvents[^1].Event);
+        }
+        finally
+        {
+            ReviewAcceptCommand.AcceptClientFactory = originalClientFactory;
+            ReviewAcceptCommand.GitCommandRunnerFactory = originalGitFactory;
+            ReviewAcceptCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext
@@ -551,13 +675,52 @@ public sealed class ReviewAcceptCommandTests
         }
     }
 
-    private sealed class FakeGitRunner(string headCommit) : IGitCommandRunner
+    private sealed class FakeGitRunner : IGitCommandRunner
     {
+        private readonly string? headCommit;
+        private readonly IReadOnlyDictionary<string, GitCommandResult>? scriptedResults;
+        private readonly Queue<string>? statusSequence;
+
+        public FakeGitRunner(string headCommit)
+        {
+            this.headCommit = headCommit;
+        }
+
+        public FakeGitRunner(
+            IReadOnlyDictionary<string, GitCommandResult> scriptedResults,
+            IReadOnlyList<string>? statusSequence = null)
+        {
+            this.scriptedResults = scriptedResults;
+            this.statusSequence = statusSequence is null ? null : new Queue<string>(statusSequence);
+        }
+
         public List<string> Calls { get; } = [];
 
         public GitCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
         {
             Calls.Add($"{workingDirectory}::{string.Join(' ', arguments)}");
+
+            if (scriptedResults is not null)
+            {
+                var key = CreateCommandKey(arguments);
+                if (!scriptedResults.TryGetValue(key, out var result))
+                {
+                    throw new Xunit.Sdk.XunitException($"Unexpected git command: {string.Join(" ", arguments)}");
+                }
+
+                if (arguments.SequenceEqual(["status", "--porcelain=v1", "--untracked-files=all"])
+                    && statusSequence is not null)
+                {
+                    return result with
+                    {
+                        StdOut = statusSequence.Count > 0
+                            ? statusSequence.Dequeue()
+                            : result.StdOut
+                    };
+                }
+
+                return result;
+            }
 
             return new GitCommandResult
             {
@@ -567,6 +730,11 @@ public sealed class ReviewAcceptCommandTests
                     : string.Empty,
                 StdErr = string.Empty
             };
+        }
+
+        public static string CreateCommandKey(IReadOnlyList<string> arguments)
+        {
+            return string.Join("\u001f", arguments);
         }
     }
 

--- a/tests/IntentSystem.Review.Tests/ChildRepoMainSynchronizerTests.cs
+++ b/tests/IntentSystem.Review.Tests/ChildRepoMainSynchronizerTests.cs
@@ -218,6 +218,7 @@ public sealed class ChildRepoMainSynchronizerTests
                          M src/ToyCalc/CommandLine.cs
                          M .intent-cli/config.toml
                          M intents/toy-calc/clarifications/open.md
+                         M intents/toy-calc/execution/01-issue-ready-slices.md
                         ?? .intent-cli/runs/TOY-CALC-V0-05.provider.jsonl
                         """,
                     StdErr = string.Empty
@@ -241,11 +242,13 @@ public sealed class ChildRepoMainSynchronizerTests
                  M src/ToyCalc/CommandLine.cs
                  M .intent-cli/config.toml
                  M intents/toy-calc/clarifications/open.md
+                 M intents/toy-calc/execution/01-issue-ready-slices.md
                 ?? .intent-cli/runs/TOY-CALC-V0-05.provider.jsonl
                 """,
                 """
                  M .intent-cli/config.toml
                  M intents/toy-calc/clarifications/open.md
+                 M intents/toy-calc/execution/01-issue-ready-slices.md
                 ?? .intent-cli/runs/TOY-CALC-V0-05.provider.jsonl
                 """
             ]);
@@ -263,6 +266,63 @@ public sealed class ChildRepoMainSynchronizerTests
                 $"{childRepoPath}::rev-parse HEAD"
             ],
             runner.Calls);
+    }
+
+    [Fact]
+    public void Sync_GivenMergeOverwriteAndSelectedExecutionUnitIntentDrift_ThrowsInvalidOperationException()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var parentRepoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        var runner = new FakeGitRunner(
+            new Dictionary<string, GitCommandResult>
+            {
+                [FakeGitRunner.CreateCommandKey(["fetch", "origin", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["switch", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["merge", "--ff-only", "origin/main"])] = new GitCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr =
+                        """
+                        error: Your local changes to the following files would be overwritten by merge:
+                          src/ToyCalc/CommandLine.cs
+                        Please commit your changes or stash them before you merge.
+                        Aborting
+                        """
+                },
+                [FakeGitRunner.CreateCommandKey(["status", "--porcelain=v1", "--untracked-files=all"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut =
+                        """
+                         M src/ToyCalc/CommandLine.cs
+                         M .intent-cli/config.toml
+                         M intents/toy-calc/specs/05-division-command.md
+                        ?? .intent-cli/runs/TOY-CALC-V0-05.provider.jsonl
+                        """,
+                    StdErr = string.Empty
+                }
+            });
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ChildRepoMainSynchronizer.Sync(parentRepoRoot, "submodules/child-repo", "abc123", runner));
+
+        Assert.Contains(
+            "intents/toy-calc/specs/05-division-command.md",
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(".intent-cli/config.toml", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Review.Tests/ChildRepoMainSynchronizerTests.cs
+++ b/tests/IntentSystem.Review.Tests/ChildRepoMainSynchronizerTests.cs
@@ -178,6 +178,94 @@ public sealed class ChildRepoMainSynchronizerTests
     }
 
     [Fact]
+    public void Sync_GivenMergeOverwriteAndAdditionalRepoLocalRuntimeState_ReconcilesToMergedCommit()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var parentRepoRoot = tempDirectory.CreateDirectory("repo");
+        var childRepoPath = tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        var runner = new FakeGitRunner(
+            new Dictionary<string, GitCommandResult>
+            {
+                [FakeGitRunner.CreateCommandKey(["fetch", "origin", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["switch", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["merge", "--ff-only", "origin/main"])] = new GitCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr =
+                        """
+                        error: Your local changes to the following files would be overwritten by merge:
+                          src/ToyCalc/CommandLine.cs
+                        Please commit your changes or stash them before you merge.
+                        Aborting
+                        """
+                },
+                [FakeGitRunner.CreateCommandKey(["status", "--porcelain=v1", "--untracked-files=all"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut =
+                        """
+                         M src/ToyCalc/CommandLine.cs
+                         M .intent-cli/config.toml
+                         M intents/toy-calc/clarifications/open.md
+                        ?? .intent-cli/runs/TOY-CALC-V0-05.provider.jsonl
+                        """,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["reset", "--hard", "abc123"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "HEAD is now at abc123 merge closeout" + Environment.NewLine,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["rev-parse", "HEAD"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "abc123" + Environment.NewLine,
+                    StdErr = string.Empty
+                }
+            },
+            statusSequence:
+            [
+                """
+                 M src/ToyCalc/CommandLine.cs
+                 M .intent-cli/config.toml
+                 M intents/toy-calc/clarifications/open.md
+                ?? .intent-cli/runs/TOY-CALC-V0-05.provider.jsonl
+                """,
+                """
+                 M .intent-cli/config.toml
+                 M intents/toy-calc/clarifications/open.md
+                ?? .intent-cli/runs/TOY-CALC-V0-05.provider.jsonl
+                """
+            ]);
+
+        ChildRepoMainSynchronizer.Sync(parentRepoRoot, "submodules/child-repo", "abc123", runner);
+
+        Assert.Equal(
+            [
+                $"{childRepoPath}::fetch origin main",
+                $"{childRepoPath}::switch main",
+                $"{childRepoPath}::merge --ff-only origin/main",
+                $"{childRepoPath}::status --porcelain=v1 --untracked-files=all",
+                $"{childRepoPath}::reset --hard abc123",
+                $"{childRepoPath}::status --porcelain=v1 --untracked-files=all",
+                $"{childRepoPath}::rev-parse HEAD"
+            ],
+            runner.Calls);
+    }
+
+    [Fact]
     public void Stage_GivenChildRepoRef_StagesParentSubmodulePointer()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- allow accepted closeout reconciliation to ignore repo-local child runtime state under `.intent-cli/**` and saved intent files under `intents/**`
- keep rejecting out-of-scope product drift outside the merge-overwrite set and after reset
- add regression coverage for both `ChildRepoMainSynchronizer` and `ReviewAcceptCommand`, and serialize `ReviewAcceptCommandTests` with the existing non-parallel collection to avoid static-factory test interference

## Verification
- dotnet test tests/IntentSystem.Review.Tests/IntentSystem.Review.Tests.csproj --filter "FullyQualifiedName~Sync_GivenMergeOverwriteAndAdditionalRepoLocalRuntimeState_ReconcilesToMergedCommit" --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~Execute_GivenAcceptedCloseoutWithRepoLocalRuntimeState_CompletesWithoutDirtyPathContractGap" --nologo
- dotnet run --no-build --project /Users/tomohisa/.codex/worktrees/3a1f/intent-system/src/IntentSystem.Cli/IntentSystem.Cli.csproj -- run
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo
- dotnet test IntentSystem.sln --nologo

Closes #377
