### PR TITLE
G180 Add context collect command for AI-thread packets

### DIFF
--- a/src/IntentSystem.Cli/Commands/ClarificationOpenDetector.cs
+++ b/src/IntentSystem.Cli/Commands/ClarificationOpenDetector.cs
@@ -1,0 +1,85 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Shared structural parser for parent-host
+/// <c>intents/&lt;domain&gt;/clarifications/open.md</c> files. The host shape places
+/// live blockers as list items under a <c>## Current Open Blockers</c> heading,
+/// with an explicit no-blocker sentinel list item when nothing is currently
+/// blocking. Detect open blockers structurally so durable prose / recently-resolved
+/// notes do not falsely look like an open blocker (G179 review fix; reused by
+/// G180 context collect).
+/// </summary>
+internal static class ClarificationOpenDetector
+{
+    public static bool HasOpenBlocker(string? content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return false;
+        }
+
+        var lines = content!.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var inBlockerSection = false;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd();
+
+            if (line.StartsWith("## ", StringComparison.Ordinal))
+            {
+                var heading = line[3..].Trim();
+                inBlockerSection = string.Equals(
+                    heading,
+                    "Current Open Blockers",
+                    StringComparison.OrdinalIgnoreCase);
+                continue;
+            }
+
+            if (!inBlockerSection)
+            {
+                continue;
+            }
+
+            var trimmed = line.TrimStart();
+            if (!trimmed.StartsWith("- ", StringComparison.Ordinal)
+                && !trimmed.StartsWith("* ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var item = trimmed[2..].Trim();
+            if (item.Length == 0)
+            {
+                continue;
+            }
+
+            if (IsNoBlockerSentinel(item))
+            {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsNoBlockerSentinel(string item)
+    {
+        // Host-established no-blocker sentinel (Japanese). Match on the substring
+        // so any minor surrounding wording (e.g. trailing punctuation, links) is
+        // still treated as a non-actionable entry.
+        const string japaneseSentinel = "現時点で child issue cut を要する root blocker はない";
+        if (item.Contains(japaneseSentinel, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // Defensive English fallback for any future host that uses a parallel
+        // English wording. Kept narrow on purpose so unrelated bullets do not
+        // accidentally suppress real blockers.
+        return item.Contains(
+            "no root blocker requiring child issue cut",
+            StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -17,7 +17,8 @@ internal static class CommandRouter
         "interview",
         "clarify",
         "intake",
-        "status"
+        "status",
+        "context"
     ];
 
     private static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, CommandHandler>> ImplementedCommands =
@@ -96,6 +97,10 @@ internal static class CommandRouter
             ["status"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["brief"] = StatusBriefCommand.Execute
+            },
+            ["context"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["collect"] = ContextCollectCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/ContextCollectAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectAnalyzer.cs
@@ -5,15 +5,17 @@ using IntentSystem.Supervisor.Serialization;
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// Read-only state collector that turns local intent-cli files into a
-/// <see cref="StatusBriefSummary"/> for the AI tasking thread (G179).
-/// Never mutates queue state, runs, GitHub, or source files.
+/// Read-only state collector that turns local intent-cli files plus parent-host
+/// domain artifacts into a <see cref="ContextCollectPacket"/> for the AI tasking
+/// thread (G180). Never mutates queue state, runs, packet files, source files,
+/// or GitHub.
 /// </summary>
-internal static class StatusBriefAnalyzer
+internal static class ContextCollectAnalyzer
 {
-    private const int RecentEventLimit = 3;
+    private const int RecentEventLimit = 5;
+    private const int MarkdownExcerptCharLimit = 1500;
 
-    public static StatusBriefSummary Analyze(CliContext context, string? domainOverride)
+    public static ContextCollectPacket Analyze(CliContext context, string? domainOverride)
     {
         ArgumentNullException.ThrowIfNull(context);
 
@@ -22,6 +24,7 @@ internal static class StatusBriefAnalyzer
             : domainOverride;
 
         var notes = new List<string>();
+
         var queueStatePath = context.GetQueueStatePath();
         var queueStatePresent = File.Exists(queueStatePath);
         var queueStateReadable = false;
@@ -51,6 +54,7 @@ internal static class StatusBriefAnalyzer
         var inFlight = new List<string>();
         var reviewUnits = new List<string>();
         string? nextCandidate = null;
+        QueueItem? focusItem = null;
 
         if (queueState is not null)
         {
@@ -60,6 +64,9 @@ internal static class StatusBriefAnalyzer
                     .Select(item => item.ExecutionUnit),
                 StringComparer.Ordinal);
 
+            QueueItem? firstReview = null;
+            QueueItem? firstActiveOrFixing = null;
+
             foreach (var item in queueState.Items)
             {
                 switch (item.State)
@@ -67,44 +74,60 @@ internal static class StatusBriefAnalyzer
                     case QueueItemState.Review:
                         reviewUnits.Add(item.ExecutionUnit);
                         inFlight.Add(item.ExecutionUnit);
+                        firstReview ??= item;
                         break;
                     case QueueItemState.Active:
                     case QueueItemState.Fixing:
                         inFlight.Add(item.ExecutionUnit);
+                        firstActiveOrFixing ??= item;
                         break;
                 }
             }
 
-            // Deterministic next candidate: first Queued item whose dependencies
-            // are all satisfied within the local queue. We keep queue-state's
-            // declared ordering — no priority sort — so the brief is stable.
-            nextCandidate = queueState.Items
+            var nextCandidateItem = queueState.Items
                 .Where(item => item.State == QueueItemState.Queued)
                 .Where(item => DependenciesSatisfied(item, completed))
-                .Select(item => item.ExecutionUnit)
                 .FirstOrDefault();
+
+            nextCandidate = nextCandidateItem?.ExecutionUnit;
+
+            // Focus precedence: review (closeout-ready), then active/fixing,
+            // then deps-satisfied next candidate. This mirrors the G179 brief
+            // recommendation precedence so the two commands stay aligned.
+            focusItem = firstReview ?? firstActiveOrFixing ?? nextCandidateItem;
         }
 
-        var clarificationPath = ResolveClarificationPath(context, domain);
+        var clarificationPath = ResolveDomainPath(context, domain, "clarifications", "open.md");
         var clarificationOpen = false;
+        string? clarificationExcerpt = null;
         if (clarificationPath is not null && File.Exists(clarificationPath))
         {
             var content = File.ReadAllText(clarificationPath);
             clarificationOpen = ClarificationOpenDetector.HasOpenBlocker(content);
+            clarificationExcerpt = TakeMarkdownExcerpt(content);
+        }
+        else if (clarificationPath is not null)
+        {
+            notes.Add($"no clarification file at {clarificationPath}");
         }
 
+        var automationBindingsPath = ResolveDomainPath(context, domain, "automation", "bindings.md");
+        var automationBindingsPresent = false;
+        string? automationBindingsExcerpt = null;
+        if (automationBindingsPath is not null && File.Exists(automationBindingsPath))
+        {
+            automationBindingsPresent = true;
+            automationBindingsExcerpt = TakeMarkdownExcerpt(File.ReadAllText(automationBindingsPath));
+        }
+        else if (automationBindingsPath is not null)
+        {
+            notes.Add($"no automation bindings file at {automationBindingsPath}");
+        }
+
+        var focusPacket = focusItem is null ? null : BuildFocusPacket(context, focusItem);
         var recentEvents = LoadRecentEvents(context, notes);
 
-        var wipPresent = inFlight.Count > 0;
-        var recommended = ComputeRecommendation(
-            queueStatePresent,
-            queueStateReadable,
-            clarificationOpen,
-            reviewUnits.Count > 0,
-            wipPresent,
-            nextCandidate is not null);
-
-        return new StatusBriefSummary
+        return new ContextCollectPacket
         {
             Domain = domain,
             QueueStatePath = queueStatePath,
@@ -112,12 +135,16 @@ internal static class StatusBriefAnalyzer
             QueueStateReadable = queueStateReadable,
             InFlightUnits = inFlight,
             ReviewUnits = reviewUnits,
-            WipPresent = wipPresent,
+            NextCandidate = nextCandidate,
+            FocusUnit = focusItem?.ExecutionUnit,
+            FocusPacket = focusPacket,
             ClarificationOpenPath = clarificationPath,
             ClarificationOpen = clarificationOpen,
-            NextCandidate = nextCandidate,
+            ClarificationExcerpt = clarificationExcerpt,
+            AutomationBindingsPath = automationBindingsPath,
+            AutomationBindingsPresent = automationBindingsPresent,
+            AutomationBindingsExcerpt = automationBindingsExcerpt,
             RecentEvents = recentEvents,
-            RecommendedAction = recommended,
             Notes = notes
         };
     }
@@ -140,7 +167,7 @@ internal static class StatusBriefAnalyzer
         return true;
     }
 
-    private static string? ResolveClarificationPath(CliContext context, string domain)
+    private static string? ResolveDomainPath(CliContext context, string domain, params string[] parts)
     {
         if (string.IsNullOrWhiteSpace(domain))
         {
@@ -152,10 +179,41 @@ internal static class StatusBriefAnalyzer
             ? context.RepoRoot
             : parentRoot;
 
-        return Path.Combine(baseRoot!, "intents", domain, "clarifications", "open.md");
+        var combined = new List<string> { baseRoot!, "intents", domain };
+        combined.AddRange(parts);
+        return Path.Combine(combined.ToArray());
     }
 
-    private static IReadOnlyList<StatusBriefRecentEvent> LoadRecentEvents(
+    private static ContextCollectPacketReference BuildFocusPacket(CliContext context, QueueItem item)
+    {
+        var implementationPath = ResolvePacketPath(context, item.PacketPaths.Implementation);
+        var reviewContextPath = ResolvePacketPath(context, item.PacketPaths.ReviewContext);
+        var yamlPath = ResolvePacketPath(context, item.PacketPaths.Yaml);
+
+        return new ContextCollectPacketReference
+        {
+            ImplementationPath = implementationPath,
+            ImplementationPresent = File.Exists(implementationPath),
+            ReviewContextPath = reviewContextPath,
+            ReviewContextPresent = File.Exists(reviewContextPath),
+            YamlPath = yamlPath,
+            YamlPresent = File.Exists(yamlPath)
+        };
+    }
+
+    private static string ResolvePacketPath(CliContext context, string relativeOrAbsolute)
+    {
+        if (string.IsNullOrWhiteSpace(relativeOrAbsolute))
+        {
+            return string.Empty;
+        }
+
+        return Path.IsPathRooted(relativeOrAbsolute)
+            ? relativeOrAbsolute
+            : Path.GetFullPath(Path.Combine(context.RepoRoot, relativeOrAbsolute));
+    }
+
+    private static IReadOnlyList<ContextCollectRecentEvent> LoadRecentEvents(
         CliContext context,
         List<string> notes)
     {
@@ -171,7 +229,7 @@ internal static class StatusBriefAnalyzer
             var events = RunLogSerializer.DeserializeAll(content);
             return events
                 .TakeLast(RecentEventLimit)
-                .Select(runEvent => new StatusBriefRecentEvent
+                .Select(runEvent => new ContextCollectRecentEvent
                 {
                     Timestamp = runEvent.Ts.ToString("O"),
                     ExecutionUnit = runEvent.ExecutionUnit,
@@ -190,40 +248,18 @@ internal static class StatusBriefAnalyzer
         }
     }
 
-    private static string ComputeRecommendation(
-        bool queueStatePresent,
-        bool queueStateReadable,
-        bool clarificationOpen,
-        bool reviewPresent,
-        bool wipPresent,
-        bool hasNextCandidate)
+    private static string TakeMarkdownExcerpt(string content)
     {
-        // Deterministic precedence — top-most match wins.
-        if (queueStatePresent && !queueStateReadable)
+        if (string.IsNullOrEmpty(content))
         {
-            return StatusBriefRecommendation.InspectManually;
+            return string.Empty;
         }
 
-        if (clarificationOpen)
+        if (content.Length <= MarkdownExcerptCharLimit)
         {
-            return StatusBriefRecommendation.ClarificationRequired;
+            return content;
         }
 
-        if (reviewPresent)
-        {
-            return StatusBriefRecommendation.ReviewCloseout;
-        }
-
-        if (wipPresent)
-        {
-            return StatusBriefRecommendation.SkipDueToWip;
-        }
-
-        if (hasNextCandidate)
-        {
-            return StatusBriefRecommendation.IssueCutReady;
-        }
-
-        return StatusBriefRecommendation.NoActionableItem;
+        return content[..MarkdownExcerptCharLimit] + "\n…(truncated)";
     }
 }

--- a/src/IntentSystem.Cli/Commands/ContextCollectCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectCommand.cs
@@ -1,0 +1,94 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G180: Read-only <c>intent-cli context collect</c> command. Aggregates
+/// queue-state, runs.jsonl, parent-host clarification and automation binding
+/// files, and packet paths for the focus execution unit into a single Markdown
+/// (default) or JSON packet for the high-context AI tasking thread. Never
+/// mutates state.
+/// </summary>
+internal static class ContextCollectCommand
+{
+    private const string FormatMarkdown = "markdown";
+    private const string FormatJson = "json";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var domainOverride, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var packet = ContextCollectAnalyzer.Analyze(context, domainOverride);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            ContextCollectRenderer.WriteJson(writer, packet);
+        }
+        else
+        {
+            ContextCollectRenderer.WriteMarkdown(writer, packet);
+        }
+
+        return 0;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? domainOverride,
+        out string format,
+        out string error)
+    {
+        domainOverride = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --domain <name> --format markdown|json.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ContextCollectPacket.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectPacket.cs
@@ -1,0 +1,100 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Read-only context packet emitted by <c>intent-cli context collect</c> (G180).
+/// Aggregates queue-state, runs.jsonl, parent-host clarification and automation
+/// binding files, and packet paths for the focus execution unit so a high-context
+/// AI tasking thread can decide its next move without manually opening five files.
+/// Field names are stable snake_case for JSON ingestion.
+/// </summary>
+internal sealed record ContextCollectPacket
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("queue_state_path")]
+    public required string QueueStatePath { get; init; }
+
+    [JsonPropertyName("queue_state_present")]
+    public required bool QueueStatePresent { get; init; }
+
+    [JsonPropertyName("queue_state_readable")]
+    public required bool QueueStateReadable { get; init; }
+
+    [JsonPropertyName("in_flight_units")]
+    public required IReadOnlyList<string> InFlightUnits { get; init; }
+
+    [JsonPropertyName("review_units")]
+    public required IReadOnlyList<string> ReviewUnits { get; init; }
+
+    [JsonPropertyName("next_candidate")]
+    public string? NextCandidate { get; init; }
+
+    [JsonPropertyName("focus_unit")]
+    public string? FocusUnit { get; init; }
+
+    [JsonPropertyName("focus_packet")]
+    public ContextCollectPacketReference? FocusPacket { get; init; }
+
+    [JsonPropertyName("clarification_open_path")]
+    public string? ClarificationOpenPath { get; init; }
+
+    [JsonPropertyName("clarification_open")]
+    public required bool ClarificationOpen { get; init; }
+
+    [JsonPropertyName("clarification_excerpt")]
+    public string? ClarificationExcerpt { get; init; }
+
+    [JsonPropertyName("automation_bindings_path")]
+    public string? AutomationBindingsPath { get; init; }
+
+    [JsonPropertyName("automation_bindings_present")]
+    public required bool AutomationBindingsPresent { get; init; }
+
+    [JsonPropertyName("automation_bindings_excerpt")]
+    public string? AutomationBindingsExcerpt { get; init; }
+
+    [JsonPropertyName("recent_events")]
+    public required IReadOnlyList<ContextCollectRecentEvent> RecentEvents { get; init; }
+
+    [JsonPropertyName("notes")]
+    public required IReadOnlyList<string> Notes { get; init; }
+}
+
+internal sealed record ContextCollectPacketReference
+{
+    [JsonPropertyName("implementation_path")]
+    public required string ImplementationPath { get; init; }
+
+    [JsonPropertyName("implementation_present")]
+    public required bool ImplementationPresent { get; init; }
+
+    [JsonPropertyName("review_context_path")]
+    public required string ReviewContextPath { get; init; }
+
+    [JsonPropertyName("review_context_present")]
+    public required bool ReviewContextPresent { get; init; }
+
+    [JsonPropertyName("yaml_path")]
+    public required string YamlPath { get; init; }
+
+    [JsonPropertyName("yaml_present")]
+    public required bool YamlPresent { get; init; }
+}
+
+internal sealed record ContextCollectRecentEvent
+{
+    [JsonPropertyName("ts")]
+    public required string Timestamp { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("event")]
+    public required string Event { get; init; }
+
+    [JsonPropertyName("by")]
+    public required string By { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/ContextCollectRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectRenderer.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Output renderer for the read-only <c>context collect</c> command (G180).
+/// Produces a Markdown packet (default) or stable snake_case JSON.
+/// </summary>
+internal static class ContextCollectRenderer
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    public static void WriteMarkdown(TextWriter writer, ContextCollectPacket packet)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(packet);
+
+        writer.WriteLine($"# Context packet: {packet.Domain}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Queue state");
+        writer.WriteLine($"- Path: `{packet.QueueStatePath}`");
+        writer.WriteLine(
+            "- Status: "
+            + (packet.QueueStatePresent
+                ? (packet.QueueStateReadable ? "present" : "present-unreadable")
+                : "missing"));
+        writer.WriteLine($"- In-flight units: {FormatList(packet.InFlightUnits)}");
+        writer.WriteLine($"- Review units: {FormatList(packet.ReviewUnits)}");
+        writer.WriteLine($"- Next candidate: {packet.NextCandidate ?? "-"}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Focus");
+        writer.WriteLine($"- Unit: {packet.FocusUnit ?? "-"}");
+        if (packet.FocusPacket is not null)
+        {
+            writer.WriteLine(
+                $"- Implementation: `{packet.FocusPacket.ImplementationPath}` ({(packet.FocusPacket.ImplementationPresent ? "present" : "missing")})");
+            writer.WriteLine(
+                $"- Review context: `{packet.FocusPacket.ReviewContextPath}` ({(packet.FocusPacket.ReviewContextPresent ? "present" : "missing")})");
+            writer.WriteLine(
+                $"- Yaml: `{packet.FocusPacket.YamlPath}` ({(packet.FocusPacket.YamlPresent ? "present" : "missing")})");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Clarification");
+        writer.WriteLine($"- Path: {(packet.ClarificationOpenPath is null ? "-" : $"`{packet.ClarificationOpenPath}`")}");
+        writer.WriteLine($"- Open blocker: {(packet.ClarificationOpen ? "yes" : "no")}");
+        if (!string.IsNullOrWhiteSpace(packet.ClarificationExcerpt))
+        {
+            writer.WriteLine();
+            writer.WriteLine("```markdown");
+            writer.WriteLine(packet.ClarificationExcerpt.TrimEnd());
+            writer.WriteLine("```");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Automation bindings");
+        writer.WriteLine($"- Path: {(packet.AutomationBindingsPath is null ? "-" : $"`{packet.AutomationBindingsPath}`")}");
+        writer.WriteLine($"- Present: {(packet.AutomationBindingsPresent ? "yes" : "no")}");
+        if (!string.IsNullOrWhiteSpace(packet.AutomationBindingsExcerpt))
+        {
+            writer.WriteLine();
+            writer.WriteLine("```markdown");
+            writer.WriteLine(packet.AutomationBindingsExcerpt.TrimEnd());
+            writer.WriteLine("```");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Recent events");
+        if (packet.RecentEvents.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var recentEvent in packet.RecentEvents)
+            {
+                writer.WriteLine(
+                    $"- `{recentEvent.Timestamp}` {recentEvent.ExecutionUnit} {recentEvent.Event} (by={recentEvent.By})");
+            }
+        }
+        writer.WriteLine();
+
+        if (packet.Notes.Count > 0)
+        {
+            writer.WriteLine("## Notes");
+            foreach (var note in packet.Notes)
+            {
+                writer.WriteLine($"- {note}");
+            }
+        }
+    }
+
+    public static void WriteJson(TextWriter writer, ContextCollectPacket packet)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(packet);
+
+        writer.WriteLine(JsonSerializer.Serialize(packet, JsonOptions));
+    }
+
+    private static string FormatList(IReadOnlyList<string> values)
+    {
+        return values.Count == 0
+            ? "-"
+            : string.Join(", ", values);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/ContextCollectCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ContextCollectCommandTests.cs
@@ -1,0 +1,322 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ContextCollectCommandTests
+{
+    [Fact]
+    public void Execute_GivenNormalWorkspace_EmitsMarkdownWithExpectedSections()
+    {
+        // Required scenario 1 (G180): normal context collection. Real queue-state with
+        // a Review unit, a clarification with no open blockers, automation bindings,
+        // and packet files for the focus unit. Output must include all packet sections
+        // and surface the focus unit so the AI tasking thread can read context without
+        // opening five files.
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteQueueState(NormalQueueStateJson);
+        workspace.WriteClarificationOpen(NoBlockerClarification);
+        workspace.WriteAutomationBindings(NormalAutomationBindings);
+        workspace.WritePacketFile("G180", "implementation.md", "# Implementation packet for G180\n");
+        workspace.WritePacketFile("G180", "review-context.md", "# Review context for G180\n");
+        workspace.WritePacketFile("G180", "packet.yaml", "execution_unit: G180\n");
+        workspace.WriteRunLog(
+            """
+            {"ts":"2026-04-29T00:00:00Z","execution_unit":"G179","event":"completed","by":"reviewer"}
+            {"ts":"2026-04-29T00:01:00Z","execution_unit":"G180","event":"queued","by":"system"}
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Context packet: intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("## Queue state", output, StringComparison.Ordinal);
+        Assert.Contains("## Focus", output, StringComparison.Ordinal);
+        Assert.Contains("## Clarification", output, StringComparison.Ordinal);
+        Assert.Contains("## Automation bindings", output, StringComparison.Ordinal);
+        Assert.Contains("## Recent events", output, StringComparison.Ordinal);
+        Assert.Contains("Unit: G180", output, StringComparison.Ordinal);
+        Assert.Contains("Open blocker: no", output, StringComparison.Ordinal);
+        Assert.Contains("G179", output, StringComparison.Ordinal); // recent event mention
+    }
+
+    [Fact]
+    public void Execute_GivenMissingOptionalArtifacts_RecordsDegradedNotesWithoutThrowing()
+    {
+        // Required scenario 2: missing optional artifacts. No queue-state, no
+        // clarification, no automation bindings, no runs.jsonl. Must succeed with
+        // explicit notes for each missing source.
+        using var workspace = new ContextCollectWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("## Notes", output, StringComparison.Ordinal);
+        Assert.Contains("no queue-state file", output, StringComparison.Ordinal);
+        Assert.Contains("no clarification file", output, StringComparison.Ordinal);
+        Assert.Contains("no automation bindings file", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedQueueState_RecordsParseNoteAndKeepsCommandReadOnly()
+    {
+        // Required scenario 3: malformed queue or run state. Must not throw; must
+        // record a deterministic degraded note and continue with the rest of the
+        // packet so the AI thread can still see clarification / runs / bindings.
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteQueueState("{ this is intentionally not valid JSON");
+        workspace.WriteRunLog("not a real json line\n");
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("queue_state_present").GetBoolean());
+        Assert.False(root.GetProperty("queue_state_readable").GetBoolean());
+        var notes = root.GetProperty("notes").EnumerateArray().Select(n => n.GetString()).ToArray();
+        Assert.Contains(notes, note => note is not null && note.Contains("queue-state", StringComparison.Ordinal));
+        Assert.Contains(notes, note => note is not null && note.Contains("runs.jsonl", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenDomainOverride_UsesOverrideForResolvedPaths()
+    {
+        // Required scenario 4: domain override. The packet's domain field and
+        // resolved clarification / automation paths must reflect the --domain value,
+        // not the workspace default.
+        using var workspace = new ContextCollectWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context,
+            ["--domain", "alt-domain", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("alt-domain", root.GetProperty("domain").GetString());
+        var clarificationPath = root.GetProperty("clarification_open_path").GetString();
+        Assert.NotNull(clarificationPath);
+        Assert.Contains(
+            Path.Combine("intents", "alt-domain", "clarifications", "open.md"),
+            clarificationPath!,
+            StringComparison.Ordinal);
+        var bindingsPath = root.GetProperty("automation_bindings_path").GetString();
+        Assert.NotNull(bindingsPath);
+        Assert.Contains(
+            Path.Combine("intents", "alt-domain", "automation", "bindings.md"),
+            bindingsPath!,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_EmitsParsableSnakeCaseFields()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteQueueState(NormalQueueStateJson);
+        workspace.WriteClarificationOpen(NoBlockerClarification);
+        workspace.WriteAutomationBindings(NormalAutomationBindings);
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        Assert.True(root.GetProperty("queue_state_readable").GetBoolean());
+        Assert.True(root.GetProperty("automation_bindings_present").GetBoolean());
+        Assert.False(root.GetProperty("clarification_open").GetBoolean());
+        Assert.Equal("G180", root.GetProperty("focus_unit").GetString());
+        Assert.True(root.TryGetProperty("focus_packet", out var focusPacket));
+        Assert.Equal(JsonValueKind.Object, focusPacket.ValueKind);
+    }
+
+    [Fact]
+    public void Execute_GivenOpenBlockerInClarificationFile_ReportsClarificationOpenTrue()
+    {
+        // Aligns with G179 semantics: structured "## Current Open Blockers" with a
+        // real entry must surface as clarification_open=true and provide the
+        // excerpt to the AI thread.
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteClarificationOpen(
+            """
+            # intent-cli clarifications
+
+            ## Current Open Blockers
+
+            - Should `context collect` include parent automation bindings by default?
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("clarification_open").GetBoolean());
+        var excerpt = root.GetProperty("clarification_excerpt").GetString();
+        Assert.NotNull(excerpt);
+        Assert.Contains("Current Open Blockers", excerpt!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsErrorExitCode()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context,
+            ["--bogus"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private const string NormalQueueStateJson =
+        """
+        {
+          "schema_version": "1",
+          "updated_at": "2026-04-29T00:00:00Z",
+          "items": [
+            {
+              "execution_unit": "G179",
+              "title": "status brief",
+              "state": "completed",
+              "dependencies": [],
+              "blocked_by": [],
+              "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+              "packet_paths": {
+                "implementation": ".intent-cli/issues/G179/implementation.md",
+                "review_context": ".intent-cli/issues/G179/review-context.md",
+                "yaml": ".intent-cli/issues/G179/packet.yaml"
+              },
+              "worker_role": "coder",
+              "review_role": "reviewer",
+              "priority": "high"
+            },
+            {
+              "execution_unit": "G180",
+              "title": "context collect",
+              "state": "review",
+              "dependencies": ["G179"],
+              "blocked_by": [],
+              "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+              "packet_paths": {
+                "implementation": ".intent-cli/issues/G180/implementation.md",
+                "review_context": ".intent-cli/issues/G180/review-context.md",
+                "yaml": ".intent-cli/issues/G180/packet.yaml"
+              },
+              "worker_role": "coder",
+              "review_role": "reviewer",
+              "priority": "high"
+            }
+          ]
+        }
+        """;
+
+    private const string NoBlockerClarification =
+        """
+        # intent-cli clarifications
+
+        durable prose
+
+        ## Current Open Blockers
+
+        - 現時点で child issue cut を要する root blocker はない。
+        """;
+
+    private const string NormalAutomationBindings =
+        """
+        # intent-cli automation bindings
+
+        - timer-implement-loop: every 10m
+        - timer-review-loop: every 5m
+        - status-brief-recommendation-mapping: review-closeout, clarification-required, ...
+        """;
+
+    private sealed class ContextCollectWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("context-collect-tests-")
+            .FullName;
+
+        public ContextCollectWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public void WriteQueueState(string content)
+        {
+            File.WriteAllText(Context.GetQueueStatePath(), content);
+        }
+
+        public void WriteRunLog(string content)
+        {
+            File.WriteAllText(Context.GetRunLogPath(), content);
+        }
+
+        public void WriteClarificationOpen(string content)
+        {
+            var path = Path.Combine(rootPath, "intents", Context.Config.Project.Domain, "clarifications");
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "open.md"), content);
+        }
+
+        public void WriteAutomationBindings(string content)
+        {
+            var path = Path.Combine(rootPath, "intents", Context.Config.Project.Domain, "automation");
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "bindings.md"), content);
+        }
+
+        public void WritePacketFile(string executionUnit, string fileName, string content)
+        {
+            var path = Path.Combine(rootPath, ".intent-cli", "issues", executionUnit);
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, fileName), content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a read-only `intent-cli context collect [--domain <name>] [--format markdown|json]` command that aggregates queue-state, `runs.jsonl`, parent-host clarification and automation binding files, and packet paths for the focus execution unit into a single Markdown (default) or stable snake_case JSON packet for the high-context Codex / Claude tasking thread.
- Aligns with the accepted G179 `status brief` concepts: same domain resolution (config + `--domain` override), same parent intent repo root resolution for `intents/<domain>/...`, same structural clarification-open detection. The shared `## Current Open Blockers` parser is extracted into a new `ClarificationOpenDetector` and reused from both `StatusBriefAnalyzer` and `ContextCollectAnalyzer` (G179 tests still pass).
- Packet contents include: `domain`, queue-state present/readable, in-flight / review / next-candidate units, focus_unit (Review → Active/Fixing → deps-satisfied Queued, mirroring G179 precedence) with `focus_packet { implementation, review_context, yaml }` paths and presence flags, clarification path/open/excerpt (truncated to 1500 chars), automation bindings path/present/excerpt, last 5 events from runs.jsonl, and degraded `notes` for missing or unparseable optional sources.
- Read-only: never mutates queue-state, runs, packet files, source files, or GitHub. Missing optional files surface a degraded packet with explicit notes instead of throwing.
- Wires a new `context` command group into `CommandRouter` alongside `status`.

## Test plan

- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~ContextCollect` — 7/7 passing including the four required scenarios (normal collection, missing optional artifacts, malformed queue/run state, domain override).
- [x] G179 `status brief` test surface: 10/10 still passing after the `ClarificationOpenDetector` extraction (no behavioural change).
- [x] Full repo `dotnet test` — 1215/1215 passing across all suites (CLI: 918 → 925 = +7 new G180 tests; no regressions).
- [ ] Manual smoke per issue Verification (recommended after merge / submodule bump in parent host):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- context collect --domain intent-cli`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- context collect --domain intent-cli --format json`

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)
