### PR TITLE
Add issue create command from draft artifact

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -72,7 +72,8 @@ internal static class CommandRouter
             },
             ["issue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
-                ["draft"] = IssueDraftCommand.Execute
+                ["draft"] = IssueDraftCommand.Execute,
+                ["create"] = IssueCreateCommand.Execute
             },
             ["bug"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/IssueCreateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssueCreateCommand.cs
@@ -1,0 +1,149 @@
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class IssueCreateCommand
+{
+    private const string TransitionActor = "intent-cli";
+    private const string DraftedPublishStatus = "drafted";
+    private const string IssueCreatedPublishStatus = "issue-created";
+
+    public static Func<IQueueDispatchPublisher> PublisherFactory { get; set; } = () => new GhQueueDispatchPublisher();
+
+    public static Func<IGitRemoteCommandRunner> GitCommandRunnerFactory { get; set; } = () => new GitRemoteCommandRunner();
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Issue create command requires an execution unit.");
+            return 1;
+        }
+
+        try
+        {
+            var result = ExecuteCore(context, args[0].Trim());
+            writer.WriteLine($"Issue created for {result.Artifact.ExecutionUnit}: {result.LinkedIssue.Url}");
+            writer.WriteLine($"Publish artifact: {result.ArtifactPath}");
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static IssueCreateCommandResult ExecuteCore(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var artifactPath = IssuePublishArtifactPathResolver.Resolve(executionUnit);
+        var absoluteArtifactPath = ResolveRepoPath(context.RepoRoot, artifactPath);
+        if (!File.Exists(absoluteArtifactPath))
+        {
+            throw new InvalidOperationException($"Drafted publish artifact was not found at {absoluteArtifactPath}");
+        }
+
+        var artifact = IssuePublishArtifactYaml.Deserialize(File.ReadAllText(absoluteArtifactPath));
+        if (!string.Equals(artifact.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Issue publish artifact execution unit '{artifact.ExecutionUnit}' does not match requested execution unit '{executionUnit}'.");
+        }
+
+        if (!string.Equals(artifact.PublishStatus, DraftedPublishStatus, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Issue publish artifact for '{executionUnit}' must be in '{DraftedPublishStatus}' status.");
+        }
+
+        var packetPath = ResolveRepoPath(context.RepoRoot, artifact.PacketPath);
+        if (!File.Exists(packetPath))
+        {
+            throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
+        }
+
+        var packet = ProjectionPacketRuntimeReader.Read(File.ReadAllText(packetPath));
+        if (!string.Equals(packet.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Projection packet execution unit '{packet.ExecutionUnit}' does not match requested execution unit '{executionUnit}'.");
+        }
+
+        var issueBodyPath = ResolveRepoPath(context.RepoRoot, artifact.IssueBodyPath);
+        if (!File.Exists(issueBodyPath))
+        {
+            throw new InvalidOperationException($"GitHub issue body artifact was not found at {issueBodyPath}");
+        }
+
+        var body = File.ReadAllText(issueBodyPath);
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            throw new InvalidOperationException("GitHub issue body artifact must not be empty.");
+        }
+
+        var targetRepo = GitHubRepositoryTargetResolver.Resolve(context.RepoRoot, packet.TargetRepo, GitCommandRunnerFactory());
+        var linkedIssue = PublisherFactory().CreateIssue(targetRepo, packet.IssueTitle, body);
+
+        var updatedArtifact = artifact with
+        {
+            PublishStatus = IssueCreatedPublishStatus,
+            CreatedIssueNumber = linkedIssue.Number,
+            CreatedIssueUrl = linkedIssue.Url
+        };
+
+        File.WriteAllText(absoluteArtifactPath, IssuePublishArtifactYaml.Serialize(updatedArtifact));
+        AppendRunEvent(
+            context,
+            new RunEvent
+            {
+                Ts = TimestampFactory(),
+                ExecutionUnit = executionUnit,
+                Event = "issue-created",
+                By = TransitionActor,
+                LinkedIssue = linkedIssue.Url,
+                PacketRef = artifact.PacketPath,
+                ResultRef = artifactPath
+            });
+
+        return new IssueCreateCommandResult
+        {
+            Artifact = updatedArtifact,
+            ArtifactPath = artifactPath,
+            LinkedIssue = linkedIssue
+        };
+    }
+
+    private static void AppendRunEvent(CliContext context, RunEvent runEvent)
+    {
+        var runLogPath = context.GetRunLogPath();
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(runLogPath, RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
+    }
+
+    private static string ResolveRepoPath(string repoRoot, string relativePath)
+    {
+        return Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+    }
+}
+
+internal sealed record IssueCreateCommandResult
+{
+    public required IssuePublishArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+
+    public required LinkedIssue LinkedIssue { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IssueDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssueDraftCommand.cs
@@ -69,7 +69,9 @@ internal static class IssueDraftCommand
             ExecutionUnit = executionUnit,
             PublishStatus = DraftedPublishStatus,
             PacketPath = relativePacketPath,
-            IssueBodyPath = relativeIssueBodyPath
+            IssueBodyPath = relativeIssueBodyPath,
+            CreatedIssueNumber = null,
+            CreatedIssueUrl = null
         };
 
         var artifactPath = WriteArtifact(context.RepoRoot, artifact);

--- a/src/IntentSystem.Cli/Commands/IssuePublishArtifactYaml.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishArtifactYaml.cs
@@ -9,6 +9,10 @@ internal sealed record IssuePublishArtifact
     public required string PacketPath { get; init; }
 
     public required string IssueBodyPath { get; init; }
+
+    public required int? CreatedIssueNumber { get; init; }
+
+    public required string? CreatedIssueUrl { get; init; }
 }
 
 internal static class IssuePublishArtifactYaml
@@ -18,7 +22,9 @@ internal static class IssuePublishArtifactYaml
         "execution_unit",
         "publish_status",
         "packet_path",
-        "issue_body_path"
+        "issue_body_path",
+        "created_issue_number",
+        "created_issue_url"
     ];
 
     public static string Serialize(IssuePublishArtifact artifact)
@@ -31,7 +37,9 @@ internal static class IssuePublishArtifactYaml
                        $"execution_unit: {artifact.ExecutionUnit}",
                        $"publish_status: {artifact.PublishStatus}",
                        $"packet_path: {Quote(artifact.PacketPath)}",
-                       $"issue_body_path: {Quote(artifact.IssueBodyPath)}"
+                       $"issue_body_path: {Quote(artifact.IssueBodyPath)}",
+                       $"created_issue_number: {FormatNullableInteger(artifact.CreatedIssueNumber)}",
+                       $"created_issue_url: {FormatNullableScalar(artifact.CreatedIssueUrl)}"
                    ])
                + Environment.NewLine;
     }
