### PR TITLE
Repair next-slice bootstrap after closeout

### DIFF
--- a/src/IntentSystem.Cli/Commands/IntakeAdvanceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeAdvanceCommand.cs
@@ -60,7 +60,7 @@ internal static class IntakeAdvanceCommand
         var (_, patchPath) = IntakePatchCommand.ExecuteCore(context.RepoRoot, domain);
         var applyResult = IntakeApplyCommand.ExecuteCore(context.RepoRoot, domain);
         var (_, executionPath) = IntakeExecutionCommand.ExecuteCore(context.RepoRoot, domain);
-        var executionApplyResult = IntakeExecutionApplyCommand.ExecuteCore(context.RepoRoot, domain);
+        var executionApplyResult = TryExecuteExecutionApply(context.RepoRoot, domain, out var skippedExecutionApply);
 
         var regeneratedArtifactPaths = new[]
         {
@@ -80,8 +80,35 @@ internal static class IntakeAdvanceCommand
             UpdatedSourceFilePaths = applyResult.ChangedFilePaths,
             UpdatedExecutionFilePaths = executionApplyResult.ChangedFilePaths,
             RegeneratedArtifactPaths = regeneratedArtifactPaths,
-            SkippedStages = []
+            SkippedStages = skippedExecutionApply ? ["execution-apply"] : []
         };
+    }
+
+    private static IntakeExecutionApplyResult TryExecuteExecutionApply(
+        string repoRoot,
+        string domain,
+        out bool skipped)
+    {
+        try
+        {
+            skipped = false;
+            return IntakeExecutionApplyCommand.ExecuteCore(repoRoot, domain);
+        }
+        catch (InvalidOperationException exception)
+            when (string.Equals(
+                exception.Message,
+                "Execution apply target could not be derived from the current execution baseline.",
+                StringComparison.Ordinal))
+        {
+            skipped = true;
+            return new IntakeExecutionApplyResult
+            {
+                Domain = domain,
+                ChangedFilePaths = [],
+                AppliedUnitCount = 0,
+                PreservedDependencyRefs = []
+            };
+        }
     }
 
     private static void EnsureConceptArtifactExists(string repoRoot, string domain)

--- a/src/IntentSystem.Cli/Commands/IntakeExecutionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeExecutionCommand.cs
@@ -71,9 +71,11 @@ internal static class IntakeExecutionCommand
             .Where(relativePath => File.Exists(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar))))
             .ToArray();
 
-        var candidates = updatedSourceFiles
-            .Select((relativePath, index) => CreateCandidate(repoRoot, patchRequest.Domain, relativePath, index + 1))
-            .ToArray();
+        var candidates = updatedSourceFiles.Length == 0
+            ? CreateCandidatesFromExecutionSourceOfTruth(repoRoot, patchRequest.Domain)
+            : updatedSourceFiles
+                .Select((relativePath, index) => CreateCandidate(repoRoot, patchRequest.Domain, relativePath, index + 1))
+                .ToArray();
 
         var conceptIds = candidates
             .Where(candidate => string.Equals(candidate.TargetPart, "concepts", StringComparison.Ordinal))
@@ -86,7 +88,9 @@ internal static class IntakeExecutionCommand
             {
                 Dependencies = string.Equals(candidate.TargetPart, "concepts", StringComparison.Ordinal)
                     ? Array.Empty<string>()
-                    : conceptIds
+                    : conceptIds.Length == 0
+                        ? candidate.Dependencies
+                        : conceptIds
             })
             .ToArray();
 
@@ -95,6 +99,135 @@ internal static class IntakeExecutionCommand
             Domain = patchRequest.Domain,
             ProposedExecutionUnits = resolvedCandidates
         };
