### PR TITLE
G178 Tolerate pending queue-state values as queued

### DIFF
--- a/src/IntentSystem.Supervisor/Serialization/QueueItemStateJsonConverter.cs
+++ b/src/IntentSystem.Supervisor/Serialization/QueueItemStateJsonConverter.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Supervisor.Serialization;
+
+/// <summary>
+/// Reads <see cref="QueueItemState"/> as canonical kebab-case strings (matching the
+/// project-wide <c>JsonStringEnumConverter(JsonNamingPolicy.KebabCaseLower)</c>) plus
+/// recognized legacy compatibility aliases. Writes back the canonical kebab-case form.
+/// </summary>
+/// <remarks>
+/// G178: parent-host queue-state may persist <c>state: "pending"</c> as a legacy
+/// synonym for canonical <see cref="QueueItemState.Queued"/>. Tolerate it at the
+/// deserialize boundary so submit/seed/numbering pipelines do not crash on a
+/// row that was emitted by an older or external producer. Any unknown value
+/// outside the recognized canonical set + alias still surfaces a clear
+/// <see cref="JsonException"/>.
+/// </remarks>
+internal sealed class QueueItemStateJsonConverter : JsonConverter<QueueItemState>
+{
+    public override QueueItemState Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException(
+                $"Unexpected token {reader.TokenType} when reading queue item state; expected string.");
+        }
+
+        var raw = reader.GetString();
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            throw new JsonException("Queue item state value was null or empty.");
+        }
+
+        if (string.Equals(raw, "pending", StringComparison.OrdinalIgnoreCase))
+        {
+            return QueueItemState.Queued;
+        }
+
+        return raw switch
+        {
+            "queued" => QueueItemState.Queued,
+            "active" => QueueItemState.Active,
+            "review" => QueueItemState.Review,
+            "fixing" => QueueItemState.Fixing,
+            "clarify-blocked" => QueueItemState.ClarifyBlocked,
+            "blocked" => QueueItemState.Blocked,
+            "completed" => QueueItemState.Completed,
+            _ => throw new JsonException(
+                $"Unrecognized queue item state value '{raw}'.")
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, QueueItemState value, JsonSerializerOptions options)
+    {
+        var canonical = value switch
+        {
+            QueueItemState.Queued => "queued",
+            QueueItemState.Active => "active",
+            QueueItemState.Review => "review",
+            QueueItemState.Fixing => "fixing",
+            QueueItemState.ClarifyBlocked => "clarify-blocked",
+            QueueItemState.Blocked => "blocked",
+            QueueItemState.Completed => "completed",
+            _ => throw new JsonException(
+                $"Unrecognized queue item state value '{value}'.")
+        };
+
+        writer.WriteStringValue(canonical);
+    }
+}

--- a/src/IntentSystem.Supervisor/Serialization/SupervisorJsonOptions.cs
+++ b/src/IntentSystem.Supervisor/Serialization/SupervisorJsonOptions.cs
@@ -18,6 +18,7 @@ internal static class SupervisorJsonOptions
             WriteIndented = writeIndented
         };
 
+        options.Converters.Add(new QueueItemStateJsonConverter());
         options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.KebabCaseLower));
 
         return options;

--- a/tests/IntentSystem.Supervisor.Tests/QueueStateSerializerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueStateSerializerTests.cs
@@ -336,4 +336,87 @@ public sealed class QueueStateSerializerTests
         var nullPrItem = Assert.Single(queueState.Items, item => item.ExecutionUnit == "SKS-G54");
         Assert.Null(nullPrItem.LinkedPr);
     }
