### PR TITLE
Preserve implement contract-gap retry exhaustion detail

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -493,12 +493,17 @@ internal static class RunSuperviseCommand
         DateTimeOffset now,
         string reason)
     {
+        var effectiveReason = PreferCurrentSessionContractGapReason(
+            context,
+            executionUnit,
+            session.WorkerEntry,
+            reason);
         var consumeCurrentFailureIntoRetryBudget = session.RetryCount < session.RetryBudget;
         var terminalReason = CreateRetryExhaustionSummary(
             context,
             executionUnit,
             session,
-            reason,
+            effectiveReason,
             consumeCurrentFailureIntoRetryBudget);
 
         return BlockForTerminalFailure(
@@ -514,7 +519,75 @@ internal static class RunSuperviseCommand
             incrementRetryCount: consumeCurrentFailureIntoRetryBudget,
             emitRetryExhaustedEvent: true,
             emitRetryAttemptedEvent: consumeCurrentFailureIntoRetryBudget,
-            retryAttemptReason: reason);
+            retryAttemptReason: effectiveReason);
+    }
+
+    private static string PreferCurrentSessionContractGapReason(
+        CliContext context,
+        string executionUnit,
+        RunSupervisionWorkerEntry workerEntry,
+        string fallbackReason)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fallbackReason);
+
+        if (workerEntry != RunSupervisionWorkerEntry.Implement)
+        {
+            return fallbackReason;
+        }
+
+        var requestArtifactPath = ResolveDirectRunRequestArtifactPath(context, executionUnit);
+        var providerLogPath = ResolveDirectRunProviderLogPath(context, executionUnit);
+        if (!File.Exists(requestArtifactPath) || !File.Exists(providerLogPath))
+        {
+            return fallbackReason;
+        }
+
+        var requestArtifact = DirectRunRequestArtifactJson.Deserialize(File.ReadAllText(requestArtifactPath));
+        if (!string.Equals(requestArtifact.EntryKind, "implement", StringComparison.Ordinal))
+        {
+            return fallbackReason;
+        }
+
+        var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(providerLogPath));
+        var currentProviderEvents = SelectCurrentSessionEvents(
+            providerEvents,
+            requestArtifact.ProviderSessionId,
+            requestArtifact.LaunchedAt);
+
+        if (DirectRunFixOutcomeSupport.TryResolveContractGapDetail(
+                currentProviderEvents,
+                executionUnit,
+                "implement",
+                out var contractGapDetail))
+        {
+            return contractGapDetail;
+        }
+
+        var canonicalBoundaryEvent = DirectRunFixOutcomeSupport.CreateCanonicalContractGapEventIfNeeded(
+            currentProviderEvents,
+            DateTimeOffset.UtcNow,
+            executionUnit,
+            "implement",
+            requestArtifact.Provider,
+            requestArtifact.ProviderSessionId,
+            providerSessionAlive: false);
+        if (canonicalBoundaryEvent is null)
+        {
+            return fallbackReason;
+        }
+
+        new DirectRunProviderEventWriter(providerLogPath).Append(canonicalBoundaryEvent);
+        currentProviderEvents = [.. currentProviderEvents, canonicalBoundaryEvent];
+
+        return DirectRunFixOutcomeSupport.TryResolveContractGapDetail(
+            currentProviderEvents,
+            executionUnit,
+            "implement",
+            out var synthesizedContractGapDetail)
+                ? synthesizedContractGapDetail
+                : fallbackReason;
     }
 
     private static RunSuperviseResult BlockForTerminalFailure(

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -922,6 +922,139 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenDeadImplementWorkerSessionAtRetryExhaustionAfterProductRead_PersistsContractGapDetail()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Active)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateActiveRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G25.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession() with
+            {
+                RetryCount = 3,
+                RetryBudget = 3
+            }));
+        WriteDeadImplementDirectRunArtifacts(repoRoot, "pid:999999");
+        File.AppendAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                new[]
+                {
+                    CreateProviderEvent(
+                        "2026-04-08T10:18:00.0000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:888888",
+                        "provider-event",
+                        new
+                        {
+                            type = "contract-gap",
+                            stop_reason = "deterministic-contract-gap",
+                            reason = "stale-older-contract-gap",
+                            detail = "stale older contract gap detail",
+                            run_status = "failed"
+                        }),
+                    CreateProviderEvent(
+                        "2026-04-08T10:20:00.1000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        "exec /bin/zsh -lc 'sed -n ''1,220p'' .intent-cli/implement/G25.request.md' succeeded in 0ms"),
+                    CreateProviderEvent(
+                        "2026-04-08T10:20:00.2000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        "exec /bin/zsh -lc 'rg --files' succeeded in 0ms"),
+                    CreateProviderEvent(
+                        "2026-04-08T10:20:00.3000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        "exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Calculator.cs' succeeded in 0ms"),
+                    CreateProviderEvent(
+                        "2026-04-08T10:20:01.0000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        new
+                        {
+                            type = "backend-exit",
+                            exit_code = 1
+                        })
+                }.Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("ended after current-session product source/test read activity", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("stale older contract gap detail", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("Worker session 'pid:999999' for 'G25' exited with backend exit code 1.", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal("blocked", session.QueueState);
+            Assert.Equal(3, session.RetryCount);
+            Assert.Contains("ended after current-session product source/test read activity", session.LastInterruptionReason, StringComparison.Ordinal);
+            Assert.DoesNotContain("stale older contract gap detail", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("retry-exhausted", runEvents[^2].Event);
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("ended after current-session product source/test read activity", runEvents[^2].Reason, StringComparison.Ordinal);
+            Assert.Contains("ended after current-session product source/test read activity", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain("stale older contract gap detail", runEvents[^2].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain("stale older contract gap detail", runEvents[^1].Reason, StringComparison.Ordinal);
+
+            var providerEvents = DirectRunProviderEventJsonl.DeserializeAll(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl")));
+            Assert.Contains(providerEvents, providerEvent =>
+                string.Equals(providerEvent.ExecutionUnit, "G25", StringComparison.Ordinal)
+                && string.Equals(providerEvent.EntryKind, "implement", StringComparison.Ordinal)
+                && string.Equals(providerEvent.SessionId, "pid:999999", StringComparison.Ordinal)
+                && providerEvent.Payload.ValueKind == JsonValueKind.Object
+                && providerEvent.Payload.TryGetProperty("type", out var typeElement)
+                && string.Equals(typeElement.GetString(), "contract-gap", StringComparison.Ordinal)
+                && providerEvent.Payload.TryGetProperty("reason", out var reasonElement)
+                && string.Equals(reasonElement.GetString(), "implement-session-ended-after-product-source-test-read", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenActiveItemWithoutExistingSessionAndDeadImplementWorkerSession_CapturesFailureAndAutoResumesImplementLoop()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- Prefer current-session implement contract-gap detail when retry exhaustion blocks a queue item
- Persist that detailed reason through supervision session state, queue blocked_by, and retry-exhausted/blocked run events
- Add regression coverage for backend-exit followed by product-read contract-gap evidence while ignoring stale older sessions

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunSuperviseCommandTests"
- dotnet test IntentSystem.sln

Fixes #420