+    }
+
+    private static IntakeExecutionUnitCandidate[] CreateCandidatesFromExecutionSourceOfTruth(string repoRoot, string domain)
+    {
+        var intentsRoot = Path.Combine(repoRoot, "intents");
+        if (!Directory.Exists(intentsRoot))
+        {
+            return [];
+        }
+
+        var candidates = new List<IntakeExecutionUnitCandidate>();
+        foreach (var absolutePath in Directory.GetFiles(intentsRoot, "*.md", SearchOption.AllDirectories)
+                     .Where(path => path.Contains($"{Path.DirectorySeparatorChar}execution{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                     .OrderBy(path => path, StringComparer.Ordinal))
+        {
+            var relativePath = Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
+            if (!BelongsToDomain(relativePath, domain))
+            {
+                continue;
+            }
+
+            candidates.AddRange(ParseIssueReadyExecutionRows(relativePath, File.ReadAllText(absolutePath)));
+        }
+
+        return candidates
+            .Where(candidate => HasDomainExecutionUnitPrefix(candidate.ExecutionUnitId, domain))
+            .GroupBy(candidate => candidate.ExecutionUnitId, StringComparer.Ordinal)
+            .Select(group => group.First())
+            .OrderBy(candidate => candidate.ExecutionUnitId, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static bool BelongsToDomain(string relativePath, string domain)
+    {
+        var normalized = relativePath.Replace('\\', '/');
+        return normalized.StartsWith($"intents/{domain}/", StringComparison.Ordinal);
+    }
+
+    private static bool HasDomainExecutionUnitPrefix(string executionUnitId, string domain)
+    {
+        var normalizedDomain = domain.Replace('/', '-').ToUpperInvariant();
+        return executionUnitId.StartsWith($"{normalizedDomain}-", StringComparison.Ordinal);
+    }
+
+    private static IReadOnlyList<IntakeExecutionUnitCandidate> ParseIssueReadyExecutionRows(string relativePath, string markdown)
+    {
+        var rows = new List<IntakeExecutionUnitCandidate>();
+        var normalized = markdown.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var lines = normalized.Split('\n', StringSplitOptions.None);
+        var inTargetTable = false;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.Trim();
+            if (line.StartsWith("| subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |", StringComparison.Ordinal))
+            {
+                inTargetTable = true;
+                continue;
+            }
+
+            if (!inTargetTable)
+            {
+                continue;
+            }
+
+            if (!line.StartsWith("|", StringComparison.Ordinal))
+            {
+                inTargetTable = false;
+                continue;
+            }
+
+            if (line.StartsWith("|---", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var cells = line.Split('|', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            if (cells.Length < 8)
+            {
+                continue;
+            }
+
+            if (!string.Equals(cells[7], "yes", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var executionUnitId = cells[0];
+            var goal = cells[2];
+            var targetPart = cells[6];
+            var dependencies = ParseDependencies(cells[3]);
+
+            rows.Add(new IntakeExecutionUnitCandidate
+            {
+                ExecutionUnitId = executionUnitId,
+                SourceFilePath = relativePath,
+                TargetPart = targetPart,
+                Dependencies = dependencies,
+                ReadinessNotes =
+                [
+                    $"Source file path: {relativePath}",
+                    $"Current goal: {goal}",
+                    $"Execution row target part: {targetPart}"
+                ],
+                VerificationHints =
+                [
+                    $"Review execution row '{executionUnitId}' in '{relativePath}'.",
+                    $"Confirm target part '{targetPart}' remains issue-ready in current source-of-truth.",
+                    "dotnet test IntentSystem.sln"
+                ]
+            });
+        }
+
+        return rows;
+    }
+
+    private static IReadOnlyList<string> ParseDependencies(string rawValue)
+    {
+        if (string.IsNullOrWhiteSpace(rawValue)
+            || string.Equals(rawValue, "none", StringComparison.OrdinalIgnoreCase))
+        {
+            return [];
+        }
+
+        return rawValue.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .Where(value => !string.Equals(value, "none", StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(value => value, StringComparer.Ordinal)
+            .ToArray();
     }
 
     private static IntakeExecutionUnitCandidate CreateCandidate(

--- a/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntakeIssueCommand.cs
@@ -339,10 +339,12 @@ internal static class IntakeIssueCommand
         IntakeIssueBaseline baseline,
         IntakeIssueParentRefs parentRefs)
     {
+        var resolvedGoal = ResolveGoal(unit);
+
         return new SubSliceRow
         {
             SourceExecutionUnit = unit.ExecutionUnitId,
-            Goal = $"Reflect the intake-origin update from `{unit.SourceFilePath}` into `{unit.TargetPart}`.",
+            Goal = resolvedGoal ?? $"Reflect the intake-origin update from `{unit.SourceFilePath}` into `{unit.TargetPart}`.",
             TargetRepo = baseline.TargetRepo,
             TargetPath = baseline.TargetPath,
             TargetPart = unit.TargetPart,
@@ -477,6 +479,12 @@ internal static class IntakeIssueCommand
 
     private static string ResolveTitle(IntakeOriginExecutionUnit unit)
     {
+        var goal = ResolveGoal(unit);
+        if (!string.IsNullOrWhiteSpace(goal))
+        {
+            return goal!;
+        }
+
         var heading = unit.ReadinessNotes
             .FirstOrDefault(note => note.StartsWith("Current heading: ", StringComparison.Ordinal));
 
@@ -492,6 +500,14 @@ internal static class IntakeIssueCommand
         }
 
         return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(fileName.Replace('-', ' '));
+    }
+
+    private static string? ResolveGoal(IntakeOriginExecutionUnit unit)
+    {
+        var goal = unit.ReadinessNotes
+            .FirstOrDefault(note => note.StartsWith("Current goal: ", StringComparison.Ordinal));
+
+        return goal?["Current goal: ".Length..].Trim();
     }
 
     private readonly record struct IntakeIssueBaseline

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -11,6 +11,7 @@ namespace IntentSystem.Cli.Commands;
 internal static class RunCommand
 {
     private sealed record AutoContinueIntakeCandidate(string Domain, string ExecutionUnit);
+    private sealed record AutoContinueIntakeRefreshTarget(string Domain, string CompletedExecutionUnit);
 
     private sealed class RunDeterministicGapException(string executionUnit, string message)
         : InvalidOperationException(message)
@@ -555,10 +556,16 @@ internal static class RunCommand
                         $"Blocked item '{blockedItem.ExecutionUnit}' requires parent-side planning.");
                 }
 
-                if (!TryResolveAutoContinueIntakeCandidate(context, queueState, out var intakeCandidate))
+                if (!TryResolveAutoContinueIntakeCandidate(context, queueState, out var intakeCandidate)
+                    && TryResolveAutoContinueIntakeRefreshTarget(context, queueState, out var refreshTarget)
+                    && refreshTarget is not null)
                 {
-                    TryRefreshIntakeDomainsForAutoContinue(context);
-                    TryResolveAutoContinueIntakeCandidate(context, queueState, out intakeCandidate);
+                    TryRefreshIntakeDomainForAutoContinue(context, refreshTarget);
+                    TryResolveAutoContinueIntakeCandidate(
+                        context,
+                        queueState,
+                        refreshTarget.Domain,
+                        out intakeCandidate);
                 }
 
                 if (intakeCandidate is not null)
@@ -637,6 +644,15 @@ internal static class RunCommand
         QueueState queueState,
         out AutoContinueIntakeCandidate? candidate)
     {
+        return TryResolveAutoContinueIntakeCandidate(context, queueState, domainFilter: null, out candidate);
+    }
+
+    private static bool TryResolveAutoContinueIntakeCandidate(
+        CliContext context,
+        QueueState queueState,
+        string? domainFilter,
+        out AutoContinueIntakeCandidate? candidate)
+    {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(queueState);
 
@@ -654,9 +670,7 @@ internal static class RunCommand
             return false;
         }
 
-        foreach (var artifactPath in Directory
-                     .EnumerateFiles(intakeDirectory, "*.execution.md", SearchOption.TopDirectoryOnly)
-                     .OrderBy(path => path, StringComparer.Ordinal))
+        foreach (var artifactPath in EnumerateIntakeExecutionArtifactsForAutoContinue(intakeDirectory, domainFilter))
         {
             IntakeExecutionRequest request;
             try
@@ -690,29 +704,102 @@ internal static class RunCommand
         return false;
     }
 
-    private static void TryRefreshIntakeDomainsForAutoContinue(
-        CliContext context)
+    private static bool TryResolveAutoContinueIntakeRefreshTarget(
+        CliContext context,
+        QueueState queueState,
+        out AutoContinueIntakeRefreshTarget? target)
     {
         ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(queueState);
 
-        foreach (var domain in EnumerateIntakeDomainsForAutoContinue(context.RepoRoot))
+        target = null;
+
+        if (queueState.Items.Count != 0
+            && !queueState.Items.Any(item => item.State == QueueItemState.Completed))
         {
-            try
-            {
-                IntakeAdvanceExecutor(context, domain);
-            }
-            catch (InvalidOperationException exception)
-            {
-                throw new RunDeterministicGapException(
-                    domain,
-                    $"Deterministic contract gap while refreshing intake domain '{domain}' before auto-continue: {exception.Message}");
-            }
+            return false;
+        }
+
+        var completedExecutionUnit = queueState.Items.LastOrDefault(item => item.State == QueueItemState.Completed)?.ExecutionUnit;
+        if (string.IsNullOrWhiteSpace(completedExecutionUnit))
+        {
+            return false;
+        }
+
+        var matchingDomains = EnumerateIntakeDomainsContainingExecutionUnit(context.RepoRoot, completedExecutionUnit);
+        if (matchingDomains.Count == 0)
+        {
+            return false;
+        }
+
+        if (matchingDomains.Count > 1)
+        {
+            throw new RunDeterministicGapException(
+                completedExecutionUnit,
+                $"Auto-continue refresh target for '{completedExecutionUnit}' is ambiguous across intake domains: {string.Join(", ", matchingDomains)}.");
+        }
+
+        var refreshDomain = matchingDomains[0];
+        var conceptArtifactPath = Path.Combine(
+            context.RepoRoot,
+            IntakeConceptArtifactPathResolver.Resolve(refreshDomain).Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(conceptArtifactPath))
+        {
+            return false;
+        }
+
+        target = new AutoContinueIntakeRefreshTarget(refreshDomain, completedExecutionUnit);
+        return true;
+    }
+
+    private static void TryRefreshIntakeDomainForAutoContinue(
+        CliContext context,
+        AutoContinueIntakeRefreshTarget refreshTarget)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(refreshTarget);
+
+        try
+        {
+            IntakeAdvanceExecutor(context, refreshTarget.Domain);
+        }
+        catch (InvalidOperationException exception)
+        {
+            throw new RunDeterministicGapException(
+                refreshTarget.CompletedExecutionUnit,
+                $"Deterministic contract gap while refreshing intake domain '{refreshTarget.Domain}' before auto-continue: {exception.Message}");
         }
     }
 
-    private static IReadOnlyList<string> EnumerateIntakeDomainsForAutoContinue(string repoRoot)
+    private static IReadOnlyList<string> EnumerateIntakeExecutionArtifactsForAutoContinue(
+        string intakeDirectory,
+        string? domainFilter)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(intakeDirectory);
+
+        if (!Directory.Exists(intakeDirectory))
+        {
+            return [];
+        }
+
+        if (!string.IsNullOrWhiteSpace(domainFilter))
+        {
+            var filteredArtifactPath = Path.Combine(intakeDirectory, $"{domainFilter}.execution.md");
+            return File.Exists(filteredArtifactPath) ? [filteredArtifactPath] : [];
+        }
+
+        return Directory
+            .EnumerateFiles(intakeDirectory, "*.execution.md", SearchOption.TopDirectoryOnly)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> EnumerateIntakeDomainsContainingExecutionUnit(
+        string repoRoot,
+        string executionUnit)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
 
         var intakeDirectory = Path.Combine(repoRoot, ".intent-cli", "intake");
         if (!Directory.Exists(intakeDirectory))
@@ -720,14 +807,45 @@ internal static class RunCommand
             return [];
         }
 
-        return Directory.EnumerateFiles(intakeDirectory, "*.concept.yaml", SearchOption.TopDirectoryOnly)
-            .Select(path => Path.GetFileName(path))
-            .Where(fileName => !string.IsNullOrWhiteSpace(fileName))
-            .Select(fileName => fileName![..^".concept.yaml".Length])
-            .Where(domain => !string.IsNullOrWhiteSpace(domain))
-            .Distinct(StringComparer.Ordinal)
-            .OrderBy(domain => domain, StringComparer.Ordinal)
-            .ToArray();
+        var matchingDomains = new List<string>();
+        foreach (var artifactPath in Directory
+                     .EnumerateFiles(intakeDirectory, "*.execution.md", SearchOption.TopDirectoryOnly)
+                     .OrderBy(path => path, StringComparer.Ordinal))
+        {
+            if (!ExecutionArtifactContainsUnit(artifactPath, executionUnit))
+            {
+                continue;
+            }
+
+            var fileName = Path.GetFileName(artifactPath);
+            if (string.IsNullOrWhiteSpace(fileName) || !fileName.EndsWith(".execution.md", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            matchingDomains.Add(fileName[..^".execution.md".Length]);
+        }
+
+        return matchingDomains;
+    }
+
+    private static bool ExecutionArtifactContainsUnit(string artifactPath, string executionUnit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        try
+        {
+            var executionUnitHeading = $"### `{executionUnit}`";
+            return File.ReadLines(artifactPath)
+                .Any(line => string.Equals(line.TrimEnd(), executionUnitHeading, StringComparison.Ordinal));
+        }
+        catch (IOException exception)
+        {
+            throw new InvalidOperationException(
+                $"Intake auto-continue could not read '{artifactPath}': {exception.Message}",
+                exception);
+        }
     }
 
     private static bool IsAutoContinueLaunchable(QueueState queueState, string executionUnit)

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -41,6 +41,9 @@ internal static class RunCommand
     public static Func<string, string, string, IntakeIssueResult> IntakeIssueExecutor { get; set; } =
         IntakeIssueCommand.ExecuteCore;
 
+    public static Func<CliContext, string, IntakeAdvanceResult> IntakeAdvanceExecutor { get; set; } =
+        IntakeAdvanceCommand.ExecuteCore;
+
     public static Func<CliContext, string, int> QueueEnqueueExecutor { get; set; } =
         ExecuteQueueEnqueue;
 
@@ -552,7 +555,13 @@ internal static class RunCommand
                         $"Blocked item '{blockedItem.ExecutionUnit}' requires parent-side planning.");
                 }
 
-                if (TryResolveAutoContinueIntakeCandidate(context, queueState, out var intakeCandidate))
+                if (!TryResolveAutoContinueIntakeCandidate(context, queueState, out var intakeCandidate))
+                {
+                    TryRefreshIntakeDomainsForAutoContinue(context);
+                    TryResolveAutoContinueIntakeCandidate(context, queueState, out intakeCandidate);
+                }
+
+                if (intakeCandidate is not null)
                 {
                     var selectedIntakeCandidate = intakeCandidate
                         ?? throw new InvalidOperationException("Auto-continue intake candidate was not resolved.");
@@ -679,6 +688,46 @@ internal static class RunCommand
         }
 
         return false;
+    }
+
+    private static void TryRefreshIntakeDomainsForAutoContinue(
+        CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        foreach (var domain in EnumerateIntakeDomainsForAutoContinue(context.RepoRoot))
+        {
+            try
+            {
+                IntakeAdvanceExecutor(context, domain);
+            }
+            catch (InvalidOperationException exception)
+            {
+                throw new RunDeterministicGapException(
+                    domain,
+                    $"Deterministic contract gap while refreshing intake domain '{domain}' before auto-continue: {exception.Message}");
+            }
+        }
+    }
+
+    private static IReadOnlyList<string> EnumerateIntakeDomainsForAutoContinue(string repoRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+
+        var intakeDirectory = Path.Combine(repoRoot, ".intent-cli", "intake");
+        if (!Directory.Exists(intakeDirectory))
+        {
+            return [];
+        }
+
+        return Directory.EnumerateFiles(intakeDirectory, "*.concept.yaml", SearchOption.TopDirectoryOnly)
+            .Select(path => Path.GetFileName(path))
+            .Where(fileName => !string.IsNullOrWhiteSpace(fileName))
+            .Select(fileName => fileName![..^".concept.yaml".Length])
+            .Where(domain => !string.IsNullOrWhiteSpace(domain))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(domain => domain, StringComparer.Ordinal)
+            .ToArray();
     }
 
     private static bool IsAutoContinueLaunchable(QueueState queueState, string executionUnit)

--- a/tests/IntentSystem.Cli.Tests/IntakeAdvanceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeAdvanceCommandTests.cs
@@ -154,6 +154,46 @@ public sealed class IntakeAdvanceCommandTests
     }
 
     [Fact]
+    public void Execute_GivenIssueReadyExecutionRowsWithoutExecutionApplyBaseline_SkipsExecutionApplyAndRefreshesDraft()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "toy-calc.concept.yaml"),
+            CreateConceptArtifactYaml("toy-calc"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "toy-calc", "iq-1.yaml"),
+            CreateInterviewArtifactYaml(CreateAnsweredItem(domain: "toy-calc", sourceConceptRef: ".intent-cli/intake/toy-calc.concept.yaml")));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "interviews", "toy-calc", "iq-1.md"),
+            "# Interview Question");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "toy-calc", "execution", "01-issue-ready-slices.md"),
+            """
+            # Toy Calc Issue-Ready Slices
+
+            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
+            |---|---|---|---|---|---|---|---|
+            | TOY-CALC-V0-06 | V0 | integer modulo command を追加する | TOY-CALC-V0-05 | . | . | CLI modulo command and verification | yes |
+            | TOY-CALC-V0-07 | V0 | integer min command を追加する | TOY-CALC-V0-06 | . | . | CLI min command and verification | yes |
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeAdvanceCommand.Execute(CreateContext(repoRoot), ["toy-calc"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Readiness status: ready", output, StringComparison.Ordinal);
+        Assert.Contains("Regenerated artifact paths:", output, StringComparison.Ordinal);
+        Assert.Contains("- .intent-cli/intake/toy-calc.execution.md", output, StringComparison.Ordinal);
+        Assert.Contains("Skipped stages:", output, StringComparison.Ordinal);
+        Assert.Contains("- execution-apply", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Execution apply target could not be derived", output, StringComparison.Ordinal);
+
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "intake", "toy-calc.execution.md")));
+    }
+
+    [Fact]
     public void Execute_GivenMissingDomainArgument_ReturnsExitCodeOne()
     {
         using var writer = new StringWriter();
@@ -181,11 +221,12 @@ public sealed class IntakeAdvanceCommandTests
     }
 
     private static IntentSystem.ConceptIntake.Models.InterviewQueueItem CreateAnsweredItem(
+        string domain = "auth",
         string sourceConceptRef = "intents/intent-cli/concepts/auth-oauth2.md")
     {
         return new IntentSystem.ConceptIntake.Models.InterviewQueueItem
         {
-            DomainSlug = "auth",
+            DomainSlug = domain,
             SourceConceptRef = sourceConceptRef,
             QuestionId = "iq-1",
             QuestionText = "What should be updated?",

--- a/tests/IntentSystem.Cli.Tests/IntakeExecutionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntakeExecutionCommandTests.cs
@@ -124,6 +124,57 @@ public sealed class IntakeExecutionCommandTests
     }
 
     [Fact]
+    public void Execute_GivenNoPatchTargetsButIssueReadyExecutionRows_WritesExecutionDraftFromCurrentExecutionSource()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "toy-calc.patch.md"),
+            """
+            # Intake Patch Draft
+
+            ## Domain
+
+            `toy-calc`
+
+            target_file_paths:
+            - none
+
+            source_concept_refs:
+            - .intent-cli/intake/toy-calc.concept.yaml
+
+            ## File-By-File Patch Candidates
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "intents", "toy-calc", "execution", "01-issue-ready-slices.md"),
+            """
+            # Toy Calc Issue-Ready Slices
+
+            | subslice_id | belongs_to_slice | goal | depends_on_subslices | target_repo | target_path | target_part | issue_cut_ready |
+            |---|---|---|---|---|---|---|---|
+            | TOY-CALC-V0-06 | V0 | integer modulo command を追加する | TOY-CALC-V0-05 | . | . | CLI modulo command and verification | yes |
+            | TOY-CALC-V0-07 | V0 | integer min command を追加する | TOY-CALC-V0-06 | . | . | CLI min command and verification | yes |
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = IntakeExecutionCommand.Execute(CreateContext(repoRoot), ["toy-calc"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Intake execution draft generated for domain 'toy-calc'.", output, StringComparison.Ordinal);
+        var artifactPath = Path.Combine(repoRoot, ".intent-cli", "intake", "toy-calc.execution.md");
+        Assert.True(File.Exists(artifactPath));
+        var markdown = File.ReadAllText(artifactPath);
+        Assert.Contains("### `TOY-CALC-V0-06`", markdown, StringComparison.Ordinal);
+        Assert.Contains("### `TOY-CALC-V0-07`", markdown, StringComparison.Ordinal);
+        Assert.Contains("source_file_path: intents/toy-calc/execution/01-issue-ready-slices.md", markdown, StringComparison.Ordinal);
+        Assert.Contains("target_part: CLI modulo command and verification", markdown, StringComparison.Ordinal);
+        Assert.Contains("target_part: CLI min command and verification", markdown, StringComparison.Ordinal);
+        Assert.Contains("- TOY-CALC-V0-06", markdown, StringComparison.Ordinal);
+        Assert.Contains("Current goal: integer min command を追加する", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenMissingPatchArtifact_ReturnsExitCodeOne()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -771,6 +771,206 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenCompletedQueueAndStaleIntakeExecutionArtifact_RefreshesIntakeBeforeLaunchingNextSlice()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(
+                CreateQueueState(
+                    CreateQueueItem(QueueItemState.Completed, executionUnit: "TOY-CALC-V0-06"))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "toy-calc.execution.md"),
+            CreateIntakeExecutionArtifactMarkdown("toy-calc", "TOY-CALC-V0-06"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "toy-calc.concept.yaml"),
+            """
+            domain_slug: toy-calc
+            concept_source: test
+            concept_text: "Toy calc"
+            upstream_paths: []
+            initial_goal: "Toy calc"
+            constraints: []
+            known_unknowns: []
+            """);
+        var originalIntakeAdvanceExecutor = RunCommand.IntakeAdvanceExecutor;
+        var originalIntakeIssueExecutor = RunCommand.IntakeIssueExecutor;
+        var originalQueueEnqueueExecutor = RunCommand.QueueEnqueueExecutor;
+        var originalQueueDispatchExecutor = RunCommand.QueueDispatchExecutor;
+        var originalRunStartExecutor = RunCommand.RunStartExecutor;
+        var originalRunImplementExecutor = RunCommand.RunImplementExecutor;
+        var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
+        var invokedSteps = new List<string>();
+
+        try
+        {
+            RunCommand.IntakeAdvanceExecutor = (context, domain) =>
+            {
+                invokedSteps.Add($"advance:{domain}");
+                File.WriteAllText(
+                    Path.Combine(context.RepoRoot, ".intent-cli", "intake", "toy-calc.execution.md"),
+                    CreateIntakeExecutionArtifactMarkdown(
+                        "toy-calc",
+                        ("TOY-CALC-V0-06", "specs"),
+                        ("TOY-CALC-V0-07", "specs")));
+
+                return new IntakeAdvanceResult
+                {
+                    Domain = domain,
+                    ReadinessStatus = "ready",
+                    UpdatedSourceFilePaths = ["intents/toy-calc/specs/07-min-command.md"],
+                    UpdatedExecutionFilePaths = ["intents/toy-calc/execution/01-issue-ready-slices.md"],
+                    RegeneratedArtifactPaths = [".intent-cli/intake/toy-calc.execution.md"],
+                    SkippedStages = []
+                };
+            };
+            RunCommand.IntakeIssueExecutor = (_, domain, executionUnit) =>
+            {
+                invokedSteps.Add($"issue:{domain}:{executionUnit}");
+                return new IntakeIssueResult
+                {
+                    Domain = domain,
+                    GeneratedExecutionUnits = [executionUnit],
+                    ArtifactPaths = [],
+                    SkippedUnits = []
+                };
+            };
+            RunCommand.QueueEnqueueExecutor = (context, executionUnit) =>
+            {
+                invokedSteps.Add($"enqueue:{executionUnit}");
+                AppendQueueItem(context.RepoRoot, CreateQueueItem(QueueItemState.Queued, executionUnit: executionUnit, withLinkedIssue: false));
+                return 0;
+            };
+            RunCommand.QueueDispatchExecutor = (context, executionUnit) =>
+            {
+                invokedSteps.Add($"dispatch:{executionUnit}");
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => string.Equals(queueItem.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                        ? queueItem with
+                        {
+                            LinkedIssue = new LinkedIssue
+                            {
+                                Repo = "J-Tech-Japan/intent-system",
+                                Number = 407,
+                                Url = "https://github.com/J-Tech-Japan/intent-system/issues/407"
+                            }
+                        }
+                        : queueItem);
+
+                return new QueueDispatchCommandResult
+                {
+                    ExecutionUnit = executionUnit,
+                    LinkedIssueUrl = "https://github.com/J-Tech-Japan/intent-system/issues/407",
+                    ReusedExistingIssue = false
+                };
+            };
+            RunCommand.RunStartExecutor = (context, executionUnit) =>
+            {
+                invokedSteps.Add($"start:{executionUnit}");
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => string.Equals(queueItem.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                        ? queueItem with { State = QueueItemState.Active }
+                        : queueItem);
+
+                return new RunStartResult
+                {
+                    ExecutionUnit = executionUnit,
+                    WorktreePath = Path.Combine(context.RepoRoot, ".intent-cli", "worktrees", executionUnit),
+                    BranchName = $"issue-407-{executionUnit.ToLowerInvariant()}"
+                };
+            };
+            RunCommand.RunImplementExecutor = (context, executionUnit) =>
+            {
+                invokedSteps.Add($"implement:{executionUnit}");
+                tempDirectory.CreateFile(
+                    Path.Combine("repo", ".intent-cli", "implement", $"{executionUnit}.request.md"),
+                    "# Execution Worker Handoff");
+
+                return new RunImplementResult
+                {
+                    Request = CreateRunImplementRequest(repoRoot, executionUnit),
+                    ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md"
+                };
+            };
+            RunCommand.RunSuperviseExecutor = (_, executionUnit) =>
+            {
+                invokedSteps.Add($"supervise:{executionUnit}");
+                return new RunSuperviseResult
+                {
+                    ExecutionUnit = executionUnit,
+                    SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                    WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                    SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                    RetryCount = 0,
+                    RetryBudget = 3,
+                    HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("TOY-CALC-V0-07", result.ExecutionUnit);
+            Assert.Equal(
+                [
+                    "advance:toy-calc",
+                    "issue:toy-calc:TOY-CALC-V0-07",
+                    "enqueue:TOY-CALC-V0-07",
+                    "dispatch:TOY-CALC-V0-07",
+                    "start:TOY-CALC-V0-07",
+                    "implement:TOY-CALC-V0-07",
+                    "supervise:TOY-CALC-V0-07"
+                ],
+                invokedSteps);
+            Assert.Collection(
+                result.Actions,
+                action =>
+                {
+                    Assert.Equal("intake issue", action.Name);
+                    Assert.Equal("TOY-CALC-V0-07", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("queue enqueue", action.Name);
+                    Assert.Equal("TOY-CALC-V0-07", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("queue dispatch", action.Name);
+                    Assert.Equal("TOY-CALC-V0-07", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("run start", action.Name);
+                    Assert.Equal("TOY-CALC-V0-07", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("run implement", action.Name);
+                    Assert.Equal("TOY-CALC-V0-07", action.ExecutionUnit);
+                },
+                action =>
+                {
+                    Assert.Equal("run supervise", action.Name);
+                    Assert.Equal("TOY-CALC-V0-07", action.ExecutionUnit);
+                });
+        }
+        finally
+        {
+            RunCommand.IntakeAdvanceExecutor = originalIntakeAdvanceExecutor;
+            RunCommand.IntakeIssueExecutor = originalIntakeIssueExecutor;
+            RunCommand.QueueEnqueueExecutor = originalQueueEnqueueExecutor;
+            RunCommand.QueueDispatchExecutor = originalQueueDispatchExecutor;
+            RunCommand.RunStartExecutor = originalRunStartExecutor;
+            RunCommand.RunImplementExecutor = originalRunImplementExecutor;
+            RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenReviewItemWithoutRequest_GeneratesReviewRequestAndStopsForReviewDecision()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -971,6 +971,191 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenCompletedQueueAndBrokenUnrelatedIntakeDomain_RefreshesOnlyContinuationDomain()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(
+                CreateQueueState(
+                    CreateQueueItem(QueueItemState.Completed, executionUnit: "TOY-CALC-V0-06"))));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "toy-calc.execution.md"),
+            CreateIntakeExecutionArtifactMarkdown("toy-calc", "TOY-CALC-V0-06"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "toy-calc.concept.yaml"),
+            """
+            domain_slug: toy-calc
+            concept_source: test
+            concept_text: "Toy calc"
+            upstream_paths: []
+            initial_goal: "Toy calc"
+            constraints: []
+            known_unknowns: []
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "intake", "broken.concept.yaml"),
+            """
+            domain_slug: broken
+            concept_source: test
+            concept_text: "Broken"
+            upstream_paths: []
+            initial_goal: "Broken"
+            constraints: []
+            known_unknowns: []
+            """);
+        var originalIntakeAdvanceExecutor = RunCommand.IntakeAdvanceExecutor;
+        var originalIntakeIssueExecutor = RunCommand.IntakeIssueExecutor;
+        var originalQueueEnqueueExecutor = RunCommand.QueueEnqueueExecutor;
+        var originalQueueDispatchExecutor = RunCommand.QueueDispatchExecutor;
+        var originalRunStartExecutor = RunCommand.RunStartExecutor;
+        var originalRunImplementExecutor = RunCommand.RunImplementExecutor;
+        var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
+        var invokedSteps = new List<string>();
+
+        try
+        {
+            RunCommand.IntakeAdvanceExecutor = (context, domain) =>
+            {
+                invokedSteps.Add($"advance:{domain}");
+                if (string.Equals(domain, "broken", StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException("Broken intake domain should not be refreshed.");
+                }
+
+                File.WriteAllText(
+                    Path.Combine(context.RepoRoot, ".intent-cli", "intake", "toy-calc.execution.md"),
+                    CreateIntakeExecutionArtifactMarkdown(
+                        "toy-calc",
+                        ("TOY-CALC-V0-06", "specs"),
+                        ("TOY-CALC-V0-07", "specs")));
+
+                return new IntakeAdvanceResult
+                {
+                    Domain = domain,
+                    ReadinessStatus = "ready",
+                    UpdatedSourceFilePaths = ["intents/toy-calc/specs/07-min-command.md"],
+                    UpdatedExecutionFilePaths = ["intents/toy-calc/execution/01-issue-ready-slices.md"],
+                    RegeneratedArtifactPaths = [".intent-cli/intake/toy-calc.execution.md"],
+                    SkippedStages = []
+                };
+            };
+            RunCommand.IntakeIssueExecutor = (_, domain, executionUnit) =>
+            {
+                invokedSteps.Add($"issue:{domain}:{executionUnit}");
+                return new IntakeIssueResult
+                {
+                    Domain = domain,
+                    GeneratedExecutionUnits = [executionUnit],
+                    ArtifactPaths = [],
+                    SkippedUnits = []
+                };
+            };
+            RunCommand.QueueEnqueueExecutor = (context, executionUnit) =>
+            {
+                invokedSteps.Add($"enqueue:{executionUnit}");
+                AppendQueueItem(context.RepoRoot, CreateQueueItem(QueueItemState.Queued, executionUnit: executionUnit, withLinkedIssue: false));
+                return 0;
+            };
+            RunCommand.QueueDispatchExecutor = (context, executionUnit) =>
+            {
+                invokedSteps.Add($"dispatch:{executionUnit}");
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => string.Equals(queueItem.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                        ? queueItem with
+                        {
+                            LinkedIssue = new LinkedIssue
+                            {
+                                Repo = "J-Tech-Japan/intent-system",
+                                Number = 407,
+                                Url = "https://github.com/J-Tech-Japan/intent-system/issues/407"
+                            }
+                        }
+                        : queueItem);
+
+                return new QueueDispatchCommandResult
+                {
+                    ExecutionUnit = executionUnit,
+                    LinkedIssueUrl = "https://github.com/J-Tech-Japan/intent-system/issues/407",
+                    ReusedExistingIssue = false
+                };
+            };
+            RunCommand.RunStartExecutor = (context, executionUnit) =>
+            {
+                invokedSteps.Add($"start:{executionUnit}");
+                PersistQueueState(
+                    context.RepoRoot,
+                    queueItem => string.Equals(queueItem.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                        ? queueItem with { State = QueueItemState.Active }
+                        : queueItem);
+
+                return new RunStartResult
+                {
+                    ExecutionUnit = executionUnit,
+                    WorktreePath = Path.Combine(context.RepoRoot, ".intent-cli", "worktrees", executionUnit),
+                    BranchName = $"issue-407-{executionUnit.ToLowerInvariant()}"
+                };
+            };
+            RunCommand.RunImplementExecutor = (context, executionUnit) =>
+            {
+                invokedSteps.Add($"implement:{executionUnit}");
+                tempDirectory.CreateFile(
+                    Path.Combine("repo", ".intent-cli", "implement", $"{executionUnit}.request.md"),
+                    "# Execution Worker Handoff");
+
+                return new RunImplementResult
+                {
+                    Request = CreateRunImplementRequest(repoRoot, executionUnit),
+                    ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md"
+                };
+            };
+            RunCommand.RunSuperviseExecutor = (_, executionUnit) =>
+            {
+                invokedSteps.Add($"supervise:{executionUnit}");
+                return new RunSuperviseResult
+                {
+                    ExecutionUnit = executionUnit,
+                    SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                    WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                    SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                    RetryCount = 0,
+                    RetryBudget = 3,
+                    HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md"
+                };
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("TOY-CALC-V0-07", result.ExecutionUnit);
+            Assert.Equal(
+                [
+                    "advance:toy-calc",
+                    "issue:toy-calc:TOY-CALC-V0-07",
+                    "enqueue:TOY-CALC-V0-07",
+                    "dispatch:TOY-CALC-V0-07",
+                    "start:TOY-CALC-V0-07",
+                    "implement:TOY-CALC-V0-07",
+                    "supervise:TOY-CALC-V0-07"
+                ],
+                invokedSteps);
+            Assert.DoesNotContain("advance:broken", invokedSteps);
+        }
+        finally
+        {
+            RunCommand.IntakeAdvanceExecutor = originalIntakeAdvanceExecutor;
+            RunCommand.IntakeIssueExecutor = originalIntakeIssueExecutor;
+            RunCommand.QueueEnqueueExecutor = originalQueueEnqueueExecutor;
+            RunCommand.QueueDispatchExecutor = originalQueueDispatchExecutor;
+            RunCommand.RunStartExecutor = originalRunStartExecutor;
+            RunCommand.RunImplementExecutor = originalRunImplementExecutor;
+            RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenReviewItemWithoutRequest_GeneratesReviewRequestAndStopsForReviewDecision()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- refresh stale intake execution drafts from current `intents/<domain>/execution/*.md` issue-ready rows when patch targets are empty
- let root `run` refresh intake state before auto-continuing into the next launchable slice
- tolerate domains whose execution source-of-truth is already canonical by skipping `execution-apply` when no apply baseline exists

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IntakeAdvanceCommandTests|FullyQualifiedName~IntakeExecutionCommandTests|FullyQualifiedName~RunCommandTests|FullyQualifiedName~IntakeIssueCommandTests" --nologo`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IntakeAdvanceCommandTests.Execute_GivenIssueReadyExecutionRowsWithoutExecutionApplyBaseline_SkipsExecutionApplyAndRefreshesDraft|FullyQualifiedName~IntakeExecutionCommandTests.Execute_GivenNoPatchTargetsButIssueReadyExecutionRows_WritesExecutionDraftFromCurrentExecutionSource|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenCompletedQueueAndStaleIntakeExecutionArtifact_RefreshesIntakeBeforeLaunchingNextSlice" --nologo`
- live dogfooding in `submodules/toy-calc-sample`:
  - `dotnet run --no-build --project submodules/intent-system/src/IntentSystem.Cli/IntentSystem.Cli.csproj -- intake advance toy-calc`
  - `dotnet run --no-build --project submodules/intent-system/src/IntentSystem.Cli/IntentSystem.Cli.csproj -- run`

## Notes
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo` was attempted but did not emit completion output in this environment after build, so validation evidence above uses the focused regressions plus live toy-calc proof.
- fixes #384
