### PR TITLE
G160 separate provider auth failures from implement retries

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunCommandSupport.cs
@@ -689,7 +689,7 @@ internal static class DirectRunCommandSupport
             && string.Equals(typeElement.GetString(), "backend-exit", StringComparison.Ordinal);
     }
 
-    private static DirectRunResolvedPolicy ResolvePolicy(
+    internal static DirectRunResolvedPolicy ResolvePolicy(
         CliContext context,
         DirectRunEntryKind entryKind)
     {

--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -113,6 +113,24 @@ internal static class DirectRunFixOutcomeSupport
         "repo-local intent/spec artifacts",
         "repo-local spec artifacts lag implementation"
     ];
+    private static readonly string[] ProviderConfigurationFailureMarkers =
+    [
+        "failed to authenticate",
+        "authentication_error",
+        "authentication error",
+        "invalid authentication credentials",
+        "invalid credentials",
+        "unauthorized",
+        "401",
+        "api key",
+        "apikey",
+        "credential",
+        "credentials",
+        "not configured",
+        "misconfigured",
+        "missing configuration",
+        "configuration error"
+    ];
     private static readonly string[] NoOpEditFreeMarkers =
     [
         "without requiring code changes",
@@ -284,6 +302,58 @@ internal static class DirectRunFixOutcomeSupport
 
         detail =
             $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' exited during provider startup before any bounded repo inspection, edit, test, refusal, or contract-gap output was emitted. Current-session provider output only contained startup warnings or noise before the backend exit.";
+        return true;
+    }
+
+    public static bool TryResolveProviderConfigurationFailureDetail(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        string entryKind,
+        out string detail)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryKind);
+
+        var orderedProviderEvents = OrderEventsForAnalysis(providerEvents);
+
+        detail = string.Empty;
+        var failingBackendExitIndex = FindFailingBackendExitIndex(orderedProviderEvents);
+        if (failingBackendExitIndex < 0)
+        {
+            return false;
+        }
+
+        string? providerConfigurationSignal = null;
+        for (var index = 0; index < failingBackendExitIndex; index++)
+        {
+            var providerEvent = orderedProviderEvents[index];
+            if (providerEvent.Kind == "session-metadata"
+                || IsIgnorableReadyEvent(providerEvent.Payload)
+                || IsIgnorableStartupPreamble(providerEvent.Payload)
+                || IsIgnorableStartupNoise(providerEvent.Payload))
+            {
+                continue;
+            }
+
+            if (ContainsInitialRepoInventory(providerEvent.Payload)
+                || ContainsRepoLocalSpecReadAttempt(providerEvent.Payload)
+                || ContainsProductSourceOrTestReadAttempt(providerEvent.Payload)
+                || ContainsBoundedFixProgressSignal(providerEvent.Payload))
+            {
+                return false;
+            }
+
+            providerConfigurationSignal ??= TryResolveProviderConfigurationSignal(providerEvent.Payload);
+        }
+
+        if (providerConfigurationSignal is null)
+        {
+            return false;
+        }
+
+        detail =
+            $"{ResolveEntryLabel(entryKind)} direct run for '{executionUnit}' failed because the selected provider could not authenticate or was misconfigured before repo inventory, repo-local spec reads, or product source/test reads. Provider configuration failure detail: {providerConfigurationSignal}";
         return true;
     }
 
@@ -1090,6 +1160,31 @@ internal static class DirectRunFixOutcomeSupport
         }
 
         return sawString;
+    }
+
+    private static string? TryResolveProviderConfigurationSignal(JsonElement payload)
+    {
+        foreach (var value in EnumeratePayloadStrings(payload))
+        {
+            var trimmed = value.Trim();
+            if (string.IsNullOrWhiteSpace(trimmed))
+            {
+                continue;
+            }
+
+            var normalized = trimmed.ToLowerInvariant();
+            if (!ProviderConfigurationFailureMarkers.Any(marker => normalized.Contains(marker, StringComparison.Ordinal)))
+            {
+                continue;
+            }
+
+            const int maxDetailLength = 240;
+            return trimmed.Length <= maxDetailLength
+                ? trimmed
+                : trimmed[..maxDetailLength];
+        }
+
+        return null;
     }
 
     private static bool ContainsBoundedFixProgressSignal(JsonElement payload)

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1139,7 +1139,11 @@ internal static class RunCommand
                 blockedItem.ExecutionUnit,
                 requestArtifact,
                 resultArtifact)
