### PR TITLE
G171: surface adoption-required for blocked implement contract-gap with worktree progress

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1304,6 +1304,20 @@ internal static class RunCommand
 
         if (isDeterministicContractGap)
         {
+            if (TryBuildBlockedImplementWorktreeProgressAdoptionDetail(
+                    context,
+                    blockedItem,
+                    session,
+                    out var adoptionDetail))
+            {
+                result = CreateStopResult(
+                    ClarificationRequiredStopReason,
+                    actions,
+                    blockedItem.ExecutionUnit,
+                    adoptionDetail);
+                return true;
+            }
+
             result = CreateStopResult(
                 DeterministicContractGapStopReason,
                 actions,
@@ -1318,6 +1332,101 @@ internal static class RunCommand
             blockedItem.ExecutionUnit,
             detail);
         return true;
+    }
+
+    private static bool TryBuildBlockedImplementWorktreeProgressAdoptionDetail(
+        CliContext context,
+        QueueItem blockedItem,
+        RunSupervisionSession session,
+        out string detail)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(blockedItem);
+        ArgumentNullException.ThrowIfNull(session);
+
+        detail = null!;
+
+        var worktreePath = string.IsNullOrWhiteSpace(session.WorktreePath)
+            ? RunStartCommand.ResolveWorktreePath(context, blockedItem.ExecutionUnit)
+            : session.WorktreePath;
+        if (!Directory.Exists(worktreePath))
+        {
+            return false;
+        }
+
+        if (!RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths(
+                GitCommandRunnerFactory(),
+                worktreePath,
+                out var changedPaths))
+        {
+            return false;
+        }
+
+        var requestArtifact = TryReadDirectRunRequestArtifact(context, blockedItem.ExecutionUnit);
+        if (requestArtifact is null
+            || !string.Equals(requestArtifact.EntryKind, "implement", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var providerEvents = TryReadDirectRunProviderEvents(context, blockedItem.ExecutionUnit);
+        if (providerEvents.Count == 0)
+        {
+            return false;
+        }
+
+        providerEvents = SelectCurrentSessionEvents(
+            providerEvents,
+            requestArtifact.ProviderSessionId,
+            requestArtifact.LaunchedAt);
+
+        if (!TryResolveFailingBackendExitCode(providerEvents, out var exitCode))
+        {
+            return false;
+        }
+
+        var verificationSignal = DirectRunFixOutcomeSupport.HasVerificationCommandSignal(providerEvents)
+            ? "dotnet-test-observed"
+            : "not-observed";
+        var rawLogRef = ResolveDirectRunProviderLogRef(context, blockedItem.ExecutionUnit);
+
+        detail =
+            $"worktree-progress-adoption-required: Implement direct run for '{blockedItem.ExecutionUnit}' " +
+            $"exited with backend exit code {exitCode} after current-session product source/test or verification activity, " +
+            "and left meaningful execution-unit worktree changes. " +
+            $"Worktree path: {worktreePath}. " +
+            $"Provider session: {requestArtifact.ProviderSessionId}. " +
+            $"Raw log ref: {rawLogRef}. " +
+            $"Changed paths: {RunWorktreeProgressSupport.SummarizePaths(changedPaths)}. " +
+            $"Verification signal: {verificationSignal}. " +
+            "Downstream automation must either carry this progress into the existing submit/review boundary " +
+            "or leave it for operator adoption; " +
+            "it must not treat the backend exit as a startup-only/provider-auth failure.";
+        return true;
+    }
+
+    private static bool TryResolveFailingBackendExitCode(
+        IReadOnlyList<DirectRunProviderEvent> providerEvents,
+        out int exitCode)
+    {
+        ArgumentNullException.ThrowIfNull(providerEvents);
+
+        for (var index = providerEvents.Count - 1; index >= 0; index--)
+        {
+            var providerEvent = providerEvents[index];
+            if (!HasBackendExitType(providerEvent)
+                || !providerEvent.Payload.TryGetProperty("exit_code", out var exitCodeElement)
+                || !exitCodeElement.TryGetInt32(out exitCode)
+                || exitCode == 0)
+            {
+                continue;
+            }
+
+            return true;
+        }
+
+        exitCode = default;
+        return false;
     }
 
     private static bool TryReconcileExternallyCompletedBlockedItem(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -6529,6 +6529,177 @@ public sealed class RunCommandTests : IDisposable
     }
 
     [Fact]
+    public void ExecuteCore_GivenBlockedImplementContractGapWithMeaningfulWorktreeProgress_StopsWithAdoptionRequired()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        const string executionUnit = "TOY-CALC-V0-11";
+        var worktreePath = tempDirectory.CreateDirectory(
+            Path.Combine("repo", ".intent-cli", "worktrees", executionUnit));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", executionUnit, "src", "ToyCalc"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", executionUnit, "tests", "ToyCalc.Tests"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "toy-calc-sample"));
+        File.WriteAllText(
+            Path.Combine(worktreePath, "src", "ToyCalc", "Calculator.cs"),
+            "namespace ToyCalc { public static class Calculator { public static int Sign(int value) => Math.Sign(value); } }");
+        File.WriteAllText(
+            Path.Combine(worktreePath, "tests", "ToyCalc.Tests", "CalculatorTests.cs"),
+            "namespace ToyCalc.Tests { public sealed class CalculatorTests { public void Sign_returns_sign() {} } }");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            queueStatePath,
+            QueueStateSerializer.Serialize(CreateQueueState(
+                CreateQueueItem(QueueItemState.Blocked, executionUnit: executionUnit) with
+                {
+                    BlockedBy =
+                    [
+                        "Worker session 'pid:71450' for 'TOY-CALC-V0-11' exited with backend exit code 1."
+                    ]
+                })));
+        tempDirectory.CreateFile(
+            Path.Combine(repoRoot, ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"TOY-CALC-V0-11","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/tomohisa/toy-calc-sample/issues/24"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"TOY-CALC-V0-11","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T12:30:00Z","execution_unit":"TOY-CALC-V0-11","event":"blocked","by":"intent-cli","reason":"Worker session 'pid:71450' for 'TOY-CALC-V0-11' exited with backend exit code 1."}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", executionUnit, "packet.yaml"),
+            """
+            execution_unit: "TOY-CALC-V0-11"
+
+            implementation_issue:
+              issue_title: "[TOY-CALC-V0-11] Sign command and mixed arity command line"
+              goal: "Add Calculator.Sign and mixed-arity command-line handling."
+              target_repo: "submodules/toy-calc-sample"
+              target_path: "."
+              target_part: "toy calc command line"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/TOY-CALC-V0-11/review-context.md"
+              clarification_return_path: "intents/toy-calc/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", $"{executionUnit}.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", $"{executionUnit}.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = executionUnit,
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                Status = RunSupervisionSessionStatus.Blocked,
+                QueueState = "blocked",
+                WorktreePath = worktreePath,
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "toy-calc-sample"),
+                Branch = "issue-24-toy-calc-v0-11",
+                LinkedIssue = "https://github.com/tomohisa/toy-calc-sample/issues/24",
+                HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md",
+                RetryCount = 2,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T11:55:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T11:55:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T11:55:00Z"),
+                LastInterruptionReason = "Worker session 'pid:71450' for 'TOY-CALC-V0-11' exited with backend exit code 1."
+            }));
+        WriteDirectRunRequest(
+            repoRoot,
+            executionUnit,
+            "implement",
+            "pid:71450",
+            provider: "Codex",
+            launchedAt: "2026-04-10T12:00:00.0000000+00:00");
+        WriteDirectRunResult(
+            repoRoot,
+            executionUnit,
+            "implement",
+            "failed",
+            providerEvents:
+            [
+                .. CreateInitialInventoryImplementProviderEvents(executionUnit, "pid:71450", includeBackendExit: false),
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.9000000+00:00",
+                    ExecutionUnit = executionUnit,
+                    Provider = "Codex",
+                    EntryKind = "implement",
+                    SessionId = "pid:71450",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'dotnet test tests/ToyCalc.Tests/ToyCalc.Tests.csproj --nologo' succeeded in 1820ms")
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = executionUnit,
+                    Provider = "Codex",
+                    EntryKind = "implement",
+                    SessionId = "pid:71450",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.1000000+00:00",
+                    ExecutionUnit = executionUnit,
+                    Provider = "Codex",
+                    EntryKind = "implement",
+                    SessionId = "pid:71450",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "contract-gap",
+                        stop_reason = "deterministic-contract-gap",
+                        reason = "implement-session-ended-after-product-source-test-read",
+                        detail =
+                            "Implement direct run for 'TOY-CALC-V0-11' reached product source/test read before death, and terminal boundary is deterministically a contract-gap.",
+                        run_status = "failed"
+                    })
+                }
+            ],
+            sessionId: "pid:71450",
+            provider: "Codex");
+
+        var originalRunGitCommandRunnerFactory = RunCommand.GitCommandRunnerFactory;
+        try
+        {
+            RunCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M src/ToyCalc/Calculator.cs
+                 M src/ToyCalc/CommandLine.cs
+                 M tests/ToyCalc.Tests/CalculatorTests.cs
+                """);
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("clarification-required", result.StopReason);
+            Assert.Equal(executionUnit, result.ExecutionUnit);
+            Assert.Empty(result.Actions);
+            Assert.Contains("worktree-progress-adoption-required", result.Detail, StringComparison.Ordinal);
+            Assert.Contains($"backend exit code 1", result.Detail, StringComparison.Ordinal);
+            Assert.Contains($"Worktree path: {worktreePath}", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("Provider session: pid:71450", result.Detail, StringComparison.Ordinal);
+            Assert.Contains($"Raw log ref: .intent-cli/runs/{executionUnit}.provider.jsonl", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("Changed paths: src/ToyCalc/Calculator.cs, src/ToyCalc/CommandLine.cs, tests/ToyCalc.Tests/CalculatorTests.cs", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("Verification signal: dotnet-test-observed", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("existing submit/review boundary", result.Detail, StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            var selectedItem = Assert.Single(queueState.Items, item => item.ExecutionUnit == executionUnit);
+            Assert.Equal(QueueItemState.Blocked, selectedItem.State);
+            Assert.NotEmpty(selectedItem.BlockedBy);
+        }
+        finally
+        {
+            RunCommand.GitCommandRunnerFactory = originalRunGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
     public void ExecuteCore_GivenReactivatedImplementWithStaleFailedResult_ReclassifiesToInspectionBoundary()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
## Summary

Closes #446.

When a blocked implement session reaches `deterministic-contract-gap` evidence AND the execution-unit worktree has meaningful changes (under `src/**` or `tests/**`), `intent-cli run` now surfaces the existing `worktree-progress-adoption-required` boundary instead of plain `deterministic-contract-gap`. The detail includes execution unit, backend exit code, worktree path, provider session id, raw provider log ref, changed paths, and verification signal — enough for the existing submit/review path or operator adoption.

When the same contract-gap evidence is present **without** meaningful product progress (out-of-scope `.intent-cli/` drift, build-output churn, or no git diff), the result stays `deterministic-contract-gap`. Provider-auth and startup-only failures continue to classify separately upstream.

## Changes

- `src/IntentSystem.Cli/Commands/RunCommand.cs`
  - `TryResolveBlockedImplementSessionFailureResult`: when `isDeterministicContractGap` is true, attempt to build a `worktree-progress-adoption-required` detail before returning `deterministic-contract-gap`.
  - New private helpers `TryBuildBlockedImplementWorktreeProgressAdoptionDetail` and `TryResolveFailingBackendExitCode`.
  - Reuses existing `RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths`, `DirectRunFixOutcomeSupport.HasVerificationCommandSignal`, and the canonical detail wording from `RunSuperviseCommand` so the boundary message is identical to the post-fix path.

- `tests/IntentSystem.Cli.Tests/RunCommandTests.cs`
  - New focused regression test `ExecuteCore_GivenBlockedImplementContractGapWithMeaningfulWorktreeProgress_StopsWithAdoptionRequired` that seeds a blocked Implement session with terminal contract-gap provider events plus a `dotnet test` verification signal, overrides `RunCommand.GitCommandRunnerFactory` to return a meaningful `git status` worktree output, and asserts the new adoption-required detail (execution unit, exit code, worktree path, provider session id, raw log ref, changed paths, `Verification signal: dotnet-test-observed`).
  - The existing `ExecuteCore_GivenBlockedImplementSessionWithBackendEvidenceAndContractGap_StopsWithDeterministicContractGap` test continues to assert the deterministic-contract-gap path (it does not override the git runner, so the bare worktree directory is treated as having no meaningful diff and the new branch is bypassed).

## Verification

```bash
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommand" --nologo
# Passed!  - Failed:     0, Passed:   112, Skipped:     0, Total:   112
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
