### PR TITLE
G161 Preserve implement worktree progress after backend exit

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunFixOutcomeSupport.cs
@@ -449,6 +449,15 @@ internal static class DirectRunFixOutcomeSupport
             && (observedProductRead || observedDotNetTest);
     }
 
+    internal static bool HasVerificationCommandSignal(IReadOnlyList<DirectRunProviderEvent> providerEvents)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        return providerEvents.Any(providerEvent =>
+            !IsIgnorableStartupPreamble(providerEvent.Payload)
+            && ContainsDotNetTestAttempt(providerEvent.Payload));
+    }
+
     private static bool TryResolveCanonicalFailureDetail(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string executionUnit,

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1074,6 +1074,16 @@ internal static class RunCommand
             return false;
         }
 
+        if (session.WorkerEntry == RunSupervisionWorkerEntry.Implement)
+        {
+            decisionResult = CreateStopResult(
+                ClarificationRequiredStopReason,
+                actions,
+                blockedItem.ExecutionUnit,
+                CreateImplementWorktreeProgressAdoptionRequiredDetail(blockedItem.ExecutionUnit, session));
+            return true;
+        }
+
         if (!string.Equals(
                 context.Config.Run.PostFixWorktreeProgressPolicy,
                 CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy,
@@ -1608,7 +1618,7 @@ internal static class RunCommand
         }
 
         session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(sessionArtifactPath));
