### PR TITLE
G159 Ignore Blank Lines When Reading runs.jsonl

### DIFF
--- a/src/IntentSystem.Supervisor/Serialization/RunLogSerializer.cs
+++ b/src/IntentSystem.Supervisor/Serialization/RunLogSerializer.cs
@@ -31,11 +31,16 @@ public static class RunLogSerializer
         }
 
         var lines = normalizedContent.Split('\n');
-        var runEvents = new RunEvent[lines.Length];
+        var runEvents = new List<RunEvent>(lines.Length);
 
         for (var index = 0; index < lines.Length; index++)
         {
-            runEvents[index] = DeserializeLine(lines[index]);
+            if (string.IsNullOrWhiteSpace(lines[index]))
+            {
+                continue;
+            }
+
+            runEvents.Add(DeserializeLine(lines[index]));
         }
 
         return runEvents;

--- a/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunImplementCommandTests.cs
@@ -126,6 +126,59 @@ public sealed class RunImplementCommandTests
     }
 
     [Fact]
+    public void Execute_GivenRunLogWithBlankLines_GeneratesHandoffAndResolvesLatestLinkedPr()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G19"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            Environment.NewLine + CreateRunLogWithEmbeddedBlankLines());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G19", "review-context.md"),
+            CreateReviewContextMarkdown());
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunImplementCommand.TimestampFactory;
+        var originalLauncherFactory = RunImplementCommand.DirectRunLauncherFactory;
+
+        try
+        {
+            RunImplementCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-09T10:15:00Z");
+            RunImplementCommand.DirectRunLauncherFactory = () => new FakeDirectRunLauncher(
+                "pid:4321",
+                "Claude",
+                "default",
+                "stdio",
+                "stdio transport launched via 'claude' in '/repo/.intent-cli/worktrees/G19' for provider 'Claude'.");
+
+            var exitCode = RunImplementCommand.Execute(CreateContext(repoRoot), ["G19"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains(
+                "Latest linked PR: https://github.com/J-Tech-Japan/intent-system/pull/67",
+                writer.ToString(),
+                StringComparison.Ordinal);
+            var markdown = File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "implement", "G19.request.md"));
+            Assert.Contains(
+                "- latest_linked_pr: https://github.com/J-Tech-Japan/intent-system/pull/67",
+                markdown,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            RunImplementCommand.TimestampFactory = originalTimestampFactory;
+            RunImplementCommand.DirectRunLauncherFactory = originalLauncherFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenFixingItemWithoutLatestPr_GeneratesArtifactWithoutLatestPr()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -951,6 +1004,19 @@ public sealed class RunImplementCommandTests
         {"ts":"2026-04-08T08:20:00Z","execution_unit":"G19","event":"fix-requested","by":"intent-cli","comment_ref":"https://github.com/J-Tech-Japan/intent-system/pull/66#issuecomment-1"}
         {"ts":"2026-04-08T08:30:00Z","execution_unit":"G19","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/67"}
         """ + Environment.NewLine;
+    }
+
+    private static string CreateRunLogWithEmbeddedBlankLines()
+    {
+        return string.Join(
+            Environment.NewLine,
+            [
+                """{"ts":"2026-04-08T08:00:00Z","execution_unit":"G19","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/66"}""",
+                "",
+                "   ",
+                """{"ts":"2026-04-08T08:30:00Z","execution_unit":"G19","event":"review","by":"intent-cli","linked_pr":"https://github.com/J-Tech-Japan/intent-system/pull/67"}""",
+                ""
+            ]);
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/tests/IntentSystem.Supervisor.Tests/RunLogSerializerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/RunLogSerializerTests.cs
@@ -49,6 +49,37 @@ public sealed class RunLogSerializerTests
     }
 
     [Fact]
+    public void DeserializeAll_GivenLeadingTrailingAndEmbeddedBlankLines_SkipsBlankLines()
+    {
+        var content = string.Join(
+            Environment.NewLine,
+            [
+                "",
+                """{"ts":"2026-04-02T09:50:13Z","execution_unit":"B1","event":"queued","by":"supervisor"}""",
+                "",
+                "   ",
+                """{"ts":"2026-04-02T10:15:13Z","execution_unit":"B1","event":"completed","by":"supervisor","reason":"done"}""",
+                ""
+            ]);
+
+        var runEvents = RunLogSerializer.DeserializeAll(content);
+
+        Assert.Equal(2, runEvents.Count);
+        Assert.Equal(["queued", "completed"], runEvents.Select(runEvent => runEvent.Event).ToArray());
+    }
+
+    [Fact]
+    public void DeserializeAll_GivenMalformedNonEmptyLine_ThrowsJsonException()
+    {
+        var content = """
+        {"ts":"2026-04-02T09:50:13Z","execution_unit":"B1","event":"queued","by":"supervisor"}
+        not-json
+        """;
+
+        Assert.Throws<JsonException>(() => RunLogSerializer.DeserializeAll(content));
+    }
+
+    [Fact]
     public void DeserializeLine_GivenUnknownEvent_PreservesTheOriginalEventName()
     {
         var line =


### PR DESCRIPTION
## Summary

- Make `RunLogSerializer.DeserializeAll` skip blank and whitespace-only JSONL lines while keeping non-empty malformed records strict.
- Add serializer coverage for leading, embedded, and trailing blank lines plus malformed non-empty JSON.
- Add a run implement regression proving blank-line `.intent-cli/runs.jsonl` still resolves the latest linked PR and generates the handoff.

## Validation

- `dotnet test tests/IntentSystem.Supervisor.Tests/IntentSystem.Supervisor.Tests.csproj --filter "FullyQualifiedName~RunLogSerializerTests"`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunImplementCommandTests"`
- `dotnet test IntentSystem.sln`

Issue: #424