### PR TITLE
G177 Support object-shaped linked_pr in queue-state deserialization

### DIFF
--- a/src/IntentSystem.Supervisor/Models/QueueItem.cs
+++ b/src/IntentSystem.Supervisor/Models/QueueItem.cs
@@ -1,3 +1,6 @@
+using System.Text.Json.Serialization;
+using IntentSystem.Supervisor.Serialization;
+
 namespace IntentSystem.Supervisor.Models;
 
 public sealed record QueueItem
@@ -18,6 +21,7 @@ public sealed record QueueItem
 
     public LinkedIssue? LinkedIssue { get; init; }
 
+    [JsonConverter(typeof(LinkedPrJsonConverter))]
     public string? LinkedPr { get; init; }
 
     public required string WorkerRole { get; init; }

--- a/src/IntentSystem.Supervisor/Serialization/LinkedPrJsonConverter.cs
+++ b/src/IntentSystem.Supervisor/Serialization/LinkedPrJsonConverter.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Supervisor.Serialization;
+
+/// <summary>
+/// Tolerates both legacy string-shaped and structured object-shaped <c>linked_pr</c>
+/// values in queue-state payloads. The structured form mirrors <c>linked_issue</c>
+/// (<c>{ repo, number, url }</c>); we extract the <c>url</c> field and keep the
+/// internal model as a <c>string?</c> so existing consumers continue to work.
+/// </summary>
+internal sealed class LinkedPrJsonConverter : JsonConverter<string?>
+{
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Null:
+                return null;
+
+            case JsonTokenType.String:
+                return reader.GetString();
+
+            case JsonTokenType.StartObject:
+                using (var document = JsonDocument.ParseValue(ref reader))
+                {
+                    if (!document.RootElement.TryGetProperty("url", out var urlElement))
+                    {
+                        return null;
+                    }
+
+                    return urlElement.ValueKind == JsonValueKind.Null ? null : urlElement.GetString();
+                }
+
+            default:
+                throw new JsonException(
+                    $"Unexpected token {reader.TokenType} when reading linked_pr; expected string, object, or null.");
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        writer.WriteStringValue(value);
+    }
+}

--- a/tests/IntentSystem.Supervisor.Tests/QueueStateSerializerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueStateSerializerTests.cs
@@ -241,4 +241,99 @@ public sealed class QueueStateSerializerTests
         Assert.Null(preIssueItem.LinkedIssue.Number);
         Assert.Null(preIssueItem.LinkedIssue.Url);
     }
