### PR TITLE
Repair accepted closeout for descendant child main heads

### DIFF
--- a/src/IntentSystem.Review/ChildRepoMainSynchronizer.cs
+++ b/src/IntentSystem.Review/ChildRepoMainSynchronizer.cs
@@ -29,10 +29,11 @@ public static class ChildRepoMainSynchronizer
 
         var headResult = Run(commandRunner, childRepoPath, ["rev-parse", "HEAD"], "child repo HEAD resolve failed.");
         var headCommit = headResult.StdOut.Trim();
-        if (!string.Equals(headCommit, mergedCommitSha, StringComparison.Ordinal))
+        if (!string.Equals(headCommit, mergedCommitSha, StringComparison.Ordinal)
+            && !DoesHeadContainMergedCommit(commandRunner, childRepoPath, mergedCommitSha, headCommit))
         {
             throw new InvalidOperationException(
-                $"Child repo main HEAD '{headCommit}' must match merged commit '{mergedCommitSha}'.");
+                $"Child repo main HEAD '{headCommit}' must contain merged commit '{mergedCommitSha}'.");
         }
     }
 
@@ -59,6 +60,26 @@ public static class ChildRepoMainSynchronizer
         }
 
         return result;
+    }
+
+    private static bool DoesHeadContainMergedCommit(
+        IGitCommandRunner commandRunner,
+        string childRepoPath,
+        string mergedCommitSha,
+        string headCommit)
+    {
+        var result = commandRunner.Run(
+            childRepoPath,
+            ["merge-base", "--is-ancestor", mergedCommitSha, headCommit]);
+        return result.ExitCode switch
+        {
+            0 => true,
+            1 => false,
+            _ => throw new InvalidOperationException(
+                string.IsNullOrWhiteSpace(result.StdErr)
+                    ? "child repo descendant containment check failed."
+                    : result.StdErr.Trim())
+        };
     }
 
     private static bool TryReconcileAcceptedWorktreeState(

--- a/tests/IntentSystem.Cli.Tests/ReviewAcceptCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewAcceptCommandTests.cs
@@ -208,7 +208,7 @@ public sealed class ReviewAcceptCommandTests
             var exitCode = ReviewAcceptCommand.Execute(CreateContext(repoRoot), ["G12"], writer);
 
             Assert.Equal(1, exitCode);
-            Assert.Contains("must match merged commit", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("must contain merged commit", writer.ToString(), StringComparison.Ordinal);
             Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
             Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
         }
@@ -216,6 +216,102 @@ public sealed class ReviewAcceptCommandTests
         {
             ReviewAcceptCommand.AcceptClientFactory = originalClientFactory;
             ReviewAcceptCommand.GitCommandRunnerFactory = originalGitFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenChildMainHeadDescendantOfMergedCommit_CompletesCloseout()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var childRepoPath = tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G12", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        using var writer = new StringWriter();
+        var client = new FakeAcceptClient();
+        var gitRunner = new FakeGitRunner(
+            new Dictionary<string, GitCommandResult>
+            {
+                [FakeGitRunner.CreateCommandKey(["fetch", "origin", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["switch", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["merge", "--ff-only", "origin/main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["rev-parse", "HEAD"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "def456" + Environment.NewLine,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["merge-base", "--is-ancestor", "abc123", "def456"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["add", "submodules/child-repo"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                }
+            });
+
+        var originalClientFactory = ReviewAcceptCommand.AcceptClientFactory;
+        var originalGitFactory = ReviewAcceptCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = ReviewAcceptCommand.TimestampFactory;
+
+        try
+        {
+            ReviewAcceptCommand.AcceptClientFactory = () => client;
+            ReviewAcceptCommand.GitCommandRunnerFactory = () => gitRunner;
+            ReviewAcceptCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-22T10:00:00Z");
+
+            var exitCode = ReviewAcceptCommand.Execute(CreateContext(repoRoot), ["G12"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Review accepted for G12", writer.ToString(), StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(QueueItemState.Completed, queueState.Items.Single(item => item.ExecutionUnit == "G12").State);
+
+            Assert.Equal(
+                [
+                    $"{childRepoPath}::fetch origin main",
+                    $"{childRepoPath}::switch main",
+                    $"{childRepoPath}::merge --ff-only origin/main",
+                    $"{childRepoPath}::rev-parse HEAD",
+                    $"{childRepoPath}::merge-base --is-ancestor abc123 def456",
+                    $"{repoRoot}::add submodules/child-repo"
+                ],
+                gitRunner.Calls);
+        }
+        finally
+        {
+            ReviewAcceptCommand.AcceptClientFactory = originalClientFactory;
+            ReviewAcceptCommand.GitCommandRunnerFactory = originalGitFactory;
+            ReviewAcceptCommand.TimestampFactory = originalTimestampFactory;
         }
     }
 
@@ -724,7 +820,11 @@ public sealed class ReviewAcceptCommandTests
 
             return new GitCommandResult
             {
-                ExitCode = 0,
+                ExitCode = arguments.Count >= 4
+                    && arguments[0] == "merge-base"
+                    && arguments[1] == "--is-ancestor"
+                    ? 1
+                    : 0,
                 StdOut = arguments.SequenceEqual(["rev-parse", "HEAD"])
                     ? headCommit + Environment.NewLine
                     : string.Empty,

--- a/tests/IntentSystem.Review.Tests/ChildRepoMainSynchronizerTests.cs
+++ b/tests/IntentSystem.Review.Tests/ChildRepoMainSynchronizerTests.cs
@@ -34,7 +34,61 @@ public sealed class ChildRepoMainSynchronizerTests
         var exception = Assert.Throws<InvalidOperationException>(
             () => ChildRepoMainSynchronizer.Sync(parentRepoRoot, "submodules/child-repo", "abc123", runner));
 
-        Assert.Contains("must match merged commit", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("must contain merged commit", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Sync_GivenHeadDescendantOfMergedCommit_AcceptsCloseout()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var parentRepoRoot = tempDirectory.CreateDirectory("repo");
+        var childRepoPath = tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "child-repo"));
+        var runner = new FakeGitRunner(
+            new Dictionary<string, GitCommandResult>
+            {
+                [FakeGitRunner.CreateCommandKey(["fetch", "origin", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["switch", "main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["merge", "--ff-only", "origin/main"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["rev-parse", "HEAD"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "def456" + Environment.NewLine,
+                    StdErr = string.Empty
+                },
+                [FakeGitRunner.CreateCommandKey(["merge-base", "--is-ancestor", "abc123", "def456"])] = new GitCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = string.Empty,
+                    StdErr = string.Empty
+                }
+            });
+
+        ChildRepoMainSynchronizer.Sync(parentRepoRoot, "submodules/child-repo", "abc123", runner);
+
+        Assert.Equal(
+            [
+                $"{childRepoPath}::fetch origin main",
+                $"{childRepoPath}::switch main",
+                $"{childRepoPath}::merge --ff-only origin/main",
+                $"{childRepoPath}::rev-parse HEAD",
+                $"{childRepoPath}::merge-base --is-ancestor abc123 def456"
+            ],
+            runner.Calls);
     }
 
     [Fact]
@@ -389,7 +443,11 @@ public sealed class ChildRepoMainSynchronizerTests
 
             return new GitCommandResult
             {
-                ExitCode = 0,
+                ExitCode = arguments.Count >= 4
+                    && arguments[0] == "merge-base"
+                    && arguments[1] == "--is-ancestor"
+                    ? 1
+                    : 0,
                 StdOut = arguments.SequenceEqual(["rev-parse", "HEAD"])
                     ? headCommit + Environment.NewLine
                     : string.Empty,


### PR DESCRIPTION
## Summary
- allow review accept closeout to succeed when child `main` HEAD is a later descendant that already contains the merged commit
- keep deterministic failure when child `main` does not contain the merged commit at all
- add focused regressions for both `ChildRepoMainSynchronizer` and `ReviewAcceptCommand` covering descendant-head success and non-containing divergence

## Verification
- dotnet test tests/IntentSystem.Review.Tests/IntentSystem.Review.Tests.csproj --filter "FullyQualifiedName~Sync_GivenHeadMismatch_ThrowsInvalidOperationException|FullyQualifiedName~Sync_GivenHeadDescendantOfMergedCommit_AcceptsCloseout" --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~Execute_GivenChildSyncFailure_ReturnsExitCodeOneWithoutMutatingFiles|FullyQualifiedName~Execute_GivenChildMainHeadDescendantOfMergedCommit_CompletesCloseout" --nologo
- dotnet run --no-build --project /Users/tomohisa/.codex/worktrees/3a1f/intent-system/src/IntentSystem.Cli/IntentSystem.Cli.csproj -- run
- dotnet test IntentSystem.sln --nologo

Closes #381
