### PR TITLE
G158 Make Run Submit Reuse Existing Pull Requests

### DIFF
--- a/src/IntentSystem.Cli/GhRunSubmitPublisher.cs
+++ b/src/IntentSystem.Cli/GhRunSubmitPublisher.cs
@@ -1,7 +1,11 @@
+using System.Text.Json;
+
 namespace IntentSystem.Cli;
 
 internal sealed class GhRunSubmitPublisher : IRunSubmitPublisher
 {
+    private const string PullRequestBase = "main";
+
     private readonly IGitHubCommandRunner commandRunner;
 
     public GhRunSubmitPublisher()
@@ -49,6 +53,12 @@ internal sealed class GhRunSubmitPublisher : IRunSubmitPublisher
                 var error = string.IsNullOrWhiteSpace(result.StdErr)
                     ? "gh pr create failed."
                     : result.StdErr.Trim();
+                if (IsExistingPullRequestError(error)
+                    && TryFindExistingPullRequest(targetRepo, headBranch, out var existingPullRequestUrl))
+                {
+                    return existingPullRequestUrl;
+                }
+
                 throw new InvalidOperationException(error);
             }
 
@@ -67,5 +77,94 @@ internal sealed class GhRunSubmitPublisher : IRunSubmitPublisher
                 File.Delete(bodyPath);
             }
         }
