### PR TITLE
G155 Add issue status command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -74,7 +74,8 @@ internal static class CommandRouter
             {
                 ["draft"] = IssueDraftCommand.Execute,
                 ["create"] = IssueCreateCommand.Execute,
-                ["publish"] = IssuePublishCommand.Execute
+                ["publish"] = IssuePublishCommand.Execute,
+                ["status"] = IssueStatusCommand.Execute
             },
             ["bug"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/IssueStatusCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssueStatusCommand.cs
@@ -1,0 +1,211 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IssueStatusCommand
+{
+    private const string DraftedPublishStatus = "drafted";
+    private const string IssueCreatedPublishStatus = "issue-created";
+    private const string PublishedStatus = "published";
+    private const string PublishLabelName = "intent-target";
+
+    public static Func<IQueueDispatchPublisher> PublisherFactory { get; set; } = () => new GhQueueDispatchPublisher();
+
+    public static Func<IGitRemoteCommandRunner> GitCommandRunnerFactory { get; set; } = () => new GitRemoteCommandRunner();
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            writer.WriteLine("Issue status command requires an execution unit.");
+            return 1;
+        }
+
+        try
+        {
+            var result = ExecuteCore(context, args[0].Trim());
+            WriteResult(writer, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static IssueStatusCommandResult ExecuteCore(CliContext context, string executionUnit)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        var artifactPath = IssuePublishArtifactPathResolver.Resolve(executionUnit);
+        var absoluteArtifactPath = ResolveRepoPath(context.RepoRoot, artifactPath);
+        if (!File.Exists(absoluteArtifactPath))
+        {
+            throw new InvalidOperationException($"Issue publish artifact was not found at {absoluteArtifactPath}");
+        }
+
+        var artifact = IssuePublishArtifactYaml.Deserialize(File.ReadAllText(absoluteArtifactPath));
+        if (!string.Equals(artifact.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Issue publish artifact execution unit '{artifact.ExecutionUnit}' does not match requested execution unit '{executionUnit}'.");
+        }
+
+        var requiresCreatedIssue = string.Equals(artifact.PublishStatus, IssueCreatedPublishStatus, StringComparison.Ordinal)
+            || string.Equals(artifact.PublishStatus, PublishedStatus, StringComparison.Ordinal);
+        var hasAnyCreatedIssueMetadata = artifact.CreatedIssueNumber is not null
+            || !string.IsNullOrWhiteSpace(artifact.CreatedIssueUrl);
+        if ((requiresCreatedIssue || hasAnyCreatedIssueMetadata)
+            && (artifact.CreatedIssueNumber is null || string.IsNullOrWhiteSpace(artifact.CreatedIssueUrl)))
+        {
+            throw new InvalidOperationException(
+                $"Issue publish artifact for '{executionUnit}' must contain both created issue number and URL.");
+        }
+
+        IssueStatusLinkedIssue? linkedIssue = null;
+        if (artifact.CreatedIssueNumber is not null && !string.IsNullOrWhiteSpace(artifact.CreatedIssueUrl))
+        {
+            var targetRepo = ResolveTargetRepo(context, artifact);
+            var labelNames = PublisherFactory().GetIssueLabels(targetRepo, artifact.CreatedIssueNumber.Value);
+            var hasIntentTargetLabel = labelNames.Contains(PublishLabelName, StringComparer.Ordinal);
+
+            linkedIssue = new IssueStatusLinkedIssue
+            {
+                TargetRepo = targetRepo,
+                Number = artifact.CreatedIssueNumber.Value,
+                Url = artifact.CreatedIssueUrl,
+                HasIntentTargetLabel = hasIntentTargetLabel
+            };
+        }
+
+        return new IssueStatusCommandResult
+        {
+            Artifact = artifact,
+            ArtifactPath = artifactPath,
+            LinkedIssue = linkedIssue,
+            AutomationState = ResolveAutomationState(artifact, linkedIssue)
+        };
+    }
+
+    private static string ResolveTargetRepo(CliContext context, IssuePublishArtifact artifact)
+    {
+        var packetPath = ResolveRepoPath(context.RepoRoot, artifact.PacketPath);
+        if (!File.Exists(packetPath))
+        {
+            throw new InvalidOperationException($"Projection packet artifact was not found at {packetPath}");
+        }
+
+        var packet = ProjectionPacketRuntimeReader.Read(File.ReadAllText(packetPath));
+        if (!string.Equals(packet.ExecutionUnit, artifact.ExecutionUnit, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Projection packet execution unit '{packet.ExecutionUnit}' does not match publish artifact execution unit '{artifact.ExecutionUnit}'.");
+        }
+
+        return GitHubRepositoryTargetResolver.Resolve(context.RepoRoot, packet.TargetRepo, GitCommandRunnerFactory());
+    }
+
+    private static IssueStatusAutomationState ResolveAutomationState(
+        IssuePublishArtifact artifact,
+        IssueStatusLinkedIssue? linkedIssue)
+    {
+        if (string.Equals(artifact.PublishStatus, DraftedPublishStatus, StringComparison.Ordinal))
+        {
+            return IssueStatusAutomationState.DraftedOnly;
+        }
+
+        if (string.Equals(artifact.PublishStatus, IssueCreatedPublishStatus, StringComparison.Ordinal))
+        {
+            return linkedIssue?.HasIntentTargetLabel == true
+                ? IssueStatusAutomationState.IssueCreatedLabelPresent
+                : IssueStatusAutomationState.IssueCreatedNotAutomationVisible;
+        }
+
+        if (string.Equals(artifact.PublishStatus, PublishedStatus, StringComparison.Ordinal))
+        {
+            return linkedIssue?.HasIntentTargetLabel == true
+                ? IssueStatusAutomationState.PublishedAndLabelPresent
+                : IssueStatusAutomationState.PublishedMissingLabelDrift;
+        }
+
+        return IssueStatusAutomationState.Unknown;
+    }
+
+    private static void WriteResult(TextWriter writer, IssueStatusCommandResult result)
+    {
+        writer.WriteLine($"Issue status for {result.Artifact.ExecutionUnit}");
+        writer.WriteLine($"Publish artifact: {result.ArtifactPath}");
+        writer.WriteLine($"Publish status: {result.Artifact.PublishStatus}");
+        writer.WriteLine($"Packet path: {result.Artifact.PacketPath}");
+        writer.WriteLine($"Issue body path: {result.Artifact.IssueBodyPath}");
+        writer.WriteLine($"Published label in artifact: {result.Artifact.PublishedLabelName ?? "none"}");
+
+        if (result.LinkedIssue is null)
+        {
+            writer.WriteLine("Created issue: none");
+            writer.WriteLine("intent-target label: not checked");
+        }
+        else
+        {
+            writer.WriteLine($"Created issue: #{result.LinkedIssue.Number} {result.LinkedIssue.Url}");
+            writer.WriteLine($"Target repo: {result.LinkedIssue.TargetRepo}");
+            writer.WriteLine($"intent-target label: {(result.LinkedIssue.HasIntentTargetLabel ? "present" : "missing")}");
+        }
+
+        writer.WriteLine($"Automation state: {FormatAutomationState(result.AutomationState)}");
+    }
+
+    private static string FormatAutomationState(IssueStatusAutomationState state)
+    {
+        return state switch
+        {
+            IssueStatusAutomationState.DraftedOnly => "drafted only; no linked GitHub issue",
+            IssueStatusAutomationState.IssueCreatedNotAutomationVisible => "issue-created but not published / not automation-visible",
+            IssueStatusAutomationState.IssueCreatedLabelPresent => "issue-created artifact but live intent-target label is already present",
+            IssueStatusAutomationState.PublishedAndLabelPresent => "published and label present",
+            IssueStatusAutomationState.PublishedMissingLabelDrift => "drift: artifact is published but live intent-target label is missing",
+            _ => "unknown publish status"
+        };
+    }
+
+    private static string ResolveRepoPath(string repoRoot, string relativePath)
+    {
+        return Path.GetFullPath(Path.Combine(repoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar)));
+    }
+}
+
+internal sealed record IssueStatusCommandResult
+{
+    public required IssuePublishArtifact Artifact { get; init; }
+
+    public required string ArtifactPath { get; init; }
+
+    public required IssueStatusLinkedIssue? LinkedIssue { get; init; }
+
+    public required IssueStatusAutomationState AutomationState { get; init; }
+}
+
+internal sealed record IssueStatusLinkedIssue
+{
+    public required string TargetRepo { get; init; }
+
+    public required int Number { get; init; }
+
+    public required string Url { get; init; }
+
+    public required bool HasIntentTargetLabel { get; init; }
+}
+
+internal enum IssueStatusAutomationState
+{
+    DraftedOnly,
+    IssueCreatedNotAutomationVisible,
+    IssueCreatedLabelPresent,
+    PublishedAndLabelPresent,
+    PublishedMissingLabelDrift,
+    Unknown
+}

--- a/src/IntentSystem.Cli/GhQueueDispatchPublisher.cs
+++ b/src/IntentSystem.Cli/GhQueueDispatchPublisher.cs
@@ -118,6 +118,48 @@ internal sealed class GhQueueDispatchPublisher : IQueueDispatchPublisher
         }
     }
 