-            || !HasImplementProviderPolicyChanged(context, requestArtifact!))
+            || !HasImplementProviderConfigurationRelaunchSignal(
+                context,
+                blockedItem.ExecutionUnit,
+                requestArtifact!,
+                session))
         {
             return false;
         }
@@ -2776,6 +2780,26 @@ internal static class RunCommand
             executionUnit,
             "implement",
             out _);
+    }
+
+    private static bool HasImplementProviderConfigurationRelaunchSignal(
+        CliContext context,
+        string executionUnit,
+        DirectRunRequestArtifact requestArtifact,
+        RunSupervisionSession session)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(requestArtifact);
+        ArgumentNullException.ThrowIfNull(session);
+
+        if (HasImplementProviderPolicyChanged(context, requestArtifact))
+        {
+            return true;
+        }
+
+        var latestFixRequestedAt = TryResolveLatestFixRequestedTimestamp(context, executionUnit);
+        return latestFixRequestedAt is not null && latestFixRequestedAt > session.UpdatedAt;
     }
 
     private static bool HasImplementProviderPolicyChanged(

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -548,6 +548,14 @@ internal static class RunCommand
                         continue;
                     }
 
+                    if (TryAutoContinueBlockedImplementProviderConfigurationBoundary(
+                            context,
+                            queueState,
+                            blockedItem))
+                    {
+                        continue;
+                    }
+
                     if (TryResolveBlockedImplementSessionFailureResult(context, actions, blockedItem, out var blockedImplementResult))
                     {
                         return blockedImplementResult;
@@ -1100,6 +1108,38 @@ internal static class RunCommand
         }
 
         if (!HasCurrentBlockedImplementRecoveredSpecBoundary(context, blockedItem.ExecutionUnit))
+        {
+            return false;
+        }
+
+        TransitionQueueItemToActive(context, queueState, blockedItem.ExecutionUnit);
+        return true;
+    }
+
+    private static bool TryAutoContinueBlockedImplementProviderConfigurationBoundary(
+        CliContext context,
+        QueueState queueState,
+        QueueItem blockedItem)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(queueState);
+        ArgumentNullException.ThrowIfNull(blockedItem);
+
+        if (!TryReadSupervisionSession(context, blockedItem.ExecutionUnit, out var session)
+            || session.WorkerEntry != RunSupervisionWorkerEntry.Implement
+            || session.Status != RunSupervisionSessionStatus.Blocked)
+        {
+            return false;
+        }
+
+        var requestArtifact = TryReadDirectRunRequestArtifact(context, blockedItem.ExecutionUnit);
+        var resultArtifact = TryReadDirectRunResultArtifact(context, blockedItem.ExecutionUnit, "implement");
+        if (!HasCurrentBlockedImplementProviderConfigurationBoundary(
+                context,
+                blockedItem.ExecutionUnit,
+                requestArtifact,
+                resultArtifact)
+            || !HasImplementProviderPolicyChanged(context, requestArtifact!))
         {
             return false;
         }
@@ -2644,6 +2684,15 @@ internal static class RunCommand
             requestArtifact.ProviderSessionId,
             requestArtifact.LaunchedAt);
 
