### PR TITLE
Fix implement handoff current slice contract sync

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
@@ -100,6 +100,10 @@ internal static class RunImplementCommand
         }
 
         SyncCurrentIssueArtifactsToWorktree(packetPath, worktreePath);
+        SyncCurrentRepoLocalContractArtifactsToWorktree(
+            childRepoPath,
+            worktreePath,
+            packet.ImplementationIssuePacket);
 
         ChildWorkTargetGuard.EnsureTargetAllowed(
             executionUnit,
@@ -224,6 +228,105 @@ internal static class RunImplementCommand
         foreach (var sourceFilePath in Directory.GetFiles(sourceIssueDirectory))
         {
             var targetFilePath = Path.Combine(targetIssueDirectory, Path.GetFileName(sourceFilePath));
+            File.Copy(sourceFilePath, targetFilePath, overwrite: true);
+        }
+    }
+
+    private static void SyncCurrentRepoLocalContractArtifactsToWorktree(
+        string childRepoPath,
+        string worktreePath,
+        Projection.Models.ImplementationIssuePacket packet)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(childRepoPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
+        ArgumentNullException.ThrowIfNull(packet);
+
+        foreach (var artifactRef in EnumerateRepoLocalContractRefs(packet))
+        {
+            if (!TryResolveRepoLocalArtifactPath(childRepoPath, artifactRef, out var sourceArtifactPath)
+                || !TryResolveRepoLocalArtifactPath(worktreePath, artifactRef, out var targetArtifactPath))
+            {
+                continue;
+            }
+
+            if (File.Exists(sourceArtifactPath))
+            {
+                var targetDirectory = Path.GetDirectoryName(targetArtifactPath)
+                    ?? throw new InvalidOperationException("Target artifact path did not contain a directory.");
+                Directory.CreateDirectory(targetDirectory);
+                File.Copy(sourceArtifactPath, targetArtifactPath, overwrite: true);
+                continue;
+            }
+
+            if (Directory.Exists(sourceArtifactPath))
+            {
+                CopyDirectory(sourceArtifactPath, targetArtifactPath);
+            }
+        }
+    }
+
+    private static IEnumerable<string> EnumerateRepoLocalContractRefs(Projection.Models.ImplementationIssuePacket packet)
+    {
+        return packet.ProjectLocalGuide
+            .Concat(packet.IntentReferences)
+            .Concat(packet.RulesAndSpecs)
+            .Distinct(StringComparer.Ordinal);
+    }
+
+    private static bool TryResolveRepoLocalArtifactPath(
+        string repoRoot,
+        string artifactRef,
+        out string artifactPath)
+    {
+        artifactPath = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(repoRoot)
+            || string.IsNullOrWhiteSpace(artifactRef)
+            || Path.IsPathRooted(artifactRef))
+        {
+            return false;
+        }
+
+        var candidatePath = Path.GetFullPath(Path.Combine(
+            repoRoot,
+            artifactRef.Replace('/', Path.DirectorySeparatorChar)));
+        if (!IsPathWithinRoot(repoRoot, candidatePath))
+        {
+            return false;
+        }
+
+        artifactPath = candidatePath;
+        return true;
+    }
+
+    private static bool IsPathWithinRoot(string rootPath, string candidatePath)
+    {
+        var normalizedRoot = Path.GetFullPath(rootPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var normalizedCandidate = Path.GetFullPath(candidatePath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        return string.Equals(normalizedRoot, normalizedCandidate, StringComparison.Ordinal)
+            || normalizedCandidate.StartsWith(
+                normalizedRoot + Path.DirectorySeparatorChar,
+                StringComparison.Ordinal);
+    }
+
+    private static void CopyDirectory(string sourceDirectory, string targetDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetDirectory);
+
+        Directory.CreateDirectory(targetDirectory);
+
+        foreach (var sourceFilePath in Directory.GetFiles(sourceDirectory, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(sourceDirectory, sourceFilePath);
+            var targetFilePath = Path.Combine(targetDirectory, relativePath);
+            var targetFileDirectory = Path.GetDirectoryName(targetFilePath)
+                ?? throw new InvalidOperationException("Target file path did not contain a directory.");
+
+            Directory.CreateDirectory(targetFileDirectory);
             File.Copy(sourceFilePath, targetFilePath, overwrite: true);
         }
     }

--- a/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunImplementCommand.cs
@@ -270,6 +270,7 @@ internal static class RunImplementCommand
         return packet.ProjectLocalGuide
             .Concat(packet.IntentReferences)
             .Concat(packet.RulesAndSpecs)
+            .Concat(["intents"])
             .Distinct(StringComparer.Ordinal);
     }
 

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -213,6 +213,84 @@ public sealed class RunImplementCommandTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenStaleRepoLocalRuleSpecInWorktree_SyncsCurrentContractArtifactsBeforeLaunch()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var worktreePath = tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G19"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown());
+
+        var currentGuideContents = "# Current AGENTS";
+        var currentSpecContents = "# Current min spec";
+        var staleGuideContents = "# Stale AGENTS";
+        var staleSpecContents = "# Stale modulo spec";
+
+        tempDirectory.CreateFile(Path.Combine("repo", "submodules", "intent-system", "AGENTS.md"), currentGuideContents);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "submodules", "intent-system", "intents", "intent-cli", "specs", "08-config-and-run-model.md"),
+            currentSpecContents);
+        tempDirectory.CreateFile(Path.Combine("repo", ".intent-cli", "worktrees", "G19", "AGENTS.md"), staleGuideContents);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "worktrees", "G19", "intents", "intent-cli", "specs", "08-config-and-run-model.md"),
+            staleSpecContents);
+
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunImplementCommand.TimestampFactory;
+        var originalLauncherFactory = RunImplementCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            RunImplementCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:15:00Z");
+            RunImplementCommand.DirectRunLauncherFactory = () => new FakeDirectRunLauncher(
+                "pid:4321",
+                "Claude",
+                "default",
+                "stdio",
+                "stdio transport launched via 'claude' in '/repo/.intent-cli/worktrees/G19' for provider 'Claude'.");
+
+            var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(currentGuideContents, File.ReadAllText(Path.Combine(worktreePath, "AGENTS.md")));
+            Assert.Equal(
+                currentSpecContents,
+                File.ReadAllText(Path.Combine(
+                    worktreePath,
+                    "intents",
+                    "intent-cli",
+                    "specs",
+                    "08-config-and-run-model.md")));
+            Assert.DoesNotContain(staleGuideContents, File.ReadAllText(Path.Combine(worktreePath, "AGENTS.md")), StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                staleSpecContents,
+                File.ReadAllText(Path.Combine(
+                    worktreePath,
+                    "intents",
+                    "intent-cli",
+                    "specs",
+                    "08-config-and-run-model.md")),
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunImplementCommand.TimestampFactory = originalTimestampFactory;
+            RunImplementCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
     private sealed class FakeDirectRunLauncher(
         string providerSessionId,
         string provider,

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -291,6 +291,97 @@ public sealed class RunImplementCommandTests
         }
     }
 