-        if (session.WorkerEntry != RunSupervisionWorkerEntry.Fix
+        if (session.WorkerEntry is not (RunSupervisionWorkerEntry.Fix or RunSupervisionWorkerEntry.Implement)
             || session.Status != RunSupervisionSessionStatus.Blocked)
         {
             return false;
@@ -1617,6 +1627,11 @@ internal static class RunCommand
         if (session.RequiresPostFixWorktreeProgressDecision)
         {
             return true;
+        }
+
+        if (session.WorkerEntry == RunSupervisionWorkerEntry.Implement)
+        {
+            return false;
         }
 
         if (!TryUpgradeLegacyPostFixWorktreeProgressDecisionSession(
@@ -1647,6 +1662,20 @@ internal static class RunCommand
                $"To continue automatically on the next root run, set [run] " +
                $"{CliRuntimeContracts.PostFixWorktreeProgressPolicyKey} = " +
                $"\"{CliRuntimeContracts.AutoContinuePostFixWorktreeProgressPolicy}\" and rerun.";
+    }
+
+    private static string CreateImplementWorktreeProgressAdoptionRequiredDetail(
+        string executionUnit,
+        RunSupervisionSession session)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(session);
+
+        var reason = string.IsNullOrWhiteSpace(session.LastInterruptionReason)
+            ? $"worktree-progress-adoption-required: Meaningful implement progress exists in the execution-unit worktree for '{executionUnit}'."
+            : session.LastInterruptionReason;
+        return $"{reason} Confirm whether to carry this progress forward through the existing submit/review boundary. " +
+               "Unverified or unrelated worktree diffs must not be auto-accepted.";
     }
 
     private static bool TryUpgradeLegacyPostFixWorktreeProgressDecisionSession(

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -919,6 +919,25 @@ internal static class RunSuperviseCommand
             return true;
         }
 
+        if (string.Equals(expectedEntryKind, "implement", StringComparison.Ordinal)
+            && TryResolveImplementWorktreeProgressFailure(
+                currentProviderEvents,
+                executionUnit,
+                requestArtifact.ProviderSessionId,
+                resultArtifact.Worktree.Path,
+                ResolveDirectRunProviderLogRef(context, executionUnit),
+                out failure))
+        {
+            File.WriteAllText(
+                resultArtifactPath,
+                DirectRunResultArtifactJson.Serialize(resultArtifact with
+                {
+                    RunStatus = "failed"
+                }));
+
+            return true;
+        }
+
         if (TryResolveTerminalFailureReason(
                 currentProviderEvents,
                 executionUnit,
@@ -1188,6 +1207,46 @@ internal static class RunSuperviseCommand
         return true;
     }
 
+    private static bool TryResolveImplementWorktreeProgressFailure(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        string providerSessionId,
+        string worktreePath,
+        string rawLogRef,
+        out WorkerSessionFailure failure)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(rawLogRef);
+
+        failure = null!;
+        if (!TryFindFailingBackendExitCode(providerEvents, out var exitCode)
+            || !DirectRunFixOutcomeSupport.HasDeepExecutionProgressSignal(providerEvents))
+        {
+            return false;
+        }
+
+        var gitCommandRunner = GitCommandRunnerFactory();
+        if (!RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths(
+                gitCommandRunner,
+                worktreePath,
+                out var changedPaths))
+        {
+            return false;
+        }
+
+        var verificationSignal = DirectRunFixOutcomeSupport.HasVerificationCommandSignal(providerEvents)
+            ? "dotnet-test-observed"
+            : "not-observed";
+        failure = new WorkerSessionFailure(
+            $"worktree-progress-adoption-required: Implement direct run for '{executionUnit}' exited with backend exit code {exitCode} after current-session product source/test or verification activity, and left meaningful execution-unit worktree changes. Worktree path: {worktreePath}. Provider session: {providerSessionId}. Raw log ref: {rawLogRef}. Changed paths: {RunWorktreeProgressSupport.SummarizePaths(changedPaths)}. Verification signal: {verificationSignal}. Downstream automation must either carry this progress into the existing submit/review boundary or leave it for operator adoption; it must not treat the backend exit as a startup-only/provider-auth failure.",
+            ReportAsNonRetryableFailure: true,
+            RequiresPostFixWorktreeProgressDecision: true);
+        return true;
+    }
+
     private static bool TryResolveTerminalFailureReason(
         IReadOnlyList<DirectRunProviderEvent> providerEvents,
         string executionUnit,
@@ -1341,6 +1400,12 @@ internal static class RunSuperviseCommand
     {
         var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
         return ResolveArtifactPath(context.RepoRoot, $"{root}/{executionUnit.Trim()}.provider.jsonl");
+    }
+
+    private static string ResolveDirectRunProviderLogRef(CliContext context, string executionUnit)
+    {
+        var root = context.Config.DirectRun.ArtifactRoot.Replace('\\', '/').TrimEnd('/');
+        return $"{root}/{executionUnit.Trim()}.provider.jsonl";
     }
 
     private static string ResolveDirectRunEntryKind(RunSupervisionWorkerEntry workerEntry)

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -7179,6 +7179,64 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenBlockedImplementSessionWithWorktreeProgress_StopsWithAdoptionRequiredDetail()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "TOY-CALC-V0-10"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(
+                CreateQueueItem(QueueItemState.Blocked, executionUnit: "TOY-CALC-V0-10") with
+                {
+                    BlockedBy =
+                    [
+                        "worktree-progress-adoption-required: Implement direct run for 'TOY-CALC-V0-10' exited with backend exit code 1 after current-session product source/test or verification activity, and left meaningful execution-unit worktree changes."
+                    ]
+                })));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"TOY-CALC-V0-10","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/tomohisa/toy-calc-sample/issues/22"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"TOY-CALC-V0-10","event":"activated","by":"intent-cli"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "TOY-CALC-V0-10.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = "TOY-CALC-V0-10",
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                Status = RunSupervisionSessionStatus.Blocked,
+                QueueState = "blocked",
+                WorktreePath = Path.Combine(repoRoot, ".intent-cli", "worktrees", "TOY-CALC-V0-10"),
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "toy-calc-sample"),
+                Branch = "issue-22-toy-calc-v0-10",
+                LinkedIssue = "https://github.com/tomohisa/toy-calc-sample/issues/22",
+                LinkedPr = null,
+                CommentRef = null,
+                HandoffArtifactRef = ".intent-cli/implement/TOY-CALC-V0-10.request.md",
+                RetryCount = 3,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T09:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T10:00:00Z"),
+                LastInterruptionReason = "worktree-progress-adoption-required: Implement direct run for 'TOY-CALC-V0-10' exited with backend exit code 1 after current-session product source/test or verification activity, and left meaningful execution-unit worktree changes. Worktree path: /repo/.intent-cli/worktrees/TOY-CALC-V0-10. Provider session: pid:31753. Raw log ref: .intent-cli/runs/TOY-CALC-V0-10.provider.jsonl. Changed paths: src/ToyCalc/Calculator.cs, src/ToyCalc/CommandLine.cs, tests/ToyCalc.Tests/CalculatorTests.cs. Verification signal: dotnet-test-observed.",
+                RequiresPostFixWorktreeProgressDecision = true
+            }));
+
+        var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+        Assert.Equal("clarification-required", result.StopReason);
+        Assert.Equal("TOY-CALC-V0-10", result.ExecutionUnit);
+        Assert.Contains("worktree-progress-adoption-required", result.Detail, StringComparison.Ordinal);
+        Assert.Contains("Provider session: pid:31753", result.Detail, StringComparison.Ordinal);
+        Assert.Contains("Raw log ref: .intent-cli/runs/TOY-CALC-V0-10.provider.jsonl", result.Detail, StringComparison.Ordinal);
+        Assert.Contains("Verification signal: dotnet-test-observed", result.Detail, StringComparison.Ordinal);
+        Assert.Contains("existing submit/review boundary", result.Detail, StringComparison.Ordinal);
+        Assert.DoesNotContain(result.Actions, action => string.Equals(action.Name, "run submit", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void ExecuteCore_GivenAutoContinuePolicyForMeaningfulFixWorktreeDiff_CommitsProgressAndResubmits()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -1055,6 +1055,94 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenDeadImplementWorkerSessionAfterProductReadWithMeaningfulWorktreeDiff_RecordsAdoptionRequired()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Active)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateActiveRunLog());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G25.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession()));
+        WriteDeadImplementDirectRunArtifacts(repoRoot, "pid:999999");
+        File.AppendAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                new[]
+                {
+                    CreateProviderEvent("2026-04-08T10:20:00.1000000+00:00", "G25", "implement", "pid:999999", "provider-event", "exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/implement/G25.request.md' succeeded in 0ms"),
+                    CreateProviderEvent("2026-04-08T10:20:00.2000000+00:00", "G25", "implement", "pid:999999", "provider-event", "exec /bin/zsh -lc 'rg --files' succeeded in 0ms"),
+                    CreateProviderEvent("2026-04-08T10:20:00.3000000+00:00", "G25", "implement", "pid:999999", "provider-event", "exec /bin/zsh -lc 'sed -n ''1,220p'' intents/toy-calc/specs/10-eq-command.md' succeeded in 0ms"),
+                    CreateProviderEvent("2026-04-08T10:20:00.4000000+00:00", "G25", "implement", "pid:999999", "provider-event", "exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Calculator.cs && sed -n ''1,220p'' tests/ToyCalc.Tests/CalculatorTests.cs' succeeded in 0ms"),
+                    CreateProviderEvent("2026-04-08T10:20:00.5000000+00:00", "G25", "implement", "pid:999999", "provider-event", "exec /bin/zsh -lc 'dotnet test ToyCalc.sln --nologo' succeeded in 0ms"),
+                    CreateProviderEvent("2026-04-08T10:20:01.0000000+00:00", "G25", "implement", "pid:999999", "provider-event", new { type = "backend-exit", exit_code = 1 })
+                }.Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+        var originalGitCommandRunnerFactory = RunSuperviseCommand.GitCommandRunnerFactory;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+            RunSuperviseCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M src/ToyCalc/Calculator.cs
+                 M src/ToyCalc/CommandLine.cs
+                 M tests/ToyCalc.Tests/CalculatorTests.cs
+                """);
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("worktree-progress-adoption-required", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("Provider session: pid:999999", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("Raw log ref: .intent-cli/runs/G25.provider.jsonl", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("Verification signal: dotnet-test-observed", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("src/ToyCalc/Calculator.cs", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(0, session.RetryCount);
+            Assert.True(session.RequiresPostFixWorktreeProgressDecision);
+            Assert.Contains("worktree-progress-adoption-required", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.result.json")));
+            Assert.Equal("failed", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("worktree-progress-adoption-required", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+            RunSuperviseCommand.GitCommandRunnerFactory = originalGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenDeadImplementWorkerSessionWithProviderAuthFailure_BlocksWithoutConsumingRetryBudget()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- detect implement backend exits after deep product/verification progress when meaningful worktree diffs remain
- record a worktree-progress-adoption-required boundary with worktree path, provider session, raw log ref, changed paths, and verification signal
- have the root run surface blocked implement progress as an explicit adoption-required stop instead of a generic opaque failure

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunSuperviseCommandTests|FullyQualifiedName~RunCommandTests|FullyQualifiedName~DirectRunFixOutcomeSupportTests" --nologo
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo

Closes #428