### PR TITLE
[G163] Stop no-progress implement auto-resume loop after dead sessions

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -166,7 +166,7 @@ internal static class RunSuperviseCommand
         if (TryCaptureDeadWorkerSessionFailure(
                 context,
                 executionUnit,
-                session.WorkerEntry,
+                session,
                 out var deadWorkerFailure))
         {
             if (deadWorkerFailure.ReportAsNonRetryableFailure)
@@ -329,7 +329,7 @@ internal static class RunSuperviseCommand
         if (TryCaptureDeadWorkerSessionFailure(
                 context,
                 executionUnit,
-                session.WorkerEntry,
+                session,
                 out var deadWorkerFailure))
         {
             if (deadWorkerFailure.ReportAsNonRetryableFailure)
@@ -425,7 +425,7 @@ internal static class RunSuperviseCommand
                 && TryCaptureDeadWorkerSessionFailure(
                     context,
                     executionUnit,
-                    resumedSession.WorkerEntry,
+                    resumedSession,
                     out var deadWorkerFailure)
                 && deadWorkerFailure.ReportAsNonRetryableFailure)
             {
@@ -845,14 +845,15 @@ internal static class RunSuperviseCommand
     private static bool TryCaptureDeadWorkerSessionFailure(
         CliContext context,
         string executionUnit,
-        RunSupervisionWorkerEntry workerEntry,
+        RunSupervisionSession session,
         out WorkerSessionFailure failure)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentNullException.ThrowIfNull(session);
 
         failure = null!;
-        var expectedEntryKind = ResolveDirectRunEntryKind(workerEntry);
+        var expectedEntryKind = ResolveDirectRunEntryKind(session.WorkerEntry);
         var requestArtifactPath = ResolveDirectRunRequestArtifactPath(context, executionUnit);
         var resultArtifactPath = ResolveDirectRunResultArtifactPath(context, executionUnit);
         if (!File.Exists(requestArtifactPath) || !File.Exists(resultArtifactPath))
@@ -926,6 +927,25 @@ internal static class RunSuperviseCommand
                 requestArtifact.ProviderSessionId,
                 resultArtifact.Worktree.Path,
                 ResolveDirectRunProviderLogRef(context, executionUnit),
+                out failure))
+        {
+            File.WriteAllText(
+                resultArtifactPath,
+                DirectRunResultArtifactJson.Serialize(resultArtifact with
+                {
+                    RunStatus = "failed"
+                }));
+
+            return true;
+        }
+
+        if (string.Equals(expectedEntryKind, "implement", StringComparison.Ordinal)
+            && TryResolveRepeatedImplementNoProgressFailure(
+                currentProviderEvents,
+                executionUnit,
+                requestArtifact.ProviderSessionId,
+                resultArtifact.Worktree.Path,
+                session,
                 out failure))
         {
             File.WriteAllText(
@@ -1064,6 +1084,63 @@ internal static class RunSuperviseCommand
             requestArtifact.LaunchedAt);
 
         return DirectRunFixOutcomeSupport.HasBoundedProgressSignal(currentProviderEvents);
+    }
+
+    private static bool TryResolveRepeatedImplementNoProgressFailure(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        string executionUnit,
+        string providerSessionId,
+        string worktreePath,
+        RunSupervisionSession session,
+        out WorkerSessionFailure failure)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerSessionId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
+        ArgumentNullException.ThrowIfNull(session);
+
+        failure = null!;
+        if (session.WorkerEntry != RunSupervisionWorkerEntry.Implement
+            || session.RetryCount < 1
+            || session.RetryCount >= session.RetryBudget
+            || !string.IsNullOrWhiteSpace(session.LinkedPr)
+            || !TryFindFailingBackendExitCode(providerEvents, out var exitCode)
+            || !DirectRunFixOutcomeSupport.HasDeepExecutionProgressSignal(providerEvents))
+        {
+            return false;
+        }
+
+        var verificationObserved = DirectRunFixOutcomeSupport.HasVerificationCommandSignal(providerEvents);
+        if (verificationObserved)
+        {
+            return false;
+        }
+
+        var gitCommandRunner = GitCommandRunnerFactory();
+        if (RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths(
+                gitCommandRunner,
+                worktreePath,
+                out _))
+        {
+            return false;
+        }
+
+        var runtimeArtifactDetail = string.Empty;
+        if (RunWorktreeProgressSupport.TryResolveOutOfScopeRuntimeArtifactDiffPaths(
+                gitCommandRunner,
+                worktreePath,
+                out var runtimeArtifactPaths))
+        {
+            runtimeArtifactDetail =
+                $" Runtime-only changed paths: {RunWorktreeProgressSupport.SummarizePaths(runtimeArtifactPaths)}.";
+        }
+
+        var planningSignal = DirectRunFixOutcomeSupport.HasPlanningProgressSignalBeyondInitialInventory(providerEvents);
+        failure = new WorkerSessionFailure(
+            $"Repeated no-progress implement loop detected for '{executionUnit}': worker session '{providerSessionId}' exited with backend exit code {exitCode} after current-session implement inspection/progress signals, but retry_count={session.RetryCount}, planning_signal={planningSignal}, verification_signal={verificationObserved}, linked_pr_present={(!string.IsNullOrWhiteSpace(session.LinkedPr)).ToString().ToLowerInvariant()}, and no meaningful execution-unit worktree diff was present under 'src/**' or 'tests/**'. Auto-resume would continue surfacing the execution unit as running/monitoring despite no bounded implement outcome.{runtimeArtifactDetail}",
+            ReportAsNonRetryableFailure: true);
+        return true;
     }
 
     private static void AppendDeterministicContractGapBoundaryIfNeeded(

--- a/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSuperviseCommand.cs
@@ -1106,6 +1106,7 @@ internal static class RunSuperviseCommand
             || session.RetryCount >= session.RetryBudget
             || !string.IsNullOrWhiteSpace(session.LinkedPr)
             || !TryFindFailingBackendExitCode(providerEvents, out var exitCode)
+            || DirectRunFixOutcomeSupport.HasExplicitContractGapSignal(providerEvents)
             || !DirectRunFixOutcomeSupport.HasDeepExecutionProgressSignal(providerEvents))
         {
             return false;

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -10255,7 +10255,7 @@ public sealed class RunCommandTests : IDisposable
     }
 
     [Fact]