@@ -48,13 +56,15 @@ internal static class IssuePublishArtifactYaml
             ExecutionUnit = GetRequiredScalar(values, "execution_unit"),
             PublishStatus = GetRequiredScalar(values, "publish_status"),
             PacketPath = GetRequiredScalar(values, "packet_path"),
-            IssueBodyPath = GetRequiredScalar(values, "issue_body_path")
+            IssueBodyPath = GetRequiredScalar(values, "issue_body_path"),
+            CreatedIssueNumber = GetNullableInteger(values, "created_issue_number"),
+            CreatedIssueUrl = GetNullableScalar(values, "created_issue_url")
         };
     }
 
-    private static Dictionary<string, string> ParseYaml(string yaml)
+    private static Dictionary<string, object?> ParseYaml(string yaml)
     {
-        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        var values = new Dictionary<string, object?>(StringComparer.Ordinal);
 
         using var reader = new StringReader(yaml);
         string? line;
@@ -73,13 +83,18 @@ internal static class IssuePublishArtifactYaml
 
             var key = line[..separatorIndex].Trim();
             var value = line[(separatorIndex + 1)..].TrimStart();
-            values[key] = ParseScalar(value);
+            values[key] = value switch
+            {
+                "null" => null,
+                _ when int.TryParse(value, out var integerValue) => integerValue,
+                _ => ParseScalar(value)
+            };
         }
 
         return values;
     }
 
