### PR TITLE
G175: reconcile existing submit PR before blocked-state guard

### DIFF
--- a/src/IntentSystem.Cli/Commands/RunSubmitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/RunSubmitCommand.cs
@@ -96,27 +96,44 @@ internal static class RunSubmitCommand
 
         var branchName = RunStartCommand.ResolveBranchName(executionUnit, queueItem.LinkedIssue);
         var gitRunner = GitCommandRunnerFactory();
-        EnsureBranchMatches(worktreePath, branchName, gitRunner);
-        var hasMeaningfulWorktreeProgress =
-            RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths(
-                gitRunner,
-                worktreePath,
-                out _);
-        var allowBlockedWorktreeAdoption =
-            queueItem.State == QueueItemState.Blocked
-            && hasMeaningfulWorktreeProgress
-            && !HasWorktreeProgressAdoptionRequiredMarker(queueItem);
-        EnsureCarryForwardCommit(executionUnit, worktreePath, branchName, gitRunner);
-        PushBranch(worktreePath, branchName, gitRunner);
-
         var targetRepo = ResolveGitHubTargetRepo(childRepoPath, gitRunner);
-        var pullRequestTitle = ResolvePullRequestTitle(queueItem);
-        var pullRequestBody = ResolvePullRequestBody(queueItem);
-        var linkedPr = PublisherFactory().CreateDraftPullRequest(
-            targetRepo,
-            branchName,
-            pullRequestTitle,
-            pullRequestBody);
+        var publisher = PublisherFactory();
+
+        string linkedPr;
+        bool allowBlockedWorktreeAdoption;
+
+        if (publisher.TryFindExistingOpenPullRequest(
+                targetRepo,
+                branchName,
+                queueItem.LinkedIssue.Url,
+                out var existingPullRequestUrl))
+        {
+            linkedPr = existingPullRequestUrl;
+            allowBlockedWorktreeAdoption = true;
+        }
+        else
+        {
+            EnsureBranchMatches(worktreePath, branchName, gitRunner);
+            var hasMeaningfulWorktreeProgress =
+                RunWorktreeProgressSupport.TryResolveMeaningfulWorktreeDiffPaths(
+                    gitRunner,
+                    worktreePath,
+                    out _);
+            allowBlockedWorktreeAdoption =
+                queueItem.State == QueueItemState.Blocked
+                && hasMeaningfulWorktreeProgress
+                && !HasWorktreeProgressAdoptionRequiredMarker(queueItem);
+            EnsureCarryForwardCommit(executionUnit, worktreePath, branchName, gitRunner);
+            PushBranch(worktreePath, branchName, gitRunner);
+
+            var pullRequestTitle = ResolvePullRequestTitle(queueItem);
+            var pullRequestBody = ResolvePullRequestBody(queueItem);
+            linkedPr = publisher.CreateDraftPullRequest(
+                targetRepo,
+                branchName,
+                pullRequestTitle,
+                pullRequestBody);
+        }
 
         var timestamp = TimestampFactory();
         var transition = QueueManager.SubmitForReview(

--- a/src/IntentSystem.Cli/GhRunSubmitPublisher.cs
+++ b/src/IntentSystem.Cli/GhRunSubmitPublisher.cs
@@ -79,6 +79,24 @@ internal sealed class GhRunSubmitPublisher : IRunSubmitPublisher
         }
     }
 
