### PR TITLE
[G162] Reconcile Adopted Child Merge After Stale Implement Block

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1391,8 +1391,7 @@ internal static class RunCommand
             var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
             linkedIssue = blockedItem.LinkedIssue?.Url
                 ?? LatestLinkedIssueResolver.Resolve(runEvents, blockedItem.ExecutionUnit);
-            linkedPr = LatestLinkedPrResolver.TryResolve(runEvents, blockedItem.ExecutionUnit) ?? string.Empty;
-            if (string.IsNullOrWhiteSpace(linkedIssue) || string.IsNullOrWhiteSpace(linkedPr))
+            if (string.IsNullOrWhiteSpace(linkedIssue))
             {
                 linkedIssue = null!;
                 linkedPr = null!;
@@ -1401,44 +1400,19 @@ internal static class RunCommand
 
             var githubRunner = GitHubCommandRunnerFactory();
             var issue = GitHubIssueRef.Parse(linkedIssue);
-            var issueResult = RunGitHub(
-                githubRunner,
-                [
-                    "issue",
-                    "view",
-                    issue.IssueNumber.ToString(),
-                    "--repo",
-                    $"{issue.Owner}/{issue.Repo}",
-                    "--json",
-                    "state"
-                ],
-                "gh issue view failed.");
-            using var issueDocument = JsonDocument.Parse(issueResult.StdOut);
-            var issueState = issueDocument.RootElement.GetProperty("state").GetString();
-            if (!string.Equals(issueState, "CLOSED", StringComparison.OrdinalIgnoreCase))
+            if (!IsIssueClosed(githubRunner, issue))
             {
                 linkedIssue = null!;
                 linkedPr = null!;
                 return false;
             }
 
-            var pullRequest = GitHubPullRequestRef.Parse(linkedPr);
-            var pullRequestResult = RunGitHub(
-                githubRunner,
-                [
-                    "pr",
-                    "view",
-                    pullRequest.PullNumber.ToString(),
-                    "--repo",
-                    $"{pullRequest.Owner}/{pullRequest.Repo}",
-                    "--json",
-                    "state,mergeCommit"
-                ],
-                "gh pr view failed.");
-            using var pullRequestDocument = JsonDocument.Parse(pullRequestResult.StdOut);
-            var isMerged = pullRequestDocument.RootElement.TryGetProperty("mergeCommit", out var mergeCommitElement)
-                && mergeCommitElement.ValueKind != JsonValueKind.Null;
-            if (!isMerged)
+            linkedPr = TryResolveMergedLinkedPullRequest(
+                    githubRunner,
+                    issue,
+                    LatestLinkedPrResolver.TryResolve(runEvents, blockedItem.ExecutionUnit))
+                ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(linkedPr))
             {
                 linkedIssue = null!;
                 linkedPr = null!;
@@ -1453,6 +1427,145 @@ internal static class RunCommand
             linkedPr = null!;
             return false;
         }