+        if (DirectRunFixOutcomeSupport.TryResolveProviderConfigurationFailureDetail(
+                providerEvents,
+                executionUnit,
+                "implement",
+                out var providerConfigurationDetail))
+        {
+            return providerConfigurationDetail;
+        }
+
         if (DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(
                 providerEvents,
                 executionUnit,
@@ -2690,6 +2739,56 @@ internal static class RunCommand
             out var synthesizedContractGapDetail)
             ? synthesizedContractGapDetail
             : null;
+    }
+
+    private static bool HasCurrentBlockedImplementProviderConfigurationBoundary(
+        CliContext context,
+        string executionUnit,
+        DirectRunRequestArtifact? requestArtifact,
+        DirectRunResultArtifact? resultArtifact)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        if (requestArtifact is null
+            || resultArtifact is null
+            || !string.Equals(requestArtifact.EntryKind, "implement", StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.EntryKind, "implement", StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.RunStatus, "failed", StringComparison.Ordinal)
+            || !string.Equals(resultArtifact.SessionId, requestArtifact.ProviderSessionId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var providerEvents = TryReadDirectRunProviderEvents(context, executionUnit);
+        if (providerEvents.Count == 0)
+        {
+            return false;
+        }
+
+        providerEvents = SelectCurrentSessionEvents(
+            providerEvents,
+            requestArtifact.ProviderSessionId,
+            requestArtifact.LaunchedAt);
+
+        return DirectRunFixOutcomeSupport.TryResolveProviderConfigurationFailureDetail(
+            providerEvents,
+            executionUnit,
+            "implement",
+            out _);
+    }
+
+    private static bool HasImplementProviderPolicyChanged(
+        CliContext context,
+        DirectRunRequestArtifact requestArtifact)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(requestArtifact);
+
+        var currentPolicy = DirectRunCommandSupport.ResolvePolicy(context, DirectRunEntryKind.Implement);
+        return !string.Equals(currentPolicy.Provider, requestArtifact.Provider, StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(currentPolicy.Model, requestArtifact.Model, StringComparison.Ordinal)
+            || !string.Equals(currentPolicy.Transport, requestArtifact.Transport, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool HasCurrentBlockedImplementRecoveredSpecBoundary(CliContext context, string executionUnit)

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -1201,6 +1201,19 @@ internal static class RunSuperviseCommand
         ArgumentException.ThrowIfNullOrWhiteSpace(expectedEntryKind);
 
         failure = null!;
+        if (string.Equals(expectedEntryKind, "implement", StringComparison.Ordinal)
+            && DirectRunFixOutcomeSupport.TryResolveProviderConfigurationFailureDetail(
+                providerEvents,
+                executionUnit,
+                expectedEntryKind,
+                out var providerConfigurationDetail))
+        {
+            failure = new WorkerSessionFailure(
+                providerConfigurationDetail,
+                ReportAsNonRetryableFailure: true);
+            return true;
+        }
+
         if ((string.Equals(expectedEntryKind, "fix", StringComparison.Ordinal)
                 || string.Equals(expectedEntryKind, "implement", StringComparison.Ordinal))
             && DirectRunFixOutcomeSupport.TryResolveStartupOnlyFailureDetail(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -4984,6 +4984,205 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenBlockedImplementProviderAuthFailureAndProviderPolicyChanged_LaunchesFreshImplementAttempt()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            queueStatePath,
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Blocked) with
+            {
+                BlockedBy =
+                [
+                    "Implement direct run for 'G226' failed because the selected provider could not authenticate or was misconfigured before repo inventory, repo-local spec reads, or product source/test reads."
+                ]
+            })));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            runLogPath,
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T12:01:00Z","execution_unit":"G226","event":"blocked","by":"intent-cli","reason":"Implement direct run for 'G226' failed because the selected provider could not authenticate or was misconfigured before repo inventory, repo-local spec reads, or product source/test reads."}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G226.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                Status = RunSupervisionSessionStatus.Blocked,
+                QueueState = "blocked",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = null,
+                CommentRef = null,
+                HandoffArtifactRef = ".intent-cli/implement/G226.request.md",
+                RetryCount = 2,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:01:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastInterruptionReason = "Implement direct run for 'G226' failed because the selected provider could not authenticate or was misconfigured before repo inventory, repo-local spec reads, or product source/test reads."
+            }));
+        WriteDirectRunRequest(repoRoot, "G226", "implement", "pid:999999", provider: "Claude");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "implement",
+            "failed",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Claude",
+                    EntryKind = "implement",
+                    SessionId = "pid:999999",
+                    Kind = "session-metadata",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        model = "sonnet",
+                        transport = "sdk",
+                        command = "claude"
+                    })
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.5000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Claude",
+                    EntryKind = "implement",
+                    SessionId = "pid:999999",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("Failed to authenticate. API Error: 401 authentication_error Invalid authentication credentials")
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "Claude",
+                    EntryKind = "implement",
+                    SessionId = "pid:999999",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                }
+            ],
+            sessionId: "pid:999999",
+            provider: "Claude");
+        var originalRunImplementExecutor = RunCommand.RunImplementExecutor;
+        var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
+        var originalTimestampFactory = RunCommand.TimestampFactory;
+
+        try
+        {
+            RunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-10T12:05:00Z");
+            RunCommand.RunImplementExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunRequest(repoRoot, executionUnit, "implement", "pid:4242", provider: "openai");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "running",
+                    providerEvents:
+                    [
+                        new DirectRunProviderEvent
+                        {
+                            Timestamp = "2026-04-10T12:05:00.0000000+00:00",
+                            ExecutionUnit = executionUnit,
+                            Provider = "openai",
+                            EntryKind = "implement",
+                            SessionId = "pid:4242",
+                            Kind = "session-metadata",
+                            Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                            {
+                                model = "gpt-5.4",
+                                transport = "responses",
+                                command = "codex"
+                            })
+                        }
+                    ],
+                    sessionId: "pid:4242",
+                    provider: "openai");
+
+                return new RunImplementResult
+                {
+                    Request = CreateRunImplementRequest(repoRoot, executionUnit),
+                    ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md"
+                };
+            };
+            RunCommand.RunSuperviseExecutor = (_, executionUnit) => new RunSuperviseResult
+            {
+                ExecutionUnit = executionUnit,
+                SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                RetryCount = 2,
+                RetryBudget = 3,
+                HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md"
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Contains(result.Actions, action => action.Name == "run implement" && action.ExecutionUnit == "G226");
+            Assert.Contains(result.Actions, action => action.Name == "run supervise" && action.ExecutionUnit == "G226");
+
+            var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var queueItem = Assert.Single(queueState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Active, queueItem.State);
+            Assert.Empty(queueItem.BlockedBy);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Contains(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "activated", StringComparison.Ordinal)
+                && runEvent.Ts == DateTimeOffset.Parse("2026-04-10T12:05:00Z"));
+        }
+        finally
+        {
+            RunCommand.RunImplementExecutor = originalRunImplementExecutor;
+            RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
+            RunCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenAutoResumedImplementSessionThatDiesAfterInitialInventory_StopsWithNonRetryableFailure()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -5183,6 +5183,224 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenBlockedImplementProviderAuthFailureAndSamePolicyFixRequested_LaunchesFreshImplementAttempt()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G226"));
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            queueStatePath,
+            QueueStateSerializer.Serialize(CreateQueueState(CreateQueueItem(QueueItemState.Blocked) with
+            {
+                BlockedBy =
+                [
+                    "Implement direct run for 'G226' failed because the selected provider could not authenticate or was misconfigured before repo inventory, repo-local spec reads, or product source/test reads."
+                ]
+            })));
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(
+            runLogPath,
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/J-Tech-Japan/intent-system/issues/226"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"G226","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T12:01:00Z","execution_unit":"G226","event":"blocked","by":"intent-cli","reason":"Implement direct run for 'G226' failed because the selected provider could not authenticate or was misconfigured before repo inventory, repo-local spec reads, or product source/test reads."}
+            {"ts":"2026-04-10T12:03:00Z","execution_unit":"G226","event":"fix-requested","by":"intent-cli","reason":"provider credentials corrected"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G226", "packet.yaml"),
+            """
+            execution_unit: "G226"
+
+            implementation_issue:
+              issue_title: "[G226] Root Run Orchestration Command"
+              goal: "Coordinate the root run loop."
+              target_repo: "submodules/intent-system"
+              target_path: "."
+              target_part: "run command"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/G226/review-context.md"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G226.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G226.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "G226",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                Status = RunSupervisionSessionStatus.Blocked,
+                QueueState = "blocked",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "G226"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "intent-system"),
+                Branch = "issue-226-g226",
+                LinkedIssue = "https://github.com/J-Tech-Japan/intent-system/issues/226",
+                LinkedPr = null,
+                CommentRef = null,
+                HandoffArtifactRef = ".intent-cli/implement/G226.request.md",
+                RetryCount = 2,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T12:01:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastInterruptionReason = "Implement direct run for 'G226' failed because the selected provider could not authenticate or was misconfigured before repo inventory, repo-local spec reads, or product source/test reads."
+            }));
+        WriteDirectRunRequest(
+            repoRoot,
+            "G226",
+            "implement",
+            "pid:999999",
+            provider: "openai",
+            model: "gpt-5.4",
+            transport: "responses");
+        WriteDirectRunResult(
+            repoRoot,
+            "G226",
+            "implement",
+            "failed",
+            providerEvents:
+            [
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "openai",
+                    EntryKind = "implement",
+                    SessionId = "pid:999999",
+                    Kind = "session-metadata",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        model = "gpt-5.4",
+                        transport = "responses",
+                        command = "codex"
+                    })
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.5000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "openai",
+                    EntryKind = "implement",
+                    SessionId = "pid:999999",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("Failed to authenticate. API Error: 401 authentication_error Invalid authentication credentials")
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = "G226",
+                    Provider = "openai",
+                    EntryKind = "implement",
+                    SessionId = "pid:999999",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                }
+            ],
+            sessionId: "pid:999999",
+            provider: "openai",
+            model: "gpt-5.4");
+        var originalRunImplementExecutor = RunCommand.RunImplementExecutor;
+        var originalRunSuperviseExecutor = RunCommand.RunSuperviseExecutor;
+        var originalTimestampFactory = RunCommand.TimestampFactory;
+
+        try
+        {
+            RunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-10T12:05:00Z");
+            RunCommand.RunImplementExecutor = (_, executionUnit) =>
+            {
+                WriteDirectRunRequest(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "pid:4242",
+                    provider: "openai",
+                    model: "gpt-5.4",
+                    transport: "responses");
+                WriteDirectRunResult(
+                    repoRoot,
+                    executionUnit,
+                    "implement",
+                    "running",
+                    providerEvents:
+                    [
+                        new DirectRunProviderEvent
+                        {
+                            Timestamp = "2026-04-10T12:05:00.0000000+00:00",
+                            ExecutionUnit = executionUnit,
+                            Provider = "openai",
+                            EntryKind = "implement",
+                            SessionId = "pid:4242",
+                            Kind = "session-metadata",
+                            Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                            {
+                                model = "gpt-5.4",
+                                transport = "responses",
+                                command = "codex"
+                            })
+                        }
+                    ],
+                    sessionId: "pid:4242",
+                    provider: "openai",
+                    model: "gpt-5.4");
+
+                return new RunImplementResult
+                {
+                    Request = CreateRunImplementRequest(repoRoot, executionUnit),
+                    ArtifactPath = $".intent-cli/implement/{executionUnit}.request.md"
+                };
+            };
+            RunCommand.RunSuperviseExecutor = (_, executionUnit) => new RunSuperviseResult
+            {
+                ExecutionUnit = executionUnit,
+                SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                SessionStatus = RunSupervisionSessionStatus.Monitoring,
+                RetryCount = 2,
+                RetryBudget = 3,
+                HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md"
+            };
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Contains(result.Actions, action => action.Name == "run implement" && action.ExecutionUnit == "G226");
+            Assert.Contains(result.Actions, action => action.Name == "run supervise" && action.ExecutionUnit == "G226");
+
+            var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var queueItem = Assert.Single(queueState.Items, item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Active, queueItem.State);
+            Assert.Empty(queueItem.BlockedBy);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G226.result.json")));
+            Assert.Equal("pid:4242", resultArtifact.SessionId);
+            Assert.Equal("running", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Contains(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "activated", StringComparison.Ordinal)
+                && runEvent.Ts == DateTimeOffset.Parse("2026-04-10T12:05:00Z"));
+            Assert.DoesNotContain(runEvents, runEvent =>
+                string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunCommand.RunImplementExecutor = originalRunImplementExecutor;
+            RunCommand.RunSuperviseExecutor = originalRunSuperviseExecutor;
+            RunCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenAutoResumedImplementSessionThatDiesAfterInitialInventory_StopsWithNonRetryableFailure()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -10380,6 +10598,7 @@ public sealed class RunCommandTests
         IReadOnlyList<DirectRunProviderEvent>? providerEvents = null,
         string sessionId = "pid:226",
         string provider = "ReviewBot",
+        string model = "gpt-5.4-mini",
         string? reviewOutcome = null,
         string? reviewCommentBodyPath = null)
     {
@@ -10396,7 +10615,7 @@ public sealed class RunCommandTests
                     EntryKind = entryKind,
                     UpstreamRequestRef = ResolveUpstreamRequestRef(executionUnit, entryKind),
                     Provider = provider,
-                    Model = "gpt-5.4-mini",
+                    Model = model,
                     SessionId = sessionId,
                     RunStatus = runStatus,
                     ReviewOutcome = reviewOutcome,
@@ -11690,6 +11909,8 @@ public sealed class RunCommandTests
         string entryKind,
         string providerSessionId,
         string provider = "ReviewBot",
+        string model = "gpt-5.4-mini",
+        string transport = "responses",
         string launchedAt = "2026-04-10T12:00:00.0000000+00:00")
     {
         var runsDirectory = Path.Combine(repoRoot, ".intent-cli", "runs");
@@ -11705,8 +11926,8 @@ public sealed class RunCommandTests
                     EntryKind = entryKind,
                     UpstreamRequestRef = ResolveUpstreamRequestRef(executionUnit, entryKind),
                     Provider = provider,
-                    Model = "gpt-5.4-mini",
-                    Transport = "responses",
+                    Model = model,
+                    Transport = transport,
                     LaunchedAt = launchedAt,
                     ProviderSessionId = providerSessionId,
                     TransportSummary = "launched"

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -1055,6 +1055,95 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenDeadImplementWorkerSessionWithProviderAuthFailure_BlocksWithoutConsumingRetryBudget()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Active)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateActiveRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G25.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession() with
+            {
+                RetryCount = 2,
+                RetryBudget = 3
+            }));
+        WriteDeadImplementDirectRunArtifacts(repoRoot, "pid:999999");
+        File.AppendAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                new[]
+                {
+                    CreateProviderEvent(
+                        "2026-04-08T10:20:00.5000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        "Failed to authenticate. API Error: 401 {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"Invalid authentication credentials\"}}"),
+                    CreateProviderEvent(
+                        "2026-04-08T10:20:01.0000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        new
+                        {
+                            type = "backend-exit",
+                            exit_code = 1
+                        })
+                }.Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("provider could not authenticate or was misconfigured", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("Invalid authentication credentials", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("Retry budget exhausted", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(2, session.RetryCount);
+            Assert.Contains("provider could not authenticate or was misconfigured", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("Invalid authentication credentials", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenActiveItemWithoutExistingSessionAndDeadImplementWorkerSession_CapturesFailureAndAutoResumesImplementLoop()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- classify implement provider authentication/configuration exits before repo/spec/product activity as provider configuration failures
- block/report that provider failure without consuming the product implement retry budget
- allow root run to launch a fresh implement attempt after the implement provider policy changes

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunSuperviseCommandTests|FullyQualifiedName~RunCommandTests"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-build --filter "FullyQualifiedName=IntentSystem.Cli.Tests.RunFixCommandTests.Execute_GivenWrapperCodexCommand_AppendsTerminalBackendExitAndUpdatesResultArtifact"

Note: a full CLI project run passed 886 tests but ended with one existing temp-directory cleanup race in RunFixCommandTests; rerunning that single test passed.

Issue: #426