+    public bool TryFindExistingOpenPullRequest(
+        string targetRepo,
+        string headBranch,
+        string linkedIssueUrl,
+        out string pullRequestUrl)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetRepo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(headBranch);
+        ArgumentException.ThrowIfNullOrWhiteSpace(linkedIssueUrl);
+
+        if (TryFindExistingPullRequest(targetRepo, headBranch, out pullRequestUrl))
+        {
+            return true;
+        }
+
+        return TryFindOpenPullRequestByLinkedIssueUrl(targetRepo, linkedIssueUrl, out pullRequestUrl);
+    }
+
     private bool TryFindExistingPullRequest(
         string targetRepo,
         string headBranch,
@@ -135,6 +153,78 @@ internal sealed class GhRunSubmitPublisher : IRunSubmitPublisher
                 if (!string.Equals(candidateHead, headBranch, StringComparison.Ordinal)
                     || !string.Equals(candidateBase, PullRequestBase, StringComparison.Ordinal)
                     || !Uri.TryCreate(candidateUrl, UriKind.Absolute, out _))
+                {
+                    continue;
+                }
+
+                pullRequestUrl = candidateUrl;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryFindOpenPullRequestByLinkedIssueUrl(
+        string targetRepo,
+        string linkedIssueUrl,
+        out string pullRequestUrl)
+    {
+        var result = commandRunner.Run(
+            [
+                "pr",
+                "list",
+                "--repo",
+                targetRepo,
+                "--base",
+                PullRequestBase,
+                "--state",
+                "open",
+                "--json",
+                "url,headRefName,baseRefName,body",
+                "--limit",
+                "100"
+            ]);
+
+        pullRequestUrl = string.Empty;
+        if (result.ExitCode != 0)
+        {
+            return false;
+        }
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(result.StdOut);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        using (document)
+        {
+            if (document.RootElement.ValueKind != JsonValueKind.Array)
+            {
+                return false;
+            }
+
+            foreach (var element in document.RootElement.EnumerateArray())
+            {
+                if (!TryGetStringProperty(element, "url", out var candidateUrl)
+                    || !TryGetStringProperty(element, "baseRefName", out var candidateBase)
+                    || !TryGetStringProperty(element, "body", out var candidateBody))
+                {
+                    continue;
+                }
+
+                if (!string.Equals(candidateBase, PullRequestBase, StringComparison.Ordinal)
+                    || !Uri.TryCreate(candidateUrl, UriKind.Absolute, out _))
+                {
+                    continue;
+                }
+
+                if (!candidateBody.Contains(linkedIssueUrl, StringComparison.Ordinal))
                 {
                     continue;
                 }

--- a/src/IntentSystem.Cli/IRunSubmitPublisher.cs
+++ b/src/IntentSystem.Cli/IRunSubmitPublisher.cs
@@ -3,4 +3,10 @@ namespace IntentSystem.Cli;
 internal interface IRunSubmitPublisher
 {
     string CreateDraftPullRequest(string targetRepo, string headBranch, string title, string body);
+
+    bool TryFindExistingOpenPullRequest(
+        string targetRepo,
+        string headBranch,
+        string linkedIssueUrl,
+        out string pullRequestUrl);
 }

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -5250,6 +5250,16 @@ recommended_updates:
         {
             return "https://github.com/J-Tech-Japan/intent-system/pull/58";
         }
+
+        public bool TryFindExistingOpenPullRequest(
+            string targetRepo,
+            string headBranch,
+            string linkedIssueUrl,
+            out string pullRequestUrl)
+        {
+            pullRequestUrl = string.Empty;
+            return false;
+        }
     }
 
     private sealed class FakeReviewAcceptClient : IReviewAcceptClient

--- a/tests/IntentSystem.Cli.Tests/GhRunSubmitPublisherTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GhRunSubmitPublisherTests.cs
@@ -131,6 +131,145 @@ public sealed class GhRunSubmitPublisherTests
         Assert.Equal(2, runner.Calls.Count);
     }
 
+    [Fact]
+    public void TryFindExistingOpenPullRequest_GivenMatchingHeadBranch_ReturnsTrueWithoutBodyScan()
+    {
+        var runner = new ScriptedRunner(
+            new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = """
+                [
+                  {
+                    "url": "https://github.com/tomohisa/toy-calc-sample/pull/25",
+                    "headRefName": "issue-24-toy-calc-v0-11",
+                    "baseRefName": "main"
+                  }
+                ]
+                """,
+                StdErr = string.Empty
+            });
+        var publisher = new GhRunSubmitPublisher(runner);
+
+        var found = publisher.TryFindExistingOpenPullRequest(
+            "tomohisa/toy-calc-sample",
+            "issue-24-toy-calc-v0-11",
+            "https://github.com/tomohisa/toy-calc-sample/issues/24",
+            out var url);
+
+        Assert.True(found);
+        Assert.Equal("https://github.com/tomohisa/toy-calc-sample/pull/25", url);
+        Assert.Single(runner.Calls);
+        Assert.Equal(
+            [
+                "pr",
+                "list",
+                "--repo",
+                "tomohisa/toy-calc-sample",
+                "--head",
+                "issue-24-toy-calc-v0-11",
+                "--base",
+                "main",
+                "--state",
+                "open",
+                "--json",
+                "url,headRefName,baseRefName"
+            ],
+            runner.Calls.Single());
+    }
+
+    [Fact]
+    public void TryFindExistingOpenPullRequest_GivenNoHeadMatchButLinkedIssueUrlInBody_ReturnsTrueViaBodyScan()
+    {
+        var runner = new ScriptedRunner(
+            new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "[]",
+                StdErr = string.Empty
+            },
+            new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = """
+                [
+                  {
+                    "url": "https://github.com/tomohisa/toy-calc-sample/pull/25",
+                    "headRefName": "issue-24-toy-calc-v0-11",
+                    "baseRefName": "main",
+                    "body": "## Summary\n\n- [TOY-CALC-V0-11] Add unary integer sign command sign\n\n## Linked Issue\n\n- https://github.com/tomohisa/toy-calc-sample/issues/24\n"
+                  }
+                ]
+                """,
+                StdErr = string.Empty
+            });
+        var publisher = new GhRunSubmitPublisher(runner);
+
+        var found = publisher.TryFindExistingOpenPullRequest(
+            "tomohisa/toy-calc-sample",
+            "different-branch-name",
+            "https://github.com/tomohisa/toy-calc-sample/issues/24",
+            out var url);
+
+        Assert.True(found);
+        Assert.Equal("https://github.com/tomohisa/toy-calc-sample/pull/25", url);
+        Assert.Equal(2, runner.Calls.Count);
+        Assert.Equal(
+            [
+                "pr",
+                "list",
+                "--repo",
+                "tomohisa/toy-calc-sample",
+                "--base",
+                "main",
+                "--state",
+                "open",
+                "--json",
+                "url,headRefName,baseRefName,body",
+                "--limit",
+                "100"
+            ],
+            runner.Calls[1]);
+    }
+
+    [Fact]
+    public void TryFindExistingOpenPullRequest_GivenNoHeadMatchAndNoBodyMatch_ReturnsFalse()
+    {
+        var runner = new ScriptedRunner(
+            new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = "[]",
+                StdErr = string.Empty
+            },
+            new GitHubCommandResult
+            {
+                ExitCode = 0,
+                StdOut = """
+                [
+                  {
+                    "url": "https://github.com/tomohisa/toy-calc-sample/pull/30",
+                    "headRefName": "issue-99-other-thing",
+                    "baseRefName": "main",
+                    "body": "Unrelated linked issue: https://github.com/tomohisa/toy-calc-sample/issues/99"
+                  }
+                ]
+                """,
+                StdErr = string.Empty
+            });
+        var publisher = new GhRunSubmitPublisher(runner);
+
+        var found = publisher.TryFindExistingOpenPullRequest(
+            "tomohisa/toy-calc-sample",
+            "different-branch-name",
+            "https://github.com/tomohisa/toy-calc-sample/issues/24",
+            out var url);
+
+        Assert.False(found);
+        Assert.Equal(string.Empty, url);
+        Assert.Equal(2, runner.Calls.Count);
+    }
+
     private sealed class ScriptedRunner(params GitHubCommandResult[] results) : IGitHubCommandRunner
     {
         private readonly Queue<GitHubCommandResult> results = new(results);

--- a/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunCommandTests.cs
@@ -13018,6 +13018,16 @@ public sealed class RunCommandTests : IDisposable
         {
             return "https://github.com/J-Tech-Japan/intent-system/pull/226";
         }
+
+        public bool TryFindExistingOpenPullRequest(
+            string targetRepo,
+            string headBranch,
+            string linkedIssueUrl,
+            out string pullRequestUrl)
+        {
+            pullRequestUrl = string.Empty;
+            return false;
+        }
     }
 
     private sealed record ExpectedReviewCommand(IReadOnlyList<string> Arguments, ReviewCommandResult Result);