-    private static void ValidateRequiredFields(IReadOnlyDictionary<string, string> values)
+    private static void ValidateRequiredFields(IReadOnlyDictionary<string, object?> values)
     {
         foreach (var field in RequiredFields)
         {
@@ -90,14 +105,44 @@ internal static class IssuePublishArtifactYaml
         }
     }
 
-    private static string GetRequiredScalar(IReadOnlyDictionary<string, string> values, string key)
+    private static string GetRequiredScalar(IReadOnlyDictionary<string, object?> values, string key)
     {
-        if (!values.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+        if (!values.TryGetValue(key, out var value) || value is not string text || string.IsNullOrWhiteSpace(text))
         {
             throw new InvalidOperationException($"Issue publish artifact YAML field '{key}' must be a scalar string.");
         }
 
-        return value;
+        return text;
+    }
+
+    private static int? GetNullableInteger(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Issue publish artifact YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            int integerValue => integerValue,
+            _ => throw new InvalidOperationException($"Issue publish artifact YAML field '{key}' must be an integer or null.")
+        };
+    }
+
+    private static string? GetNullableScalar(IReadOnlyDictionary<string, object?> values, string key)
+    {
+        if (!values.TryGetValue(key, out var value))
+        {
+            throw new InvalidOperationException($"Issue publish artifact YAML field '{key}' must be present.");
+        }
+
+        return value switch
+        {
+            null => null,
+            string text => text,
+            _ => throw new InvalidOperationException($"Issue publish artifact YAML field '{key}' must be a scalar string or null.")
+        };
     }
 
     private static string ParseScalar(string value)
@@ -114,6 +159,16 @@ internal static class IssuePublishArtifactYaml
         }
 
         return value;