-    public void ExecuteCore_GivenFixingItemWithoutReviewCommentButWithBlockedImplementLineage_ReactivatesImplementRetry()
+    public void ExecuteCore_GivenFixingItemWithoutReviewCommentButWithRepeatedNoProgressImplementLineage_StopsWithNonRetryableFailure()
     {
         using var tempDirectory = new TemporaryDirectory();
         var repoRoot = tempDirectory.CreateDirectory("repo");
@@ -10503,23 +10503,25 @@ public sealed class RunCommandTests : IDisposable
                     ExecutionUnit = executionUnit,
                     SessionArtifactPath = $".intent-cli/supervision/{executionUnit}.session.json",
                     WorkerEntry = RunSupervisionWorkerEntry.Implement,
-                    SessionStatus = RunSupervisionSessionStatus.Monitoring,
-                    RetryCount = 0,
+                    SessionStatus = RunSupervisionSessionStatus.Blocked,
+                    RetryCount = 1,
                     RetryBudget = 3,
                     HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md",
-                    AutoResumed = true
+                    Blocked = true,
+                    ReportAsNonRetryableFailure = true,
+                    FailureReason = "Repeated no-progress implement loop detected for 'TOY-CALC-V0-05': worker session 'pid:14401' exited with backend exit code 1 after current-session implement inspection/progress signals, but retry_count=1, planning_signal=false, verification_signal=false, linked_pr_present=false, and no meaningful execution-unit worktree diff was present under 'src/**' or 'tests/**'. Auto-resume would continue surfacing the execution unit as running/monitoring despite no bounded implement outcome."
                 };
             };
 
             var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
 
-            Assert.Equal("no-actionable-item", result.StopReason);
+            Assert.Equal("non-retryable-failure", result.StopReason);
             Assert.Equal("TOY-CALC-V0-05", result.ExecutionUnit);
             Assert.Equal(3, result.Actions.Count);
             Assert.Equal("run implement", result.Actions[0].Name);
             Assert.Equal("run supervise", result.Actions[1].Name);
             Assert.Equal("run supervise", result.Actions[2].Name);
