### PR TITLE
Add issue draft publish artifact foundation

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -10,6 +10,7 @@ internal static class CommandRouter
         "project",
         "projection",
         "queue",
+        "issue",
         "bug",
         "run",
         "review",
@@ -68,6 +69,10 @@ internal static class CommandRouter
                 ["enqueue"] = QueueEnqueueCommand.Execute,
                 ["dispatch"] = QueueDispatchCommand.Execute,
                 ["transition"] = QueueTransitionCommand.Execute
+            },
+            ["issue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["draft"] = IssueDraftCommand.Execute
             },
             ["bug"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/IssueDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssueDraftCommand.cs
@@ -1,0 +1,139 @@
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class IssueDraftCommand
+{
+    private const string TransitionActor = "intent-cli";
+    private const string DraftedPublishStatus = "drafted";
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Issue draft command requires an execution unit.");
+            return 1;
+        }
+
+        try
+        {
+            var result = ExecuteCore(context, args[0].Trim());
+            writer.WriteLine($"Issue draft prepared for {result.Artifact.ExecutionUnit}.");
+            writer.WriteLine($"Publish artifact: {result.ArtifactPath}");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static IssueDraftCommandResult ExecuteCore(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var packetPath = QueueEnqueueCommand.ResolvePacketPath(context, executionUnit);
+        if (!File.Exists(packetPath))
+        {
+            throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
+        }
+
+        var packetYaml = File.ReadAllText(packetPath);
+        _ = QueueEnqueueCommand.ReadPacket(packetYaml, executionUnit);
+
+        var issueBodyPath = ResolveIssueBodyPath(packetPath);
+        if (!File.Exists(issueBodyPath))
+        {
+            throw new InvalidOperationException($"GitHub issue body artifact was not found at {issueBodyPath}");
+        }
+
+        var issueBody = File.ReadAllText(issueBodyPath);
+        if (string.IsNullOrWhiteSpace(issueBody))
+        {
+            throw new InvalidOperationException("GitHub issue body artifact must not be empty.");
+        }
+
+        var relativePacketPath = ToRelativeRepoPath(context.RepoRoot, packetPath);
+        var relativeIssueBodyPath = ToRelativeRepoPath(context.RepoRoot, issueBodyPath);
+        var artifact = new IssuePublishArtifact
+        {
+            ExecutionUnit = executionUnit,
+            PublishStatus = DraftedPublishStatus,
+            PacketPath = relativePacketPath,
+            IssueBodyPath = relativeIssueBodyPath
+        };
+
+        var artifactPath = WriteArtifact(context.RepoRoot, artifact);
+        AppendRunEvent(
+            context,
+            new RunEvent
+            {
+                Ts = TimestampFactory(),
+                ExecutionUnit = executionUnit,
+                Event = "issue-drafted",
+                By = TransitionActor,
+                PacketRef = relativePacketPath,
+                ResultRef = artifactPath
+            });
+
+        return new IssueDraftCommandResult
+        {
+            Artifact = artifact,
+            ArtifactPath = artifactPath
+        };
+    }
+
+    internal static string ResolveIssueBodyPath(string packetPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packetPath);
+
+        var directoryPath = Path.GetDirectoryName(packetPath)
+            ?? throw new InvalidOperationException("Packet path did not contain a directory.");
+
+        return Path.Combine(directoryPath, "github-body.md");
+    }
+
+    private static string WriteArtifact(string repoRoot, IssuePublishArtifact artifact)
+    {
+        var relativePath = IssuePublishArtifactPathResolver.Resolve(artifact.ExecutionUnit);
+        var absolutePath = Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var directoryPath = Path.GetDirectoryName(absolutePath)
+            ?? throw new InvalidOperationException("Issue publish artifact path did not contain a directory.");
+
+        Directory.CreateDirectory(directoryPath);
+        File.WriteAllText(absolutePath, IssuePublishArtifactYaml.Serialize(artifact));
+
+        return relativePath;
+    }
+
+    private static void AppendRunEvent(CliContext context, RunEvent runEvent)
+    {
+        var runLogPath = context.GetRunLogPath();
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(runLogPath, RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
+    }
+
+    private static string ToRelativeRepoPath(string repoRoot, string absolutePath)
+    {
+        return Path.GetRelativePath(repoRoot, absolutePath).Replace(Path.DirectorySeparatorChar, '/');
+    }
+}
+
+internal sealed record IssueDraftCommandResult
+{
+    public required IssuePublishArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IssuePublishArtifactPathResolver.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishArtifactPathResolver.cs
@@ -1,0 +1,11 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IssuePublishArtifactPathResolver
+{
+    public static string Resolve(string executionUnit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        return $".intent-cli/issues/{executionUnit}/publish.yaml";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IssuePublishArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishArtifactYaml.cs
@@ -1,0 +1,128 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IssuePublishArtifact
+{
+    public required string ExecutionUnit { get; init; }
+
+    public required string PublishStatus { get; init; }
+
+    public required string PacketPath { get; init; }
+
+    public required string IssueBodyPath { get; init; }
+}
+
+internal static class IssuePublishArtifactYaml
+{
+    private static readonly string[] RequiredFields =
+    [
+        "execution_unit",
+        "publish_status",
+        "packet_path",
+        "issue_body_path"
+    ];
+
+    public static string Serialize(IssuePublishArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        return string.Join(
+                   Environment.NewLine,
+                   [
+                       $"execution_unit: {artifact.ExecutionUnit}",
+                       $"publish_status: {artifact.PublishStatus}",
+                       $"packet_path: {Quote(artifact.PacketPath)}",
+                       $"issue_body_path: {Quote(artifact.IssueBodyPath)}"
+                   ])
+               + Environment.NewLine;
+    }
+
+    public static IssuePublishArtifact Deserialize(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var values = ParseYaml(yaml);
+        ValidateRequiredFields(values);
+
+        return new IssuePublishArtifact
+        {
+            ExecutionUnit = GetRequiredScalar(values, "execution_unit"),
+            PublishStatus = GetRequiredScalar(values, "publish_status"),
+            PacketPath = GetRequiredScalar(values, "packet_path"),
+            IssueBodyPath = GetRequiredScalar(values, "issue_body_path")
+        };
+    }
+
+    private static Dictionary<string, string> ParseYaml(string yaml)
+    {
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        using var reader = new StringReader(yaml);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var separatorIndex = line.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                throw new InvalidOperationException($"Issue publish artifact YAML field line is missing ':': '{line}'.");
+            }
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].TrimStart();
+            values[key] = ParseScalar(value);
+        }
+
+        return values;
+    }
+
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, string> values)
+    {
+        foreach (var field in RequiredFields)
+        {
+            if (!values.ContainsKey(field))
+            {
+                throw new InvalidOperationException($"Issue publish artifact YAML must contain required field '{field}'.");
+            }
+        }
+    }
+
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, string> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"Issue publish artifact YAML field '{key}' must be a scalar string.");
+        }
+
+        return value;
+    }
+
+    private static string ParseScalar(string value)
+    {
+        if (value.Length >= 2
+            && value[0] == '"'
+            && value[^1] == '"')
+        {
+            return value[1..^1]
+                .Replace("\\n", "\n", StringComparison.Ordinal)
+                .Replace("\\r", "\r", StringComparison.Ordinal)
+                .Replace("\\\"", "\"", StringComparison.Ordinal)
+                .Replace("\\\\", "\\", StringComparison.Ordinal);
+        }
+
+        return value;
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            + "\"";
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -26,6 +26,7 @@ public sealed class CommandRouterTests
         Assert.Contains("project", output, StringComparison.Ordinal);
         Assert.Contains("projection", output, StringComparison.Ordinal);
         Assert.Contains("queue", output, StringComparison.Ordinal);
+        Assert.Contains("issue", output, StringComparison.Ordinal);
         Assert.Contains("run", output, StringComparison.Ordinal);
         Assert.Contains("review", output, StringComparison.Ordinal);
         Assert.Contains("interview", output, StringComparison.Ordinal);
@@ -2417,6 +2418,44 @@ public sealed class CommandRouterTests
         finally
         {
             QueueEnqueueCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenIssueDraftCommand_DispatchesToIssueDraftRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            """
+            execution_unit: G13
+            implementation_issue:
+              issue_title: "[G13] Add issue draft foundation"
+              target_repo: "submodules/intent-system"
+              target_path: "src/IntentSystem.Cli"
+              target_part: "issue draft command"
+              dependencies: []
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        using var writer = new StringWriter();
+        var originalTimestampFactory = IssueDraftCommand.TimestampFactory;
+
+        try
+        {
+            IssueDraftCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-23T00:00:00Z");
+
+            var exitCode = CommandRouter.Execute(["issue", "draft", "G13"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Issue draft prepared for G13.", writer.ToString(), StringComparison.Ordinal);
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "G13", "publish.yaml")));
+        }
+        finally
+        {
+            IssueDraftCommand.TimestampFactory = originalTimestampFactory;
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/IssueDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssueDraftCommandTests.cs
@@ -1,0 +1,181 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IssueDraftCommandTests
+{
+    [Fact]
+    public void Execute_GivenPacketAndGitHubBody_WritesPublishArtifactAndAppendsRunLog()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        using var writer = new StringWriter();
+        var originalTimestampFactory = IssueDraftCommand.TimestampFactory;
+
+        try
+        {
+            IssueDraftCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-23T00:00:00Z");
+
+            var exitCode = IssueDraftCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Issue draft prepared for G13.", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains(".intent-cli/issues/G13/publish.yaml", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = IssuePublishArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "G13", "publish.yaml")));
+            Assert.Equal("G13", artifact.ExecutionUnit);
+            Assert.Equal("drafted", artifact.PublishStatus);
+            Assert.Equal(".intent-cli/issues/G13/packet.yaml", artifact.PacketPath);
+            Assert.Equal(".intent-cli/issues/G13/github-body.md", artifact.IssueBodyPath);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            var draftedEvent = Assert.Single(runEvents);
+            Assert.Equal("issue-drafted", draftedEvent.Event);
+            Assert.Equal(".intent-cli/issues/G13/packet.yaml", draftedEvent.PacketRef);
+            Assert.Equal(".intent-cli/issues/G13/publish.yaml", draftedEvent.ResultRef);
+        }
+        finally
+        {
+            IssueDraftCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenExistingPublishArtifact_OverwritesItWithDraftedState()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "publish.yaml"),
+            """
+            execution_unit: G13
+            publish_status: published
+            packet_path: ".intent-cli/issues/G13/old-packet.yaml"
+            issue_body_path: ".intent-cli/issues/G13/old-body.md"
+            """);
+
+        var exitCode = IssueDraftCommand.Execute(CreateContext(repoRoot), ["G13"], TextWriter.Null);
+
+        Assert.Equal(0, exitCode);
+
+        var artifact = IssuePublishArtifactYaml.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "G13", "publish.yaml")));
+        Assert.Equal("drafted", artifact.PublishStatus);
+        Assert.Equal(".intent-cli/issues/G13/packet.yaml", artifact.PacketPath);
+        Assert.Equal(".intent-cli/issues/G13/github-body.md", artifact.IssueBodyPath);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingGitHubBodyArtifact_ReturnsExitCodeOneWithoutWritingPublishArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+
+        var exitCode = IssueDraftCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("GitHub issue body artifact was not found", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "G13", "publish.yaml")));
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+    }
+
+    [Fact]
+    public void Execute_GivenOnlyLocalArtifacts_SucceedsWithoutQueueStateOrGitHubMutation()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+
+        var exitCode = IssueDraftCommand.Execute(CreateContext(repoRoot), ["G13"], TextWriter.Null);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+        Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "G13", "publish.yaml")));
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static string CreatePacketYaml()
+    {
+        return
+            """
+            execution_unit: G13
+            implementation_issue:
+              issue_title: "[G13] Add issue draft foundation"
+              target_repo: "submodules/intent-system"
+              target_path: "src/IntentSystem.Cli"
+              target_part: "issue draft command"
+              dependencies: []
+            """;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-issue-draft-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add the `issue draft` command group entry and local draft command
- write `.intent-cli/issues/<execution-unit>/publish.yaml` in `drafted` state
- append a normalized `issue-drafted` run event and cover the flow with focused CLI tests

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IssueDraftCommandTests|FullyQualifiedName~CommandRouterTests"`
- `git diff --check`

Refs #410