+    }
+
+    private static string FormatNullableInteger(int? value)
+    {
+        return value?.ToString() ?? "null";
+    }
+
+    private static string FormatNullableScalar(string? value)
+    {
+        return value is null ? "null" : Quote(value);
     }
 
     private static string Quote(string value)

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -2460,6 +2460,61 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIssueCreateCommand_DispatchesToIssueCreateRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            """
+            execution_unit: G13
+            implementation_issue:
+              issue_title: "[G13] Add issue create foundation"
+              target_repo: "submodules/intent-system"
+              target_path: "src/IntentSystem.Cli"
+              target_part: "issue create command"
+              dependencies: []
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "publish.yaml"),
+            """
+            execution_unit: G13
+            publish_status: drafted
+            packet_path: ".intent-cli/issues/G13/packet.yaml"
+            issue_body_path: ".intent-cli/issues/G13/github-body.md"
+            created_issue_number: null
+            created_issue_url: null
+            """);
+        using var writer = new StringWriter();
+        var originalPublisherFactory = IssueCreateCommand.PublisherFactory;
+        var originalGitCommandRunnerFactory = IssueCreateCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = IssueCreateCommand.TimestampFactory;
+
+        try
+        {
+            IssueCreateCommand.PublisherFactory = () => new FakeQueueDispatchPublisher();
+            IssueCreateCommand.GitCommandRunnerFactory = () => new FakeQueueDispatchGitRunner();
+            IssueCreateCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-23T00:10:00Z");
+
+            var exitCode = CommandRouter.Execute(["issue", "create", "G13"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Issue created for G13", writer.ToString(), StringComparison.Ordinal);
+            Assert.True(File.Exists(Path.Combine(repoRoot, ".intent-cli", "issues", "G13", "publish.yaml")));
+        }
+        finally
+        {
+            IssueCreateCommand.PublisherFactory = originalPublisherFactory;
+            IssueCreateCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+            IssueCreateCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenIntakeConceptCommand_DispatchesToIntakeConceptRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IssueCreateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssueCreateCommandTests.cs
@@ -1,0 +1,256 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IssueCreateCommandTests
+{
+    [Fact]
+    public void Execute_GivenDraftedArtifact_CreatesIssueAndAdvancesPublishArtifact()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "publish.yaml"),
+            CreateDraftedPublishYaml());
+        using var writer = new StringWriter();
+        var publisher = new CapturingPublisher();
+        var gitRunner = new CapturingGitCommandRunner();
+        var originalPublisherFactory = IssueCreateCommand.PublisherFactory;
+        var originalGitCommandRunnerFactory = IssueCreateCommand.GitCommandRunnerFactory;
+        var originalTimestampFactory = IssueCreateCommand.TimestampFactory;
+
+        try
+        {
+            IssueCreateCommand.PublisherFactory = () => publisher;
+            IssueCreateCommand.GitCommandRunnerFactory = () => gitRunner;
+            IssueCreateCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-23T00:10:00Z");
+
+            var exitCode = IssueCreateCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Issue created for G13", writer.ToString(), StringComparison.Ordinal);
+
+            var artifact = IssuePublishArtifactYaml.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "issues", "G13", "publish.yaml")));
+            Assert.Equal("issue-created", artifact.PublishStatus);
+            Assert.Equal(73, artifact.CreatedIssueNumber);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/73", artifact.CreatedIssueUrl);
+
+            var runEvents = RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            var createdEvent = Assert.Single(runEvents);
+            Assert.Equal("issue-created", createdEvent.Event);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/73", createdEvent.LinkedIssue);
+            Assert.Equal(".intent-cli/issues/G13/publish.yaml", createdEvent.ResultRef);
+
+            Assert.Equal("J-Tech-Japan/intent-system", publisher.TargetRepo);
+            Assert.Equal("[G13] Add issue create foundation", publisher.Title);
+            Assert.Equal("# Goal", publisher.Body);
+            Assert.Single(gitRunner.Calls);
+            Assert.Equal(["remote", "get-url", "origin"], gitRunner.Calls[0].Arguments);
+        }
+        finally
+        {
+            IssueCreateCommand.PublisherFactory = originalPublisherFactory;
+            IssueCreateCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+            IssueCreateCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDraftedArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = IssueCreateCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Drafted publish artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNonDraftedArtifact_ReturnsExitCodeOneWithoutCreatingIssue()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "github-body.md"),
+            "# Goal");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "publish.yaml"),
+            """
+            execution_unit: G13
+            publish_status: issue-created
+            packet_path: ".intent-cli/issues/G13/packet.yaml"
+            issue_body_path: ".intent-cli/issues/G13/github-body.md"
+            created_issue_number: 73
+            created_issue_url: "https://github.com/J-Tech-Japan/intent-system/issues/73"
+            """);
+        using var writer = new StringWriter();
+        var originalPublisherFactory = IssueCreateCommand.PublisherFactory;
+
+        try
+        {
+            IssueCreateCommand.PublisherFactory = () => new ThrowingPublisher();
+
+            var exitCode = IssueCreateCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("must be in 'drafted' status", writer.ToString(), StringComparison.Ordinal);
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+        }
+        finally
+        {
+            IssueCreateCommand.PublisherFactory = originalPublisherFactory;
+        }
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private static string CreatePacketYaml()
+    {
+        return
+            """
+            execution_unit: G13
+            implementation_issue:
+              issue_title: "[G13] Add issue create foundation"
+              target_repo: "submodules/intent-system"
+              target_path: "src/IntentSystem.Cli"
+              target_part: "issue create command"
+              dependencies: []
+            """;
+    }
+
+    private static string CreateDraftedPublishYaml()
+    {
+        return
+            """
+            execution_unit: G13
+            publish_status: drafted
+            packet_path: ".intent-cli/issues/G13/packet.yaml"
+            issue_body_path: ".intent-cli/issues/G13/github-body.md"
+            created_issue_number: null
+            created_issue_url: null
+            """;
+    }
+
+    private sealed class CapturingPublisher : IQueueDispatchPublisher
+    {
+        public string TargetRepo { get; private set; } = string.Empty;
+
+        public string Title { get; private set; } = string.Empty;
+
+        public string Body { get; private set; } = string.Empty;
+
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            TargetRepo = targetRepo;
+            Title = title;
+            Body = body;
+
+            return new LinkedIssue
+            {
+                Repo = targetRepo,
+                Number = 73,
+                Url = "https://github.com/J-Tech-Japan/intent-system/issues/73"
+            };
+        }
+    }
+
+    private sealed class ThrowingPublisher : IQueueDispatchPublisher
+    {
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            throw new InvalidOperationException("CreateIssue should not be called.");
+        }
+    }
+
+    private sealed class CapturingGitCommandRunner : IGitRemoteCommandRunner
+    {
+        public List<GitCommandCall> Calls { get; } = [];
+
+        public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Calls.Add(new GitCommandCall
+            {
+                WorkingDirectory = workingDirectory,
+                Arguments = [..arguments]
+            });
+
+            return new GitRemoteCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "git@github.com:J-Tech-Japan/intent-system.git" + Environment.NewLine,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed record GitCommandCall
+    {
+        public required string WorkingDirectory { get; init; }
+
+        public required IReadOnlyList<string> Arguments { get; init; }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-issue-create-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IssueDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssueDraftCommandTests.cs
@@ -36,6 +36,8 @@ public sealed class IssueDraftCommandTests
             Assert.Equal("drafted", artifact.PublishStatus);
             Assert.Equal(".intent-cli/issues/G13/packet.yaml", artifact.PacketPath);
             Assert.Equal(".intent-cli/issues/G13/github-body.md", artifact.IssueBodyPath);
+            Assert.Null(artifact.CreatedIssueNumber);
+            Assert.Null(artifact.CreatedIssueUrl);
 
             var runEvents = RunLogSerializer.DeserializeAll(
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
@@ -68,6 +70,8 @@ public sealed class IssueDraftCommandTests
             publish_status: published
             packet_path: ".intent-cli/issues/G13/old-packet.yaml"
             issue_body_path: ".intent-cli/issues/G13/old-body.md"
+            created_issue_number: 91
+            created_issue_url: "https://github.com/J-Tech-Japan/intent-system/issues/91"
             """);
 
         var exitCode = IssueDraftCommand.Execute(CreateContext(repoRoot), ["G13"], TextWriter.Null);
@@ -79,6 +83,8 @@ public sealed class IssueDraftCommandTests
         Assert.Equal("drafted", artifact.PublishStatus);
         Assert.Equal(".intent-cli/issues/G13/packet.yaml", artifact.PacketPath);
         Assert.Equal(".intent-cli/issues/G13/github-body.md", artifact.IssueBodyPath);
+        Assert.Null(artifact.CreatedIssueNumber);
+        Assert.Null(artifact.CreatedIssueUrl);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add `intent-cli issue create <execution-unit>` on top of the drafted publish artifact
- advance `.intent-cli/issues/<execution-unit>/publish.yaml` to `issue-created` with created issue metadata
- append normalized `issue-created` events and cover routing/artifact advancement with focused CLI tests

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IssueDraftCommandTests|FullyQualifiedName~IssueCreateCommandTests|FullyQualifiedName~CommandRouterTests"`
- `git diff --check`

Refs #412