+
+    [Fact]
+    public void Deserialize_GivenLegacyPendingState_TolerantlyMapsToQueued()
+    {
+        // G178: parent-host queue-state may persist `state: "pending"` as a legacy
+        // synonym for canonical `Queued`. The deserialize boundary must accept it
+        // and normalize to QueueItemState.Queued so submit/seed/numbering pipelines
+        // do not crash with JsonException at $.items[*].state.
+        var json = """
+        {
+          "schema_version": "1",
+          "updated_at": "2026-04-28T04:44:00Z",
+          "items": [
+            {
+              "execution_unit": "SKS-G87",
+              "title": "SKS-G87 Cross-Surface Consistency Repair Proposal Read-Only Baseline",
+              "state": "pending",
+              "dependencies": [],
+              "blocked_by": [],
+              "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+              "packet_paths": {
+                "implementation": ".intent-cli/issues/SKS-G87/implementation.md",
+                "review_context": ".intent-cli/issues/SKS-G87/review-context.md",
+                "yaml": ".intent-cli/issues/SKS-G87/packet.yaml"
+              },
+              "linked_issue": {
+                "repo": "J-Tech-Japan/SekibanAsAService",
+                "number": 292,
+                "url": "https://github.com/J-Tech-Japan/SekibanAsAService/issues/292"
+              },
+              "linked_pr": null,
+              "worker_role": "coder",
+              "review_role": "reviewer",
+              "priority": "high"
+            }
+          ]
+        }
+        """;
+
+        var queueState = QueueStateSerializer.Deserialize(json);
+
+        var item = Assert.Single(queueState.Items);
+        Assert.Equal(QueueItemState.Queued, item.State);
+    }
+
+    [Fact]
+    public void Serialize_GivenQueuedState_EmitsCanonicalQueuedNotPending()
+    {
+        // G178: the legacy `pending` alias is read-only tolerance. On the way out
+        // we always emit the canonical `queued` form so the parent-host queue-state
+        // converges on the canonical schema as it gets rewritten.
+        var queueState = new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-28T04:44:00Z"),
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = "SKS-G87",
+                    Title = "Round-trip canonicalization",
+                    State = QueueItemState.Queued,
+                    Dependencies = [],
+                    BlockedBy = [],
+                    ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/SKS-G87/implementation.md",
+                        ReviewContext = ".intent-cli/issues/SKS-G87/review-context.md",
+                        Yaml = ".intent-cli/issues/SKS-G87/packet.yaml"
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "high"
+                }
+            ]
+        };
+
+        var serialized = QueueStateSerializer.Serialize(queueState);
+
+        Assert.Contains("\"state\": \"queued\"", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"pending\"", serialized, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
## Summary

- Tolerates the legacy `state: "pending"` value at the queue-state deserialize boundary by mapping it to canonical `QueueItemState.Queued`, mirroring the family of compatibility shims already added for `linked_issue` (G176 / #458) and `linked_pr` (G177 / #460).
- Adds `QueueItemStateJsonConverter` accepting the canonical kebab-case set (`queued`, `active`, `review`, `fixing`, `clarify-blocked`, `blocked`, `completed`) plus the legacy `"pending"` alias. Unknown values still surface a clear `JsonException`.
- Wires the converter into `SupervisorJsonOptions` ahead of the existing `JsonStringEnumConverter` so it takes precedence for `QueueItemState` only; other enums continue to use the project-wide kebab-case strategy.
- On the way out we always emit canonical `"queued"` so the parent-host queue-state converges on the canonical schema as it gets rewritten — no new first-class `Pending` state was introduced (per Out of Scope).

## Test plan

- [x] `dotnet test tests/IntentSystem.Supervisor.Tests/IntentSystem.Supervisor.Tests.csproj` — 52/52 passing including the new `Deserialize_GivenLegacyPendingState_TolerantlyMapsToQueued` and `Serialize_GivenQueuedState_EmitsCanonicalQueuedNotPending`.
- [x] Full repo `dotnet test` — 1029/1029 passing across all suites (Supervisor / CLI / Review / Workflow / Clarify / Projection / DomainBinding / WorkerAdapter / DogfoodingBridge / ConceptIntake / Drift). No regressions.
- [ ] Parent-host repro per issue Verification: `cd /Users/tomohisa/dev/GitHub/MyIntentHost && dotnet run --project submodules/intent-system/src/IntentSystem.Cli/IntentSystem.Cli.csproj -- run submit TOY-CALC-V0-11` no longer throws `System.Text.Json.JsonException` at `$.items[288].state`. (Recommend running on host after merge / submodule bump; the deserialize path that crashed is exactly what this PR repairs and is covered by the new regression test.)

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
