### PR TITLE
G183 Add standalone issue body completeness validator

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -79,7 +79,8 @@ internal static class CommandRouter
                 ["draft"] = IssueDraftCommand.Execute,
                 ["create"] = IssueCreateCommand.Execute,
                 ["publish"] = IssuePublishCommand.Execute,
-                ["status"] = IssueStatusCommand.Execute
+                ["status"] = IssueStatusCommand.Execute,
+                ["validate-body"] = IssueValidateBodyCommand.Execute
             },
             ["bug"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/IssueValidateBodyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssueValidateBodyCommand.cs
@@ -1,0 +1,108 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G183: Read-only <c>intent-cli issue validate-body --from-file &lt;path&gt;
+/// [--format text|json]</c> command. Validates a standalone Markdown child
+/// issue body against the host-review-loop Child Issue Contract: required
+/// headings present, <c>Related Links</c> contains at least one
+/// non-placeholder list item. Exits 0 when valid and non-zero otherwise.
+/// Never mutates parent queue state, runs, packets, GitHub objects, or labels.
+/// </summary>
+internal static class IssueValidateBodyCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var fromFile, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        if (!File.Exists(fromFile))
+        {
+            writer.WriteLine($"--from-file path '{fromFile}' does not exist.");
+            return 1;
+        }
+
+        var content = File.ReadAllText(fromFile);
+        var result = IssueValidateBodyValidator.Validate(fromFile, content);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            IssueValidateBodyRenderer.WriteJson(writer, result);
+        }
+        else
+        {
+            IssueValidateBodyRenderer.WriteText(writer, result);
+        }
+
+        return result.IsValid ? 0 : 1;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string fromFile,
+        out string format,
+        out string error)
+    {
+        fromFile = string.Empty;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-file":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-file requires a non-empty path.";
+                        return false;
+                    }
+
+                    fromFile = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --from-file <path> --format text|json.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromFile))
+        {
+            error = "--from-file is required.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IssueValidateBodyRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IssueValidateBodyRenderer.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Output renderer for <c>issue validate-body</c> (G183). Produces a
+/// deterministic human-readable summary (default) or stable snake_case JSON.
+/// </summary>
+internal static class IssueValidateBodyRenderer
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    public static void WriteText(TextWriter writer, IssueValidateBodyResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"Source: {result.SourcePath}");
+        if (result.IsValid)
+        {
+            writer.WriteLine("Result: valid — issue body satisfies the Child Issue Contract.");
+            return;
+        }
+
+        writer.WriteLine("Result: invalid");
+
+        if (result.MissingHeadings.Count > 0)
+        {
+            writer.WriteLine("Missing required headings:");
+            foreach (var heading in result.MissingHeadings)
+            {
+                writer.WriteLine($"- {heading}");
+            }
+        }
+
+        if (result.RelatedLinksInvalid)
+        {
+            writer.WriteLine($"Related Links: {result.RelatedLinksReason ?? "invalid."}");
+        }
+    }
+
+    public static void WriteJson(TextWriter writer, IssueValidateBodyResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IssueValidateBodyResult.cs
+++ b/src/IntentSystem.Cli/Commands/IssueValidateBodyResult.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Result of validating a standalone Markdown child issue body against the
+/// host-review-loop Child Issue Contract (G183). Field names are stable
+/// snake_case for JSON ingestion.
+/// </summary>
+internal sealed record IssueValidateBodyResult
+{
+    [JsonPropertyName("source_path")]
+    public required string SourcePath { get; init; }
+
+    [JsonPropertyName("is_valid")]
+    public required bool IsValid { get; init; }
+
+    [JsonPropertyName("missing_headings")]
+    public required IReadOnlyList<string> MissingHeadings { get; init; }
+
+    [JsonPropertyName("related_links_invalid")]
+    public required bool RelatedLinksInvalid { get; init; }
+
+    [JsonPropertyName("related_links_reason")]
+    public string? RelatedLinksReason { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IssueValidateBodyValidator.cs
+++ b/src/IntentSystem.Cli/Commands/IssueValidateBodyValidator.cs
@@ -1,0 +1,220 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Pure validator for standalone Markdown child issue bodies (G183). Checks
+/// the 10 host-review-loop Child Issue Contract headings and ensures the
+/// <c>Related Links</c> section contains at least one non-placeholder list
+/// item. Read-only and side-effect-free.
+/// </summary>
+internal static class IssueValidateBodyValidator
+{
+    /// <summary>
+    /// Required Child Issue Contract headings, in canonical order.
+    /// "Target Repo / Path / Part" is the canonical form; the hyphen variant
+    /// "Target Repo-Path-Part" is also accepted because both shapes are in
+    /// active use across the host workflow.
+    /// </summary>
+    public static IReadOnlyList<string> RequiredHeadings { get; } =
+    [
+        "Goal",
+        "Why This Slice Exists Now",
+        "Current Observed State",
+        "Accepted Baseline You May Assume",
+        "Target Repo / Path / Part",
+        "In Scope",
+        "Out Of Scope",
+        "Acceptance Criteria",
+        "Verification",
+        "Related Links"
+    ];
+
+    private static readonly IReadOnlyDictionary<string, string[]> HeadingAliases =
+        new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Target Repo / Path / Part"] = ["Target Repo-Path-Part"]
+        };
+
+    /// <summary>
+    /// Trimmed bullet contents that count as placeholders rather than real
+    /// links. Match is case-insensitive and applies to the full trimmed item
+    /// (after stripping leading list markers and trailing punctuation).
+    /// </summary>
+    private static readonly HashSet<string> PlaceholderTokens = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "todo",
+        "fixme",
+        "tbd",
+        "n/a",
+        "na",
+        "none",
+        "placeholder",
+        "...",
+        "-"
+    };
+
+    public static IssueValidateBodyResult Validate(string sourcePath, string content)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourcePath);
+        ArgumentNullException.ThrowIfNull(content);
+
+        var sections = ExtractSections(content);
+        var missing = new List<string>();
+        foreach (var heading in RequiredHeadings)
+        {
+            if (!sections.ContainsKey(heading) && !TryFindAlias(heading, sections))
+            {
+                missing.Add(heading);
+            }
+        }
+
+        var relatedLinksInvalid = false;
+        string? relatedLinksReason = null;
+        if (sections.TryGetValue("Related Links", out var relatedLinksBody))
+        {
+            (relatedLinksInvalid, relatedLinksReason) = ValidateRelatedLinks(relatedLinksBody);
+        }
+
+        var isValid = missing.Count == 0 && !relatedLinksInvalid;
+
+        return new IssueValidateBodyResult
+        {
+            SourcePath = sourcePath,
+            IsValid = isValid,
+            MissingHeadings = missing,
+            RelatedLinksInvalid = relatedLinksInvalid,
+            RelatedLinksReason = relatedLinksReason
+        };
+    }
+
+    private static bool TryFindAlias(string canonicalHeading, IReadOnlyDictionary<string, string> sections)
+    {
+        if (!HeadingAliases.TryGetValue(canonicalHeading, out var aliases))
+        {
+            return false;
+        }
+
+        foreach (var alias in aliases)
+        {
+            if (sections.ContainsKey(alias))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IReadOnlyDictionary<string, string> ExtractSections(string content)
+    {
+        var sections = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var lines = content.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+
+        string? currentHeading = null;
+        var currentBody = new List<string>();
+
+        void Flush()
+        {
+            if (currentHeading is null)
+            {
+                return;
+            }
+
+            sections[currentHeading] = string.Join("\n", currentBody);
+        }
+
+        foreach (var rawLine in lines)
+        {
+            var trimmedLine = rawLine.TrimEnd();
+            if (trimmedLine.StartsWith("## ", StringComparison.Ordinal))
+            {
+                Flush();
+                currentBody.Clear();
+                currentHeading = trimmedLine[3..].Trim();
+                continue;
+            }
+
+            if (currentHeading is not null)
+            {
+                currentBody.Add(rawLine);
+            }
+        }
+
+        Flush();
+        return sections;
+    }
+
+    private static (bool Invalid, string? Reason) ValidateRelatedLinks(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return (true, "Related Links section is empty.");
+        }
+
+        var lines = body.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var foundAnyItem = false;
+        var hasMeaningfulItem = false;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimStart();
+            if (!line.StartsWith("- ", StringComparison.Ordinal)
+                && !line.StartsWith("* ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foundAnyItem = true;
+            var item = line[2..].Trim().TrimEnd('.', ',', ';', ':');
+
+            // Strip surrounding parentheses/brackets that operators sometimes
+            // add around placeholders, e.g. "(TODO)" or "[N/A]".
+            item = StripWrappers(item);
+
+            if (item.Length == 0)
+            {
+                continue;
+            }
+
+            if (PlaceholderTokens.Contains(item))
+            {
+                continue;
+            }
+
+            hasMeaningfulItem = true;
+            break;
+        }
+
+        if (!foundAnyItem)
+        {
+            return (true, "Related Links section has no list items.");
+        }
+
+        if (!hasMeaningfulItem)
+        {
+            return (true, "Related Links section contains only TODO/FIXME/placeholder entries.");
+        }
+
+        return (false, null);
+    }
+
+    private static string StripWrappers(string value)
+    {
+        var trimmed = value.Trim();
+        while (trimmed.Length >= 2)
+        {
+            var first = trimmed[0];
+            var last = trimmed[^1];
+            if ((first == '(' && last == ')')
+                || (first == '[' && last == ']')
+                || (first == '"' && last == '"'))
+            {
+                trimmed = trimmed[1..^1].Trim();
+                continue;
+            }
+
+            break;
+        }
+
+        return trimmed;
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IssueValidateBodyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssueValidateBodyCommandTests.cs
@@ -1,0 +1,292 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IssueValidateBodyCommandTests
+{
+    [Fact]
+    public void Execute_GivenCompleteIssueBody_ReturnsZeroExitAndReportsValid()
+    {
+        // Required scenario 1 (G183): a complete Child Issue Contract body must
+        // exit 0 and report valid.
+        using var workspace = new IssueValidateBodyWorkspace();
+        workspace.WriteBody("issue.md", CompleteValidBody);
+        using var writer = new StringWriter();
+
+        var exitCode = IssueValidateBodyCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("issue.md")],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("valid", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenBodyMissingRequiredHeading_ReturnsNonZeroAndIdentifiesMissingHeading()
+    {
+        // Required scenario 2: missing required heading must exit non-zero and
+        // identify the missing heading deterministically.
+        using var workspace = new IssueValidateBodyWorkspace();
+        var bodyWithoutVerification = CompleteValidBody.Replace(
+            "## Verification\n\nRun the focused suite.\n\n",
+            string.Empty,
+            StringComparison.Ordinal);
+        workspace.WriteBody("issue.md", bodyWithoutVerification);
+
+        using var writer = new StringWriter();
+        var exitCode = IssueValidateBodyCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("issue.md")],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Verification", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenBodyWithEmptyRelatedLinks_ReturnsNonZeroAndExplainsRelatedLinks()
+    {
+        // Required scenario 3 (a): empty Related Links section must exit non-zero.
+        using var workspace = new IssueValidateBodyWorkspace();
+        var bodyWithEmptyLinks = CompleteValidBody.Replace(
+            "## Related Links\n\n- Host runbook: intents/rules/automations/runbook.md",
+            "## Related Links\n",
+            StringComparison.Ordinal);
+        workspace.WriteBody("issue.md", bodyWithEmptyLinks);
+
+        using var writer = new StringWriter();
+        var exitCode = IssueValidateBodyCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("issue.md"), "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("is_valid").GetBoolean());
+        Assert.True(root.GetProperty("related_links_invalid").GetBoolean());
+        Assert.NotNull(root.GetProperty("related_links_reason").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenBodyWithPlaceholderOnlyRelatedLinks_ReturnsNonZero()
+    {
+        // Required scenario 3 (b): TODO/FIXME/placeholder-only Related Links
+        // must exit non-zero. We exercise both list-marker styles and a couple
+        // of placeholder spellings to lock the behaviour down.
+        using var workspace = new IssueValidateBodyWorkspace();
+        var placeholderLinks =
+            "## Related Links\n\n- TODO\n- (FIXME)\n* placeholder\n- N/A";
+        var body = CompleteValidBody.Replace(
+            "## Related Links\n\n- Host runbook: intents/rules/automations/runbook.md",
+            placeholderLinks,
+            StringComparison.Ordinal);
+        workspace.WriteBody("issue.md", body);
+
+        using var writer = new StringWriter();
+        var exitCode = IssueValidateBodyCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("issue.md")],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Related Links", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFromFileFlag_ReturnsNonZero()
+    {
+        // Required scenario 4 (a): missing --from-file flag.
+        using var workspace = new IssueValidateBodyWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IssueValidateBodyCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-file", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenBlankFromFileValue_ReturnsNonZero()
+    {
+        // Required scenario 4 (b): blank --from-file value.
+        using var workspace = new IssueValidateBodyWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IssueValidateBodyCommand.Execute(
+            workspace.Context,
+            ["--from-file", "   "],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-file", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNonexistentInputFile_ReturnsNonZero()
+    {
+        // Required scenario 4 (c): nonexistent input file.
+        using var workspace = new IssueValidateBodyWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IssueValidateBodyCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("missing.md")],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("does not exist", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_EmitsParsableSnakeCaseFields()
+    {
+        using var workspace = new IssueValidateBodyWorkspace();
+        workspace.WriteBody("issue.md", CompleteValidBody);
+
+        using var writer = new StringWriter();
+        var exitCode = IssueValidateBodyCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("issue.md"), "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("is_valid").GetBoolean());
+        Assert.False(root.GetProperty("related_links_invalid").GetBoolean());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("missing_headings").ValueKind);
+        Assert.Equal(0, root.GetProperty("missing_headings").GetArrayLength());
+        Assert.True(root.TryGetProperty("source_path", out _));
+    }
+
+    [Fact]
+    public void Execute_GivenBodyWithHyphenTargetRepoVariant_AcceptsAsAlias()
+    {
+        // The host-review-loop runbook canonical heading is "Target Repo / Path / Part",
+        // but earlier issues in the workflow use the "Target Repo-Path-Part" hyphen
+        // variant. The validator should treat both as satisfying the contract.
+        using var workspace = new IssueValidateBodyWorkspace();
+        var hyphenVariant = CompleteValidBody.Replace(
+            "## Target Repo / Path / Part",
+            "## Target Repo-Path-Part",
+            StringComparison.Ordinal);
+        workspace.WriteBody("issue.md", hyphenVariant);
+
+        using var writer = new StringWriter();
+        var exitCode = IssueValidateBodyCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("issue.md")],
+            writer);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsNonZero()
+    {
+        using var workspace = new IssueValidateBodyWorkspace();
+        workspace.WriteBody("issue.md", CompleteValidBody);
+
+        using var writer = new StringWriter();
+        var exitCode = IssueValidateBodyCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("issue.md"), "--bogus"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private const string CompleteValidBody =
+        """
+        # G999 Example child issue body for validator tests
+
+        ## Goal
+
+        Stand-alone description of what this slice changes.
+
+        ## Why This Slice Exists Now
+
+        Surrounding rationale for cutting the slice now.
+
+        ## Current Observed State
+
+        Observed state described in actionable terms.
+
+        ## Accepted Baseline You May Assume
+
+        Baseline assumptions stated explicitly.
+
+        ## Target Repo / Path / Part
+
+        - Repository: J-Tech-Japan/intent-system
+        - Likely areas: src/, tests/
+
+        ## In Scope
+
+        - The slice change itself.
+
+        ## Out Of Scope
+
+        - Adjacent refactors.
+
+        ## Acceptance Criteria
+
+        - Deterministic behaviour described here.
+
+        ## Verification
+
+        Run the focused suite.
+
+        ## Related Links
+
+        - Host runbook: intents/rules/automations/runbook.md
+        """;
+
+    private sealed class IssueValidateBodyWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("issue-validate-body-tests-")
+            .FullName;
+
+        public IssueValidateBodyWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string GetPath(string relative) => Path.Combine(rootPath, relative);
+
+        public void WriteBody(string relative, string content)
+        {
+            File.WriteAllText(GetPath(relative), content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a read-only `intent-cli issue validate-body --from-file <path> [--format text|json]` command that validates a standalone Markdown child issue body against the host-review-loop Child Issue Contract before any GitHub or parent-state mutation is attempted.
- Validates all 10 required headings (`Goal`, `Why This Slice Exists Now`, `Current Observed State`, `Accepted Baseline You May Assume`, `Target Repo / Path / Part`, `In Scope`, `Out Of Scope`, `Acceptance Criteria`, `Verification`, `Related Links`). The hyphen variant `Target Repo-Path-Part` is accepted as an alias because both shapes are in active use across the host workflow.
- Validates that `Related Links` contains at least one non-placeholder list item. Empty / TODO-only / FIXME-only / TBD / N/A / placeholder / `...` / `-` entries are rejected (case-insensitive; surrounding parentheses / brackets / quotes are stripped before the placeholder check).
- Exit codes: `0` when the body satisfies the contract; `1` for missing headings, invalid `Related Links`, missing `--from-file` flag, blank `--from-file` value, nonexistent input file, or unknown arguments.
- Output: deterministic human-readable text (default) or stable snake_case JSON (`{source_path, is_valid, missing_headings, related_links_invalid, related_links_reason}`) for AI-thread ingestion.
- Wired as a new `validate-body` subcommand under the existing `issue` command group alongside `draft` / `create` / `publish` / `status`. Never mutates parent queue state, runs, packets, GitHub objects, or labels.

## Test plan

- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~IssueValidateBody` — 10/10 passing including the four required scenarios (valid body, missing required heading, invalid Related Links, missing input file/path) plus blank-flag value, nonexistent input file, JSON round-trip, hyphen heading alias, and unknown-arg failure paths.
- [x] G179 / G180 / G181 / G182 surfaces unaffected; full repo `dotnet test` — 1242/1242 passing across all suites (CLI: 942 → 952 = +10 new G183 tests; no regressions).
- [ ] Manual smoke per issue Verification (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- issue validate-body --from-file .intent-cli/issues/G183/github-body.md`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- issue validate-body --from-file /path/to/incomplete-body.md`

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)
