### PR TITLE
G174: keep worktree adoption submit eligibility stable across rerun

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunSubmitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSubmitCommand.cs
@@ -97,6 +97,15 @@ internal static class RunSubmitCommand
         var branchName = RunStartCommand.ResolveBranchName(executionUnit, queueItem.LinkedIssue);
         var gitRunner = GitCommandRunnerFactory();
         EnsureBranchMatches(worktreePath, branchName, gitRunner);
+        var hasMeaningfulWorktreeProgress =
+            RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths(
+                gitRunner,
+                worktreePath,
+                out _);
+        var allowBlockedWorktreeAdoption =
+            queueItem.State == QueueItemState.Blocked
+            && hasMeaningfulWorktreeProgress
+            && !HasWorktreeProgressAdoptionRequiredMarker(queueItem);
         EnsureCarryForwardCommit(executionUnit, worktreePath, branchName, gitRunner);
         PushBranch(worktreePath, branchName, gitRunner);
 
@@ -115,7 +124,8 @@ internal static class RunSubmitCommand
             executionUnit,
             TransitionActor,
             timestamp,
-            linkedPr);
+            linkedPr,
+            allowBlockedWorktreeAdoption);
         PersistSubmit(context, transition);
 
         return new RunSubmitResult
@@ -151,6 +161,28 @@ internal static class RunSubmitCommand
 
             - {{queueItem.LinkedIssue.Url}}
             """;
+    }
+
+    private static bool HasWorktreeProgressAdoptionRequiredMarker(QueueItem queueItem)
+    {
+        ArgumentNullException.ThrowIfNull(queueItem);
+
+        foreach (var reason in queueItem.BlockedBy)
+        {
+            if (reason is null)
+            {
+                continue;
+            }
+
+            if (reason.StartsWith(
+                    QueueManager.WorktreeProgressAdoptionRequiredBlockedReasonPrefix,
+                    StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string ResolveChildRepoPath(string repoRoot, string childRepoRef)

--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -161,16 +161,29 @@ public static class QueueManager
     /// <summary>
     /// Transition an active item — or an adoption-required blocked item — to review.
     /// </summary>
+    /// <param name="allowBlockedWorktreeAdoption">
+    /// When <c>true</c>, accept a blocked queue item even when its
+    /// <see cref="QueueItem.BlockedBy"/> reason does not carry the
+    /// <see cref="WorktreeProgressAdoptionRequiredBlockedReasonPrefix"/> marker.
+    /// The caller is responsible for verifying out-of-band that the same bounded
+    /// worktree-progress evidence which originally produced the marker is still
+    /// present (rerun-stable adoption). Ordinary blocked rejection is unaffected
+    /// when the flag is false.
+    /// </param>
     public static QueueTransitionResult SubmitForReview(
         QueueState state, string executionUnit, string by, DateTimeOffset ts,
-        string? linkedPr = null)
+        string? linkedPr = null,
+        bool allowBlockedWorktreeAdoption = false)
     {
         ArgumentNullException.ThrowIfNull(state);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
         ArgumentException.ThrowIfNullOrWhiteSpace(by);
 
         var item = FindItem(state, executionUnit);
-        if (item.State != QueueItemState.Active && !IsWorktreeProgressAdoptionRequiredBlocked(item))
+        var isBlockedAdoption =
+            IsWorktreeProgressAdoptionRequiredBlocked(item)
+            || (allowBlockedWorktreeAdoption && item.State == QueueItemState.Blocked);
+        if (item.State != QueueItemState.Active && !isBlockedAdoption)
         {
             AssertState(item, QueueItemState.Active, "submit-for-review");
         }

--- a/tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs
@@ -132,6 +132,64 @@ public sealed class RunSubmitCommandTests
     }
 
     [Fact]
+    public void Execute_GivenRerunStableBlockedItemWithMeaningfulWorktreeProgress_PushesAndTransitionsToReview()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G14"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(
+                primaryItemState: QueueItemState.Blocked,
+                primaryBlockedBy:
+                [
+                    "Implement direct run for 'G14' ended after current-session product source/test read activity but before a bounded repair outcome. Current-session evidence observed request_reread=True, repo_inventory=True, repo_local_spec_read=True, product_source_or_test_read=True. A failing backend-exit was captured after product source/test read activity, so the normalized failure must preserve that later evidence rather than collapsing it into an earlier pre-read backend-exit boundary."
+                ])));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var publisher = new FakePublisher();
+        var originalGitFactory = RunSubmitCommand.GitCommandRunnerFactory;
+        var originalPublisherFactory = RunSubmitCommand.PublisherFactory;
+        var originalTimestampFactory = RunSubmitCommand.TimestampFactory;
+
+        try
+        {
+            RunSubmitCommand.GitCommandRunnerFactory =
+                () => new FakeGitRunnerWithDirtyWorktree(branchName: "issue-56-g14");
+            RunSubmitCommand.PublisherFactory = () => publisher;
+            RunSubmitCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-25T16:50:00Z");
+
+            var exitCode = RunSubmitCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run submitted for G14", writer.ToString(), StringComparison.Ordinal);
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            var submittedItem = queueState.Items.Single(item => item.ExecutionUnit == "G14");
+            Assert.Equal(QueueItemState.Review, submittedItem.State);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", submittedItem.LinkedPr);
+
+            var reviewEvent = Assert.Single(RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl"))));
+            Assert.Equal("review", reviewEvent.Event);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/58", reviewEvent.LinkedPr);
+        }
+        finally
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+            RunSubmitCommand.PublisherFactory = originalPublisherFactory;
+            RunSubmitCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenOrdinaryBlockedItem_ReturnsExitCodeOneWithoutMutatingFiles()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
@@ -92,6 +92,51 @@ public sealed class QueueManagerTests
     }
 
     [Fact]
+    public void SubmitForReview_GivenBlockedWithoutMarkerAndAllowOverride_TransitionsToReview()
+    {
+        var blockedItem = CreateItem("A1", QueueItemState.Blocked) with
+        {
+            BlockedBy =
+            [
+                "Implement direct run for 'A1' ended after current-session product source/test read activity but before a bounded repair outcome."
+            ]
+        };
+        var state = CreateState([blockedItem]);
+
+        var result = QueueManager.SubmitForReview(
+            state,
+            "A1",
+            "intent-cli",
+            BaseTime,
+            linkedPr: "https://github.com/org/repo/pull/11",
+            allowBlockedWorktreeAdoption: true);
+
+        var updatedItem = FindItem(result.UpdatedState, "A1");
+        Assert.Equal(QueueItemState.Review, updatedItem.State);
+        Assert.Equal("https://github.com/org/repo/pull/11", updatedItem.LinkedPr);
+        Assert.Equal("review", result.Event.Event);
+        Assert.Equal("https://github.com/org/repo/pull/11", result.Event.LinkedPr);
+    }
+
+    [Fact]
+    public void SubmitForReview_GivenActiveAndAllowOverride_TransitionsToReview()
+    {
+        var state = CreateState(QueueItemState.Active);
+
+        var result = QueueManager.SubmitForReview(
+            state,
+            "A1",
+            "intent-cli",
+            BaseTime,
+            linkedPr: "https://github.com/org/repo/pull/12",
+            allowBlockedWorktreeAdoption: true);
+
+        var updatedItem = FindItem(result.UpdatedState, "A1");
+        Assert.Equal(QueueItemState.Review, updatedItem.State);
+        Assert.Equal("https://github.com/org/repo/pull/12", updatedItem.LinkedPr);
+    }
+
+    [Fact]
     public void RequestFix_GivenReviewItem_TransitionsToFixing()
     {
         var state = CreateState(QueueItemState.Review);


### PR DESCRIPTION
## Summary

Closes #452 (G174).

Make `run submit <execution-unit>` derive
`worktree-progress-adoption-required` eligibility from the same bounded
worktree evidence even when the durable `BlockedBy` reason has reverted to
an older deterministic-contract-gap message after a rerun. With this fix
the `TOY-CALC-V0-11` rerun-stable adoption state can carry the existing
worktree into the existing submit/review boundary again, while ordinary
blocked items remain protected.

## Approach

The G173 acceptance path keyed off the durable
`worktree-progress-adoption-required` prefix in `BlockedBy`. After a rerun,
that string can be replaced by the older deterministic-contract-gap detail
even though the worktree still has meaningful progress and the linked
issue context. Per the issue's "In Scope":

> Either normalize the blocked reason back to
> `worktree-progress-adoption-required` during root `run`, or make
> `run submit` derive adoption eligibility from the same bounded worktree
> evidence.

This PR takes the second option:

- `RunSubmitCommand.ExecuteCore` calls
  `RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths` (the
  same helper used by G171's adoption-required emission and the existing
  carry-forward staging) after `EnsureBranchMatches`, then sets
  `allowBlockedWorktreeAdoption = true` only when the queue item is
  `Blocked`, the `BlockedBy` does not already carry the G173 marker prefix,
  and the worktree still has meaningful progress.
- `QueueManager.SubmitForReview` gains an opt-in
  `allowBlockedWorktreeAdoption = false` parameter. Active submits and
  G173's marker-based acceptance are unchanged. Ordinary blocked items
  still fail with `expected state 'Active' but found 'Blocked'` when the
  override is not asserted.

The override is keyed on the same evidence that originally produced the
`worktree-progress-adoption-required` boundary, so root `run` and direct
`run submit` agree on the adoption-required eligibility for this
same-surface state without changing root `run` semantics.

## Changes

- `src/IntentSystem.Cli/Commands/RunSubmitCommand.cs`
  - Add the worktree-evidence classification step before the carry-forward
    commit; pass the resulting flag through to `QueueManager.SubmitForReview`.
  - Add a private `HasWorktreeProgressAdoptionRequiredMarker` helper that
    reuses the public `QueueManager.WorktreeProgressAdoptionRequiredBlockedReasonPrefix`
    constant introduced by G173.
- `src/IntentSystem.Supervisor/QueueManager.cs`
  - Add the opt-in `allowBlockedWorktreeAdoption` parameter on
    `SubmitForReview` with documentation calling out that the caller must
    verify the worktree-progress evidence out of band.
- `tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs`
  - Add `Execute_GivenRerunStableBlockedItemWithMeaningfulWorktreeProgress_PushesAndTransitionsToReview`
    covering the `TOY-CALC-V0-11`-shaped state through the full
    `RunSubmitCommand.Execute` surface (push, draft PR, queue + run-log
    persistence) without relying on parent-host absolute paths.
- `tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs`
  - Add `SubmitForReview_GivenBlockedWithoutMarkerAndAllowOverride_TransitionsToReview`
    (positive same-surface regression when caller explicitly opts in).
  - Add `SubmitForReview_GivenActiveAndAllowOverride_TransitionsToReview`
    (positive: the override does not break Active submits).
  - The existing G173 negative regression
    `SubmitForReview_GivenOrdinaryBlocked_ThrowsInvalidOperationException`
    pins the unchanged rejection when the override is not asserted.

## Verification

```
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
  --filter "FullyQualifiedName~RunCommand|FullyQualifiedName~RunSubmitCommand" --nologo
# Failed: 0, Passed: 132, Skipped: 0, Total: 132
```

```
dotnet test tests/IntentSystem.Supervisor.Tests/IntentSystem.Supervisor.Tests.csproj \
  --filter "FullyQualifiedName~QueueManager" --nologo
# Failed: 0, Passed: 31, Skipped: 0, Total: 31
```

Both suites pass on the `claude/g174-rerun-stable-adoption` branch.

## Out Of Scope

- Modifying toy-calc product code.
- Automatically accepting, merging, or reviewing product worktree changes.
- Making every blocked item submittable.
- Changing provider auth/startup classification.
- Adding a new queue workflow state.

## Test plan

- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunCommand|FullyQualifiedName~RunSubmitCommand" --nologo`
- [x] `dotnet test tests/IntentSystem.Supervisor.Tests/IntentSystem.Supervisor.Tests.csproj --filter "FullyQualifiedName~QueueManager" --nologo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
