### PR TITLE
G181 Add clarify draft command for owner-question packets

### DIFF
--- a/src/IntentSystem.Cli/Commands/ClarifyDraftAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyDraftAnalyzer.cs
@@ -1,0 +1,204 @@
+using System.Text.Json;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Read-only state collector that turns local intent-cli files plus the
+/// operator-supplied question into a <see cref="ClarifyDraftPacket"/> scaffold
+/// for owner review (G181). Never mutates queue state, runs, packet files,
+/// clarification files, or GitHub.
+/// </summary>
+internal static class ClarifyDraftAnalyzer
+{
+    public static ClarifyDraftPacket Analyze(CliContext context, string? domainOverride, string question)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(question);
+
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride;
+
+        var notes = new List<string>();
+        var background = new List<string>();
+
+        // Clarification return path
+        var clarificationPath = ResolveDomainPath(context, domain, "clarifications", "open.md");
+        var clarificationOpen = false;
+        if (clarificationPath is not null)
+        {
+            if (File.Exists(clarificationPath))
+            {
+                var content = File.ReadAllText(clarificationPath);
+                clarificationOpen = ClarificationOpenDetector.HasOpenBlocker(content);
+                background.Add(
+                    $"Clarification return path: {clarificationPath} (open blocker: {(clarificationOpen ? "yes" : "no")})");
+            }
+            else
+            {
+                notes.Add($"no clarification file at {clarificationPath}");
+                background.Add($"Clarification return path: {clarificationPath} (file not present)");
+            }
+        }
+        else
+        {
+            background.Add("Clarification return path: -");
+        }
+
+        // Queue focus
+        var queueStatePath = context.GetQueueStatePath();
+        if (File.Exists(queueStatePath))
+        {
+            try
+            {
+                var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+                AppendFocusBackground(queueState, background);
+            }
+            catch (Exception exception) when (
+                exception is JsonException
+                or InvalidOperationException)
+            {
+                notes.Add($"queue-state could not be parsed: {exception.Message}");
+            }
+        }
+        else
+        {
+            notes.Add($"no queue-state file at {queueStatePath}");
+        }
+
+        // Recent events
+        var runLogPath = context.GetRunLogPath();
+        if (File.Exists(runLogPath))
+        {
+            try
+            {
+                var content = File.ReadAllText(runLogPath);
+                var events = RunLogSerializer.DeserializeAll(content);
+                var recent = events.TakeLast(3).ToArray();
+                if (recent.Length > 0)
+                {
+                    background.Add("Recent run events:");
+                    foreach (var runEvent in recent)
+                    {
+                        background.Add(
+                            $"- {runEvent.Ts:O} {runEvent.ExecutionUnit} {runEvent.Event} (by={runEvent.By})");
+                    }
+                }
+            }
+            catch (Exception exception) when (
+                exception is JsonException
+                or InvalidOperationException
+                or FormatException)
+            {
+                notes.Add($"runs.jsonl could not be parsed: {exception.Message}");
+            }
+        }
+
+        // Two-option scaffold so the AI tasking thread fills in deterministically.
+        var options = new[]
+        {
+            new ClarifyDraftOption
+            {
+                Label = "A",
+                Description = "(operator to fill)",
+                Pros = new List<string>(),
+                Cons = new List<string>()
+            },
+            new ClarifyDraftOption
+            {
+                Label = "B",
+                Description = "(operator to fill)",
+                Pros = new List<string>(),
+                Cons = new List<string>()
+            }
+        };
+
+        return new ClarifyDraftPacket
+        {
+            Domain = domain,
+            Question = question.Trim(),
+            Background = background,
+            Options = options,
+            Recommendation = null,
+            ReturnPath = clarificationPath,
+            Notes = notes
+        };
+    }
+
+    private static void AppendFocusBackground(QueueState queueState, List<string> background)
+    {
+        var inFlightUnits = queueState.Items
+            .Where(item => item.State is QueueItemState.Active
+                or QueueItemState.Review
+                or QueueItemState.Fixing)
+            .Select(item => $"{item.ExecutionUnit} ({FormatState(item.State)})")
+            .ToArray();
+
+        background.Add(inFlightUnits.Length == 0
+            ? "In-flight units: -"
+            : $"In-flight units: {string.Join(", ", inFlightUnits)}");
+
+        var completed = new HashSet<string>(
+            queueState.Items
+                .Where(item => item.State == QueueItemState.Completed)
+                .Select(item => item.ExecutionUnit),
+            StringComparer.Ordinal);
+
+        var nextCandidate = queueState.Items
+            .Where(item => item.State == QueueItemState.Queued)
+            .Where(item => DependenciesSatisfied(item, completed))
+            .Select(item => item.ExecutionUnit)
+            .FirstOrDefault();
+
+        background.Add($"Next candidate: {nextCandidate ?? "-"}");
+    }
+
+    private static bool DependenciesSatisfied(QueueItem item, HashSet<string> completed)
+    {
+        if (item.Dependencies.Count == 0)
+        {
+            return true;
+        }
+
+        foreach (var dependency in item.Dependencies)
+        {
+            if (!completed.Contains(dependency))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string FormatState(QueueItemState state) => state switch
+    {
+        QueueItemState.Queued => "queued",
+        QueueItemState.Active => "active",
+        QueueItemState.Review => "review",
+        QueueItemState.Fixing => "fixing",
+        QueueItemState.ClarifyBlocked => "clarify-blocked",
+        QueueItemState.Blocked => "blocked",
+        QueueItemState.Completed => "completed",
+        _ => state.ToString().ToLowerInvariant()
+    };
+
+    private static string? ResolveDomainPath(CliContext context, string domain, params string[] parts)
+    {
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            return null;
+        }
+
+        var parentRoot = context.ResolveParentIntentRepoRootPath();
+        var baseRoot = string.IsNullOrWhiteSpace(parentRoot)
+            ? context.RepoRoot
+            : parentRoot;
+
+        var combined = new List<string> { baseRoot!, "intents", domain };
+        combined.AddRange(parts);
+        return Path.Combine(combined.ToArray());
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ClarifyDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyDraftCommand.cs
@@ -1,0 +1,113 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G181: Read-only <c>intent-cli clarify draft</c> command. Emits a structured
+/// clarification draft scaffold (background, question, options, pros/cons,
+/// recommendation, return path) so the AI tasking thread + owner can review a
+/// consistent shape before a follow-up command records the accepted decision.
+/// Never mutates clarifications/open.md or any other state.
+/// </summary>
+internal static class ClarifyDraftCommand
+{
+    private const string FormatMarkdown = "markdown";
+    private const string FormatJson = "json";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var domainOverride, out var question, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var packet = ClarifyDraftAnalyzer.Analyze(context, domainOverride, question);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            ClarifyDraftRenderer.WriteJson(writer, packet);
+        }
+        else
+        {
+            ClarifyDraftRenderer.WriteMarkdown(writer, packet);
+        }
+
+        return 0;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? domainOverride,
+        out string question,
+        out string format,
+        out string error)
+    {
+        domainOverride = null;
+        question = string.Empty;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--question":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--question requires a value.";
+                        return false;
+                    }
+
+                    question = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --domain <name> --question <text> --format markdown|json.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(question))
+        {
+            error = "--question is required.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ClarifyDraftPacket.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyDraftPacket.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Structured clarification draft packet emitted by
+/// <c>intent-cli clarify draft</c> (G181). Read-only scaffold the AI tasking
+/// thread can review with the owner before recording an accepted decision.
+/// Field names are stable snake_case for JSON ingestion.
+/// </summary>
+internal sealed record ClarifyDraftPacket
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("question")]
+    public required string Question { get; init; }
+
+    [JsonPropertyName("background")]
+    public required IReadOnlyList<string> Background { get; init; }
+
+    [JsonPropertyName("options")]
+    public required IReadOnlyList<ClarifyDraftOption> Options { get; init; }
+
+    [JsonPropertyName("recommendation")]
+    public string? Recommendation { get; init; }
+
+    [JsonPropertyName("return_path")]
+    public string? ReturnPath { get; init; }
+
+    [JsonPropertyName("notes")]
+    public required IReadOnlyList<string> Notes { get; init; }
+}
+
+internal sealed record ClarifyDraftOption
+{
+    [JsonPropertyName("label")]
+    public required string Label { get; init; }
+
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    [JsonPropertyName("pros")]
+    public required IReadOnlyList<string> Pros { get; init; }
+
+    [JsonPropertyName("cons")]
+    public required IReadOnlyList<string> Cons { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/ClarifyDraftRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyDraftRenderer.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Output renderer for the read-only <c>clarify draft</c> command (G181).
+/// Produces a Markdown packet (default) or stable snake_case JSON.
+/// </summary>
+internal static class ClarifyDraftRenderer
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    public static void WriteMarkdown(TextWriter writer, ClarifyDraftPacket packet)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(packet);
+
+        writer.WriteLine($"# Clarification draft: {packet.Domain}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Question");
+        writer.WriteLine(packet.Question);
+        writer.WriteLine();
+
+        writer.WriteLine("## Background");
+        if (packet.Background.Count == 0)
+        {
+            writer.WriteLine("- (none captured)");
+        }
+        else
+        {
+            foreach (var entry in packet.Background)
+            {
+                writer.WriteLine(entry.StartsWith("- ", StringComparison.Ordinal) ? entry : $"- {entry}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Options");
+        if (packet.Options.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var option in packet.Options)
+            {
+                writer.WriteLine($"### {option.Label}. {option.Description}");
+                writer.WriteLine();
+                writer.WriteLine("Pros:");
+                if (option.Pros.Count == 0)
+                {
+                    writer.WriteLine("- (operator to fill)");
+                }
+                else
+                {
+                    foreach (var pro in option.Pros)
+                    {
+                        writer.WriteLine($"- {pro}");
+                    }
+                }
+                writer.WriteLine();
+                writer.WriteLine("Cons:");
+                if (option.Cons.Count == 0)
+                {
+                    writer.WriteLine("- (operator to fill)");
+                }
+                else
+                {
+                    foreach (var con in option.Cons)
+                    {
+                        writer.WriteLine($"- {con}");
+                    }
+                }
+                writer.WriteLine();
+            }
+        }
+
+        writer.WriteLine("## Recommendation");
+        writer.WriteLine(string.IsNullOrWhiteSpace(packet.Recommendation)
+            ? "(operator to fill)"
+            : packet.Recommendation);
+        writer.WriteLine();
+
+        writer.WriteLine("## Return path");
+        writer.WriteLine(packet.ReturnPath ?? "-");
+        writer.WriteLine();
+
+        if (packet.Notes.Count > 0)
+        {
+            writer.WriteLine("## Notes");
+            foreach (var note in packet.Notes)
+            {
+                writer.WriteLine($"- {note}");
+            }
+        }
+    }
+
+    public static void WriteJson(TextWriter writer, ClarifyDraftPacket packet)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(packet);
+
+        writer.WriteLine(JsonSerializer.Serialize(packet, JsonOptions));
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -61,7 +61,8 @@ internal static class CommandRouter
             {
                 ["open"] = ClarifyOpenCommand.Execute,
                 ["list"] = ClarifyListCommand.Execute,
-                ["answer"] = ClarifyAnswerCommand.Execute
+                ["answer"] = ClarifyAnswerCommand.Execute,
+                ["draft"] = ClarifyDraftCommand.Execute
             },
             ["queue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/tests/IntentSystem.Cli.Tests/ClarifyDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClarifyDraftCommandTests.cs
@@ -1,0 +1,272 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ClarifyDraftCommandTests
+{
+    [Fact]
+    public void Execute_GivenQuestionAndDomain_EmitsMarkdownDraftPacketWithExpectedSections()
+    {
+        // Required scenario 1 (G181): normal draft generation. The packet must
+        // include all structured sections so the AI tasking thread + owner can
+        // review a consistent shape.
+        using var workspace = new ClarifyDraftWorkspace();
+        workspace.WriteQueueState(NormalQueueStateJson);
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyDraftCommand.Execute(
+            workspace.Context,
+            ["--question", "Should the next issue be G182 or G183?"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Clarification draft: intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("## Question", output, StringComparison.Ordinal);
+        Assert.Contains("Should the next issue be G182 or G183?", output, StringComparison.Ordinal);
+        Assert.Contains("## Background", output, StringComparison.Ordinal);
+        Assert.Contains("## Options", output, StringComparison.Ordinal);
+        Assert.Contains("### A.", output, StringComparison.Ordinal);
+        Assert.Contains("### B.", output, StringComparison.Ordinal);
+        Assert.Contains("Pros:", output, StringComparison.Ordinal);
+        Assert.Contains("Cons:", output, StringComparison.Ordinal);
+        Assert.Contains("## Recommendation", output, StringComparison.Ordinal);
+        Assert.Contains("## Return path", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_EmitsParsableSnakeCaseFields()
+    {
+        // Required scenario 2: JSON output. Stable snake_case field names so the
+        // AI tasking thread can ingest the packet directly.
+        using var workspace = new ClarifyDraftWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyDraftCommand.Execute(
+            workspace.Context,
+            ["--question", "Should we keep markdown default?", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        Assert.Equal("Should we keep markdown default?", root.GetProperty("question").GetString());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("background").ValueKind);
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("options").ValueKind);
+        Assert.Equal(2, root.GetProperty("options").GetArrayLength());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("notes").ValueKind);
+        Assert.True(root.TryGetProperty("return_path", out _));
+        var firstOption = root.GetProperty("options")[0];
+        Assert.Equal("A", firstOption.GetProperty("label").GetString());
+        Assert.Equal(JsonValueKind.Array, firstOption.GetProperty("pros").ValueKind);
+        Assert.Equal(JsonValueKind.Array, firstOption.GetProperty("cons").ValueKind);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingOptionalContext_RecordsDegradedNotesWithoutThrowing()
+    {
+        // Required scenario 3: missing optional context (no queue-state, no
+        // clarification file). Must succeed with explicit notes for each missing
+        // source — no unhandled exceptions.
+        using var workspace = new ClarifyDraftWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyDraftCommand.Execute(
+            workspace.Context,
+            ["--question", "Is it safe to start G182 now?"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("## Notes", output, StringComparison.Ordinal);
+        Assert.Contains("no queue-state file", output, StringComparison.Ordinal);
+        Assert.Contains("no clarification file", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingQuestion_ReturnsErrorExitCode()
+    {
+        // Required scenario 4 (a): invalid arguments — --question missing entirely.
+        using var workspace = new ClarifyDraftWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyDraftCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--question", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsErrorExitCode()
+    {
+        // Required scenario 4 (b): invalid arguments — unknown flag.
+        using var workspace = new ClarifyDraftWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyDraftCommand.Execute(
+            workspace.Context,
+            ["--question", "Q", "--bogus"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenInvalidFormatValue_ReturnsErrorExitCode()
+    {
+        using var workspace = new ClarifyDraftWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyDraftCommand.Execute(
+            workspace.Context,
+            ["--question", "Q", "--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenDomainOverride_ResolvesReturnPathUnderOverrideDomain()
+    {
+        using var workspace = new ClarifyDraftWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyDraftCommand.Execute(
+            workspace.Context,
+            ["--domain", "alt-domain", "--question", "Q", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("alt-domain", root.GetProperty("domain").GetString());
+        var returnPath = root.GetProperty("return_path").GetString();
+        Assert.NotNull(returnPath);
+        Assert.Contains(
+            Path.Combine("intents", "alt-domain", "clarifications", "open.md"),
+            returnPath!,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenOpenBlockerInClarificationFile_AnnotatesBackgroundAccordingly()
+    {
+        using var workspace = new ClarifyDraftWorkspace();
+        workspace.WriteClarificationOpen(
+            """
+            # intent-cli clarifications
+
+            ## Current Open Blockers
+
+            - Should we ship clarify draft now?
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyDraftCommand.Execute(
+            workspace.Context,
+            ["--question", "Q", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var background = document.RootElement.GetProperty("background")
+            .EnumerateArray()
+            .Select(item => item.GetString() ?? string.Empty)
+            .ToArray();
+        Assert.Contains(background, item => item.Contains("open blocker: yes", StringComparison.Ordinal));
+    }
+
+    private const string NormalQueueStateJson =
+        """
+        {
+          "schema_version": "1",
+          "updated_at": "2026-04-29T00:00:00Z",
+          "items": [
+            {
+              "execution_unit": "G180",
+              "title": "context collect",
+              "state": "completed",
+              "dependencies": [],
+              "blocked_by": [],
+              "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+              "packet_paths": {
+                "implementation": ".intent-cli/issues/G180/implementation.md",
+                "review_context": ".intent-cli/issues/G180/review-context.md",
+                "yaml": ".intent-cli/issues/G180/packet.yaml"
+              },
+              "worker_role": "coder",
+              "review_role": "reviewer",
+              "priority": "high"
+            },
+            {
+              "execution_unit": "G181",
+              "title": "clarify draft",
+              "state": "active",
+              "dependencies": ["G180"],
+              "blocked_by": [],
+              "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+              "packet_paths": {
+                "implementation": ".intent-cli/issues/G181/implementation.md",
+                "review_context": ".intent-cli/issues/G181/review-context.md",
+                "yaml": ".intent-cli/issues/G181/packet.yaml"
+              },
+              "worker_role": "coder",
+              "review_role": "reviewer",
+              "priority": "high"
+            }
+          ]
+        }
+        """;
+
+    private sealed class ClarifyDraftWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("clarify-draft-tests-")
+            .FullName;
+
+        public ClarifyDraftWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public void WriteQueueState(string content)
+        {
+            File.WriteAllText(Context.GetQueueStatePath(), content);
+        }
+
+        public void WriteClarificationOpen(string content)
+        {
+            var path = Path.Combine(rootPath, "intents", Context.Config.Project.Domain, "clarifications");
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "open.md"), content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a read-only `intent-cli clarify draft --domain <name> --question <text> [--format markdown|json]` command that emits a structured clarification draft scaffold (background, question, options A/B with pros/cons placeholders, recommendation, return path) so the AI tasking thread + owner can review a consistent shape before a follow-up command records the accepted decision.
- Aligns with the accepted G179 / G180 concepts: same domain resolution (config + `--domain` override), same parent-intent-repo-root resolution for `intents/<domain>/...`, reuses the shared `ClarificationOpenDetector` to annotate background with whether the return path currently has an open blocker, reuses queue-state + runs.jsonl to surface in-flight units, the next deterministic candidate, and recent run events.
- Read-only: never mutates `clarifications/open.md`, queue-state, runs, packet files, source files, or GitHub. Missing optional context (no queue-state / no clarification file) surfaces explicit `notes` entries instead of throwing.
- Wired as a new `draft` subcommand under the existing `clarify` command group (alongside `open`, `list`, `answer`).

## Test plan

- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~ClarifyDraft` — 8/8 passing including the four required scenarios (normal draft generation, JSON output, missing optional context, invalid arguments) plus `--domain` override and open-blocker background annotation.
- [x] G179 / G180 surfaces unaffected; full repo `dotnet test` — 1223/1223 passing across all suites (CLI: 925 → 933 = +8 new G181 tests; no regressions).
- [ ] Manual smoke per issue Verification (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- clarify draft --domain intent-cli --question "Should the next issue be G182 or G183?"`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- clarify draft --domain intent-cli --question "Should the next issue be G182 or G183?" --format json`

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)