--- a/tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunSubmitCommandTests.cs
@@ -190,6 +190,81 @@ public sealed class RunSubmitCommandTests
     }
 
     [Fact]
+    public void Execute_GivenOrdinaryBlockedItemWithMatchingExistingPr_ReconcilesAndTransitionsToReviewWithoutPushOrCreate()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", "submodules", "intent-system"));
+        var worktreePath = tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli", "worktrees", "G14"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState(
+                primaryItemState: QueueItemState.Blocked,
+                primaryBlockedBy: ["dependency-incomplete: G13"])));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G14", "packet.yaml"),
+            CreatePacketYaml());
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "runs.jsonl"),
+            string.Empty);
+        using var writer = new StringWriter();
+        var gitRunner = new FakeGitRunner(branchName: "wrong-branch");
+        var publisher = new FakePublisher();
+        publisher.RegisterExistingOpenPullRequest(
+            "J-Tech-Japan/intent-system",
+            "issue-56-g14",
+            "https://github.com/J-Tech-Japan/intent-system/issues/56",
+            "https://github.com/J-Tech-Japan/intent-system/pull/25");
+        var originalGitFactory = RunSubmitCommand.GitCommandRunnerFactory;
+        var originalPublisherFactory = RunSubmitCommand.PublisherFactory;
+        var originalTimestampFactory = RunSubmitCommand.TimestampFactory;
+
+        try
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = () => gitRunner;
+            RunSubmitCommand.PublisherFactory = () => publisher;
+            RunSubmitCommand.TimestampFactory = () => DateTimeOffset.Parse("2026-04-25T17:00:00Z");
+
+            var exitCode = RunSubmitCommand.Execute(CreateContext(repoRoot), ["G14"], writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("Run submitted for G14", writer.ToString(), StringComparison.Ordinal);
+            Assert.Equal(0, publisher.CallCount);
+            Assert.Equal(1, publisher.FindCallCount);
+
+            Assert.DoesNotContain(
+                gitRunner.Calls,
+                call => call.Contains("rev-parse --abbrev-ref HEAD", StringComparison.Ordinal));
+            Assert.DoesNotContain(
+                gitRunner.Calls,
+                call => call.Contains("push -u", StringComparison.Ordinal));
+            Assert.DoesNotContain(
+                gitRunner.Calls,
+                call => call.Contains($"{worktreePath}::add", StringComparison.Ordinal));
+            Assert.DoesNotContain(
+                gitRunner.Calls,
+                call => call.Contains($"{worktreePath}::commit", StringComparison.Ordinal));
+
+            var queueState = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+            var submittedItem = queueState.Items.Single(item => item.ExecutionUnit == "G14");
+            Assert.Equal(QueueItemState.Review, submittedItem.State);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/25", submittedItem.LinkedPr);
+
+            var reviewEvent = Assert.Single(RunLogSerializer.DeserializeAll(
+                File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl"))));
+            Assert.Equal("review", reviewEvent.Event);
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/25", reviewEvent.LinkedPr);
+        }
+        finally
+        {
+            RunSubmitCommand.GitCommandRunnerFactory = originalGitFactory;
+            RunSubmitCommand.PublisherFactory = originalPublisherFactory;
+            RunSubmitCommand.TimestampFactory = originalTimestampFactory;
+        }
+    }
+
+    [Fact]
     public void Execute_GivenOrdinaryBlockedItem_ReturnsExitCodeOneWithoutMutatingFiles()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -1263,11 +1338,24 @@ public sealed class RunSubmitCommandTests
 
     private sealed class FakePublisher(string linkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/58") : IRunSubmitPublisher
     {
+        private readonly Dictionary<(string TargetRepo, string HeadBranch, string LinkedIssueUrl), string> existingPullRequests
+            = new(EqualityComparer<(string, string, string)>.Default);
+
         public string TargetRepo { get; private set; } = string.Empty;
         public string HeadBranch { get; private set; } = string.Empty;
         public string Title { get; private set; } = string.Empty;
         public string Body { get; private set; } = string.Empty;
         public int CallCount { get; private set; }
+        public int FindCallCount { get; private set; }
+
+        public void RegisterExistingOpenPullRequest(
+            string targetRepo,
+            string headBranch,
+            string linkedIssueUrl,
+            string url)
+        {
+            existingPullRequests[(targetRepo, headBranch, linkedIssueUrl)] = url;
+        }
 
         public string CreateDraftPullRequest(string targetRepo, string headBranch, string title, string body)
         {
@@ -1279,6 +1367,23 @@ public sealed class RunSubmitCommandTests
 
             return linkedPr;
         }
+
+        public bool TryFindExistingOpenPullRequest(
+            string targetRepo,
+            string headBranch,
+            string linkedIssueUrl,
+            out string pullRequestUrl)
+        {
+            FindCallCount++;
+            if (existingPullRequests.TryGetValue((targetRepo, headBranch, linkedIssueUrl), out var url))
+            {
+                pullRequestUrl = url;
+                return true;
+            }
+
+            pullRequestUrl = string.Empty;
+            return false;
+        }
     }
 
     private sealed class FailingPublisher : IRunSubmitPublisher
@@ -1286,6 +1391,16 @@ public sealed class RunSubmitCommandTests
         public string CreateDraftPullRequest(string targetRepo, string headBranch, string title, string body)
         {
             throw new InvalidOperationException("gh pr create failed.");
+        }
+
+        public bool TryFindExistingOpenPullRequest(
+            string targetRepo,
+            string headBranch,
+            string linkedIssueUrl,
+            out string pullRequestUrl)
+        {
+            pullRequestUrl = string.Empty;
+            return false;
         }
     }
 


### PR DESCRIPTION
Closes #455.

## Summary

- Add `IRunSubmitPublisher.TryFindExistingOpenPullRequest` with two-step lookup: head-branch match first, then a linked-issue-URL body-scan fallback for PRs whose body uses `Linked Issue` rather than `Closes #N`.
- Short-circuit `RunSubmitCommand.ExecuteCore` to reuse a matching open PR (skipping `EnsureBranchMatches`, carry-forward, push, and `CreateDraftPullRequest`) and pass `allowBlockedWorktreeAdoption = true` to `QueueManager.SubmitForReview`.
- Preserve ordinary blocked rejection unchanged when no matching PR exists.
- Update peer fakes (`FakeRunSubmitPublisher`, `FailingPublisher`) to satisfy the extended interface.

## Tests

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~RunSubmitCommand|FullyQualifiedName~GhRunSubmitPublisher" --nologo` → **26 passed**
- Full project: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo` → **908 passed, 0 failed**

New focused tests:
- `GhRunSubmitPublisherTests.TryFindExistingOpenPullRequest_GivenMatchingHeadBranch_ReturnsTrueWithoutBodyScan`
- `GhRunSubmitPublisherTests.TryFindExistingOpenPullRequest_GivenNoHeadMatchButLinkedIssueUrlInBody_ReturnsTrueViaBodyScan`
- `GhRunSubmitPublisherTests.TryFindExistingOpenPullRequest_GivenNoHeadMatchAndNoBodyMatch_ReturnsFalse`
- `RunSubmitCommandTests.Execute_GivenOrdinaryBlockedItemWithMatchingExistingPr_ReconcilesAndTransitionsToReviewWithoutPushOrCreate`