### PR TITLE
G173: allow adoption-required blocked items into submit/review boundary

### DIFF
--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -148,7 +148,18 @@ public static class QueueManager
     }
 
     /// <summary>
-    /// Transition an active item to review.
+    /// Marker prefix recorded in <see cref="QueueItem.BlockedBy"/> when a direct run
+    /// emits <c>worktree-progress-adoption-required</c>. Submit-for-review accepts a
+    /// blocked item only when its <c>BlockedBy</c> reason starts with this prefix so
+    /// the deterministic continuation path "run submit" can carry the worktree
+    /// progress into the existing submit/review boundary instead of leaving the
+    /// item stuck.
+    /// </summary>
+    public const string WorktreeProgressAdoptionRequiredBlockedReasonPrefix =
+        "worktree-progress-adoption-required";
+
+    /// <summary>
+    /// Transition an active item — or an adoption-required blocked item — to review.
     /// </summary>
     public static QueueTransitionResult SubmitForReview(
         QueueState state, string executionUnit, string by, DateTimeOffset ts,
@@ -159,7 +170,10 @@ public static class QueueManager
         ArgumentException.ThrowIfNullOrWhiteSpace(by);
 
         var item = FindItem(state, executionUnit);
-        AssertState(item, QueueItemState.Active, "submit-for-review");
+        if (item.State != QueueItemState.Active && !IsWorktreeProgressAdoptionRequiredBlocked(item))
+        {
+            AssertState(item, QueueItemState.Active, "submit-for-review");
+        }
 
         return ApplyTransition(state, executionUnit, QueueItemState.Review, new RunEvent
         {
@@ -169,6 +183,31 @@ public static class QueueManager
             By = by,
             LinkedPr = linkedPr
         });
+    }
+
+    private static bool IsWorktreeProgressAdoptionRequiredBlocked(QueueItem item)
+    {
+        if (item.State != QueueItemState.Blocked)
+        {
+            return false;
+        }
+
+        foreach (var reason in item.BlockedBy)
+        {
+            if (reason is null)
+            {
+                continue;
+            }
+
+            if (reason.StartsWith(
+                    WorktreeProgressAdoptionRequiredBlockedReasonPrefix,
+                    StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs
@@ -75,6 +75,106 @@ public sealed class RunSubmitCommandTests
     }
 
     [Fact]
+    public void Execute_GivenWorktreeProgressAdoptionRequiredBlockedItem_PushesAndTransitionsToReview()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G14"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(
+                primaryItemState: QueueItemState.Blocked,
+                primaryBlockedBy:
+                [
+                    "worktree-progress-adoption-required: Implement direct run for 'G14' exited with backend exit code 1 after current-session product source/test or verification activity, and left meaningful execution-unit worktree changes."
+                ])));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var publisher = new FakePublisher();
+        var originalGitFactory = RunSubmitCommand.GitCommandRunnerFactory;
+        var originalPublisherFactory = RunSubmitCommand.PublisherFactory;
+        var originalTimestampFactory = RunSubmitCommand.TimestampFactory;
+
+        try
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = () => new FakeGitRunner(branchName: "issue-56-g14");
+            RunSubmitCommand.PublisherFactory = () => publisher;
+            RunSubmitCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-25T15:50:00Z");
+
+            var exitCode = RunSubmitCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run submitted for G14", writer.ToString(), StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            var submittedItem = queueState.Items.Single(item => item.ExecutionUnit == "G14");
+            Assert.Equal(QueueItemState.Review, submittedItem.State);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", submittedItem.LinkedPr);
+
+            var reviewEvent = Assert.Single(RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl"))));
+            Assert.Equal("review", reviewEvent.Event);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", reviewEvent.LinkedPr);
+        }
+        finally
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+            RunSubmitCommand.PublisherFactory = originalPublisherFactory;
+            RunSubmitCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenOrdinaryBlockedItem_ReturnsExitCodeOneWithoutMutatingFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G14"));
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(
+                primaryItemState: QueueItemState.Blocked,
+                primaryBlockedBy: ["dependency-incomplete: G13"])));
+        var runLogPath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        using var writer = new StringWriter();
+        var originalGitFactory = RunSubmitCommand.GitCommandRunnerFactory;
+        var originalPublisherFactory = RunSubmitCommand.PublisherFactory;
+
+        try
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = () => new FakeGitRunner(branchName: "issue-56-g14");
+            RunSubmitCommand.PublisherFactory = () => new FakePublisher();
+
+            var originalQueueState = File.ReadAllText(queueStatePath);
+            var exitCode = RunSubmitCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("expected state 'Active'", writer.ToString(), StringComparison.Ordinal);
+            Assert.Contains("found 'Blocked'", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(originalQueueState, File.ReadAllText(queueStatePath));
+            Assert.Empty(File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+            RunSubmitCommand.PublisherFactory = originalPublisherFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenPublisherReusesExistingPr_PersistsLinkedPrAndTransitionsToReview()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -569,15 +669,24 @@ public sealed class RunSubmitCommandTests
         };
     }
 