+
+    [Fact]
+    public void Deserialize_GivenObjectShapedLinkedPr_TolerantlyExtractsUrl()
+    {
+        // G177: parent-host queue-state may carry rows whose linked_pr is the
+        // structured GitHub PR reference shape { repo, number, url } — same family
+        // of canonical shape as linked_issue. The deserialize boundary must accept
+        // both the legacy bare-string form and the structured object form so that
+        // run submit does not crash with JsonException at $.items[*].linked_pr.
+        var json = """
+        {
+          "schema_version": "1",
+          "updated_at": "2026-04-27T20:56:58Z",
+          "items": [
+            {
+              "execution_unit": "SKS-A1",
+              "title": "SKS-A1 Bootstrap Management Service Control Plane",
+              "state": "completed",
+              "dependencies": [],
+              "blocked_by": [],
+              "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+              "packet_paths": {
+                "implementation": ".intent-cli/issues/SKS-A1/implementation.md",
+                "review_context": ".intent-cli/issues/SKS-A1/review-context.md",
+                "yaml": ".intent-cli/issues/SKS-A1/packet.yaml"
+              },
+              "linked_issue": {
+                "repo": "J-Tech-Japan/SekibanAsAService",
+                "number": 85,
+                "url": "https://github.com/J-Tech-Japan/SekibanAsAService/issues/85"
+              },
+              "linked_pr": {
+                "repo": "J-Tech-Japan/SekibanAsAService",
+                "number": 86,
+                "url": "https://github.com/J-Tech-Japan/SekibanAsAService/pull/86"
+              },
+              "worker_role": "coder",
+              "review_role": "reviewer",
+              "priority": "high"
+            },
+            {
+              "execution_unit": "TOY-CALC-V0-11",
+              "title": "Legacy bare-string linked_pr",
+              "state": "completed",
+              "dependencies": [],
+              "blocked_by": [],
+              "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+              "packet_paths": {
+                "implementation": ".intent-cli/issues/TOY-CALC-V0-11/implementation.md",
+                "review_context": ".intent-cli/issues/TOY-CALC-V0-11/review-context.md",
+                "yaml": ".intent-cli/issues/TOY-CALC-V0-11/packet.yaml"
+              },
+              "linked_pr": "https://github.com/tomohisa/toy-calc-sample/pull/25",
+              "worker_role": "coder",
+              "review_role": "reviewer",
+              "priority": "high"
+            },
+            {
+              "execution_unit": "SKS-G54",
+              "title": "Pre-PR row with null linked_pr",
+              "state": "queued",
+              "dependencies": [],
+              "blocked_by": [],
+              "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+              "packet_paths": {
+                "implementation": ".intent-cli/issues/SKS-G54/implementation.md",
+                "review_context": ".intent-cli/issues/SKS-G54/review-context.md",
+                "yaml": ".intent-cli/issues/SKS-G54/packet.yaml"
+              },
+              "linked_pr": null,
+              "worker_role": "coder",
+              "review_role": "reviewer",
+              "priority": "high"
+            }
+          ]
+        }
+        """;
+
+        var queueState = QueueStateSerializer.Deserialize(json);
+
+        Assert.Equal(3, queueState.Items.Count);
+
+        var objectShapedItem = Assert.Single(queueState.Items, item => item.ExecutionUnit == "SKS-A1");
+        Assert.Equal(
+            "https://github.com/J-Tech-Japan/SekibanAsAService/pull/86",
+            objectShapedItem.LinkedPr);
+
+        var legacyStringItem = Assert.Single(queueState.Items, item => item.ExecutionUnit == "TOY-CALC-V0-11");
+        Assert.Equal(
+            "https://github.com/tomohisa/toy-calc-sample/pull/25",
+            legacyStringItem.LinkedPr);
+
+        var nullPrItem = Assert.Single(queueState.Items, item => item.ExecutionUnit == "SKS-G54");
+        Assert.Null(nullPrItem.LinkedPr);
+    }
 }


### PR DESCRIPTION
## Summary

- Tolerates object-shaped `linked_pr` (`{ repo, number, url }`) in queue-state JSON at the deserialize boundary, mirroring the family of canonical GitHub entity shapes used by `linked_issue` (G176 / #458).
- Adds `LinkedPrJsonConverter` accepting string, null, and object forms; wired in via `[JsonConverter]` on `QueueItem.LinkedPr` only.
- Keeps the in-memory `QueueItem.LinkedPr` as `string?` URL so existing consumers (`RunSubmitCommand`, `QueueManager`, `LatestLinkedPrResolver`, etc.) continue to work without ripple. Object form is unwrapped to its `url` member.
- Adds a focused regression test covering object-shaped, legacy bare-string, and null `linked_pr` in the same payload.

## Test plan

- [x] `dotnet test tests/IntentSystem.Supervisor.Tests/IntentSystem.Supervisor.Tests.csproj` — 50/50 passing including the new `Deserialize_GivenObjectShapedLinkedPr_TolerantlyExtractsUrl`.
- [x] Full repo `dotnet test` — 1196/1196 passing (no regressions in CLI / Review / Workflow / Clarify suites).
- [ ] Parent-host repro per issue Verification: `cd /Users/tomohisa/dev/GitHub/MyIntentHost && dotnet run --project submodules/intent-system/src/IntentSystem.Cli/IntentSystem.Cli.csproj -- run submit TOY-CALC-V0-11` no longer throws `System.Text.Json.JsonException` at `$.items[186].linked_pr`. (Recommend running on host after merge / submodule bump; the deserialize path that crashed is exactly what this PR repairs and is covered by the new regression test.)

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)