+    public IReadOnlyList<string> GetIssueLabels(string targetRepo, int issueNumber)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetRepo);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(issueNumber);
+
+        var repoRef = GitHubRepositoryRef.Parse(targetRepo);
+        var result = commandRunner.Run(
+            [
+                "api",
+                $"repos/{repoRef.Owner}/{repoRef.Repo}/issues/{issueNumber}/labels",
+                "--method",
+                "GET"
+            ]);
+
+        if (result.ExitCode != 0)
+        {
+            var error = string.IsNullOrWhiteSpace(result.StdErr)
+                ? "gh api issue labels get failed."
+                : result.StdErr.Trim();
+            throw new InvalidOperationException(error);
+        }
+
+        using var document = JsonDocument.Parse(result.StdOut);
+        if (document.RootElement.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidOperationException("GitHub issue labels response must be an array.");
+        }
+
+        var labels = new List<string>();
+        foreach (var labelElement in document.RootElement.EnumerateArray())
+        {
+            if (labelElement.TryGetProperty("name", out var nameElement)
+                && !string.IsNullOrWhiteSpace(nameElement.GetString()))
+            {
+                labels.Add(nameElement.GetString()
+                    ?? throw new InvalidOperationException("GitHub issue label name was null."));
+            }
+        }
+
+        return labels;
+    }
+
     private sealed record GitHubRepositoryRef
     {
         public required string Owner { get; init; }

--- a/src/IntentSystem.Cli/IQueueDispatchPublisher.cs
+++ b/src/IntentSystem.Cli/IQueueDispatchPublisher.cs
@@ -10,4 +10,9 @@ internal interface IQueueDispatchPublisher
     {
         throw new NotSupportedException("This publisher does not support issue label application.");
     }
+
+    IReadOnlyList<string> GetIssueLabels(string targetRepo, int issueNumber)
+    {
+        throw new NotSupportedException("This publisher does not support issue label inspection.");
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -2569,6 +2569,56 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenIssueStatusCommand_DispatchesToIssueStatusRenderer()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            """
+            execution_unit: G13
+            implementation_issue:
+              issue_title: "[G13] Add issue status foundation"
+              target_repo: "submodules/intent-system"
+              target_path: "src/IntentSystem.Cli"
+              target_part: "issue status command"
+              dependencies: []
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "publish.yaml"),
+            """
+            execution_unit: G13
+            publish_status: published
+            packet_path: ".intent-cli/issues/G13/packet.yaml"
+            issue_body_path: ".intent-cli/issues/G13/github-body.md"
+            created_issue_number: 73
+            created_issue_url: "https://github.com/J-Tech-Japan/intent-system/issues/73"
+            published_label_name: "intent-target"
+            """);
+        using var writer = new StringWriter();
+        var originalPublisherFactory = IssueStatusCommand.PublisherFactory;
+        var originalGitCommandRunnerFactory = IssueStatusCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            IssueStatusCommand.PublisherFactory = () => new FakeQueueDispatchPublisher();
+            IssueStatusCommand.GitCommandRunnerFactory = () => new FakeQueueDispatchGitRunner();
+
+            var exitCode = CommandRouter.Execute(["issue", "status", "G13"], CreateContext(repoRoot), writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Issue status for G13", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Automation state: published and label present", writer.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            IssueStatusCommand.PublisherFactory = originalPublisherFactory;
+            IssueStatusCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenIntakeConceptCommand_DispatchesToIntakeConceptRenderer()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -5083,6 +5133,11 @@ recommended_updates:
 
         public void AddLabel(string targetRepo, int issueNumber, string labelName)
         {
+        }
+
+        public IReadOnlyList<string> GetIssueLabels(string targetRepo, int issueNumber)
+        {
+            return ["intent-target"];
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/GhQueueDispatchPublisherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GhQueueDispatchPublisherTests.cs
@@ -41,25 +41,49 @@ public sealed class GhQueueDispatchPublisherTests
         Assert.Contains("owner/repo shape", exception.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void GetIssueLabels_GivenTargetRepoAndIssueNumber_ReadsLabelsViaGhApi()
+    {
+        var runner = new FakeRunner
+        {
+            ResponseStdOut = """[{"name":"intent-target"},{"name":"bug"}]"""
+        };
+        var publisher = new GhQueueDispatchPublisher(runner);
+
+        var labels = publisher.GetIssueLabels("J-Tech-Japan/intent-system", 53);
+
+        Assert.Equal(["intent-target", "bug"], labels);
+        Assert.Equal(
+            "repos/J-Tech-Japan/intent-system/issues/53/labels",
+            runner.Arguments[1]);
+        Assert.Equal("GET", runner.Arguments[3]);
+        Assert.Empty(runner.PayloadJson);
+    }
+
     private sealed class FakeRunner : IGitHubCommandRunner
     {
         public IReadOnlyList<string> Arguments { get; private set; } = [];
 
         public string PayloadJson { get; private set; } = string.Empty;
 
+        public string ResponseStdOut { get; init; } =
+            """{"number":53,"html_url":"https://github.com/J-Tech-Japan/intent-system/issues/53"}""";
+
         public GitHubCommandResult Run(IReadOnlyList<string> arguments)
         {
             Arguments = arguments.ToArray();
-            var payloadIndex = Arguments
+            var payloadItem = Arguments
                 .Select((argument, index) => (argument, index))
-                .First(item => string.Equals(item.argument, "--input", StringComparison.Ordinal))
-                .index + 1;
-            PayloadJson = File.ReadAllText(Arguments[payloadIndex]);
+                .FirstOrDefault(item => string.Equals(item.argument, "--input", StringComparison.Ordinal));
+            if (payloadItem.argument is not null)
+            {
+                PayloadJson = File.ReadAllText(Arguments[payloadItem.index + 1]);
+            }
 
             return new GitHubCommandResult
             {
                 ExitCode = 0,
-                StdOut = """{"number":53,"html_url":"https://github.com/J-Tech-Japan/intent-system/issues/53"}""",
+                StdOut = ResponseStdOut,
                 StdErr = string.Empty
             };
         }

--- a/tests/IntentSystem.Cli.Tests/IssueStatusCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssueStatusCommandTests.cs
@@ -1,0 +1,356 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IssueStatusCommandTests
+{
+    [Fact]
+    public void Execute_GivenDraftedArtifact_PrintsDraftStateWithoutGitHubLookup()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var publishPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "publish.yaml"),
+            CreatePublishYaml("drafted", "null", "null", "null"));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            "{\"event\":\"issue-drafted\"}" + Environment.NewLine);
+        using var writer = new StringWriter();
+        var publisher = new CapturingPublisher([]);
+        var originalPublisherFactory = IssueStatusCommand.PublisherFactory;
+
+        try
+        {
+            IssueStatusCommand.PublisherFactory = () => publisher;
+            var originalPublishYaml = File.ReadAllText(publishPath);
+            var originalRunLog = File.ReadAllText(runLogPath);
+
+            var exitCode = IssueStatusCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+            var output = writer.ToString();
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Issue status for G13", output, StringComparison.Ordinal);
+            Assert.Contains("Publish status: drafted", output, StringComparison.Ordinal);
+            Assert.Contains("Created issue: none", output, StringComparison.Ordinal);
+            Assert.Contains("Automation state: drafted only", output, StringComparison.Ordinal);
+            Assert.Equal(0, publisher.GetIssueLabelsCallCount);
+            Assert.False(publisher.CreateIssueCalled);
+            Assert.False(publisher.AddLabelCalled);
+            Assert.Equal(originalPublishYaml, File.ReadAllText(publishPath));
+            Assert.Equal(originalRunLog, File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            IssueStatusCommand.PublisherFactory = originalPublisherFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenIssueCreatedArtifactWithoutIntentTarget_PrintsNotAutomationVisibleState()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = CreateRepoWithPacket(tempDirectory);
+        var publishPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "publish.yaml"),
+            CreatePublishYaml(
+                "issue-created",
+                "73",
+                "\"https://github.com/J-Tech-Japan/intent-system/issues/73\"",
+                "null"));
+        using var writer = new StringWriter();
+        var publisher = new CapturingPublisher(["bug"]);
+        var gitRunner = new CapturingGitCommandRunner();
+        var originalPublisherFactory = IssueStatusCommand.PublisherFactory;
+        var originalGitCommandRunnerFactory = IssueStatusCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            IssueStatusCommand.PublisherFactory = () => publisher;
+            IssueStatusCommand.GitCommandRunnerFactory = () => gitRunner;
+            var originalPublishYaml = File.ReadAllText(publishPath);
+
+            var exitCode = IssueStatusCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+            var output = writer.ToString();
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Created issue: #73 https://github.com/J-Tech-Japan/intent-system/issues/73", output, StringComparison.Ordinal);
+            Assert.Contains("intent-target label: missing", output, StringComparison.Ordinal);
+            Assert.Contains("Automation state: issue-created but not published / not automation-visible", output, StringComparison.Ordinal);
+            Assert.Equal("J-Tech-Japan/intent-system", publisher.TargetRepo);
+            Assert.Equal(73, publisher.IssueNumber);
+            Assert.Equal(1, publisher.GetIssueLabelsCallCount);
+            Assert.False(publisher.CreateIssueCalled);
+            Assert.False(publisher.AddLabelCalled);
+            Assert.Single(gitRunner.Calls);
+            Assert.False(File.Exists(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            Assert.Equal(originalPublishYaml, File.ReadAllText(publishPath));
+        }
+        finally
+        {
+            IssueStatusCommand.PublisherFactory = originalPublisherFactory;
+            IssueStatusCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenPublishedArtifactWithIntentTarget_PrintsPublishedReadyState()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = CreateRepoWithPacket(tempDirectory);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "publish.yaml"),
+            CreatePublishYaml(
+                "published",
+                "73",
+                "\"https://github.com/J-Tech-Japan/intent-system/issues/73\"",
+                "\"intent-target\""));
+        using var writer = new StringWriter();
+        var publisher = new CapturingPublisher(["intent-target"]);
+        var originalPublisherFactory = IssueStatusCommand.PublisherFactory;
+        var originalGitCommandRunnerFactory = IssueStatusCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            IssueStatusCommand.PublisherFactory = () => publisher;
+            IssueStatusCommand.GitCommandRunnerFactory = () => new CapturingGitCommandRunner();
+
+            var exitCode = IssueStatusCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Published label in artifact: intent-target", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("intent-target label: present", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("Automation state: published and label present", writer.ToString(), StringComparison.Ordinal);
+            Assert.False(publisher.CreateIssueCalled);
+            Assert.False(publisher.AddLabelCalled);
+        }
+        finally
+        {
+            IssueStatusCommand.PublisherFactory = originalPublisherFactory;
+            IssueStatusCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenPublishedArtifactWithMissingIntentTarget_PrintsDriftState()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = CreateRepoWithPacket(tempDirectory);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "publish.yaml"),
+            CreatePublishYaml(
+                "published",
+                "73",
+                "\"https://github.com/J-Tech-Japan/intent-system/issues/73\"",
+                "\"intent-target\""));
+        using var writer = new StringWriter();
+        var publisher = new CapturingPublisher(["documentation"]);
+        var originalPublisherFactory = IssueStatusCommand.PublisherFactory;
+        var originalGitCommandRunnerFactory = IssueStatusCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            IssueStatusCommand.PublisherFactory = () => publisher;
+            IssueStatusCommand.GitCommandRunnerFactory = () => new CapturingGitCommandRunner();
+
+            var exitCode = IssueStatusCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("intent-target label: missing", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains(
+                "Automation state: drift: artifact is published but live intent-target label is missing",
+                writer.ToString(),
+                StringComparison.Ordinal);
+            Assert.False(publisher.CreateIssueCalled);
+            Assert.False(publisher.AddLabelCalled);
+        }
+        finally
+        {
+            IssueStatusCommand.PublisherFactory = originalPublisherFactory;
+            IssueStatusCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPublishArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        using var writer = new StringWriter();
+
+        var exitCode = IssueStatusCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Issue publish artifact was not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMismatchedPublishArtifact_ReturnsExitCodeOne()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "publish.yaml"),
+            """
+            execution_unit: G99
+            publish_status: drafted
+            packet_path: ".intent-cli/issues/G13/packet.yaml"
+            issue_body_path: ".intent-cli/issues/G13/github-body.md"
+            created_issue_number: null
+            created_issue_url: null
+            published_label_name: null
+            """);
+        using var writer = new StringWriter();
+
+        var exitCode = IssueStatusCommand.Execute(CreateContext(repoRoot), ["G13"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("does not match requested execution unit 'G13'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static string CreateRepoWithPacket(TemporaryDirectory tempDirectory)
+    {
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G13", "packet.yaml"),
+            """
+            execution_unit: G13
+            implementation_issue:
+              issue_title: "[G13] Add issue status foundation"
+              target_repo: "submodules/intent-system"
+              target_path: "src/IntentSystem.Cli"
+              target_part: "issue status command"
+              dependencies: []
+            """);
+
+        return repoRoot;
+    }
+
+    private static string CreatePublishYaml(
+        string publishStatus,
+        string createdIssueNumber,
+        string createdIssueUrl,
+        string publishedLabelName)
+    {
+        return
+            $$"""
+            execution_unit: G13
+            publish_status: {{publishStatus}}
+            packet_path: ".intent-cli/issues/G13/packet.yaml"
+            issue_body_path: ".intent-cli/issues/G13/github-body.md"
+            created_issue_number: {{createdIssueNumber}}
+            created_issue_url: {{createdIssueUrl}}
+            published_label_name: {{publishedLabelName}}
+            """;
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-system",
+                    ArtifactRoot = ".intent-cli"
+                }
+            }
+        };
+    }
+
+    private sealed class CapturingPublisher(IReadOnlyList<string> labels) : IQueueDispatchPublisher
+    {
+        public string TargetRepo { get; private set; } = string.Empty;
+
+        public int IssueNumber { get; private set; }
+
+        public int GetIssueLabelsCallCount { get; private set; }
+
+        public bool CreateIssueCalled { get; private set; }
+
+        public bool AddLabelCalled { get; private set; }
+
+        public LinkedIssue CreateIssue(string targetRepo, string title, string body)
+        {
+            CreateIssueCalled = true;
+            throw new InvalidOperationException("CreateIssue should not be called during issue status.");
+        }
+
+        public void AddLabel(string targetRepo, int issueNumber, string labelName)
+        {
+            AddLabelCalled = true;
+            throw new InvalidOperationException("AddLabel should not be called during issue status.");
+        }
+
+        public IReadOnlyList<string> GetIssueLabels(string targetRepo, int issueNumber)
+        {
+            TargetRepo = targetRepo;
+            IssueNumber = issueNumber;
+            GetIssueLabelsCallCount++;
+            return labels;
+        }
+    }
+
+    private sealed class CapturingGitCommandRunner : IGitRemoteCommandRunner
+    {
+        public List<GitCommandCall> Calls { get; } = [];
+
+        public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Calls.Add(new GitCommandCall
+            {
+                WorkingDirectory = workingDirectory,
+                Arguments = [..arguments]
+            });
+
+            return new GitRemoteCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "git@github.com:J-Tech-Japan/intent-system.git" + Environment.NewLine,
+                StdErr = string.Empty
+            };
+        }
+    }
+
+    private sealed record GitCommandCall
+    {
+        public required string WorkingDirectory { get; init; }
+
+        public required IReadOnlyList<string> Arguments { get; init; }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-issue-status-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public string CreateFile(string relativePath, string contents)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            var directoryPath = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("Temporary file path did not contain a directory.");
+
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(fullPath, contents);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `intent-cli issue status <execution-unit>` routing and read-only status rendering for issue publish artifacts.
- Add read-only GitHub issue label lookup for `intent-target` state and drift detection.
- Cover drafted, issue-created, published, missing-label drift, routing, and gh label lookup behavior.

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IssueStatusCommandTests|FullyQualifiedName~GhQueueDispatchPublisherTests|FullyQualifiedName~CommandRouterTests.Execute_GivenIssueStatusCommand_DispatchesToIssueStatusRenderer"`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj`

Refs #416