### PR TITLE
G176 Guard submit queue-state deserialization for null linked_issue.number

### DIFF
--- a/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
+++ b/src/IntentSystem.Cli/Commands/DirectRunResultArtifactJson.cs
@@ -63,10 +63,10 @@ internal sealed record DirectRunLinkedIssueContext
     public required string Repo { get; init; }
 
     [JsonPropertyName("number")]
-    public required int Number { get; init; }
+    public int? Number { get; init; }
 
     [JsonPropertyName("url")]
-    public required string Url { get; init; }
+    public string? Url { get; init; }
 }
 
 internal sealed record DirectRunLinkedPullRequestContext

--- a/src/IntentSystem.Supervisor/Models/LinkedIssue.cs
+++ b/src/IntentSystem.Supervisor/Models/LinkedIssue.cs
@@ -4,7 +4,7 @@ public sealed record LinkedIssue
 {
     public required string Repo { get; init; }
 
-    public required int Number { get; init; }
+    public int? Number { get; init; }
 
-    public required string Url { get; init; }
+    public string? Url { get; init; }
 }

--- a/tests/IntentSystem.Supervisor.Tests/QueueStateSerializerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueStateSerializerTests.cs
@@ -166,4 +166,79 @@ public sealed class QueueStateSerializerTests
         Assert.DoesNotContain("\"packetPaths\"", serialized, StringComparison.Ordinal);
         Assert.Contains("\n  \"updated_at\"", serialized, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void Deserialize_GivenLinkedIssueWithNullNumberAndUrl_TolerantlyReturnsNullableFields()
+    {
+        // G176: parent-host queue-state can carry pre-issue rows whose linked_issue.number / url
+        // are still null. The submit/seed/numbering pipeline must not crash on the deserialize
+        // boundary just because one row is mid-publish.
+        var json = """
+        {
+          "schema_version": "1",
+          "updated_at": "2026-04-26T05:00:00Z",
+          "items": [
+            {
+              "execution_unit": "TOY-CALC-V0-11",
+              "title": "Submitted unit",
+              "state": "active",
+              "dependencies": [],
+              "blocked_by": [],
+              "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+              "packet_paths": {
+                "implementation": ".intent-cli/issues/TOY-CALC-V0-11/implementation.md",
+                "review_context": ".intent-cli/issues/TOY-CALC-V0-11/review-context.md",
+                "yaml": ".intent-cli/issues/TOY-CALC-V0-11/packet.yaml"
+              },
+              "linked_issue": {
+                "repo": "tomohisa/toy-calc-sample",
+                "number": 24,
+                "url": "https://github.com/tomohisa/toy-calc-sample/issues/24"
+              },
+              "worker_role": "coder",
+              "review_role": "reviewer",
+              "priority": "high"
+            },
+            {
+              "execution_unit": "SKS-G54",
+              "title": "Pre-issue row mid-publish",
+              "state": "queued",
+              "dependencies": [],
+              "blocked_by": [],
+              "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+              "packet_paths": {
+                "implementation": ".intent-cli/issues/SKS-G54/implementation.md",
+                "review_context": ".intent-cli/issues/SKS-G54/review-context.md",
+                "yaml": ".intent-cli/issues/SKS-G54/packet.yaml"
+              },
+              "linked_issue": {
+                "repo": "J-Tech-Japan/intent-system",
+                "number": null,
+                "url": null
+              },
+              "worker_role": "coder",
+              "review_role": "reviewer",
+              "priority": "high"
+            }
+          ]
+        }
+        """;
+
+        var queueState = QueueStateSerializer.Deserialize(json);
+
+        Assert.Equal(2, queueState.Items.Count);
+
+        var resolvedItem = Assert.Single(queueState.Items, item => item.ExecutionUnit == "TOY-CALC-V0-11");
+        Assert.NotNull(resolvedItem.LinkedIssue);
+        Assert.Equal(24, resolvedItem.LinkedIssue!.Number);
+        Assert.Equal(
+            "https://github.com/tomohisa/toy-calc-sample/issues/24",
+            resolvedItem.LinkedIssue.Url);
+
+        var preIssueItem = Assert.Single(queueState.Items, item => item.ExecutionUnit == "SKS-G54");
+        Assert.NotNull(preIssueItem.LinkedIssue);
+        Assert.Equal("J-Tech-Japan/intent-system", preIssueItem.LinkedIssue!.Repo);
+        Assert.Null(preIssueItem.LinkedIssue.Number);
+        Assert.Null(preIssueItem.LinkedIssue.Url);
+    }
 }


### PR DESCRIPTION
Closes #457.

## Summary

- Make `LinkedIssue.Number` (`int?`) and `LinkedIssue.Url` (`string?`) nullable, dropping `required`, so a `queue-state.json` row whose linked issue is mid-publish (`number: null`, `url: null`) no longer crashes `System.Text.Json` at the deserialize seam in front of `run submit`.
- Mirror the same nullability on `DirectRunLinkedIssueContext` so the direct-run result artifact shape stays consistent end-to-end.
- Existing call sites either already null-guard (`LinkedIssue is null`) or read fields off the targeted execution unit's linked issue, so the targeted unit's behavior is preserved.

## Tests

- `dotnet test tests/IntentSystem.Supervisor.Tests/IntentSystem.Supervisor.Tests.csproj --nologo` → **49 passed, 0 failed** (1 new regression test).
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo` → **908 passed, 0 failed**.

New regression test:
- `QueueStateSerializerTests.Deserialize_GivenLinkedIssueWithNullNumberAndUrl_TolerantlyReturnsNullableFields` — pins a fixture mirroring the SKS-G54 shape (`number: null, url: null`) alongside a fully-resolved item, asserting both deserialize without throwing and that the resolved item's number/url survive.