### PR TITLE
G179 Add intent status brief for AI-thread tasking

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -16,7 +16,8 @@ internal static class CommandRouter
         "review",
         "interview",
         "clarify",
-        "intake"
+        "intake",
+        "status"
     ];
 
     private static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, CommandHandler>> ImplementedCommands =
@@ -91,6 +92,10 @@ internal static class CommandRouter
                 ["intent-comment"] = BugIntentCommentCommand.Execute,
                 ["implementation-repair"] = BugImplementationRepairCommand.Execute,
                 ["implementation-issue"] = BugImplementationIssueCommand.Execute
+            },
+            ["status"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["brief"] = StatusBriefCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/StatusBriefAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/StatusBriefAnalyzer.cs
@@ -87,13 +87,10 @@ internal static class StatusBriefAnalyzer
 
         var clarificationPath = ResolveClarificationPath(context, domain);
         var clarificationOpen = false;
-        if (clarificationPath is not null)
+        if (clarificationPath is not null && File.Exists(clarificationPath))
         {
-            if (File.Exists(clarificationPath))
-            {
-                var content = File.ReadAllText(clarificationPath);
-                clarificationOpen = !string.IsNullOrWhiteSpace(content);
-            }
+            var content = File.ReadAllText(clarificationPath);
+            clarificationOpen = HasOpenBlocker(content);
         }
 
         var recentEvents = LoadRecentEvents(context, notes);
@@ -141,6 +138,93 @@ internal static class StatusBriefAnalyzer
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Parent-host clarification files (<c>intents/&lt;domain&gt;/clarifications/open.md</c>)
+    /// are durable markdown artifacts that remain non-empty even when there is
+    /// no root blocker. The host shape places live blockers as list items under a
+    /// "## Current Open Blockers" heading, with an explicit no-blocker sentinel
+    /// list item when nothing is currently blocking. Detect open blockers
+    /// structurally so that a no-blocker file does not falsely force the
+    /// <c>clarification-required</c> recommendation (G179 review fix).
+    /// </summary>
+    /// <remarks>
+    /// Conservative behaviour: if no <c>## Current Open Blockers</c> section is
+    /// present, treat the file as having no open blocker. The caller already
+    /// records degraded notes for missing files; the AI tasking thread can still
+    /// inspect manually if it suspects the file shape has drifted.
+    /// </remarks>
+    private static bool HasOpenBlocker(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return false;
+        }
+
+        var lines = content.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var inBlockerSection = false;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd();
+
+            if (line.StartsWith("## ", StringComparison.Ordinal))
+            {
+                var heading = line[3..].Trim();
+                inBlockerSection = string.Equals(
+                    heading,
+                    "Current Open Blockers",
+                    StringComparison.OrdinalIgnoreCase);
+                continue;
+            }
+
+            if (!inBlockerSection)
+            {
+                continue;
+            }
+
+            var trimmed = line.TrimStart();
+            if (!trimmed.StartsWith("- ", StringComparison.Ordinal)
+                && !trimmed.StartsWith("* ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var item = trimmed[2..].Trim();
+            if (item.Length == 0)
+            {
+                continue;
+            }
+
+            if (IsNoBlockerSentinel(item))
+            {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsNoBlockerSentinel(string item)
+    {
+        // Host-established no-blocker sentinel (Japanese). Match on the substring
+        // so any minor surrounding wording (e.g. trailing punctuation, links) is
+        // still treated as a non-actionable entry.
+        const string japaneseSentinel = "現時点で child issue cut を要する root blocker はない";
+        if (item.Contains(japaneseSentinel, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // Defensive English fallback for any future host that uses a parallel
+        // English wording. Kept narrow on purpose so unrelated bullets do not
+        // accidentally suppress real blockers.
+        return item.Contains(
+            "no root blocker requiring child issue cut",
+            StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? ResolveClarificationPath(CliContext context, string domain)

--- a/src/IntentSystem.Cli/Commands/StatusBriefAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/StatusBriefAnalyzer.cs
@@ -1,0 +1,232 @@
+using System.Text.Json;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Read-only state collector that turns local intent-cli files into a
+/// <see cref="StatusBriefSummary"/> for the AI tasking thread (G179).
+/// Never mutates queue state, runs, GitHub, or source files.
+/// </summary>
+internal static class StatusBriefAnalyzer
+{
+    private const int RecentEventLimit = 3;
+
+    public static StatusBriefSummary Analyze(CliContext context, string? domainOverride)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride;
+
+        var notes = new List<string>();
+        var queueStatePath = context.GetQueueStatePath();
+        var queueStatePresent = File.Exists(queueStatePath);
+        var queueStateReadable = false;
+        QueueState? queueState = null;
+
+        if (queueStatePresent)
+        {
+            try
+            {
+                queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+                queueStateReadable = true;
+            }
+            catch (JsonException jsonException)
+            {
+                notes.Add($"queue-state JSON could not be parsed: {jsonException.Message}");
+            }
+            catch (InvalidOperationException invalidOperation)
+            {
+                notes.Add($"queue-state payload was invalid: {invalidOperation.Message}");
+            }
+        }
+        else
+        {
+            notes.Add($"no queue-state file at {queueStatePath}");
+        }
+
+        var inFlight = new List<string>();
+        var reviewUnits = new List<string>();
+        string? nextCandidate = null;
+
+        if (queueState is not null)
+        {
+            var completed = new HashSet<string>(
+                queueState.Items
+                    .Where(item => item.State == QueueItemState.Completed)
+                    .Select(item => item.ExecutionUnit),
+                StringComparer.Ordinal);
+
+            foreach (var item in queueState.Items)
+            {
+                switch (item.State)
+                {
+                    case QueueItemState.Review:
+                        reviewUnits.Add(item.ExecutionUnit);
+                        inFlight.Add(item.ExecutionUnit);
+                        break;
+                    case QueueItemState.Active:
+                    case QueueItemState.Fixing:
+                        inFlight.Add(item.ExecutionUnit);
+                        break;
+                }
+            }
+
+            // Deterministic next candidate: first Queued item whose dependencies
+            // are all satisfied within the local queue. We keep queue-state's
+            // declared ordering — no priority sort — so the brief is stable.
+            nextCandidate = queueState.Items
+                .Where(item => item.State == QueueItemState.Queued)
+                .Where(item => DependenciesSatisfied(item, completed))
+                .Select(item => item.ExecutionUnit)
+                .FirstOrDefault();
+        }
+
+        var clarificationPath = ResolveClarificationPath(context, domain);
+        var clarificationOpen = false;
+        if (clarificationPath is not null)
+        {
+            if (File.Exists(clarificationPath))
+            {
+                var content = File.ReadAllText(clarificationPath);
+                clarificationOpen = !string.IsNullOrWhiteSpace(content);
+            }
+        }
+
+        var recentEvents = LoadRecentEvents(context, notes);
+
+        var wipPresent = inFlight.Count > 0;
+        var recommended = ComputeRecommendation(
+            queueStatePresent,
+            queueStateReadable,
+            clarificationOpen,
+            reviewUnits.Count > 0,
+            wipPresent,
+            nextCandidate is not null);
+
+        return new StatusBriefSummary
+        {
+            Domain = domain,
+            QueueStatePath = queueStatePath,
+            QueueStatePresent = queueStatePresent,
+            QueueStateReadable = queueStateReadable,
+            InFlightUnits = inFlight,
+            ReviewUnits = reviewUnits,
+            WipPresent = wipPresent,
+            ClarificationOpenPath = clarificationPath,
+            ClarificationOpen = clarificationOpen,
+            NextCandidate = nextCandidate,
+            RecentEvents = recentEvents,
+            RecommendedAction = recommended,
+            Notes = notes
+        };
+    }
+
+    private static bool DependenciesSatisfied(QueueItem item, HashSet<string> completed)
+    {
+        if (item.Dependencies.Count == 0)
+        {
+            return true;
+        }
+
+        foreach (var dependency in item.Dependencies)
+        {
+            if (!completed.Contains(dependency))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string? ResolveClarificationPath(CliContext context, string domain)
+    {
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            return null;
+        }
+
+        var parentRoot = context.ResolveParentIntentRepoRootPath();
+        var baseRoot = string.IsNullOrWhiteSpace(parentRoot)
+            ? context.RepoRoot
+            : parentRoot;
+
+        return Path.Combine(baseRoot!, "intents", domain, "clarifications", "open.md");
+    }
+
+    private static IReadOnlyList<StatusBriefRecentEvent> LoadRecentEvents(
+        CliContext context,
+        List<string> notes)
+    {
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            return [];
+        }
+
+        try
+        {
+            var content = File.ReadAllText(runLogPath);
+            var events = RunLogSerializer.DeserializeAll(content);
+            return events
+                .TakeLast(RecentEventLimit)
+                .Select(runEvent => new StatusBriefRecentEvent
+                {
+                    Timestamp = runEvent.Ts.ToString("O"),
+                    ExecutionUnit = runEvent.ExecutionUnit,
+                    Event = runEvent.Event,
+                    By = runEvent.By
+                })
+                .ToArray();
+        }
+        catch (Exception exception) when (
+            exception is JsonException
+            or InvalidOperationException
+            or FormatException)
+        {
+            notes.Add($"runs.jsonl could not be parsed: {exception.Message}");
+            return [];
+        }
+    }
+
+    private static string ComputeRecommendation(
+        bool queueStatePresent,
+        bool queueStateReadable,
+        bool clarificationOpen,
+        bool reviewPresent,
+        bool wipPresent,
+        bool hasNextCandidate)
+    {
+        // Deterministic precedence — top-most match wins.
+        if (queueStatePresent && !queueStateReadable)
+        {
+            return StatusBriefRecommendation.InspectManually;
+        }
+
+        if (clarificationOpen)
+        {
+            return StatusBriefRecommendation.ClarificationRequired;
+        }
+
+        if (reviewPresent)
+        {
+            return StatusBriefRecommendation.ReviewCloseout;
+        }
+
+        if (wipPresent)
+        {
+            return StatusBriefRecommendation.SkipDueToWip;
+        }
+
+        if (hasNextCandidate)
+        {
+            return StatusBriefRecommendation.IssueCutReady;
+        }
+
+        return StatusBriefRecommendation.NoActionableItem;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/StatusBriefCommand.cs
+++ b/src/IntentSystem.Cli/Commands/StatusBriefCommand.cs
@@ -1,0 +1,93 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G179: Read-only <c>intent-cli status brief</c> command. Emits a compact,
+/// AI-thread-friendly snapshot of the current intent workspace so the human-operated
+/// Codex / Claude tasking thread can decide its next move without launching nested
+/// AI processes. Never mutates state.
+/// </summary>
+internal static class StatusBriefCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var domainOverride, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var summary = StatusBriefAnalyzer.Analyze(context, domainOverride);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            StatusBriefRenderer.WriteJson(writer, summary);
+        }
+        else
+        {
+            StatusBriefRenderer.WriteText(writer, summary);
+        }
+
+        return 0;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? domainOverride,
+        out string format,
+        out string error)
+    {
+        domainOverride = null;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --domain <name> --format text|json.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/StatusBriefRecommendation.cs
+++ b/src/IntentSystem.Cli/Commands/StatusBriefRecommendation.cs
@@ -1,0 +1,15 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Allowed recommended next operator actions for <c>status brief</c>.
+/// G179: deterministic single-string output the AI tasking thread can switch on.
+/// </summary>
+internal static class StatusBriefRecommendation
+{
+    public const string ReviewCloseout = "review-closeout";
+    public const string ClarificationRequired = "clarification-required";
+    public const string IssueCutReady = "issue-cut-ready";
+    public const string SkipDueToWip = "skip-due-to-wip";
+    public const string NoActionableItem = "no-actionable-item";
+    public const string InspectManually = "inspect-manually";
+}

--- a/src/IntentSystem.Cli/Commands/StatusBriefRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/StatusBriefRenderer.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Output renderer for the read-only <c>status brief</c> command (G179).
+/// </summary>
+internal static class StatusBriefRenderer
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    public static void WriteText(TextWriter writer, StatusBriefSummary summary)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(summary);
+
+        writer.WriteLine($"Domain: {summary.Domain}");
+        writer.WriteLine(
+            $"Queue state: {(summary.QueueStatePresent ? (summary.QueueStateReadable ? "present" : "present-unreadable") : "missing")}"
+            + $" ({summary.QueueStatePath})");
+        writer.WriteLine($"In-flight units: {FormatList(summary.InFlightUnits)}");
+        writer.WriteLine($"Review units: {FormatList(summary.ReviewUnits)}");
+        writer.WriteLine($"WIP present: {(summary.WipPresent ? "yes" : "no")}");
+        writer.WriteLine($"Clarification open: {(summary.ClarificationOpen ? "yes" : "no")}"
+            + (summary.ClarificationOpenPath is null ? string.Empty : $" ({summary.ClarificationOpenPath})"));
+        writer.WriteLine($"Next candidate: {summary.NextCandidate ?? "-"}");
+
+        writer.WriteLine("Recent events:");
+        if (summary.RecentEvents.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var recentEvent in summary.RecentEvents)
+            {
+                writer.WriteLine(
+                    $"- {recentEvent.Timestamp} {recentEvent.ExecutionUnit} {recentEvent.Event} by={recentEvent.By}");
+            }
+        }
+
+        writer.WriteLine($"Recommended action: {summary.RecommendedAction}");
+
+        if (summary.Notes.Count > 0)
+        {
+            writer.WriteLine("Notes:");
+            foreach (var note in summary.Notes)
+            {
+                writer.WriteLine($"- {note}");
+            }
+        }
+    }
+
+    public static void WriteJson(TextWriter writer, StatusBriefSummary summary)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(summary);
+
+        writer.WriteLine(JsonSerializer.Serialize(summary, JsonOptions));
+    }
+
+    private static string FormatList(IReadOnlyList<string> values)
+    {
+        return values.Count == 0
+            ? "-"
+            : string.Join(", ", values);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/StatusBriefSummary.cs
+++ b/src/IntentSystem.Cli/Commands/StatusBriefSummary.cs
@@ -1,0 +1,64 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Compact, AI-thread-friendly read-only snapshot produced by <c>intent-cli status brief</c>.
+/// Field names are stable and snake_case-serialized for JSON ingestion (G179).
+/// </summary>
+internal sealed record StatusBriefSummary
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("queue_state_path")]
+    public required string QueueStatePath { get; init; }
+
+    [JsonPropertyName("queue_state_present")]
+    public required bool QueueStatePresent { get; init; }
+
+    [JsonPropertyName("queue_state_readable")]
+    public required bool QueueStateReadable { get; init; }
+
+    [JsonPropertyName("in_flight_units")]
+    public required IReadOnlyList<string> InFlightUnits { get; init; }
+
+    [JsonPropertyName("review_units")]
+    public required IReadOnlyList<string> ReviewUnits { get; init; }
+
+    [JsonPropertyName("wip_present")]
+    public required bool WipPresent { get; init; }
+
+    [JsonPropertyName("clarification_open_path")]
+    public string? ClarificationOpenPath { get; init; }
+
+    [JsonPropertyName("clarification_open")]
+    public required bool ClarificationOpen { get; init; }
+
+    [JsonPropertyName("next_candidate")]
+    public string? NextCandidate { get; init; }
+
+    [JsonPropertyName("recent_events")]
+    public required IReadOnlyList<StatusBriefRecentEvent> RecentEvents { get; init; }
+
+    [JsonPropertyName("recommended_action")]
+    public required string RecommendedAction { get; init; }
+
+    [JsonPropertyName("notes")]
+    public required IReadOnlyList<string> Notes { get; init; }
+}
+
+internal sealed record StatusBriefRecentEvent
+{
+    [JsonPropertyName("ts")]
+    public required string Timestamp { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("event")]
+    public required string Event { get; init; }
+
+    [JsonPropertyName("by")]
+    public required string By { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/StatusBriefCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/StatusBriefCommandTests.cs
@@ -1,0 +1,310 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class StatusBriefCommandTests
+{
+    [Fact]
+    public void Execute_GivenNoQueueStateAndNoClarification_RecommendsNoActionableItem()
+    {
+        // Scenario 1 of the four-required cases (G179): nothing to do, no actionable item.
+        using var workspace = new StatusBriefWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = StatusBriefCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains($"Recommended action: {StatusBriefRecommendation.NoActionableItem}", output, StringComparison.Ordinal);
+        Assert.Contains("In-flight units: -", output, StringComparison.Ordinal);
+        Assert.Contains("Clarification open: no", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenActiveQueueItem_RecommendsSkipDueToWip()
+    {
+        // Scenario 2: WIP present (Active), no review, no clarification.
+        using var workspace = new StatusBriefWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G180",
+                  "title": "context collect command",
+                  "state": "active",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {
+                    "implementation": ".intent-cli/issues/G180/implementation.md",
+                    "review_context": ".intent-cli/issues/G180/review-context.md",
+                    "yaml": ".intent-cli/issues/G180/packet.yaml"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = StatusBriefCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains($"Recommended action: {StatusBriefRecommendation.SkipDueToWip}", output, StringComparison.Ordinal);
+        Assert.Contains("In-flight units: G180", output, StringComparison.Ordinal);
+        Assert.Contains("WIP present: yes", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenOpenClarificationFile_RecommendsClarificationRequiredOverEverythingElse()
+    {
+        // Scenario 3: clarification blocker present. Even with WIP and a queued candidate
+        // present, clarification-required wins (HARD CLARIFICATION precedence).
+        using var workspace = new StatusBriefWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G181",
+                  "title": "clarify draft command",
+                  "state": "active",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {
+                    "implementation": ".intent-cli/issues/G181/implementation.md",
+                    "review_context": ".intent-cli/issues/G181/review-context.md",
+                    "yaml": ".intent-cli/issues/G181/packet.yaml"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                },
+                {
+                  "execution_unit": "G182",
+                  "title": "clarify record command",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {
+                    "implementation": ".intent-cli/issues/G182/implementation.md",
+                    "review_context": ".intent-cli/issues/G182/review-context.md",
+                    "yaml": ".intent-cli/issues/G182/packet.yaml"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                }
+              ]
+            }
+            """);
+        workspace.WriteClarificationOpen("# Open\n\n- Should we use plain text format by default?\n");
+
+        using var writer = new StringWriter();
+        var exitCode = StatusBriefCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+        Assert.Equal(
+            StatusBriefRecommendation.ClarificationRequired,
+            root.GetProperty("recommended_action").GetString());
+        Assert.True(root.GetProperty("clarification_open").GetBoolean());
+        Assert.True(root.GetProperty("wip_present").GetBoolean());
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedQueueState_RecommendsInspectManuallyAndDoesNotThrow()
+    {
+        // Scenario 4: degraded state — queue-state.json exists but cannot be parsed.
+        // Must not throw; must return a deterministic inspect-manually fallback.
+        using var workspace = new StatusBriefWorkspace();
+        workspace.WriteQueueState("{ this is not valid json at all");
+
+        using var writer = new StringWriter();
+        var exitCode = StatusBriefCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains($"Recommended action: {StatusBriefRecommendation.InspectManually}", output, StringComparison.Ordinal);
+        Assert.Contains("Queue state: present-unreadable", output, StringComparison.Ordinal);
+        Assert.Contains("Notes:", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenReviewItem_RecommendsReviewCloseout()
+    {
+        using var workspace = new StatusBriefWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G179",
+                  "title": "status brief",
+                  "state": "review",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {
+                    "implementation": ".intent-cli/issues/G179/implementation.md",
+                    "review_context": ".intent-cli/issues/G179/review-context.md",
+                    "yaml": ".intent-cli/issues/G179/packet.yaml"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = StatusBriefCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains($"Recommended action: {StatusBriefRecommendation.ReviewCloseout}", output, StringComparison.Ordinal);
+        Assert.Contains("Review units: G179", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenQueuedItemAndNoBlockers_RecommendsIssueCutReady()
+    {
+        using var workspace = new StatusBriefWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G180",
+                  "title": "context collect",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {
+                    "implementation": ".intent-cli/issues/G180/implementation.md",
+                    "review_context": ".intent-cli/issues/G180/review-context.md",
+                    "yaml": ".intent-cli/issues/G180/packet.yaml"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = StatusBriefCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains($"Recommended action: {StatusBriefRecommendation.IssueCutReady}", output, StringComparison.Ordinal);
+        Assert.Contains("Next candidate: G180", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormatRequest_EmitsParsableJsonWithStableFieldNames()
+    {
+        using var workspace = new StatusBriefWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = StatusBriefCommand.Execute(
+            workspace.Context,
+            ["--format", "json", "--domain", "custom-domain"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("custom-domain", root.GetProperty("domain").GetString());
+        Assert.False(root.GetProperty("queue_state_present").GetBoolean());
+        Assert.False(root.GetProperty("queue_state_readable").GetBoolean());
+        Assert.False(root.GetProperty("wip_present").GetBoolean());
+        Assert.Equal(
+            StatusBriefRecommendation.NoActionableItem,
+            root.GetProperty("recommended_action").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsErrorExitCodeAndMessage()
+    {
+        using var workspace = new StatusBriefWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = StatusBriefCommand.Execute(workspace.Context, ["--bogus"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private sealed class StatusBriefWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("status-brief-tests-")
+            .FullName;
+
+        public StatusBriefWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public void WriteQueueState(string content)
+        {
+            File.WriteAllText(Context.GetQueueStatePath(), content);
+        }
+
+        public void WriteClarificationOpen(string content)
+        {
+            var path = Path.Combine(rootPath, "intents", "intent-cli", "clarifications");
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "open.md"), content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/StatusBriefCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/StatusBriefCommandTests.cs
@@ -111,7 +111,17 @@ public sealed class StatusBriefCommandTests
               ]
             }
             """);
-        workspace.WriteClarificationOpen("# Open\n\n- Should we use plain text format by default?\n");
+        workspace.WriteClarificationOpen(
+            """
+            # intent-cli clarifications
+
+            Some durable prose that should not by itself force the brief to
+            report a clarification.
+
+            ## Current Open Blockers
+
+            - Should we use plain text format by default for `status brief`?
+            """);
 
         using var writer = new StringWriter();
         var exitCode = StatusBriefCommand.Execute(
@@ -225,6 +235,103 @@ public sealed class StatusBriefCommandTests
         var output = writer.ToString();
         Assert.Contains($"Recommended action: {StatusBriefRecommendation.IssueCutReady}", output, StringComparison.Ordinal);
         Assert.Contains("Next candidate: G180", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenRealisticNoBlockerClarificationFile_DoesNotForceClarificationRequired()
+    {
+        // Review fix for G179: parent-host `intents/<domain>/clarifications/open.md` is a
+        // durable markdown artifact and remains non-empty even when there is no root
+        // blocker. The brief must parse the structured "Current Open Blockers" section
+        // and treat the explicit no-blocker sentinel as not-open, so review/WIP/issue-cut
+        // recommendations are not masked by `clarification-required`.
+        using var workspace = new StatusBriefWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G180",
+                  "title": "context collect",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {
+                    "implementation": ".intent-cli/issues/G180/implementation.md",
+                    "review_context": ".intent-cli/issues/G180/review-context.md",
+                    "yaml": ".intent-cli/issues/G180/packet.yaml"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                }
+              ]
+            }
+            """);
+        workspace.WriteClarificationOpen(
+            """
+            # intent-cli clarifications
+
+            このファイルは durable な markdown artifact として残し続けるため、本文が
+            空になることはない。clarification-required を出すのは「現時点で実際に
+            blocker が立っているとき」だけにする。
+
+            ## Recently Resolved
+
+            - G178 pending alias を queued に正規化する方針で確定。
+
+            ## Current Open Blockers
+
+            - 現時点で child issue cut を要する root blocker はない。
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = StatusBriefCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("clarification_open").GetBoolean());
+        Assert.NotEqual(
+            StatusBriefRecommendation.ClarificationRequired,
+            root.GetProperty("recommended_action").GetString());
+        // With no WIP / no review and a deps-satisfied queued item, the next
+        // recommendation should fall through to issue-cut-ready.
+        Assert.Equal(
+            StatusBriefRecommendation.IssueCutReady,
+            root.GetProperty("recommended_action").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationFileWithoutCurrentOpenBlockersHeading_DoesNotMarkClarificationOpen()
+    {
+        // Defensive: a clarifications/open.md that contains only prose (no
+        // structured "## Current Open Blockers" heading) should not be misread
+        // as an open blocker.
+        using var workspace = new StatusBriefWorkspace();
+        workspace.WriteClarificationOpen(
+            """
+            # intent-cli clarifications
+
+            参考メモ。実際の blocker 一覧は別ドキュメントで管理している想定の
+            導入文だけのファイル。
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = StatusBriefCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.False(document.RootElement.GetProperty("clarification_open").GetBoolean());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Adds a read-only `intent-cli status brief [--domain <name>] [--format text|json]` command that gives the high-context Codex / Claude tasking thread a deterministic snapshot of the current intent workspace without launching nested AI processes.
- The brief reports: domain, queue-state presence/readability, in-flight units, review units, WIP-cap signal, clarification blocker (read from `intents/<domain>/clarifications/open.md`, resolved against parent intent repo root when configured), next deterministic candidate, last 3 events from `runs.jsonl`, and a single `recommended_action` from a stable closed set.
- Recommendation precedence (top-most match wins): unreadable queue-state → `inspect-manually`; open clarification → `clarification-required`; any Review item → `review-closeout`; any Active/Fixing → `skip-due-to-wip`; deps-satisfied Queued item → `issue-cut-ready`; otherwise → `no-actionable-item`.
- Read-only: never mutates queue-state, runs, GitHub issues/PRs/labels, or source files. Missing optional files produce a degraded summary instead of throwing. JSON output uses stable snake_case field names for AI-thread ingestion.
- Wires a new `status` command group into `CommandRouter` alongside the existing groups.

## Test plan

- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~StatusBrief` — 8/8 passing including the four required scenarios (no actionable items, WIP present, clarification blocker, malformed queue-state).
- [x] Full repo `dotnet test` — 1206/1206 passing across all suites (CLI: 908 → 916 = +8 new tests; no regressions in Supervisor / Review / Workflow / Clarify / Projection / DomainBinding / WorkerAdapter / DogfoodingBridge / ConceptIntake / Drift).
- [ ] Manual smoke per issue Verification (recommended after merge / submodule bump in parent host):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- status brief --domain intent-cli`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- status brief --domain intent-cli --format json`

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)