+    }
+
+    private bool TryFindExistingPullRequest(
+        string targetRepo,
+        string headBranch,
+        out string pullRequestUrl)
+    {
+        var result = commandRunner.Run(
+            [
+                "pr",
+                "list",
+                "--repo",
+                targetRepo,
+                "--head",
+                headBranch,
+                "--base",
+                PullRequestBase,
+                "--state",
+                "open",
+                "--json",
+                "url,headRefName,baseRefName"
+            ]);
+
+        pullRequestUrl = string.Empty;
+        if (result.ExitCode != 0)
+        {
+            return false;
+        }
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(result.StdOut);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        using (document)
+        {
+            if (document.RootElement.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            foreach (var element in document.RootElement.EnumerateArray())
+            {
+                if (!TryGetStringProperty(element, "url", out var candidateUrl)
+                    || !TryGetStringProperty(element, "headRefName", out var candidateHead)
+                    || !TryGetStringProperty(element, "baseRefName", out var candidateBase))
+                {
+                    continue;
+                }
+
+                if (!string.Equals(candidateHead, headBranch, StringComparison.Ordinal)
+                    || !string.Equals(candidateBase, PullRequestBase, StringComparison.Ordinal)
+                    || !Uri.TryCreate(candidateUrl, UriKind.Absolute, out _))
+                {
+                    continue;
+                }
+
+                pullRequestUrl = candidateUrl;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetStringProperty(JsonElement element, string propertyName, out string value)
+    {
+        value = string.Empty;
+        if (element.ValueKind == JsonValueKind.Object
+            && element.TryGetProperty(propertyName, out var property)
+            && property.ValueKind == JsonValueKind.String
+            && !string.IsNullOrWhiteSpace(property.GetString()))
+        {
+            value = property.GetString()!;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsExistingPullRequestError(string error)
+    {
+        return error.Contains("pull request", StringComparison.OrdinalIgnoreCase)
+            && error.Contains("already exist", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/IntentSystem.Supervisor/Models/QueueItem.cs
+++ b/src/IntentSystem.Supervisor/Models/QueueItem.cs
@@ -18,6 +18,8 @@ public sealed record QueueItem
 
     public LinkedIssue? LinkedIssue { get; init; }
 
+    public string? LinkedPr { get; init; }
+
     public required string WorkerRole { get; init; }
 
     public required string ReviewRole { get; init; }

--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -509,9 +509,16 @@ public static class QueueManager
             var item = state.Items[i];
             if (string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal))
             {
-                updatedItems[i] = blockedBy is null
+                var updatedItem = blockedBy is null
                     ? item with { State = newState }
                     : item with { State = newState, BlockedBy = blockedBy };
+
+                if (!string.IsNullOrWhiteSpace(runEvent.LinkedPr))
+                {
+                    updatedItem = updatedItem with { LinkedPr = runEvent.LinkedPr };
+                }
+
+                updatedItems[i] = updatedItem;
             }
             else
             {

--- a/tests/IntentSystem.Cli.Tests/GhRunSubmitPublisherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GhRunSubmitPublisherTests.cs
@@ -5,7 +5,13 @@ public sealed class GhRunSubmitPublisherTests
     [Fact]
     public void CreateDraftPullRequest_GivenTargetRepoBranchTitleAndBody_CreatesDraftPrAndReturnsUrl()
     {
-        var runner = new FakeRunner();
+        var runner = new ScriptedRunner(
+            new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "https://github.com/J-Tech-Japan/intent-system/pull/58" + Environment.NewLine,
+                StdErr = string.Empty
+            });
         var publisher = new GhRunSubmitPublisher(runner);
 
         var linkedPr = publisher.CreateDraftPullRequest(
@@ -31,13 +37,105 @@ public sealed class GhRunSubmitPublisherTests
                 "--repo",
                 "J-Tech-Japan/intent-system"
             ],
-            runner.Arguments);
+            runner.Calls.Single());
         Assert.Equal("Linked issue", runner.BodyContents);
     }
 
-    private sealed class FakeRunner : IGitHubCommandRunner
+    [Fact]
+    public void CreateDraftPullRequest_GivenExistingMatchingPr_ReusesExistingPrUrl()
     {
-        public IReadOnlyList<string> Arguments { get; private set; } = [];
+        var runner = new ScriptedRunner(
+            new GitHubCommandResult
+            {
+                ExitCode = 1,
+                StdOut = string.Empty,
+                StdErr = "GraphQL: A pull request already exists for J-Tech-Japan:issue-18-toy-calc-v0-08."
+            },
+            new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = """
+                [
+                  {
+                    "url": "https://github.com/J-Tech-Japan/intent-system/pull/19",
+                    "headRefName": "issue-18-toy-calc-v0-08",
+                    "baseRefName": "main"
+                  }
+                ]
+                """,
+                StdErr = string.Empty
+            });
+        var publisher = new GhRunSubmitPublisher(runner);
+
+        var linkedPr = publisher.CreateDraftPullRequest(
+            "J-Tech-Japan/intent-system",
+            "issue-18-toy-calc-v0-08",
+            "[G158] Make Run Submit Reuse Existing Pull Requests",
+            "Linked issue");
+
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/19", linkedPr);
+        Assert.Equal(2, runner.Calls.Count);
+        Assert.Single(runner.Calls, call => call.Take(2).SequenceEqual(["pr", "create"]));
+        Assert.Equal(
+            [
+                "pr",
+                "list",
+                "--repo",
+                "J-Tech-Japan/intent-system",
+                "--head",
+                "issue-18-toy-calc-v0-08",
+                "--base",
+                "main",
+                "--state",
+                "open",
+                "--json",
+                "url,headRefName,baseRefName"
+            ],
+            runner.Calls[1]);
+    }
+
+    [Fact]
+    public void CreateDraftPullRequest_GivenExistingPrErrorWithoutMatchingPr_ThrowsOriginalCreateError()
+    {
+        var runner = new ScriptedRunner(
+            new GitHubCommandResult
+            {
+                ExitCode = 1,
+                StdOut = string.Empty,
+                StdErr = "GraphQL: A pull request already exists for J-Tech-Japan:issue-18-toy-calc-v0-08."
+            },
+            new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = """
+                [
+                  {
+                    "url": "https://github.com/J-Tech-Japan/intent-system/pull/19",
+                    "headRefName": "different-branch",
+                    "baseRefName": "main"
+                  }
+                ]
+                """,
+                StdErr = string.Empty
+            });
+        var publisher = new GhRunSubmitPublisher(runner);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => publisher.CreateDraftPullRequest(
+                "J-Tech-Japan/intent-system",
+                "issue-18-toy-calc-v0-08",
+                "[G158] Make Run Submit Reuse Existing Pull Requests",
+                "Linked issue"));
+
+        Assert.Contains("already exists", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(2, runner.Calls.Count);
+    }
+
+    private sealed class ScriptedRunner(params GitHubCommandResult[] results) : IGitHubCommandRunner
+    {
+        private readonly Queue<GitHubCommandResult> results = new(results);
+
+        public List<IReadOnlyList<string>> Calls { get; } = [];
 
         public string BodyFilePath { get; private set; } = string.Empty;
 
@@ -45,16 +143,15 @@ public sealed class GhRunSubmitPublisherTests
 
         public GitHubCommandResult Run(IReadOnlyList<string> arguments)
         {
-            Arguments = arguments.ToArray();
-            BodyFilePath = Arguments[10];
-            BodyContents = File.ReadAllText(BodyFilePath);
-
-            return new GitHubCommandResult
+            Calls.Add(arguments.ToArray());
+            if (arguments.Count > 10 && arguments.Take(2).SequenceEqual(["pr", "create"]))
             {
-                ExitCode = 0,
-                StdOut = "https://github.com/J-Tech-Japan/intent-system/pull/58" + Environment.NewLine,
-                StdErr = string.Empty
-            };
+                BodyFilePath = arguments[10];
+                BodyContents = File.ReadAllText(BodyFilePath);
+            }
+
+            Assert.NotEmpty(results);
+            return results.Dequeue();
         }
     }
 }

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -64,7 +64,8 @@ public sealed class RunCommandTests
                     context.RepoRoot,
                     queueItem => queueItem with
                     {
-                        State = QueueItemState.Review
+                        State = QueueItemState.Review,
+                        LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226"
                     });
 
                 return new RunSubmitResult