-    private static QueueState CreateQueueState(bool withLinkedIssue = true)
+    private static QueueState CreateQueueState(
+        bool withLinkedIssue = true,
+        QueueItemState primaryItemState = QueueItemState.Active,
+        IReadOnlyList<string>? primaryBlockedBy = null)
     {
+        var primaryItem = CreateItem("G14", primaryItemState, withLinkedIssue);
+        if (primaryBlockedBy is { Count: > 0 })
+        {
+            primaryItem = primaryItem with { BlockedBy = primaryBlockedBy };
+        }
+
         return new QueueState
         {
             SchemaVersion = "1",
             UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
             Items =
             [
-                CreateItem("G14", QueueItemState.Active, withLinkedIssue),
+                primaryItem,
                 CreateItem("G15", QueueItemState.Blocked, false) with
                 {
                     Dependencies = ["G14"],

--- a/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
@@ -46,6 +46,52 @@ public sealed class QueueManagerTests
     }
 
     [Fact]
+    public void SubmitForReview_GivenWorktreeProgressAdoptionRequiredBlocked_TransitionsToReview()
+    {
+        var blockedItem = CreateItem("A1", QueueItemState.Blocked) with
+        {
+            BlockedBy =
+            [
+                "worktree-progress-adoption-required: Implement direct run for 'A1' exited with backend exit code 1 ..."
+            ]
+        };
+        var state = CreateState([blockedItem]);
+
+        var result = QueueManager.SubmitForReview(
+            state,
+            "A1",
+            "intent-cli",
+            BaseTime,
+            linkedPr: "https://github.com/org/repo/pull/9");
+
+        var updatedItem = FindItem(result.UpdatedState, "A1");
+        Assert.Equal(QueueItemState.Review, updatedItem.State);
+        Assert.Equal("https://github.com/org/repo/pull/9", updatedItem.LinkedPr);
+        Assert.Equal("review", result.Event.Event);
+        Assert.Equal("https://github.com/org/repo/pull/9", result.Event.LinkedPr);
+    }
+
+    [Fact]
+    public void SubmitForReview_GivenOrdinaryBlocked_ThrowsInvalidOperationException()
+    {
+        var blockedItem = CreateItem("A1", QueueItemState.Blocked) with
+        {
+            BlockedBy = ["dependency-incomplete: B1"]
+        };
+        var state = CreateState([blockedItem]);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => QueueManager.SubmitForReview(
+                state,
+                "A1",
+                "intent-cli",
+                BaseTime));
+
+        Assert.Contains("expected state 'Active'", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("found 'Blocked'", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RequestFix_GivenReviewItem_TransitionsToFixing()
     {
         var state = CreateState(QueueItemState.Review);


### PR DESCRIPTION
## Summary

Closes #450 (G173).

Extend `QueueManager.SubmitForReview` so that a queue item in state `Blocked`
is accepted by `run submit <execution-unit>` only when its `BlockedBy` reason
starts with the deterministic
`worktree-progress-adoption-required` marker emitted by `intent-cli run` in
G171/G172. Any other blocked reason still fails deterministically with the
existing `expected state 'Active' but found 'Blocked'` message, and ordinary
`Active` submit behavior is unchanged.

This makes the continuation path emitted by G172
(`'run submit' opens the pull request against linked child issue …; the
standard submit/review boundary then carries the worktree changes forward.`)
actually executable for `TOY-CALC-V0-11` and any future adoption-required
worktree progress, while preserving the rejection invariant for unrelated
blocked states.

## Changes

- `src/IntentSystem.Supervisor/QueueManager.cs`
  - Add public constant `WorktreeProgressAdoptionRequiredBlockedReasonPrefix`
    (`worktree-progress-adoption-required`).
  - Loosen the `SubmitForReview` precondition to accept either `Active` or a
    `Blocked` item whose `BlockedBy` reason starts with the marker prefix;
    every other state path still goes through the original `AssertState`
    guard so the deterministic error message for unrelated blocked items is
    preserved verbatim.
- `tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs`
  - Add `SubmitForReview_GivenWorktreeProgressAdoptionRequiredBlocked_TransitionsToReview`
    (positive same-surface regression).
  - Add `SubmitForReview_GivenOrdinaryBlocked_ThrowsInvalidOperationException`
    (negative same-surface regression).
- `tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs`
  - Add `Execute_GivenWorktreeProgressAdoptionRequiredBlockedItem_PushesAndTransitionsToReview`
    covering the `TOY-CALC-V0-11`-shaped state through the full
    `RunSubmitCommand.Execute` surface (push, draft PR, queue + run-log
    persistence) without relying on parent-host absolute paths.
  - Add `Execute_GivenOrdinaryBlockedItem_ReturnsExitCodeOneWithoutMutatingFiles`
    asserting the deterministic blocked rejection still fires for non-adoption
    blocked items and leaves queue-state / runs.jsonl untouched.
  - Extend the `CreateQueueState` helper with `primaryItemState` /
    `primaryBlockedBy` parameters so adoption-required and ordinary-blocked
    fixtures can share the same queue-state shape.

## Verification

```
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
  --filter "FullyQualifiedName~RunSubmitCommand" --nologo
# Failed: 0, Passed: 18, Skipped: 0, Total: 18
```

```
dotnet test tests/IntentSystem.Supervisor.Tests/IntentSystem.Supervisor.Tests.csproj \
  --filter "FullyQualifiedName~QueueManager" --nologo
# Failed: 0, Passed: 29, Skipped: 0, Total: 29
```

Both suites pass on the `claude/g173-blocked-worktree-submit` branch.

## Out Of Scope

- Modifying toy-calc product code.
- Automatically accepting, merging, or reviewing product worktree changes.
- Making every blocked item submittable.
- Provider startup/auth classification.
- Adding a new queue workflow state.

## Test plan

- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunSubmitCommand" --nologo`
- [x] `dotnet test tests/IntentSystem.Supervisor.Tests/IntentSystem.Supervisor.Tests.csproj --filter "FullyQualifiedName~QueueManager" --nologo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
