### PR TITLE
G182 Add clarify record command for owner decisions

### DIFF
--- a/src/IntentSystem.Cli/Commands/ClarifyRecordCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyRecordCommand.cs
@@ -1,0 +1,153 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G182: <c>intent-cli clarify record --domain &lt;name&gt; --from-file &lt;path&gt;
+/// [--dry-run]</c>. Records an owner-approved clarification decision into
+/// <c>intents/&lt;domain&gt;/clarifications/open.md</c> under <c>## Recently
+/// Resolved</c>. Validates required fields before mutation; <c>--dry-run</c>
+/// prints the intended update and does not write. Never picks or rewrites the
+/// owner answer; never touches files outside the resolved clarification return
+/// path.
+/// </summary>
+internal static class ClarifyRecordCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var domainOverride, out var fromFile, out var dryRun, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride;
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            writer.WriteLine("Domain could not be resolved. Provide --domain or set Project.Domain in config.");
+            return 1;
+        }
+
+        if (!File.Exists(fromFile))
+        {
+            writer.WriteLine($"--from-file path '{fromFile}' does not exist.");
+            return 1;
+        }
+
+        var decisionContent = File.ReadAllText(fromFile);
+        if (!ClarifyRecordDecisionParser.TryParse(decisionContent, out var decision, out var parseError))
+        {
+            writer.WriteLine(parseError);
+            return 1;
+        }
+
+        var clarificationPath = ResolveClarificationPath(context, domain);
+        if (clarificationPath is null)
+        {
+            writer.WriteLine("Clarification return path could not be resolved.");
+            return 1;
+        }
+
+        if (!File.Exists(clarificationPath))
+        {
+            writer.WriteLine($"Clarification return path '{clarificationPath}' does not exist.");
+            return 1;
+        }
+
+        var existing = File.ReadAllText(clarificationPath);
+        var timestamp = DateTimeOffset.UtcNow;
+        var entry = ClarifyRecordWriter.FormatEntry(decision!, timestamp);
+        var updated = ClarifyRecordWriter.InsertDecision(existing, decision!, timestamp);
+
+        if (dryRun)
+        {
+            writer.WriteLine($"Would record decision into '{clarificationPath}':");
+            writer.WriteLine(entry);
+            return 0;
+        }
+
+        File.WriteAllText(clarificationPath, updated);
+
+        writer.WriteLine($"Recorded decision into '{clarificationPath}':");
+        writer.WriteLine(entry);
+        return 0;
+    }
+
+    private static string? ResolveClarificationPath(CliContext context, string domain)
+    {
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            return null;
+        }
+
+        var parentRoot = context.ResolveParentIntentRepoRootPath();
+        var baseRoot = string.IsNullOrWhiteSpace(parentRoot)
+            ? context.RepoRoot
+            : parentRoot;
+
+        return Path.Combine(baseRoot!, "intents", domain, "clarifications", "open.md");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? domainOverride,
+        out string fromFile,
+        out bool dryRun,
+        out string error)
+    {
+        domainOverride = null;
+        fromFile = string.Empty;
+        dryRun = false;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--from-file":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-file requires a path.";
+                        return false;
+                    }
+
+                    fromFile = args[index + 1];
+                    index++;
+                    break;
+
+                case "--dry-run":
+                    dryRun = true;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --domain <name> --from-file <path> [--dry-run].";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromFile))
+        {
+            error = "--from-file is required.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ClarifyRecordDecision.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyRecordDecision.cs
@@ -1,0 +1,15 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Owner-approved clarification decision parsed from the artifact passed via
+/// <c>--from-file</c> to <c>intent-cli clarify record</c> (G182). The CLI never
+/// chooses or rewrites the decision; this record is purely the parsed payload.
+/// </summary>
+internal sealed record ClarifyRecordDecision
+{
+    public required string Question { get; init; }
+
+    public required string Decision { get; init; }
+
+    public string? Rationale { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/ClarifyRecordDecisionParser.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyRecordDecisionParser.cs
@@ -1,0 +1,106 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Parser for the owner-filled decision artifact consumed by
+/// <c>intent-cli clarify record</c> (G182). The expected shape is a Markdown
+/// document with at least these sections:
+///
+/// <code>
+/// ## Question
+/// &lt;text&gt;
+///
+/// ## Decision
+/// &lt;text&gt;
+///
+/// ## Rationale  (optional)
+/// &lt;text&gt;
+/// </code>
+///
+/// Section bodies span until the next <c>##</c> heading or end of file. Heading
+/// titles are matched case-insensitively, but the parser does NOT invent or
+/// rewrite content — it only extracts the owner's prose verbatim.
+/// </summary>
+internal static class ClarifyRecordDecisionParser
+{
+    public static bool TryParse(string content, out ClarifyRecordDecision? decision, out string error)
+    {
+        decision = null;
+        error = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            error = "decision artifact was empty.";
+            return false;
+        }
+
+        var lines = content.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        string? question = null;
+        string? decisionText = null;
+        string? rationale = null;
+
+        var currentHeading = (string?)null;
+        var currentBody = new List<string>();
+
+        void Flush()
+        {
+            if (currentHeading is null)
+            {
+                return;
+            }
+
+            var body = string.Join("\n", currentBody).Trim();
+            switch (currentHeading)
+            {
+                case "question":
+                    question = body;
+                    break;
+                case "decision":
+                    decisionText = body;
+                    break;
+                case "rationale":
+                    rationale = body.Length == 0 ? null : body;
+                    break;
+            }
+        }
+
+        foreach (var rawLine in lines)
+        {
+            var trimmed = rawLine.TrimEnd();
+            if (trimmed.StartsWith("## ", StringComparison.Ordinal))
+            {
+                Flush();
+                currentBody.Clear();
+                currentHeading = trimmed[3..].Trim().ToLowerInvariant();
+                continue;
+            }
+
+            if (currentHeading is not null)
+            {
+                currentBody.Add(rawLine);
+            }
+        }
+
+        Flush();
+
+        if (string.IsNullOrWhiteSpace(question))
+        {
+            error = "decision artifact is missing a non-empty '## Question' section.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(decisionText))
+        {
+            error = "decision artifact is missing a non-empty '## Decision' section.";
+            return false;
+        }
+
+        decision = new ClarifyRecordDecision
+        {
+            Question = question.Trim(),
+            Decision = decisionText.Trim(),
+            Rationale = rationale
+        };
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ClarifyRecordWriter.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyRecordWriter.cs
@@ -1,0 +1,113 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Insertion helper for the owner-approved decision entry into the parent
+/// clarification return path (G182). Writes only into the
+/// <c>## Recently Resolved</c> section; preserves all other content verbatim.
+/// </summary>
+internal static class ClarifyRecordWriter
+{
+    private const string RecentlyResolvedHeading = "## Recently Resolved";
+
+    /// <summary>
+    /// Returns the updated <c>open.md</c> content with a new accepted-decision
+    /// entry inserted at the top of the <c>## Recently Resolved</c> section.
+    /// If the section is missing, it is appended at the end of the file.
+    /// </summary>
+    public static string InsertDecision(
+        string existingContent,
+        ClarifyRecordDecision decision,
+        DateTimeOffset timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+
+        var existing = existingContent ?? string.Empty;
+        var entry = FormatEntry(decision, timestamp);
+
+        var lines = existing.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n').ToList();
+        var headingIndex = -1;
+        for (var index = 0; index < lines.Count; index++)
+        {
+            if (string.Equals(
+                    lines[index].TrimEnd(),
+                    RecentlyResolvedHeading,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                headingIndex = index;
+                break;
+            }
+        }
+
+        if (headingIndex < 0)
+        {
+            // Append a new section at the end. Ensure a blank line separator.
+            var builder = new System.Text.StringBuilder();
+            builder.Append(existing);
+            if (existing.Length > 0 && !existing.EndsWith('\n'))
+            {
+                builder.Append('\n');
+            }
+
+            if (existing.Length > 0)
+            {
+                builder.Append('\n');
+            }
+
+            builder.AppendLine(RecentlyResolvedHeading);
+            builder.AppendLine();
+            builder.AppendLine(entry);
+            return builder.ToString();
+        }
+
+        // Insert after the heading and any trailing blank lines so the new
+        // entry becomes the first list item under "## Recently Resolved".
+        var insertAt = headingIndex + 1;
+        while (insertAt < lines.Count && string.IsNullOrWhiteSpace(lines[insertAt]))
+        {
+            insertAt++;
+        }
+
+        // Preserve a single blank line after the heading.
+        var inserted = new List<string>(lines.Count + 4);
+        inserted.AddRange(lines.Take(headingIndex + 1));
+        inserted.Add(string.Empty);
+        inserted.AddRange(entry.Split('\n'));
+        if (insertAt < lines.Count)
+        {
+            inserted.Add(string.Empty);
+            inserted.AddRange(lines.Skip(insertAt));
+        }
+
+        return string.Join("\n", inserted);
+    }
+
+    /// <summary>
+    /// Plain text representation of the entry the command would write — used by
+    /// <c>--dry-run</c> and the post-write confirmation output.
+    /// </summary>
+    public static string FormatEntry(ClarifyRecordDecision decision, DateTimeOffset timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+
+        var lines = new List<string>
+        {
+            $"- {timestamp:yyyy-MM-ddTHH:mm:ssZ} — {SingleLine(decision.Question)}",
+            $"  - Decision: {SingleLine(decision.Decision)}"
+        };
+
+        if (!string.IsNullOrWhiteSpace(decision.Rationale))
+        {
+            lines.Add($"  - Rationale: {SingleLine(decision.Rationale!)}");
+        }
+
+        return string.Join("\n", lines);
+    }
+
+    private static string SingleLine(string value)
+    {
+        return value
+            .Replace("\r\n", " ", StringComparison.Ordinal)
+            .Replace('\n', ' ')
+            .Trim();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -62,7 +62,8 @@ internal static class CommandRouter
                 ["open"] = ClarifyOpenCommand.Execute,
                 ["list"] = ClarifyListCommand.Execute,
                 ["answer"] = ClarifyAnswerCommand.Execute,
-                ["draft"] = ClarifyDraftCommand.Execute
+                ["draft"] = ClarifyDraftCommand.Execute,
+                ["record"] = ClarifyRecordCommand.Execute
             },
             ["queue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/tests/IntentSystem.Cli.Tests/ClarifyRecordCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClarifyRecordCommandTests.cs
@@ -1,0 +1,322 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ClarifyRecordCommandTests
+{
+    [Fact]
+    public void Execute_GivenValidDecisionArtifact_RecordsEntryAndPreservesExistingContent()
+    {
+        // Required scenario 1 (G182): successful record. The accepted decision must
+        // appear under the "## Recently Resolved" section, the existing
+        // "## Current Open Blockers" entries must remain intact, and the file
+        // must still parse as the host-shape clarification artifact.
+        using var workspace = new ClarifyRecordWorkspace();
+        const string existing =
+            """
+            # intent-cli clarifications
+
+            durable prose preserved by the recorder.
+
+            ## Current Open Blockers
+
+            - 現時点で child issue cut を要する root blocker はない。
+
+            ## Recently Resolved
+
+            - 2026-04-28T12:00:00Z — Earlier accepted decision
+              - Decision: ship G179 as a status brief command.
+            """;
+        workspace.WriteClarification(existing);
+        workspace.WriteDecisionArtifact(
+            """
+            # Clarification decision
+
+            ## Question
+            Should we ship clarify draft as the structured A/B option scaffold?
+
+            ## Decision
+            Yes — proceed with the structured scaffold approach.
+
+            ## Rationale
+            The shape produced by G181 is enough to support owner review.
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyRecordCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.DecisionArtifactPath],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var updated = workspace.ReadClarification();
+        Assert.Contains("Should we ship clarify draft as the structured A/B option scaffold?", updated, StringComparison.Ordinal);
+        Assert.Contains("Decision: Yes — proceed with the structured scaffold approach.", updated, StringComparison.Ordinal);
+        Assert.Contains("Rationale: The shape produced by G181 is enough", updated, StringComparison.Ordinal);
+        // Existing content preserved.
+        Assert.Contains("durable prose preserved by the recorder.", updated, StringComparison.Ordinal);
+        Assert.Contains("現時点で child issue cut を要する root blocker はない", updated, StringComparison.Ordinal);
+        Assert.Contains("Earlier accepted decision", updated, StringComparison.Ordinal);
+
+        // New entry appears above the earlier "Recently Resolved" entry (newest-first).
+        var newIndex = updated.IndexOf("Should we ship clarify draft", StringComparison.Ordinal);
+        var oldIndex = updated.IndexOf("Earlier accepted decision", StringComparison.Ordinal);
+        Assert.True(newIndex >= 0 && oldIndex >= 0);
+        Assert.True(newIndex < oldIndex, "expected newest decision to appear above the older one");
+
+        Assert.Contains("Recorded decision into", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenDryRunFlag_PrintsIntendedChangeAndDoesNotMutateFile()
+    {
+        // Required scenario 2: dry-run no-mutation. Stdout shows the entry; the
+        // file on disk is byte-identical to the pre-call content.
+        using var workspace = new ClarifyRecordWorkspace();
+        var existing = "# clar\n\n## Current Open Blockers\n\n- still here\n";
+        workspace.WriteClarification(existing);
+        workspace.WriteDecisionArtifact(
+            """
+            # Clarification decision
+
+            ## Question
+            Should we run the dry-run path?
+
+            ## Decision
+            Yes — dry-run path must not mutate.
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyRecordCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.DecisionArtifactPath, "--dry-run"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(existing, workspace.ReadClarification());
+        var output = writer.ToString();
+        Assert.Contains("Would record decision into", output, StringComparison.Ordinal);
+        Assert.Contains("Should we run the dry-run path?", output, StringComparison.Ordinal);
+        Assert.Contains("Decision: Yes — dry-run path must not mutate.", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedDecisionArtifact_FailsBeforeMutation()
+    {
+        // Required scenario 3: malformed input. Missing the "## Decision"
+        // section must fail with a clear error before any mutation.
+        using var workspace = new ClarifyRecordWorkspace();
+        var existing = "# clar\n\n## Current Open Blockers\n\n- still here\n";
+        workspace.WriteClarification(existing);
+        workspace.WriteDecisionArtifact(
+            """
+            # Clarification decision
+
+            ## Question
+            Should we ship clarify draft now?
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyRecordCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.DecisionArtifactPath],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(existing, workspace.ReadClarification());
+        Assert.Contains("Decision", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingClarificationReturnPath_FailsWithClearError()
+    {
+        // Required scenario 4: missing return path. clarifications/open.md does
+        // not exist for the resolved domain; must fail with a clear error and no
+        // mutation. Any neighbouring host files must remain untouched.
+        using var workspace = new ClarifyRecordWorkspace(writeClarification: false);
+        workspace.WriteDecisionArtifact(
+            """
+            # Clarification decision
+
+            ## Question
+            Q?
+
+            ## Decision
+            A.
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyRecordCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.DecisionArtifactPath],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Clarification return path", output, StringComparison.Ordinal);
+        Assert.Contains("does not exist", output, StringComparison.Ordinal);
+        Assert.False(File.Exists(workspace.ClarificationPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFromFileFlag_ReturnsErrorExitCode()
+    {
+        using var workspace = new ClarifyRecordWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = ClarifyRecordCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-file", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenFromFilePathThatDoesNotExist_ReturnsErrorExitCode()
+    {
+        using var workspace = new ClarifyRecordWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = ClarifyRecordCommand.Execute(
+            workspace.Context,
+            ["--from-file", Path.Combine(workspace.RootPath, "missing.md")],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("does not exist", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsErrorExitCode()
+    {
+        using var workspace = new ClarifyRecordWorkspace();
+        workspace.WriteDecisionArtifact(MinimalArtifact);
+        using var writer = new StringWriter();
+
+        var exitCode = ClarifyRecordCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.DecisionArtifactPath, "--bogus"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenDomainOverride_ResolvesReturnPathUnderOverrideDomain()
+    {
+        using var workspace = new ClarifyRecordWorkspace(writeClarification: false);
+        workspace.WriteDecisionArtifact(MinimalArtifact);
+        var altPath = Path.Combine(workspace.RootPath, "intents", "alt-domain", "clarifications", "open.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(altPath)!);
+        File.WriteAllText(altPath, "# alt clarifications\n\n## Recently Resolved\n");
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyRecordCommand.Execute(
+            workspace.Context,
+            ["--domain", "alt-domain", "--from-file", workspace.DecisionArtifactPath],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var content = File.ReadAllText(altPath);
+        Assert.Contains("Q?", content, StringComparison.Ordinal);
+        Assert.Contains("Decision: A.", content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationFileWithoutRecentlyResolvedSection_AppendsSection()
+    {
+        using var workspace = new ClarifyRecordWorkspace();
+        var existing = "# clar\n\n## Current Open Blockers\n\n- still here\n";
+        workspace.WriteClarification(existing);
+        workspace.WriteDecisionArtifact(MinimalArtifact);
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyRecordCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.DecisionArtifactPath],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var updated = workspace.ReadClarification();
+        Assert.Contains("- still here", updated, StringComparison.Ordinal);
+        Assert.Contains("## Recently Resolved", updated, StringComparison.Ordinal);
+        Assert.Contains("Q?", updated, StringComparison.Ordinal);
+    }
+
+    private const string MinimalArtifact =
+        """
+        # Clarification decision
+
+        ## Question
+        Q?
+
+        ## Decision
+        A.
+        """;
+
+    private sealed class ClarifyRecordWorkspace : IDisposable
+    {
+        public ClarifyRecordWorkspace(bool writeClarification = true)
+        {
+            RootPath = Directory.CreateTempSubdirectory("clarify-record-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            ClarificationPath = Path.Combine(
+                RootPath,
+                "intents",
+                "intent-cli",
+                "clarifications",
+                "open.md");
+            DecisionArtifactPath = Path.Combine(RootPath, "decision.md");
+
+            if (writeClarification)
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(ClarificationPath)!);
+                File.WriteAllText(ClarificationPath, "# placeholder\n");
+            }
+
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string RootPath { get; }
+
+        public string ClarificationPath { get; }
+
+        public string DecisionArtifactPath { get; }
+
+        public void WriteClarification(string content)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(ClarificationPath)!);
+            File.WriteAllText(ClarificationPath, content);
+        }
+
+        public string ReadClarification() => File.ReadAllText(ClarificationPath);
+
+        public void WriteDecisionArtifact(string content)
+        {
+            File.WriteAllText(DecisionArtifactPath, content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `intent-cli clarify record --domain <name> --from-file <path> [--dry-run]` that records an owner-approved clarification decision into the parent clarification return path (`intents/<domain>/clarifications/open.md`). The CLI never picks or rewrites the answer; it only validates the artifact, resolves the return path, and inserts a structured entry under `## Recently Resolved`.
- Validation precedence (errors fire **before** any mutation):
  1. `--from-file` is required and must reference an existing path.
  2. The artifact must contain non-empty `## Question` and `## Decision` sections; `## Rationale` is optional.
  3. The resolved clarification return path must exist (the CLI does not create the parent intent file).
- Write behaviour: inserts at the top of `## Recently Resolved` (newest-first), preserves every other byte in the file (durable prose, open blockers, earlier resolved entries). If the heading is missing, appends a new section at the end. Each entry uses a stable shape:
  ```
  - <UTC ISO8601> — <question single-line>
    - Decision: <text>
    - Rationale: <text>   (only when supplied)
  ```
- `--dry-run` prints the intended entry and target path; no mutation.
- Wired as a new `record` subcommand under the existing `clarify` group (alongside `open` / `list` / `answer` / `draft`).

## Test plan

- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~ClarifyRecord` — 9/9 passing including the four required scenarios (successful record, dry-run no-mutation, malformed input, missing clarification return path) plus missing-flag/missing-path/unknown-arg failure paths, `--domain` override, and `## Recently Resolved` auto-append.
- [x] G179 / G180 / G181 surfaces unaffected; full repo `dotnet test` — 1232/1232 passing across all suites (CLI: 933 → 942 = +9 new G182 tests).
- [ ] Manual smoke per issue Verification (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- clarify record --domain intent-cli --from-file /path/to/accepted-clarification.md --dry-run`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- clarify record --domain intent-cli --from-file /path/to/accepted-clarification.md`

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)
