### PR TITLE
G172: embed continuation path in worktree-progress-adoption-required detail

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunCommand.cs
@@ -1389,6 +1389,10 @@ internal static class RunCommand
             ? "dotnet-test-observed"
             : "not-observed";
         var rawLogRef = ResolveDirectRunProviderLogRef(context, blockedItem.ExecutionUnit);
+        var continuationPath = BuildBlockedImplementWorktreeProgressContinuationPath(
+            blockedItem.ExecutionUnit,
+            worktreePath,
+            session);
 
         detail =
             $"worktree-progress-adoption-required: Implement direct run for '{blockedItem.ExecutionUnit}' " +
@@ -1399,10 +1403,40 @@ internal static class RunCommand
             $"Raw log ref: {rawLogRef}. " +
             $"Changed paths: {RunWorktreeProgressSupport.SummarizePaths(changedPaths)}. " +
             $"Verification signal: {verificationSignal}. " +
+            $"Continuation path: {continuationPath} " +
             "Downstream automation must either carry this progress into the existing submit/review boundary " +
             "or leave it for operator adoption; " +
             "it must not treat the backend exit as a startup-only/provider-auth failure.";
         return true;
+    }
+
+    private static string BuildBlockedImplementWorktreeProgressContinuationPath(
+        string executionUnit,
+        string worktreePath,
+        RunSupervisionSession session)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(worktreePath);
+        ArgumentNullException.ThrowIfNull(session);
+
+        if (!string.IsNullOrWhiteSpace(session.LinkedPr))
+        {
+            return
+                $"carry the worktree changes for '{executionUnit}' at {worktreePath} through " +
+                $"'run submit' followed by 'run rereview' to update the existing pull request {session.LinkedPr}.";
+        }
+
+        if (!string.IsNullOrWhiteSpace(session.LinkedIssue))
+        {
+            return
+                $"'run submit' opens the pull request against linked child issue {session.LinkedIssue} " +
+                $"using the worktree at {worktreePath}; " +
+                "the standard submit/review boundary then carries the worktree changes forward.";
+        }
+
+        return
+            $"operator must adopt the worktree changes for '{executionUnit}' at {worktreePath} manually " +
+            "before any submit/review handoff.";
     }
 
     private static bool TryResolveFailingBackendExitCode(

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -6686,12 +6686,180 @@ public sealed class RunCommandTests : IDisposable
             Assert.Contains($"Raw log ref: .intent-cli/runs/{executionUnit}.provider.jsonl", result.Detail, StringComparison.Ordinal);
             Assert.Contains("Changed paths: src/ToyCalc/Calculator.cs, src/ToyCalc/CommandLine.cs, tests/ToyCalc.Tests/CalculatorTests.cs", result.Detail, StringComparison.Ordinal);
             Assert.Contains("Verification signal: dotnet-test-observed", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("Continuation path:", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("'run submit' opens the pull request against linked child issue https://github.com/tomohisa/toy-calc-sample/issues/24", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("the standard submit/review boundary then carries the worktree changes forward", result.Detail, StringComparison.Ordinal);
             Assert.Contains("existing submit/review boundary", result.Detail, StringComparison.Ordinal);
 
             var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
             var selectedItem = Assert.Single(queueState.Items, item => item.ExecutionUnit == executionUnit);
             Assert.Equal(QueueItemState.Blocked, selectedItem.State);
             Assert.NotEmpty(selectedItem.BlockedBy);
+        }
+        finally
+        {
+            RunCommand.GitCommandRunnerFactory = originalRunGitCommandRunnerFactory;
+        }
+    }
+
+    [Fact]
+    public void ExecuteCore_GivenBlockedImplementContractGapWithLinkedPrAndWorktreeProgress_StopsWithAdoptionRequiredAndPrContinuationPath()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        const string executionUnit = "TOY-CALC-V0-11";
+        const string linkedPr = "https://github.com/tomohisa/toy-calc-sample/pull/77";
+        var worktreePath = tempDirectory.CreateDirectory(
+            Path.Combine("repo", ".intent-cli", "worktrees", executionUnit));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", executionUnit, "src", "ToyCalc"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", executionUnit, "tests", "ToyCalc.Tests"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "toy-calc-sample"));
+        File.WriteAllText(
+            Path.Combine(worktreePath, "src", "ToyCalc", "Calculator.cs"),
+            "namespace ToyCalc { public static class Calculator { public static int Sign(int value) => Math.Sign(value); } }");
+        File.WriteAllText(
+            Path.Combine(worktreePath, "tests", "ToyCalc.Tests", "CalculatorTests.cs"),
+            "namespace ToyCalc.Tests { public sealed class CalculatorTests { public void Sign_returns_sign() {} } }");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            queueStatePath,
+            QueueStateSerializer.Serialize(CreateQueueState(
+                CreateQueueItem(QueueItemState.Blocked, executionUnit: executionUnit) with
+                {
+                    BlockedBy =
+                    [
+                        "Worker session 'pid:71450' for 'TOY-CALC-V0-11' exited with backend exit code 1."
+                    ]
+                })));
+        tempDirectory.CreateFile(
+            Path.Combine(repoRoot, ".intent-cli", "runs.jsonl"),
+            """
+            {"ts":"2026-04-10T09:50:00Z","execution_unit":"TOY-CALC-V0-11","event":"issue-created","by":"intent-cli","linked_issue":"https://github.com/tomohisa/toy-calc-sample/issues/24"}
+            {"ts":"2026-04-10T10:00:00Z","execution_unit":"TOY-CALC-V0-11","event":"activated","by":"intent-cli"}
+            {"ts":"2026-04-10T12:30:00Z","execution_unit":"TOY-CALC-V0-11","event":"blocked","by":"intent-cli","reason":"Worker session 'pid:71450' for 'TOY-CALC-V0-11' exited with backend exit code 1."}
+            """ + Environment.NewLine);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", executionUnit, "packet.yaml"),
+            """
+            execution_unit: "TOY-CALC-V0-11"
+
+            implementation_issue:
+              issue_title: "[TOY-CALC-V0-11] Sign command and mixed arity command line"
+              goal: "Add Calculator.Sign and mixed-arity command-line handling."
+              target_repo: "submodules/toy-calc-sample"
+              target_path: "."
+              target_part: "toy calc command line"
+              dependencies: []
+
+            review:
+              review_context_path: ".intent-cli/issues/TOY-CALC-V0-11/review-context.md"
+              clarification_return_path: "intents/toy-calc/clarifications/open.md"
+            """);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "implement", $"{executionUnit}.request.md"),
+            "# Execution Worker Handoff");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "supervision", $"{executionUnit}.session.json"),
+            RunSupervisionSessionArtifactJson.Serialize(new RunSupervisionSession
+            {
+                ExecutionUnit = executionUnit,
+                WorkerEntry = RunSupervisionWorkerEntry.Implement,
+                Status = RunSupervisionSessionStatus.Blocked,
+                QueueState = "blocked",
+                WorktreePath = worktreePath,
+                ChildRepoPath = Path.Combine(repoRoot, "submodules", "toy-calc-sample"),
+                Branch = "issue-24-toy-calc-v0-11",
+                LinkedIssue = "https://github.com/tomohisa/toy-calc-sample/issues/24",
+                LinkedPr = linkedPr,
+                HandoffArtifactRef = $".intent-cli/implement/{executionUnit}.request.md",
+                RetryCount = 2,
+                RetryBudget = 3,
+                CreatedAt = DateTimeOffset.Parse("2026-04-10T11:55:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-10T11:55:00Z"),
+                LastHeartbeatAt = DateTimeOffset.Parse("2026-04-10T11:55:00Z"),
+                LastInterruptionReason = "Worker session 'pid:71450' for 'TOY-CALC-V0-11' exited with backend exit code 1."
+            }));
+        WriteDirectRunRequest(
+            repoRoot,
+            executionUnit,
+            "implement",
+            "pid:71450",
+            provider: "Codex",
+            launchedAt: "2026-04-10T12:00:00.0000000+00:00");
+        WriteDirectRunResult(
+            repoRoot,
+            executionUnit,
+            "implement",
+            "failed",
+            providerEvents:
+            [
+                .. CreateInitialInventoryImplementProviderEvents(executionUnit, "pid:71450", includeBackendExit: false),
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:00.9000000+00:00",
+                    ExecutionUnit = executionUnit,
+                    Provider = "Codex",
+                    EntryKind = "implement",
+                    SessionId = "pid:71450",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement("exec /bin/zsh -lc 'dotnet test tests/ToyCalc.Tests/ToyCalc.Tests.csproj --nologo' succeeded in 1820ms")
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.0000000+00:00",
+                    ExecutionUnit = executionUnit,
+                    Provider = "Codex",
+                    EntryKind = "implement",
+                    SessionId = "pid:71450",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "backend-exit",
+                        exit_code = 1
+                    })
+                },
+                new DirectRunProviderEvent
+                {
+                    Timestamp = "2026-04-10T12:00:01.1000000+00:00",
+                    ExecutionUnit = executionUnit,
+                    Provider = "Codex",
+                    EntryKind = "implement",
+                    SessionId = "pid:71450",
+                    Kind = "provider-event",
+                    Payload = System.Text.Json.JsonSerializer.SerializeToElement(new
+                    {
+                        type = "contract-gap",
+                        stop_reason = "deterministic-contract-gap",
+                        reason = "implement-session-ended-after-product-source-test-read",
+                        detail =
+                            "Implement direct run for 'TOY-CALC-V0-11' reached product source/test read before death, and terminal boundary is deterministically a contract-gap.",
+                        run_status = "failed"
+                    })
+                }
+            ],
+            sessionId: "pid:71450",
+            provider: "Codex");
+
+        var originalRunGitCommandRunnerFactory = RunCommand.GitCommandRunnerFactory;
+        try
+        {
+            RunCommand.GitCommandRunnerFactory = () => new FakeGitRunner(
+                """
+                 M src/ToyCalc/Calculator.cs
+                 M src/ToyCalc/CommandLine.cs
+                 M tests/ToyCalc.Tests/CalculatorTests.cs
+                """);
+
+            var result = RunCommand.ExecuteCore(CreateContext(repoRoot));
+
+            Assert.Equal("clarification-required", result.StopReason);
+            Assert.Equal(executionUnit, result.ExecutionUnit);
+            Assert.Empty(result.Actions);
+            Assert.Contains("worktree-progress-adoption-required", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("Continuation path:", result.Detail, StringComparison.Ordinal);
+            Assert.Contains($"carry the worktree changes for '{executionUnit}' at {worktreePath}", result.Detail, StringComparison.Ordinal);
+            Assert.Contains($"'run submit' followed by 'run rereview' to update the existing pull request {linkedPr}", result.Detail, StringComparison.Ordinal);
+            Assert.Contains("existing submit/review boundary", result.Detail, StringComparison.Ordinal);
         }
         finally
         {


### PR DESCRIPTION
## Summary

Closes #448.

When the blocked-implement contract-gap path surfaces `worktree-progress-adoption-required` (G171), the result detail now also embeds a deterministic continuation path so downstream automation or the operator can act on the existing implementation worktree without ambiguous prose.

The stop reason stays `clarification-required` (per AC: "compatible with current clarifications workflow when human decision is still required"), and the existing `deterministic-contract-gap` / `non-retryable-failure` / startup-only / provider-auth handling is unchanged. The continuation path uses the in-worktree path emitted by the same builder, so child code does not assume parent-host absolute paths (per AC: "avoid parent-host absolute path assumptions inside child code").

## Continuation path branches

The new `BuildBlockedImplementWorktreeProgressContinuationPath` helper picks one of three deterministic strings based on session state:

- `session.LinkedPr` present:
  > carry the worktree changes for '<EU>' at <worktree-path> through 'run submit' followed by 'run rereview' to update the existing pull request <LinkedPr>.

- `session.LinkedIssue` only (no `LinkedPr`):
  > 'run submit' opens the pull request against linked child issue <LinkedIssue> using the worktree at <worktree-path>; the standard submit/review boundary then carries the worktree changes forward.

- neither:
  > operator must adopt the worktree changes for '<EU>' at <worktree-path> manually before any submit/review handoff.

The string is inserted as a `Continuation path: ...` segment between the existing `Verification signal: ...` segment and the trailing operator-prose hint, so the rest of the adoption-required detail (`Worktree path:`, `Provider session:`, `Raw log ref:`, `Changed paths:`, `Verification signal:`, downstream-automation guidance) is preserved verbatim.

## Changes

- `src/IntentSystem.Cli/Commands/RunCommand.cs`
  - `TryBuildBlockedImplementWorktreeProgressAdoptionDetail`: appends the new `Continuation path:` segment from `BuildBlockedImplementWorktreeProgressContinuationPath`.
  - New private helper `BuildBlockedImplementWorktreeProgressContinuationPath`.
- `tests/IntentSystem.Cli.Tests/RunCommandTests.cs`
  - Existing G171 test `ExecuteCore_GivenBlockedImplementContractGapWithMeaningfulWorktreeProgress_StopsWithAdoptionRequired` now asserts the `Continuation path:` LinkedIssue branch.
  - New test `ExecuteCore_GivenBlockedImplementContractGapWithLinkedPrAndWorktreeProgress_StopsWithAdoptionRequiredAndPrContinuationPath` exercises the LinkedPr branch end-to-end via `ExecuteCore`.

## Verification

```bash
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommand" --nologo
# Passed!  - Failed:     0, Passed:   113, Skipped:     0, Total:   113
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