@@ -1649,7 +1650,8 @@ public sealed class RunCommandTests
                     context.RepoRoot,
                     queueItem => queueItem with
                     {
-                        State = QueueItemState.Review
+                        State = QueueItemState.Review,
+                        LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/226"
                     });
 
                 return new RunSubmitResult
@@ -1690,6 +1692,11 @@ public sealed class RunCommandTests
                     Assert.Equal("review run", action.Name);
                     Assert.Equal("G226", action.ExecutionUnit);
                 });
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(
+                "https://github.com/J-Tech-Japan/intent-system/pull/226",
+                queueState.Items.Single(item => item.ExecutionUnit == "G226").LinkedPr);
         }
         finally
         {

--- a/tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs
@@ -49,7 +49,9 @@ public sealed class RunSubmitCommandTests
 
             var queueState = QueueStateSerializer.Deserialize(
                 File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
-            Assert.Equal(QueueItemState.Review, queueState.Items.Single(item => item.ExecutionUnit == "G14").State);
+            var submittedItem = queueState.Items.Single(item => item.ExecutionUnit == "G14");
+            Assert.Equal(QueueItemState.Review, submittedItem.State);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", submittedItem.LinkedPr);
             Assert.Equal(QueueItemState.Blocked, queueState.Items.Single(item => item.ExecutionUnit == "G15").State);
 
             Assert.Contains($"{worktreePath}::rev-parse --abbrev-ref HEAD", gitRunner.Calls);
@@ -63,6 +65,58 @@ public sealed class RunSubmitCommandTests
             var reviewEvent = Assert.Single(runEvents);
             Assert.Equal("review", reviewEvent.Event);
             Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", reviewEvent.LinkedPr);
+        }
+        finally
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+            RunSubmitCommand.PublisherFactory = originalPublisherFactory;
+            RunSubmitCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenPublisherReusesExistingPr_PersistsLinkedPrAndTransitionsToReview()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G14"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var publisher = new FakePublisher("https://github.com/J-Tech-Japan/intent-system/pull/19");
+        var originalGitFactory = RunSubmitCommand.GitCommandRunnerFactory;
+        var originalPublisherFactory = RunSubmitCommand.PublisherFactory;
+        var originalTimestampFactory = RunSubmitCommand.TimestampFactory;
+
+        try
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = () => new FakeGitRunner(branchName: "issue-56-g14");
+            RunSubmitCommand.PublisherFactory = () => publisher;
+            RunSubmitCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-05T10:15:00Z");
+
+            var exitCode = RunSubmitCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(1, publisher.CallCount);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            var submittedItem = queueState.Items.Single(item => item.ExecutionUnit == "G14");
+            Assert.Equal(QueueItemState.Review, submittedItem.State);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/19", submittedItem.LinkedPr);
+
+            var reviewEvent = Assert.Single(RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl"))));
+            Assert.Equal("review", reviewEvent.Event);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/19", reviewEvent.LinkedPr);
         }
         finally
         {
@@ -1040,21 +1094,23 @@ public sealed class RunSubmitCommandTests
         }
     }
 