-            Assert.Contains("auto-resumed", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("Repeated no-progress implement loop detected", result.Detail, StringComparison.Ordinal);
             Assert.DoesNotContain(".intent-cli/reviews/TOY-CALC-V0-05.comment.json", result.Detail, StringComparison.Ordinal);
 
             var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
@@ -10532,7 +10534,7 @@ public sealed class RunCommandTests : IDisposable
                 string.Equals(runEvent.Event, "fix-requested", StringComparison.Ordinal)
                 && string.Equals(runEvent.ExecutionUnit, "TOY-CALC-V0-05", StringComparison.Ordinal));
             Assert.Contains(runEvents, runEvent =>
-                string.Equals(runEvent.Event, "auto-resumed", StringComparison.Ordinal)
+                string.Equals(runEvent.Event, "retry-attempted", StringComparison.Ordinal)
                 && string.Equals(runEvent.ExecutionUnit, "TOY-CALC-V0-05", StringComparison.Ordinal));
         }
         finally

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -1143,6 +1143,141 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenRepeatedDeadImplementSessionWithBoundedContractGapRefusal_PreservesContractGapBoundary()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Active)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateActiveRunLog()
+            + """
+            {"ts":"2026-04-08T10:21:00Z","execution_unit":"G25","event":"retry-attempted","by":"intent-cli","reason":"Worker session 'pid:888888' for 'G25' exited with backend exit code 1."}
+            {"ts":"2026-04-08T10:21:00Z","execution_unit":"G25","event":"auto-resumed","by":"intent-cli","reason":"run implement"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G25.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession() with
+            {
+                RetryCount = 1,
+                RetryBudget = 3,
+                UpdatedAt = DateTimeOffset.Parse("2026-04-08T10:21:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-08T10:21:00Z")
+            }));
+        WriteDeadImplementDirectRunArtifacts(repoRoot, "pid:999999");
+        File.AppendAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                new[]
+                {
+                    CreateProviderEvent(
+                        "2026-04-08T10:22:00.1000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        "Use the request artifact at '/repo/.intent-cli/implement/G25.request.md' as the bounded source of truth for this direct run."),
+                    CreateProviderEvent(
+                        "2026-04-08T10:22:00.2000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        "exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/implement/G25.request.md' succeeded in 0ms"),
+                    CreateProviderEvent(
+                        "2026-04-08T10:22:00.3000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        "exec /bin/zsh -lc 'rg --files -g ''src/**'' -g ''tests/**'' -g ''.intent-cli/**''' succeeded in 0ms"),
+                    CreateProviderEvent(
+                        "2026-04-08T10:22:00.4000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        "exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Calculator.cs && sed -n ''1,220p'' tests/ToyCalc.Tests/CalculatorTests.cs' succeeded in 0ms"),
+                    CreateProviderEvent(
+                        "2026-04-08T10:22:00.5000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        new
+                        {
+                            type = "contract-gap",
+                            stop_reason = "deterministic-contract-gap",
+                            reason = "provider-explicit-contract-gap-refusal",
+                            detail = "bounded refusal after product read",
+                            run_status = "failed"
+                        }),
+                    CreateProviderEvent(
+                        "2026-04-08T10:22:01.0000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        new
+                        {
+                            type = "backend-exit",
+                            exit_code = 1
+                        })
+                }.Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("bounded refusal after product read", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("Repeated no-progress implement loop detected", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(1, session.RetryCount);
+            Assert.Contains("bounded refusal after product read", session.LastInterruptionReason, StringComparison.Ordinal);
+            Assert.DoesNotContain("Repeated no-progress implement loop detected", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.result.json")));
+            Assert.Equal("failed", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("bounded refusal after product read", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain("Repeated no-progress implement loop detected", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenRepeatedDeadImplementSessionWithoutWorktreeProgress_BlocksInsteadOfAutoResumingLoop()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -2694,7 +2829,7 @@ public sealed class RunSuperviseCommandTests
             Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
 
             var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
-        var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
             Assert.Equal(QueueItemState.Blocked, selectedItem.State);
             Assert.Contains("Non-retryable auto-resume failure", selectedItem.BlockedBy[0], StringComparison.Ordinal);
 

--- a/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSuperviseCommandTests.cs
@@ -1143,6 +1143,129 @@ public sealed class RunSuperviseCommandTests
     }
 
     [Fact]
+    public void Execute_GivenRepeatedDeadImplementSessionWithoutWorktreeProgress_BlocksInsteadOfAutoResumingLoop()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G25"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(QueueItemState.Active)));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            CreateActiveRunLog()
+            + """
+            {"ts":"2026-04-08T10:21:00Z","execution_unit":"G25","event":"retry-attempted","by":"intent-cli","reason":"Worker session 'pid:888888' for 'G25' exited with backend exit code 1."}
+            {"ts":"2026-04-08T10:21:00Z","execution_unit":"G25","event":"auto-resumed","by":"intent-cli","reason":"run implement"}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G25", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", "G25.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", "G25.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(CreateMonitoringSession() with
+            {
+                RetryCount = 1,
+                RetryBudget = 3,
+                UpdatedAt = DateTimeOffset.Parse("2026-04-08T10:21:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-08T10:21:00Z")
+            }));
+        WriteDeadImplementDirectRunArtifacts(repoRoot, "pid:999999");
+        File.AppendAllText(
+            Path.Combine(repoRoot, ".intent-cli", "runs", "G25.provider.jsonl"),
+            string.Join(
+                Environment.NewLine,
+                new[]
+                {
+                    CreateProviderEvent(
+                        "2026-04-08T10:22:00.1000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        "Use the request artifact at '/repo/.intent-cli/implement/G25.request.md' as the bounded source of truth for this direct run."),
+                    CreateProviderEvent(
+                        "2026-04-08T10:22:00.2000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        "exec /bin/zsh -lc 'sed -n ''1,220p'' /repo/.intent-cli/implement/G25.request.md' succeeded in 0ms"),
+                    CreateProviderEvent(
+                        "2026-04-08T10:22:00.3000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        "exec /bin/zsh -lc 'rg --files -g ''src/**'' -g ''tests/**'' -g ''.intent-cli/**''' succeeded in 0ms"),
+                    CreateProviderEvent(
+                        "2026-04-08T10:22:00.4000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        "exec /bin/zsh -lc 'sed -n ''1,220p'' src/ToyCalc/Calculator.cs && sed -n ''1,220p'' tests/ToyCalc.Tests/CalculatorTests.cs' succeeded in 0ms"),
+                    CreateProviderEvent(
+                        "2026-04-08T10:22:01.0000000+00:00",
+                        "G25",
+                        "implement",
+                        "pid:999999",
+                        "provider-event",
+                        new
+                        {
+                            type = "backend-exit",
+                            exit_code = 1
+                        })
+                }.Select(DirectRunProviderEventJsonl.SerializeLine)) + Environment.NewLine);
+        using var writer = new StringWriter();
+        var originalTimestampFactory = RunSuperviseCommand.TimestampFactory;
+
+        try
+        {
+            RunSuperviseCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-08T10:30:00Z");
+
+            var exitCode = RunSuperviseCommand.Execute(CreateContext(repoRoot), ["G25"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Blocked transition applied: yes", writer.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("Auto-resumed: yes", writer.ToString(), StringComparison.Ordinal);
+
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(updatedState.Items, item => item.ExecutionUnit == "G25");
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.Contains("Repeated no-progress implement loop detected", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.Contains("retry_count=1", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+            Assert.DoesNotContain("Retry budget exhausted", selectedItem.BlockedBy[0], StringComparison.Ordinal);
+
+            var session = RunSupervisionSessionArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "supervision", "G25.session.json")));
+            Assert.Equal(RunSupervisionSessionStatus.Blocked, session.Status);
+            Assert.Equal(1, session.RetryCount);
+            Assert.Contains("Repeated no-progress implement loop detected", session.LastInterruptionReason, StringComparison.Ordinal);
+
+            var resultArtifact = DirectRunResultArtifactJson.Deserialize(File.ReadAllText(
+                Path.Combine(repoRoot, ".intent-cli", "runs", "G25.result.json")));
+            Assert.Equal("failed", resultArtifact.RunStatus);
+
+            var runEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            Assert.Equal("blocked", runEvents[^1].Event);
+            Assert.Contains("Repeated no-progress implement loop detected", runEvents[^1].Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain(runEvents.SkipLast(1), runEvent =>
+                string.Equals(runEvent.Event, "auto-resumed", StringComparison.Ordinal)
+                && runEvent.Ts == DateTimeOffset.Parse("2026-04-08T10:30:00Z"));
+            Assert.DoesNotContain(runEvents, runEvent => string.Equals(runEvent.Event, "retry-exhausted", StringComparison.Ordinal));
+        }
+        finally
+        {
+            RunSuperviseCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenDeadImplementWorkerSessionWithProviderAuthFailure_BlocksWithoutConsumingRetryBudget()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary
- block repeated no-progress implement dead-session loops before they keep surfacing as healthy monitoring
- preserve existing worktree-progress adoption and retry-exhaustion behavior
- cover the repeated no-progress loop in both supervise and root run regressions

## Validation
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "Execute_GivenRepeatedDeadImplementSessionWithoutWorktreeProgress_BlocksInsteadOfAutoResumingLoop|Execute_GivenDeadImplementWorkerSessionAtRetryExhaustionAfterProductRead_PersistsContractGapDetail|Execute_GivenDeadImplementWorkerSessionAfterProductReadWithMeaningfulWorktreeDiff_RecordsAdoptionRequired|ExecuteCore_GivenBlockedImplementSessionWithFallbackSpecRecovery_LaunchesFreshImplementContinuation|ExecuteCore_GivenFixingItemWithoutReviewCommentButWithRepeatedNoProgressImplementLineage_StopsWithNonRetryableFailure"
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "Execute_GivenRepeatedDeadImplementSessionWithoutWorktreeProgress_BlocksInsteadOfAutoResumingLoop|Execute_GivenDeadImplementWorkerSessionAtRetryExhaustionAfterProductRead_PersistsContractGapDetail|ExecuteCore_GivenFixingItemWithoutReviewCommentButWithRepeatedNoProgressImplementLineage_StopsWithNonRetryableFailure"

Closes #432