+    }
+
+    private static bool IsIssueClosed(IGitHubCommandRunner githubRunner, GitHubIssueRef issue)
+    {
+        ArgumentNullException.ThrowIfNull(githubRunner);
+        ArgumentNullException.ThrowIfNull(issue);
+
+        var issueResult = RunGitHub(
+            githubRunner,
+            [
+                "issue",
+                "view",
+                issue.IssueNumber.ToString(),
+                "--repo",
+                $"{issue.Owner}/{issue.Repo}",
+                "--json",
+                "state"
+            ],
+            "gh issue view failed.");
+        using var issueDocument = JsonDocument.Parse(issueResult.StdOut);
+        var issueState = issueDocument.RootElement.GetProperty("state").GetString();
+        return string.Equals(issueState, "CLOSED", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string? TryResolveMergedLinkedPullRequest(
+        IGitHubCommandRunner githubRunner,
+        GitHubIssueRef issue,
+        string? linkedPr)
+    {
+        ArgumentNullException.ThrowIfNull(githubRunner);
+        ArgumentNullException.ThrowIfNull(issue);
+
+        if (!string.IsNullOrWhiteSpace(linkedPr)
+            && IsPullRequestMerged(githubRunner, linkedPr))
+        {
+            return linkedPr;
+        }
+
+        return TryResolveMergedPullRequestFromIssueTimeline(githubRunner, issue);
+    }
+
+    private static string? TryResolveMergedPullRequestFromIssueTimeline(
+        IGitHubCommandRunner githubRunner,
+        GitHubIssueRef issue)
+    {
+        ArgumentNullException.ThrowIfNull(githubRunner);
+        ArgumentNullException.ThrowIfNull(issue);
+
+        var timelineResult = RunGitHub(
+            githubRunner,
+            [
+                "api",
+                $"repos/{issue.Owner}/{issue.Repo}/issues/{issue.IssueNumber}/timeline"
+            ],
+            "gh api issue timeline failed.");
+        using var timelineDocument = JsonDocument.Parse(timelineResult.StdOut);
+        if (timelineDocument.RootElement.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidOperationException("GitHub issue timeline response must be an array.");
+        }
+
+        var linkedPrCandidates = new List<string>();
+        foreach (var timelineItem in timelineDocument.RootElement.EnumerateArray())
+        {
+            if (!TryResolveTimelinePullRequestUrl(timelineItem, out var candidateLinkedPr))
+            {
+                continue;
+            }
+
+            linkedPrCandidates.Add(candidateLinkedPr);
+        }
+
+        for (var index = linkedPrCandidates.Count - 1; index >= 0; index--)
+        {
+            var candidateLinkedPr = linkedPrCandidates[index];
+            if (IsPullRequestMerged(githubRunner, candidateLinkedPr))
+            {
+                return candidateLinkedPr;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryResolveTimelinePullRequestUrl(JsonElement timelineItem, out string linkedPr)
+    {
+        linkedPr = null!;
+        if (!timelineItem.TryGetProperty("source", out var sourceElement)
+            || sourceElement.ValueKind != JsonValueKind.Object
+            || !sourceElement.TryGetProperty("issue", out var issueElement)
+            || issueElement.ValueKind != JsonValueKind.Object
+            || !issueElement.TryGetProperty("pull_request", out var pullRequestElement)
+            || pullRequestElement.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        linkedPr = TryGetHtmlUrl(issueElement) ?? TryGetHtmlUrl(pullRequestElement) ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(linkedPr))
+        {
+            linkedPr = null!;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsPullRequestMerged(IGitHubCommandRunner githubRunner, string linkedPr)
+    {
+        ArgumentNullException.ThrowIfNull(githubRunner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(linkedPr);
+
+        var pullRequest = GitHubPullRequestRef.Parse(linkedPr);
+        var pullRequestResult = RunGitHub(
+            githubRunner,
+            [
+                "pr",
+                "view",
+                pullRequest.PullNumber.ToString(),
+                "--repo",
+                $"{pullRequest.Owner}/{pullRequest.Repo}",
+                "--json",
+                "state,mergeCommit"
+            ],
+            "gh pr view failed.");
+        using var pullRequestDocument = JsonDocument.Parse(pullRequestResult.StdOut);
+        return pullRequestDocument.RootElement.TryGetProperty("mergeCommit", out var mergeCommitElement)
+            && mergeCommitElement.ValueKind != JsonValueKind.Null;
+    }
+
+    private static string? TryGetHtmlUrl(JsonElement element)
+    {
+        if (!element.TryGetProperty("html_url", out var htmlUrlElement)
+            || htmlUrlElement.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        return htmlUrlElement.GetString();
     }
 
     private static GitHubCommandResult RunGitHub(

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1585,8 +1585,10 @@ internal static class RunCommand
                     ? bodyElement.GetString()
                     : null;
 
-            return ContainsExecutionUnitIdentity(title, executionUnit)
-                || ContainsExecutionUnitIdentity(body, executionUnit);
+            return (ContainsExecutionUnitIdentity(title, executionUnit)
+                    || ContainsExecutionUnitIdentity(body, executionUnit))
+                && (ContainsLinkedIssueIdentity(title, issue)
+                    || ContainsLinkedIssueIdentity(body, issue));
         }
         catch (InvalidOperationException)
         {
@@ -1607,6 +1609,25 @@ internal static class RunCommand
             || Regex.IsMatch(
                 text,
                 $@"(?<![A-Z0-9-]){Regex.Escape(executionUnit)}(?![A-Z0-9-])",
+                RegexOptions.CultureInvariant);
+    }
+
+    private static bool ContainsLinkedIssueIdentity(string? text, GitHubIssueRef issue)
+    {
+        ArgumentNullException.ThrowIfNull(issue);
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        return text.Contains(
+                $"https://github.com/{issue.Owner}/{issue.Repo}/issues/{issue.IssueNumber}",
+                StringComparison.Ordinal)
+            || text.Contains($"{issue.Owner}/{issue.Repo}#{issue.IssueNumber}", StringComparison.Ordinal)
+            || Regex.IsMatch(
+                text,
+                $@"(?<![A-Z0-9-])#{issue.IssueNumber}(?![A-Z0-9-])",
                 RegexOptions.CultureInvariant);
     }
 

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using IntentSystem.Projection.Serialization;
 using IntentSystem.Review;
 using IntentSystem.Supervisor;
@@ -1410,6 +1411,7 @@ internal static class RunCommand
             linkedPr = TryResolveMergedLinkedPullRequest(
                     githubRunner,
                     issue,
+                    blockedItem.ExecutionUnit,
                     LatestLinkedPrResolver.TryResolve(runEvents, blockedItem.ExecutionUnit))
                 ?? string.Empty;
             if (string.IsNullOrWhiteSpace(linkedPr))
@@ -1454,10 +1456,12 @@ internal static class RunCommand
     private static string? TryResolveMergedLinkedPullRequest(
         IGitHubCommandRunner githubRunner,
         GitHubIssueRef issue,
+        string executionUnit,
         string? linkedPr)
     {
         ArgumentNullException.ThrowIfNull(githubRunner);
         ArgumentNullException.ThrowIfNull(issue);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
 
         if (!string.IsNullOrWhiteSpace(linkedPr)
             && IsPullRequestMerged(githubRunner, linkedPr))
@@ -1465,15 +1469,17 @@ internal static class RunCommand
             return linkedPr;
         }
 
-        return TryResolveMergedPullRequestFromIssueTimeline(githubRunner, issue);
+        return TryResolveMergedPullRequestFromIssueTimeline(githubRunner, issue, executionUnit);
     }
 
     private static string? TryResolveMergedPullRequestFromIssueTimeline(
         IGitHubCommandRunner githubRunner,
-        GitHubIssueRef issue)
+        GitHubIssueRef issue,
+        string executionUnit)
     {
         ArgumentNullException.ThrowIfNull(githubRunner);
         ArgumentNullException.ThrowIfNull(issue);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
 
         var timelineResult = RunGitHub(
             githubRunner,
@@ -1496,7 +1502,11 @@ internal static class RunCommand
                 continue;
             }
 
-            if (!IsTimelinePullRequestFromLinkedIssueRepo(issue, candidateLinkedPr))
+            if (!IsTimelinePullRequestDeterministicMatch(
+                    timelineItem,
+                    issue,
+                    executionUnit,
+                    candidateLinkedPr))
             {
                 continue;
             }
@@ -1539,23 +1549,65 @@ internal static class RunCommand
         return true;
     }
 
-    private static bool IsTimelinePullRequestFromLinkedIssueRepo(
+    private static bool IsTimelinePullRequestDeterministicMatch(
+        JsonElement timelineItem,
         GitHubIssueRef issue,
+        string executionUnit,
         string linkedPr)
     {
         ArgumentNullException.ThrowIfNull(issue);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
         ArgumentException.ThrowIfNullOrWhiteSpace(linkedPr);
 
         try
         {
             var pullRequest = GitHubPullRequestRef.Parse(linkedPr);
-            return string.Equals(pullRequest.Owner, issue.Owner, StringComparison.Ordinal)
-                && string.Equals(pullRequest.Repo, issue.Repo, StringComparison.Ordinal);
+            if (!string.Equals(pullRequest.Owner, issue.Owner, StringComparison.Ordinal)
+                || !string.Equals(pullRequest.Repo, issue.Repo, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (!timelineItem.TryGetProperty("source", out var sourceElement)
+                || sourceElement.ValueKind != JsonValueKind.Object
+                || !sourceElement.TryGetProperty("issue", out var issueElement)
+                || issueElement.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            var title = issueElement.TryGetProperty("title", out var titleElement)
+                && titleElement.ValueKind == JsonValueKind.String
+                    ? titleElement.GetString()
+                    : null;
+            var body = issueElement.TryGetProperty("body", out var bodyElement)
+                && bodyElement.ValueKind == JsonValueKind.String
+                    ? bodyElement.GetString()
+                    : null;
+
+            return ContainsExecutionUnitIdentity(title, executionUnit)
+                || ContainsExecutionUnitIdentity(body, executionUnit);
         }
         catch (InvalidOperationException)
         {
             return false;
         }
+    }
+
+    private static bool ContainsExecutionUnitIdentity(string? text, string executionUnit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        return text.Contains($"[{executionUnit}]", StringComparison.Ordinal)
+            || Regex.IsMatch(
+                text,
+                $@"(?<![A-Z0-9-]){Regex.Escape(executionUnit)}(?![A-Z0-9-])",
+                RegexOptions.CultureInvariant);
     }
 
     private static bool IsPullRequestMerged(IGitHubCommandRunner githubRunner, string linkedPr)

--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1496,6 +1496,11 @@ internal static class RunCommand
                 continue;
             }
 
+            if (!IsTimelinePullRequestFromLinkedIssueRepo(issue, candidateLinkedPr))
+            {
+                continue;
+            }
+
             linkedPrCandidates.Add(candidateLinkedPr);
         }
 
@@ -1532,6 +1537,25 @@ internal static class RunCommand
         }
 
         return true;
+    }
+
+    private static bool IsTimelinePullRequestFromLinkedIssueRepo(
+        GitHubIssueRef issue,
+        string linkedPr)
+    {
+        ArgumentNullException.ThrowIfNull(issue);
+        ArgumentException.ThrowIfNullOrWhiteSpace(linkedPr);
+
+        try
+        {
+            var pullRequest = GitHubPullRequestRef.Parse(linkedPr);
+            return string.Equals(pullRequest.Owner, issue.Owner, StringComparison.Ordinal)
+                && string.Equals(pullRequest.Repo, issue.Repo, StringComparison.Ordinal);
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
     }
 
     private static bool IsPullRequestMerged(IGitHubCommandRunner githubRunner, string linkedPr)

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -9491,6 +9491,55 @@ public sealed class RunCommandTests : IDisposable
     }
 
     [Fact]
+    public void ExecuteCore_GivenBlockedItemWithClosedIssueAndUnrelatedMergedTimelinePullRequest_StopsWithParentIntentUpdateRequired()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(
+                CreateQueueItem(QueueItemState.Blocked) with
+                {
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "tomohisa/toy-calc-sample",
+                        Number = 3,
+                        Url = "https://github.com/tomohisa/toy-calc-sample/issues/3"
+                    }
+                })));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/tomohisa/toy-calc-sample/issues/3"}
+            """ + Environment.NewLine);
+        var originalGitHubCommandRunnerFactory = RunCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            RunCommand.GitHubCommandRunnerFactory = () => new ScriptedGitHubCommandRunner(
+            [
+                new ExpectedGitHubCommand(
+                    ["issue", "view", "3", "--repo", "tomohisa/toy-calc-sample", "--json", "state"],
+                    Success("""{"state":"CLOSED"}""")),
+                new ExpectedGitHubCommand(
+                    ["api", "repos/tomohisa/toy-calc-sample/issues/3/timeline"],
+                    Success("""[{"event":"cross-referenced","source":{"issue":{"html_url":"https://github.com/other-org/other-repo/pull/99","pull_request":{"html_url":"https://github.com/other-org/other-repo/pull/99"}}}}]"""))
+            ]);
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("parent-intent-update-required", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("requires parent-side planning", result.Detail, StringComparison.Ordinal);
+            Assert.Empty(result.Actions);
+        }
+        finally
+        {
+            RunCommand.GitHubCommandRunnerFactory = originalGitHubCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenBlockedImplementSessionWithFallbackSpecRecovery_LaunchesFreshImplementContinuation()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -9400,7 +9400,7 @@ public sealed class RunCommandTests : IDisposable
                     Success("""{"state":"CLOSED"}""")),
                 new ExpectedGitHubCommand(
                     ["api", "repos/tomohisa/toy-calc-sample/issues/3/timeline"],
-                    Success("""[{"event":"cross-referenced","source":{"issue":{"title":"[G226] Adopted child completion","html_url":"https://github.com/tomohisa/toy-calc-sample/pull/23","pull_request":{"html_url":"https://github.com/tomohisa/toy-calc-sample/pull/23"}}}}]""")),
+                    Success("""[{"event":"cross-referenced","source":{"issue":{"title":"[G226] Adopted child completion","body":"Closes https://github.com/tomohisa/toy-calc-sample/issues/3","html_url":"https://github.com/tomohisa/toy-calc-sample/pull/23","pull_request":{"html_url":"https://github.com/tomohisa/toy-calc-sample/pull/23"}}}}]""")),
                 new ExpectedGitHubCommand(
                     ["pr", "view", "23", "--repo", "tomohisa/toy-calc-sample", "--json", "state,mergeCommit"],
                     Success("""{"state":"MERGED","mergeCommit":{"oid":"ccfef2c122b39f37ca5fe70744b72403b9e24234"}}"""))
@@ -9573,6 +9573,55 @@ public sealed class RunCommandTests : IDisposable
                 new ExpectedGitHubCommand(
                     ["api", "repos/tomohisa/toy-calc-sample/issues/3/timeline"],
                     Success("""[{"event":"cross-referenced","source":{"issue":{"title":"[G999] Unrelated child completion","html_url":"https://github.com/tomohisa/toy-calc-sample/pull/99","pull_request":{"html_url":"https://github.com/tomohisa/toy-calc-sample/pull/99"}}}}]"""))
+            ]);
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("parent-intent-update-required", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("requires parent-side planning", result.Detail, StringComparison.Ordinal);
+            Assert.Empty(result.Actions);
+        }
+        finally
+        {
+            RunCommand.GitHubCommandRunnerFactory = originalGitHubCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenBlockedItemWithClosedIssueAndSameRepoExecutionUnitMentionOnlyTimelinePullRequest_StopsWithParentIntentUpdateRequired()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(
+                CreateQueueItem(QueueItemState.Blocked) with
+                {
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "tomohisa/toy-calc-sample",
+                        Number = 3,
+                        Url = "https://github.com/tomohisa/toy-calc-sample/issues/3"
+                    }
+                })));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/tomohisa/toy-calc-sample/issues/3"}
+            """ + Environment.NewLine);
+        var originalGitHubCommandRunnerFactory = RunCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            RunCommand.GitHubCommandRunnerFactory = () => new ScriptedGitHubCommandRunner(
+            [
+                new ExpectedGitHubCommand(
+                    ["issue", "view", "3", "--repo", "tomohisa/toy-calc-sample", "--json", "state"],
+                    Success("""{"state":"CLOSED"}""")),
+                new ExpectedGitHubCommand(
+                    ["api", "repos/tomohisa/toy-calc-sample/issues/3/timeline"],
+                    Success("""[{"event":"cross-referenced","source":{"issue":{"title":"[G226] Unrelated child completion","body":"Carries forward G226 without issue linkage.","html_url":"https://github.com/tomohisa/toy-calc-sample/pull/100","pull_request":{"html_url":"https://github.com/tomohisa/toy-calc-sample/pull/100"}}}}]"""))
             ]);
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -9,8 +9,18 @@ using IntentSystem.Supervisor.Serialization;
 namespace IntentSystem.Cli.Tests;
 
 [Collection(RunSubmitCommandCollection.Name)]
-public sealed class RunCommandTests
+public sealed class RunCommandTests : IDisposable
 {
+    public RunCommandTests()
+    {
+        RunCommand.GitHubCommandRunnerFactory = () => new FailingGitHubCommandRunner();
+    }
+
+    public void Dispose()
+    {
+        RunCommand.GitHubCommandRunnerFactory = () => new GhCommandRunner();
+    }
+
     [Fact]
     public void Execute_GivenNoActionableQueue_PersistsRootRunArtifactAndWritesSummary()
     {
@@ -9356,6 +9366,78 @@ public sealed class RunCommandTests
     }
 
     [Fact]
+    public void ExecuteCore_GivenBlockedItemWithMergedAdoptedPullRequest_ReconcilesCompletedAndPreservesBlockedEvidence()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(
+                CreateQueueItem(QueueItemState.Blocked) with
+                {
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "tomohisa/toy-calc-sample",
+                        Number = 3,
+                        Url = "https://github.com/tomohisa/toy-calc-sample/issues/3"
+                    }
+                })));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/tomohisa/toy-calc-sample/issues/3"}
+            {"ts":"2026-04-10T10:10:00Z","execution_unit":"G226","event":"blocked","by":"intent-cli","reason":"Implement direct run for 'G226' ended after current-session product source/test read activity but before a bounded repair outcome."}
+            """ + Environment.NewLine);
+        var originalGitHubCommandRunnerFactory = RunCommand.GitHubCommandRunnerFactory;
+        var originalTimestampFactory = RunCommand.TimestampFactory;
+
+        try
+        {
+            RunCommand.GitHubCommandRunnerFactory = () => new ScriptedGitHubCommandRunner(
+            [
+                new ExpectedGitHubCommand(
+                    ["issue", "view", "3", "--repo", "tomohisa/toy-calc-sample", "--json", "state"],
+                    Success("""{"state":"CLOSED"}""")),
+                new ExpectedGitHubCommand(
+                    ["api", "repos/tomohisa/toy-calc-sample/issues/3/timeline"],
+                    Success("""[{"event":"cross-referenced","source":{"issue":{"html_url":"https://github.com/tomohisa/toy-calc-sample/pull/23","pull_request":{"html_url":"https://github.com/tomohisa/toy-calc-sample/pull/23"}}}}]""")),
+                new ExpectedGitHubCommand(
+                    ["pr", "view", "23", "--repo", "tomohisa/toy-calc-sample", "--json", "state,mergeCommit"],
+                    Success("""{"state":"MERGED","mergeCommit":{"oid":"ccfef2c122b39f37ca5fe70744b72403b9e24234"}}"""))
+            ]);
+            RunCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-23T15:12:00Z");
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("externally completed linked child state", result.Detail, StringComparison.Ordinal);
+            Assert.Empty(result.Actions);
+
+            var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            var selectedItem = queueState.Items.Single(item => item.ExecutionUnit == "G226");
+            Assert.Equal(QueueItemState.Completed, selectedItem.State);
+            Assert.Empty(selectedItem.BlockedBy);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+            var blockedEvent = Assert.Single(
+                runEvents,
+                runEvent => string.Equals(runEvent.Event, "blocked", StringComparison.Ordinal));
+            Assert.Contains("current-session product source/test read activity", blockedEvent.Reason, StringComparison.Ordinal);
+            Assert.Equal("pr-merged", runEvents[^3].Event);
+            Assert.Equal("https://github.com/tomohisa/toy-calc-sample/pull/23", runEvents[^3].LinkedPr);
+            Assert.Equal("issue-closed", runEvents[^2].Event);
+            Assert.Equal("https://github.com/tomohisa/toy-calc-sample/issues/3", runEvents[^2].LinkedIssue);
+            Assert.Equal("completed", runEvents[^1].Event);
+        }
+        finally
+        {
+            RunCommand.GitHubCommandRunnerFactory = originalGitHubCommandRunnerFactory;
+            RunCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenBlockedItemWithClosedIssueButUnmergedPullRequest_StopsWithParentIntentUpdateRequired()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -9389,7 +9471,10 @@ public sealed class RunCommandTests
                     Success("""{"state":"CLOSED"}""")),
                 new ExpectedGitHubCommand(
                     ["pr", "view", "4", "--repo", "tomohisa/toy-calc-sample", "--json", "state,mergeCommit"],
-                    Success("""{"state":"OPEN","mergeCommit":null}"""))
+                    Success("""{"state":"OPEN","mergeCommit":null}""")),
+                new ExpectedGitHubCommand(
+                    ["api", "repos/tomohisa/toy-calc-sample/issues/3/timeline"],
+                    Success("[]"))
             ]);
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
@@ -12113,6 +12198,19 @@ public sealed class RunCommandTests
             var expected = expectedCalls.Dequeue();
             Assert.Equal(expected.Arguments, arguments);
             return expected.Result;
+        }
+    }
+
+    private sealed class FailingGitHubCommandRunner : IGitHubCommandRunner
+    {
+        public GitHubCommandResult Run(IReadOnlyList<string> arguments)
+        {
+            return new GitHubCommandResult
+            {
+                ExitCode = 1,
+                StdOut = string.Empty,
+                StdErr = "gh disabled in test unless explicitly scripted"
+            };
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -9400,7 +9400,7 @@ public sealed class RunCommandTests : IDisposable
                     Success("""{"state":"CLOSED"}""")),
                 new ExpectedGitHubCommand(
                     ["api", "repos/tomohisa/toy-calc-sample/issues/3/timeline"],
-                    Success("""[{"event":"cross-referenced","source":{"issue":{"html_url":"https://github.com/tomohisa/toy-calc-sample/pull/23","pull_request":{"html_url":"https://github.com/tomohisa/toy-calc-sample/pull/23"}}}}]""")),
+                    Success("""[{"event":"cross-referenced","source":{"issue":{"title":"[G226] Adopted child completion","html_url":"https://github.com/tomohisa/toy-calc-sample/pull/23","pull_request":{"html_url":"https://github.com/tomohisa/toy-calc-sample/pull/23"}}}}]""")),
                 new ExpectedGitHubCommand(
                     ["pr", "view", "23", "--repo", "tomohisa/toy-calc-sample", "--json", "state,mergeCommit"],
                     Success("""{"state":"MERGED","mergeCommit":{"oid":"ccfef2c122b39f37ca5fe70744b72403b9e24234"}}"""))
@@ -9523,7 +9523,56 @@ public sealed class RunCommandTests : IDisposable
                     Success("""{"state":"CLOSED"}""")),
                 new ExpectedGitHubCommand(
                     ["api", "repos/tomohisa/toy-calc-sample/issues/3/timeline"],
-                    Success("""[{"event":"cross-referenced","source":{"issue":{"html_url":"https://github.com/other-org/other-repo/pull/99","pull_request":{"html_url":"https://github.com/other-org/other-repo/pull/99"}}}}]"""))
+                    Success("""[{"event":"cross-referenced","source":{"issue":{"title":"[G226] Adopted child completion","html_url":"https://github.com/other-org/other-repo/pull/99","pull_request":{"html_url":"https://github.com/other-org/other-repo/pull/99"}}}}]"""))
+            ]);
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("parent-intent-update-required", result.StopReason);
+            Assert.Equal("G226", result.ExecutionUnit);
+            Assert.Contains("requires parent-side planning", result.Detail, StringComparison.Ordinal);
+            Assert.Empty(result.Actions);
+        }
+        finally
+        {
+            RunCommand.GitHubCommandRunnerFactory = originalGitHubCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenBlockedItemWithClosedIssueAndSameRepoUnrelatedMergedTimelinePullRequest_StopsWithParentIntentUpdateRequired()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(
+                CreateQueueItem(QueueItemState.Blocked) with
+                {
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "tomohisa/toy-calc-sample",
+                        Number = 3,
+                        Url = "https://github.com/tomohisa/toy-calc-sample/issues/3"
+                    }
+                })));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"G226","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/tomohisa/toy-calc-sample/issues/3"}
+            """ + Environment.NewLine);
+        var originalGitHubCommandRunnerFactory = RunCommand.GitHubCommandRunnerFactory;
+
+        try
+        {
+            RunCommand.GitHubCommandRunnerFactory = () => new ScriptedGitHubCommandRunner(
+            [
+                new ExpectedGitHubCommand(
+                    ["issue", "view", "3", "--repo", "tomohisa/toy-calc-sample", "--json", "state"],
+                    Success("""{"state":"CLOSED"}""")),
+                new ExpectedGitHubCommand(
+                    ["api", "repos/tomohisa/toy-calc-sample/issues/3/timeline"],
+                    Success("""[{"event":"cross-referenced","source":{"issue":{"title":"[G999] Unrelated child completion","html_url":"https://github.com/tomohisa/toy-calc-sample/pull/99","pull_request":{"html_url":"https://github.com/tomohisa/toy-calc-sample/pull/99"}}}}]"""))
             ]);
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));


### PR DESCRIPTION
## Summary
- reconcile blocked execution units when the linked child issue is closed and the merged child PR must be discovered from issue timeline evidence
- record the discovered merged PR back into the run log so downstream automation can continue while preserving the original blocked evidence
- add regression coverage for adopted merged PR recovery and keep RunCommand tests deterministic by default

## Verification
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "ExecuteCore_GivenBlockedItemWithExternallyCompletedLinkedChildState_ReconcilesCompletedWithoutParentPlanning|ExecuteCore_GivenBlockedItemWithMergedAdoptedPullRequest_ReconcilesCompletedAndPreservesBlockedEvidence|ExecuteCore_GivenBlockedItemWithClosedIssueButUnmergedPullRequest_StopsWithParentIntentUpdateRequired"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj

Refs #430