+    [Fact]
+    public void Execute_GivenToyCalcV07StyleStaleMinSpecInWorktree_SyncsCurrentIntentTreeBeforeLaunch()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var worktreePath = tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G19"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown());
+
+        var currentMinSpecContents = """
+            # Toy Calc Min Command v0
+
+            - `toy-calc min <left> <right>`
+            - returns the smaller integer
+            """;
+        var staleModuloSpecContents = """
+            # Toy Calc Modulo Command v0
+
+            - `toy-calc mod <left> <right>`
+            - divide-by-zero must fail deterministically
+            """;
+
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "submodules", "intent-system", "intents", "toy-calc", "specs", "07-min-command.md"),
+            currentMinSpecContents);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", "submodules", "intent-system", "intents", "toy-calc", "specs", "06-modulo-command.md"),
+            staleModuloSpecContents);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "worktrees", "G19", "intents", "toy-calc", "specs", "07-min-command.md"),
+            staleModuloSpecContents);
+
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunImplementCommand.TimestampFactory;
+        var originalLauncherFactory = RunImplementCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            RunImplementCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:15:00Z");
+            RunImplementCommand.DirectRunLauncherFactory = () => new FakeDirectRunLauncher(
+                "pid:4321",
+                "Claude",
+                "default",
+                "stdio",
+                "stdio transport launched via 'claude' in '/repo/.intent-cli/worktrees/G19' for provider 'Claude'.");
+
+            var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(
+                currentMinSpecContents,
+                File.ReadAllText(Path.Combine(
+                    worktreePath,
+                    "intents",
+                    "toy-calc",
+                    "specs",
+                    "07-min-command.md")));
+            Assert.DoesNotContain(
+                "Modulo Command",
+                File.ReadAllText(Path.Combine(
+                    worktreePath,
+                    "intents",
+                    "toy-calc",
+                    "specs",
+                    "07-min-command.md")),
+                StringComparison.Ordinal);
+            Assert.True(File.Exists(Path.Combine(
+                worktreePath,
+                "intents",
+                "toy-calc",
+                "specs",
+                "06-modulo-command.md")));
+        }
+        finally
+        {
+            RunImplementCommand.TimestampFactory = originalTimestampFactory;
+            RunImplementCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
     private sealed class FakeDirectRunLauncher(
         string providerSessionId,
         string provider,


### PR DESCRIPTION
## Summary
- sync repo-local contract artifacts referenced by the active implementation packet into the execution-unit worktree before launching `run implement`
- keep issue artifact sync behavior intact while preventing stale worktree copies of `AGENTS.md` and rules/spec files from bleeding into the current implement session
- add a focused `RunImplementCommand` regression covering stale worktree rule/spec content being replaced by the current child-repo contract

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo --filter RunImplementCommandTests` *(could not run in this environment: `dotnet` is not installed)*
- `dotnet test IntentSystem.sln --nologo` *(could not run in this environment: `dotnet` is not installed)*

Closes #386