-    private sealed class FakePublisher : IRunSubmitPublisher
+    private sealed class FakePublisher(string linkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/58") : IRunSubmitPublisher
     {
         public string TargetRepo { get; private set; } = string.Empty;
         public string HeadBranch { get; private set; } = string.Empty;
         public string Title { get; private set; } = string.Empty;
         public string Body { get; private set; } = string.Empty;
+        public int CallCount { get; private set; }
 
         public string CreateDraftPullRequest(string targetRepo, string headBranch, string title, string body)
         {
+            CallCount++;
             TargetRepo = targetRepo;
             HeadBranch = headBranch;
             Title = title;
             Body = body;
 
-            return "https://github.com/J-Tech-Japan/intent-system/pull/58";
+            return linkedPr;
         }
     }
 

--- a/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
@@ -38,7 +38,9 @@ public sealed class QueueManagerTests
 
         var result = QueueManager.SubmitForReview(state, "A1", "worker", BaseTime, linkedPr: "https://github.com/org/repo/pull/1");
 
-        Assert.Equal(QueueItemState.Review, FindItem(result.UpdatedState, "A1").State);
+        var updatedItem = FindItem(result.UpdatedState, "A1");
+        Assert.Equal(QueueItemState.Review, updatedItem.State);
+        Assert.Equal("https://github.com/org/repo/pull/1", updatedItem.LinkedPr);
         Assert.Equal("review", result.Event.Event);
         Assert.Equal("https://github.com/org/repo/pull/1", result.Event.LinkedPr);
     }
@@ -67,7 +69,9 @@ public sealed class QueueManagerTests
             BaseTime,
             linkedPr: "https://github.com/org/repo/pull/2");
 
-        Assert.Equal(QueueItemState.Review, FindItem(result.UpdatedState, "A1").State);
+        var updatedItem = FindItem(result.UpdatedState, "A1");
+        Assert.Equal(QueueItemState.Review, updatedItem.State);
+        Assert.Equal("https://github.com/org/repo/pull/2", updatedItem.LinkedPr);
         Assert.Equal("review", result.Event.Event);
         Assert.Equal("https://github.com/org/repo/pull/2", result.Event.LinkedPr);
     }


### PR DESCRIPTION
## Summary

- Reuse an open PR when `gh pr create` reports one already exists for the exact run-submit repo/base/head branch.
- Persist the recovered or newly-created PR URL on the queue item `linked_pr` as well as the submit run event.
- Cover existing-PR reuse, mismatched-PR rejection, queue linked PR persistence, and root-run continuation into review.

## Validation

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunSubmitCommandTests|FullyQualifiedName~GhRunSubmitPublisherTests|FullyQualifiedName~RunCommandTests.ExecuteCore_GivenSucceededImplementRun_ReusesRunSubmitBoundary"`
- `dotnet test tests/IntentSystem.Supervisor.Tests/IntentSystem.Supervisor.Tests.csproj`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --blame-hang --blame-hang-timeout 120s --blame-hang-dump-type none`
- `dotnet test IntentSystem.sln`

Issue: #422