### PR TITLE
G184: add intent-cli issue prepare and publish-reviewed boundary

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -80,7 +80,9 @@ internal static class CommandRouter
                 ["create"] = IssueCreateCommand.Execute,
                 ["publish"] = IssuePublishCommand.Execute,
                 ["status"] = IssueStatusCommand.Execute,
-                ["validate-body"] = IssueValidateBodyCommand.Execute
+                ["validate-body"] = IssueValidateBodyCommand.Execute,
+                ["prepare"] = IssuePrepareCommand.Execute,
+                ["publish-reviewed"] = IssuePublishReviewedCommand.Execute
             },
             ["bug"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/GhIssueCreator.cs
+++ b/src/IntentSystem.Cli/Commands/GhIssueCreator.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Default <see cref="IGhIssueCreator"/> implementation. Shells out to
+/// <c>gh issue create --repo &lt;repo&gt; --title &lt;title&gt; --body-file &lt;path&gt;</c>
+/// and returns the trimmed stdout (the issue URL printed by gh). No labels are
+/// passed; that boundary is owned by the host-review-loop runbook.
+/// </summary>
+internal sealed class GhIssueCreator : IGhIssueCreator
+{
+    public string CreateIssue(string repo, string title, string bodyFilePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        ArgumentException.ThrowIfNullOrWhiteSpace(bodyFilePath);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        startInfo.ArgumentList.Add("issue");
+        startInfo.ArgumentList.Add("create");
+        startInfo.ArgumentList.Add("--repo");
+        startInfo.ArgumentList.Add(repo);
+        startInfo.ArgumentList.Add("--title");
+        startInfo.ArgumentList.Add(title);
+        startInfo.ArgumentList.Add("--body-file");
+        startInfo.ArgumentList.Add(bodyFilePath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start gh process.");
+        var stdOut = process.StandardOutput.ReadToEnd();
+        var stdErr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"gh issue create failed (exit {process.ExitCode}): {stdErr.Trim()}");
+        }
+
+        return stdOut.Trim();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IGhIssueCreator.cs
+++ b/src/IntentSystem.Cli/Commands/IGhIssueCreator.cs
@@ -1,0 +1,18 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G184 testability seam: minimal interface for creating a single GitHub issue
+/// from a reviewed publish packet via <c>gh issue create</c>. The contract is
+/// deliberately narrow — it has no label parameter so the host-owned
+/// <c>intent-target</c> boundary cannot be crossed by accident.
+/// </summary>
+internal interface IGhIssueCreator
+{
+    /// <summary>
+    /// Creates one issue in <paramref name="repo"/> with the given
+    /// <paramref name="title"/> and Markdown body file. Returns the URL printed
+    /// by <c>gh issue create</c> (one line, e.g.
+    /// <c>https://github.com/owner/repo/issues/123</c>).
+    /// </summary>
+    string CreateIssue(string repo, string title, string bodyFilePath);
+}

--- a/src/IntentSystem.Cli/Commands/IssuePrepareCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePrepareCommand.cs
@@ -1,0 +1,215 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G184: <c>intent-cli issue prepare --from-file &lt;body.md&gt;
+/// --execution-unit &lt;id&gt; --title &lt;title&gt; --out &lt;packet.json&gt;</c>.
+/// Validates a standalone Markdown child issue body via the G183 validator and
+/// writes a deterministic reviewed publish packet on success. Refuses to write
+/// any packet on failure. Never invokes AI providers; never mutates GitHub or
+/// parent queue state.
+/// </summary>
+internal static class IssuePrepareCommand
+{
+    private static readonly JsonSerializerOptions PacketSerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var fromFile, out var executionUnit, out var title, out var outPath, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        if (!File.Exists(fromFile))
+        {
+            writer.WriteLine($"--from-file path '{fromFile}' does not exist.");
+            return 1;
+        }
+
+        var content = File.ReadAllText(fromFile);
+        var validation = IssueValidateBodyValidator.Validate(fromFile, content);
+        if (!validation.IsValid)
+        {
+            writer.WriteLine("Issue body failed validation; refusing to write packet.");
+            if (validation.MissingHeadings.Count > 0)
+            {
+                writer.WriteLine("Missing required headings:");
+                foreach (var heading in validation.MissingHeadings)
+                {
+                    writer.WriteLine($"- {heading}");
+                }
+            }
+
+            if (validation.RelatedLinksInvalid)
+            {
+                writer.WriteLine($"Related Links: {validation.RelatedLinksReason ?? "invalid."}");
+            }
+
+            return 1;
+        }
+
+        var fileBytes = File.ReadAllBytes(fromFile);
+        var sha256 = ComputeSha256Hex(fileBytes);
+        var packet = new IssueReviewedPublishPacket
+        {
+            ExecutionUnit = executionUnit,
+            Title = title,
+            SourcePath = fromFile,
+            SourceBodySha256 = sha256,
+            ValidationStatus = "valid",
+            Reviewed = true,
+            Published = false,
+            IssueNumber = null,
+            IssueUrl = null,
+            PreparedAtUtc = FormatUtcTimestamp(TimestampFactory()),
+            PublishedAtUtc = null
+        };
+
+        var serialized = JsonSerializer.Serialize(packet, PacketSerializerOptions);
+        var outDirectory = Path.GetDirectoryName(outPath);
+        if (!string.IsNullOrEmpty(outDirectory))
+        {
+            Directory.CreateDirectory(outDirectory);
+        }
+
+        File.WriteAllText(outPath, serialized);
+
+        writer.WriteLine($"Prepared reviewed publish packet for {executionUnit} at {outPath}");
+        return 0;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string fromFile,
+        out string executionUnit,
+        out string title,
+        out string outPath,
+        out string error)
+    {
+        fromFile = string.Empty;
+        executionUnit = string.Empty;
+        title = string.Empty;
+        outPath = string.Empty;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-file":
+                    if (!TryReadValue(args, ref index, "--from-file", out var fromFileValue, out error))
+                    {
+                        return false;
+                    }
+
+                    fromFile = fromFileValue;
+                    break;
+
+                case "--execution-unit":
+                    if (!TryReadValue(args, ref index, "--execution-unit", out var executionUnitValue, out error))
+                    {
+                        return false;
+                    }
+
+                    executionUnit = executionUnitValue;
+                    break;
+
+                case "--title":
+                    if (!TryReadValue(args, ref index, "--title", out var titleValue, out error))
+                    {
+                        return false;
+                    }
+
+                    title = titleValue;
+                    break;
+
+                case "--out":
+                    if (!TryReadValue(args, ref index, "--out", out var outValue, out error))
+                    {
+                        return false;
+                    }
+
+                    outPath = outValue;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --from-file, --execution-unit, --title, --out.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromFile))
+        {
+            error = "--from-file is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            error = "--execution-unit is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            error = "--title is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(outPath))
+        {
+            error = "--out is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadValue(string[] args, ref int index, string flag, out string value, out string error)
+    {
+        value = string.Empty;
+        error = string.Empty;
+        if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+        {
+            error = $"{flag} requires a non-empty value.";
+            return false;
+        }
+
+        value = args[index + 1];
+        index++;
+        return true;
+    }
+
+    private static string ComputeSha256Hex(byte[] bytes)
+    {
+        var hash = SHA256.HashData(bytes);
+        var builder = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash)
+        {
+            builder.Append(b.ToString("x2", CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
+    }
+
+    internal static string FormatUtcTimestamp(DateTimeOffset timestamp)
+    {
+        return timestamp.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IssuePrepareCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePrepareCommand.cs
@@ -196,7 +196,7 @@ internal static class IssuePrepareCommand
         return true;
     }
 
-    private static string ComputeSha256Hex(byte[] bytes)
+    internal static string ComputeSha256Hex(byte[] bytes)
     {
         var hash = SHA256.HashData(bytes);
         var builder = new StringBuilder(hash.Length * 2);

--- a/src/IntentSystem.Cli/Commands/IssuePublishReviewedCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishReviewedCommand.cs
@@ -82,11 +82,19 @@ internal static class IssuePublishReviewedCommand
             return 1;
         }
 
-        var sourceContent = File.ReadAllText(packet.SourcePath);
+        var sourceBytes = File.ReadAllBytes(packet.SourcePath);
+        var sourceContent = System.Text.Encoding.UTF8.GetString(sourceBytes);
         var validation = IssueValidateBodyValidator.Validate(packet.SourcePath, sourceContent);
         if (!validation.IsValid)
         {
             writer.WriteLine("source body no longer passes validation");
+            return 1;
+        }
+
+        var currentSha256 = IssuePrepareCommand.ComputeSha256Hex(sourceBytes);
+        if (!string.Equals(currentSha256, packet.SourceBodySha256, StringComparison.Ordinal))
+        {
+            writer.WriteLine("source body sha256 does not match reviewed packet");
             return 1;
         }
 

--- a/src/IntentSystem.Cli/Commands/IssuePublishReviewedCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishReviewedCommand.cs
@@ -1,0 +1,202 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G184: <c>intent-cli issue publish-reviewed --from-file &lt;packet.json&gt;
+/// --repo &lt;owner/repo&gt;</c>. Reads a reviewed publish packet emitted by
+/// <c>issue prepare</c>, refuses to mutate GitHub if the packet is missing,
+/// invalid, unreviewed, already published, or points to a body that no longer
+/// passes validation, and otherwise creates exactly one GitHub issue via
+/// <c>gh issue create</c> (no <c>--label</c>) and records the issue number and
+/// URL back into the packet.
+/// </summary>
+internal static class IssuePublishReviewedCommand
+{
+    private static readonly JsonSerializerOptions PacketSerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    public static Func<IGhIssueCreator> GhIssueCreatorFactory { get; set; } = () => new GhIssueCreator();
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var fromFile, out var repo, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        if (!File.Exists(fromFile))
+        {
+            writer.WriteLine($"--from-file path '{fromFile}' does not exist.");
+            return 1;
+        }
+
+        IssueReviewedPublishPacket? packet;
+        try
+        {
+            packet = JsonSerializer.Deserialize<IssueReviewedPublishPacket>(File.ReadAllText(fromFile), PacketSerializerOptions);
+        }
+        catch (JsonException exception)
+        {
+            writer.WriteLine($"Failed to parse reviewed publish packet: {exception.Message}");
+            return 1;
+        }
+
+        if (packet is null)
+        {
+            writer.WriteLine("Reviewed publish packet is empty.");
+            return 1;
+        }
+
+        if (!packet.Reviewed)
+        {
+            writer.WriteLine("missing reviewed marker");
+            return 1;
+        }
+
+        if (!string.Equals(packet.ValidationStatus, "valid", StringComparison.Ordinal))
+        {
+            writer.WriteLine("validation status is not valid");
+            return 1;
+        }
+
+        if (packet.Published)
+        {
+            writer.WriteLine("packet is already published");
+            return 1;
+        }
+
+        if (!File.Exists(packet.SourcePath))
+        {
+            writer.WriteLine("source body no longer passes validation");
+            return 1;
+        }
+
+        var sourceContent = File.ReadAllText(packet.SourcePath);
+        var validation = IssueValidateBodyValidator.Validate(packet.SourcePath, sourceContent);
+        if (!validation.IsValid)
+        {
+            writer.WriteLine("source body no longer passes validation");
+            return 1;
+        }
+
+        var creator = GhIssueCreatorFactory();
+        string rawUrl;
+        try
+        {
+            rawUrl = creator.CreateIssue(repo, packet.Title, packet.SourcePath);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException || exception is IOException)
+        {
+            writer.WriteLine($"gh issue create failed: {exception.Message}");
+            return 1;
+        }
+
+        var issueUrl = rawUrl.Trim();
+        if (!TryExtractIssueNumber(issueUrl, out var issueNumber))
+        {
+            writer.WriteLine($"Could not parse issue number from gh output: '{issueUrl}'");
+            return 1;
+        }
+
+        var updated = packet with
+        {
+            Published = true,
+            IssueNumber = issueNumber,
+            IssueUrl = issueUrl,
+            PublishedAtUtc = IssuePrepareCommand.FormatUtcTimestamp(TimestampFactory())
+        };
+
+        File.WriteAllText(fromFile, JsonSerializer.Serialize(updated, PacketSerializerOptions));
+        writer.WriteLine($"Published {updated.ExecutionUnit} as {issueUrl}");
+        return 0;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string fromFile,
+        out string repo,
+        out string error)
+    {
+        fromFile = string.Empty;
+        repo = string.Empty;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-file":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-file requires a non-empty value.";
+                        return false;
+                    }
+
+                    fromFile = args[index + 1];
+                    index++;
+                    break;
+
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a non-empty value.";
+                        return false;
+                    }
+
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --from-file, --repo.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromFile))
+        {
+            error = "--from-file is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "--repo is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryExtractIssueNumber(string url, out int issueNumber)
+    {
+        issueNumber = 0;
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return false;
+        }
+
+        var trimmed = url.TrimEnd('/');
+        var slashIndex = trimmed.LastIndexOf('/');
+        if (slashIndex < 0 || slashIndex == trimmed.Length - 1)
+        {
+            return false;
+        }
+
+        var tail = trimmed[(slashIndex + 1)..];
+        return int.TryParse(tail, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out issueNumber)
+            && issueNumber > 0;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IssueReviewedPublishPacket.cs
+++ b/src/IntentSystem.Cli/Commands/IssueReviewedPublishPacket.cs
@@ -1,0 +1,44 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G184 reviewed publish packet. Snake_case JSON shape that
+/// <c>intent-cli issue prepare</c> writes and
+/// <c>intent-cli issue publish-reviewed</c> consumes.
+/// </summary>
+internal sealed record IssueReviewedPublishPacket
+{
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    [JsonPropertyName("source_path")]
+    public required string SourcePath { get; init; }
+
+    [JsonPropertyName("source_body_sha256")]
+    public required string SourceBodySha256 { get; init; }
+
+    [JsonPropertyName("validation_status")]
+    public required string ValidationStatus { get; init; }
+
+    [JsonPropertyName("reviewed")]
+    public required bool Reviewed { get; init; }
+
+    [JsonPropertyName("published")]
+    public required bool Published { get; init; }
+
+    [JsonPropertyName("issue_number")]
+    public int? IssueNumber { get; init; }
+
+    [JsonPropertyName("issue_url")]
+    public string? IssueUrl { get; init; }
+
+    [JsonPropertyName("prepared_at_utc")]
+    public required string PreparedAtUtc { get; init; }
+
+    [JsonPropertyName("published_at_utc")]
+    public string? PublishedAtUtc { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/IssuePrepareCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePrepareCommandTests.cs
@@ -1,0 +1,243 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IssuePrepareCommandTests : IDisposable
+{
+    private readonly Func<DateTimeOffset> originalTimestampFactory;
+
+    public IssuePrepareCommandTests()
+    {
+        originalTimestampFactory = IssuePrepareCommand.TimestampFactory;
+    }
+
+    public void Dispose()
+    {
+        IssuePrepareCommand.TimestampFactory = originalTimestampFactory;
+    }
+
+    [Fact]
+    public void Execute_GivenValidBody_WritesReviewedPacketAndReturnsZero()
+    {
+        using var workspace = new IssuePrepareWorkspace();
+        workspace.WriteFile("body.md", CompleteValidBody);
+        var bodyPath = workspace.GetPath("body.md");
+        var outPath = workspace.GetPath("packet.json");
+        IssuePrepareCommand.TimestampFactory = () => new DateTimeOffset(2026, 4, 28, 12, 34, 56, TimeSpan.Zero);
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePrepareCommand.Execute(
+            workspace.Context,
+            ["--from-file", bodyPath, "--execution-unit", "G184", "--title", "G184 sample title", "--out", outPath],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(outPath));
+        Assert.Contains("Prepared reviewed publish packet for G184", writer.ToString(), StringComparison.Ordinal);
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(outPath));
+        var root = doc.RootElement;
+        Assert.Equal("G184", root.GetProperty("execution_unit").GetString());
+        Assert.Equal("G184 sample title", root.GetProperty("title").GetString());
+        Assert.Equal(bodyPath, root.GetProperty("source_path").GetString());
+        Assert.Equal("valid", root.GetProperty("validation_status").GetString());
+        Assert.True(root.GetProperty("reviewed").GetBoolean());
+        Assert.False(root.GetProperty("published").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("issue_number").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("issue_url").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("published_at_utc").ValueKind);
+        Assert.Equal("2026-04-28T12:34:56.000Z", root.GetProperty("prepared_at_utc").GetString());
+        var sha = root.GetProperty("source_body_sha256").GetString();
+        Assert.NotNull(sha);
+        Assert.Equal(64, sha!.Length);
+    }
+
+    [Fact]
+    public void Execute_GivenInvalidBody_ReturnsNonZeroAndWritesNoPacket()
+    {
+        using var workspace = new IssuePrepareWorkspace();
+        var brokenBody = CompleteValidBody.Replace(
+            "## Verification",
+            "## Not Verification",
+            StringComparison.Ordinal);
+        workspace.WriteFile("body.md", brokenBody);
+        var outPath = workspace.GetPath("packet.json");
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePrepareCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("body.md"), "--execution-unit", "G184", "--title", "t", "--out", outPath],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+        Assert.Contains("Verification", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFlag_ReturnsNonZero()
+    {
+        using var workspace = new IssuePrepareWorkspace();
+        workspace.WriteFile("body.md", CompleteValidBody);
+
+        using var writer = new StringWriter();
+        // missing --out
+        var exitCode = IssuePrepareCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("body.md"), "--execution-unit", "G184", "--title", "t"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--out", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNonexistentBodyFile_ReturnsNonZero()
+    {
+        using var workspace = new IssuePrepareWorkspace();
+        var outPath = workspace.GetPath("packet.json");
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePrepareCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("missing.md"), "--execution-unit", "G184", "--title", "t", "--out", outPath],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+        Assert.Contains("does not exist", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenValidBody_PacketJsonRoundTripsStably()
+    {
+        using var workspace = new IssuePrepareWorkspace();
+        workspace.WriteFile("body.md", CompleteValidBody);
+        var outPath = workspace.GetPath("packet.json");
+        IssuePrepareCommand.TimestampFactory = () => new DateTimeOffset(2026, 4, 28, 9, 0, 0, TimeSpan.Zero);
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePrepareCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("body.md"), "--execution-unit", "G184", "--title", "G184 RT", "--out", outPath],
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var json = File.ReadAllText(outPath);
+        var packet = JsonSerializer.Deserialize<IssueReviewedPublishPacket>(json);
+        Assert.NotNull(packet);
+        Assert.Equal("G184", packet!.ExecutionUnit);
+        Assert.Equal("G184 RT", packet.Title);
+        Assert.Equal(workspace.GetPath("body.md"), packet.SourcePath);
+        Assert.Equal("valid", packet.ValidationStatus);
+        Assert.True(packet.Reviewed);
+        Assert.False(packet.Published);
+        Assert.Null(packet.IssueNumber);
+        Assert.Null(packet.IssueUrl);
+        Assert.Null(packet.PublishedAtUtc);
+        Assert.Equal("2026-04-28T09:00:00.000Z", packet.PreparedAtUtc);
+
+        // Round-trip again to confirm stable shape.
+        var again = JsonSerializer.Serialize(packet);
+        var packet2 = JsonSerializer.Deserialize<IssueReviewedPublishPacket>(again);
+        Assert.NotNull(packet2);
+        Assert.Equal(packet.SourceBodySha256, packet2!.SourceBodySha256);
+        Assert.Equal(packet.PreparedAtUtc, packet2.PreparedAtUtc);
+        Assert.Equal(packet.Title, packet2.Title);
+        Assert.Equal(packet.ExecutionUnit, packet2.ExecutionUnit);
+    }
+
+    // Hand-crafted minimal Markdown body satisfying all 10 G183 required headings.
+    // NOTE: closing `"""` does not add a trailing newline, so any subsequent
+    // string.Replace must not assume one.
+    internal const string CompleteValidBody =
+        """
+        # G184 Sample child issue body for prepare/publish-reviewed tests
+
+        ## Goal
+
+        Stand-alone description of what this slice changes.
+
+        ## Why This Slice Exists Now
+
+        Surrounding rationale for cutting the slice now.
+
+        ## Current Observed State
+
+        Observed state described in actionable terms.
+
+        ## Accepted Baseline You May Assume
+
+        Baseline assumptions stated explicitly.
+
+        ## Target Repo / Path / Part
+
+        - Repository: J-Tech-Japan/intent-system
+        - Likely areas: src/, tests/
+
+        ## In Scope
+
+        - The slice change itself.
+
+        ## Out Of Scope
+
+        - Adjacent refactors.
+
+        ## Acceptance Criteria
+
+        - Deterministic behaviour described here.
+
+        ## Verification
+
+        Run the focused suite.
+
+        ## Related Links
+
+        - Host runbook: intents/rules/automations/runbook.md
+        """;
+
+    internal sealed class IssuePrepareWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("issue-prepare-tests-")
+            .FullName;
+
+        public IssuePrepareWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string GetPath(string relative) => Path.Combine(rootPath, relative);
+
+        public void WriteFile(string relative, string content)
+        {
+            File.WriteAllText(GetPath(relative), content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IssuePublishReviewedCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishReviewedCommandTests.cs
@@ -197,6 +197,43 @@ public sealed class IssuePublishReviewedCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_GivenSourceBodyChangedButStillValid_ReturnsNonZeroBeforeGhCall()
+    {
+        // Regression for the G184 reviewed-publish boundary: if the body file
+        // is replaced with DIFFERENT but still G183-contract-valid Markdown
+        // after `issue prepare`, `publish-reviewed` must refuse before any
+        // GitHub mutation because the recorded SHA-256 no longer matches.
+        using var workspace = new IssuePublishWorkspace();
+        var (bodyPath, packetPath) = workspace.PrepareValidPacket();
+
+        // Replace the body with a different but still-valid body. Appending
+        // any non-whitespace content changes the bytes (and therefore the
+        // sha256) without removing or invalidating any required heading.
+        var mutatedBody = IssuePrepareCommandTests.CompleteValidBody
+            + "\n\nAdditional prose appended after review approved the packet.\n";
+        File.WriteAllText(bodyPath, mutatedBody);
+
+        var fakeCreator = new RecordingGhIssueCreator("unused");
+        IssuePublishReviewedCommand.GhIssueCreatorFactory = () => fakeCreator;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishReviewedCommand.Execute(
+            workspace.Context,
+            ["--from-file", packetPath, "--repo", "owner/repo"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(fakeCreator.Calls);
+        Assert.Contains("sha256", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+
+        // Packet must remain unpublished on disk.
+        var packet = JsonSerializer.Deserialize<IssueReviewedPublishPacket>(File.ReadAllText(packetPath))!;
+        Assert.False(packet.Published);
+        Assert.Null(packet.IssueNumber);
+        Assert.Null(packet.IssueUrl);
+    }
+
+    [Fact]
     public void Execute_GivenMissingPacketFile_ReturnsNonZero()
     {
         using var workspace = new IssuePublishWorkspace();

--- a/tests/IntentSystem.Cli.Tests/IssuePublishReviewedCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishReviewedCommandTests.cs
@@ -1,0 +1,295 @@
+using System.Reflection;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IssuePublishReviewedCommandTests : IDisposable
+{
+    private readonly Func<IGhIssueCreator> originalCreatorFactory;
+    private readonly Func<DateTimeOffset> originalTimestampFactory;
+    private readonly Func<DateTimeOffset> originalPrepareTimestampFactory;
+
+    public IssuePublishReviewedCommandTests()
+    {
+        originalCreatorFactory = IssuePublishReviewedCommand.GhIssueCreatorFactory;
+        originalTimestampFactory = IssuePublishReviewedCommand.TimestampFactory;
+        originalPrepareTimestampFactory = IssuePrepareCommand.TimestampFactory;
+    }
+
+    public void Dispose()
+    {
+        IssuePublishReviewedCommand.GhIssueCreatorFactory = originalCreatorFactory;
+        IssuePublishReviewedCommand.TimestampFactory = originalTimestampFactory;
+        IssuePrepareCommand.TimestampFactory = originalPrepareTimestampFactory;
+    }
+
+    [Fact]
+    public void Execute_GivenReviewedValidPacket_CreatesIssueAndUpdatesPacket()
+    {
+        using var workspace = new IssuePublishWorkspace();
+        var (bodyPath, packetPath) = workspace.PrepareValidPacket();
+
+        var fakeCreator = new RecordingGhIssueCreator("https://github.com/owner/repo/issues/473");
+        IssuePublishReviewedCommand.GhIssueCreatorFactory = () => fakeCreator;
+        IssuePublishReviewedCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 28, 13, 0, 0, TimeSpan.Zero);
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishReviewedCommand.Execute(
+            workspace.Context,
+            ["--from-file", packetPath, "--repo", "owner/repo"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Single(fakeCreator.Calls);
+        var call = fakeCreator.Calls[0];
+        Assert.Equal("owner/repo", call.Repo);
+        Assert.Equal("G184 sample title", call.Title);
+        Assert.Equal(bodyPath, call.BodyFilePath);
+
+        Assert.Contains("Published G184 as https://github.com/owner/repo/issues/473", writer.ToString(), StringComparison.Ordinal);
+
+        var packet = JsonSerializer.Deserialize<IssueReviewedPublishPacket>(File.ReadAllText(packetPath));
+        Assert.NotNull(packet);
+        Assert.True(packet!.Published);
+        Assert.Equal(473, packet.IssueNumber);
+        Assert.Equal("https://github.com/owner/repo/issues/473", packet.IssueUrl);
+        Assert.Equal("2026-04-28T13:00:00.000Z", packet.PublishedAtUtc);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingReviewedMarker_ReturnsNonZeroBeforeGhCall()
+    {
+        using var workspace = new IssuePublishWorkspace();
+        var (_, packetPath) = workspace.PrepareValidPacket();
+
+        // Mutate the on-disk packet so reviewed=false.
+        var packet = JsonSerializer.Deserialize<IssueReviewedPublishPacket>(File.ReadAllText(packetPath))!;
+        File.WriteAllText(packetPath, JsonSerializer.Serialize(packet with { Reviewed = false }));
+
+        var fakeCreator = new RecordingGhIssueCreator("unused");
+        IssuePublishReviewedCommand.GhIssueCreatorFactory = () => fakeCreator;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishReviewedCommand.Execute(
+            workspace.Context,
+            ["--from-file", packetPath, "--repo", "owner/repo"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(fakeCreator.Calls);
+        Assert.Contains("missing reviewed marker", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenAlreadyPublished_ReturnsNonZeroBeforeGhCall()
+    {
+        using var workspace = new IssuePublishWorkspace();
+        var (_, packetPath) = workspace.PrepareValidPacket();
+
+        var packet = JsonSerializer.Deserialize<IssueReviewedPublishPacket>(File.ReadAllText(packetPath))!;
+        File.WriteAllText(packetPath, JsonSerializer.Serialize(packet with
+        {
+            Published = true,
+            IssueNumber = 1,
+            IssueUrl = "https://github.com/owner/repo/issues/1",
+            PublishedAtUtc = "2026-04-01T00:00:00.000Z"
+        }));
+
+        var fakeCreator = new RecordingGhIssueCreator("unused");
+        IssuePublishReviewedCommand.GhIssueCreatorFactory = () => fakeCreator;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishReviewedCommand.Execute(
+            workspace.Context,
+            ["--from-file", packetPath, "--repo", "owner/repo"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(fakeCreator.Calls);
+        Assert.Contains("already published", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenInvalidValidationStatus_ReturnsNonZeroBeforeGhCall()
+    {
+        using var workspace = new IssuePublishWorkspace();
+        var (_, packetPath) = workspace.PrepareValidPacket();
+
+        var packet = JsonSerializer.Deserialize<IssueReviewedPublishPacket>(File.ReadAllText(packetPath))!;
+        File.WriteAllText(packetPath, JsonSerializer.Serialize(packet with { ValidationStatus = "invalid" }));
+
+        var fakeCreator = new RecordingGhIssueCreator("unused");
+        IssuePublishReviewedCommand.GhIssueCreatorFactory = () => fakeCreator;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishReviewedCommand.Execute(
+            workspace.Context,
+            ["--from-file", packetPath, "--repo", "owner/repo"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(fakeCreator.Calls);
+        Assert.Contains("validation status is not valid", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenSourceBodyNoLongerValid_ReturnsNonZeroBeforeGhCall()
+    {
+        using var workspace = new IssuePublishWorkspace();
+        var (bodyPath, packetPath) = workspace.PrepareValidPacket();
+
+        // Corrupt the source body so the validator now rejects it.
+        File.WriteAllText(bodyPath, "# Just a title with no required sections.\n");
+
+        var fakeCreator = new RecordingGhIssueCreator("unused");
+        IssuePublishReviewedCommand.GhIssueCreatorFactory = () => fakeCreator;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishReviewedCommand.Execute(
+            workspace.Context,
+            ["--from-file", packetPath, "--repo", "owner/repo"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(fakeCreator.Calls);
+        Assert.Contains("source body no longer passes validation", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenReviewedValidPacket_NeverPassesLabelToGh()
+    {
+        // Contract assertion: the IGhIssueCreator interface itself has no
+        // label parameter, and the captured call records show no label.
+        var createMethod = typeof(IGhIssueCreator).GetMethod(
+            nameof(IGhIssueCreator.CreateIssue),
+            BindingFlags.Public | BindingFlags.Instance)!;
+        var parameterNames = createMethod.GetParameters().Select(p => p.Name).ToArray();
+        Assert.DoesNotContain(parameterNames, name => name is not null
+            && name.Contains("label", StringComparison.OrdinalIgnoreCase));
+
+        using var workspace = new IssuePublishWorkspace();
+        var (_, packetPath) = workspace.PrepareValidPacket();
+
+        var fakeCreator = new RecordingGhIssueCreator("https://github.com/owner/repo/issues/200");
+        IssuePublishReviewedCommand.GhIssueCreatorFactory = () => fakeCreator;
+        IssuePublishReviewedCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 28, 14, 0, 0, TimeSpan.Zero);
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishReviewedCommand.Execute(
+            workspace.Context,
+            ["--from-file", packetPath, "--repo", "owner/repo"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Single(fakeCreator.Calls);
+        var call = fakeCreator.Calls[0];
+        // The recorded call surface only contains repo/title/bodyFilePath.
+        Assert.DoesNotContain("intent-target", call.Repo, StringComparison.Ordinal);
+        Assert.DoesNotContain("intent-target", call.Title, StringComparison.Ordinal);
+        Assert.DoesNotContain("--label", call.Repo, StringComparison.Ordinal);
+        Assert.DoesNotContain("--label", call.Title, StringComparison.Ordinal);
+        Assert.DoesNotContain("--label", call.BodyFilePath, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketFile_ReturnsNonZero()
+    {
+        using var workspace = new IssuePublishWorkspace();
+        var fakeCreator = new RecordingGhIssueCreator("unused");
+        IssuePublishReviewedCommand.GhIssueCreatorFactory = () => fakeCreator;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishReviewedCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("missing-packet.json"), "--repo", "owner/repo"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(fakeCreator.Calls);
+        Assert.Contains("does not exist", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private sealed class RecordingGhIssueCreator : IGhIssueCreator
+    {
+        private readonly string urlToReturn;
+
+        public RecordingGhIssueCreator(string urlToReturn)
+        {
+            this.urlToReturn = urlToReturn;
+        }
+
+        public List<RecordedCall> Calls { get; } = new();
+
+        public string CreateIssue(string repo, string title, string bodyFilePath)
+        {
+            Calls.Add(new RecordedCall(repo, title, bodyFilePath));
+            return urlToReturn;
+        }
+
+        public sealed record RecordedCall(string Repo, string Title, string BodyFilePath);
+    }
+
+    internal sealed class IssuePublishWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("issue-publish-reviewed-tests-")
+            .FullName;
+
+        public IssuePublishWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string GetPath(string relative) => Path.Combine(rootPath, relative);
+
+        public (string BodyPath, string PacketPath) PrepareValidPacket()
+        {
+            var bodyPath = GetPath("body.md");
+            File.WriteAllText(bodyPath, IssuePrepareCommandTests.CompleteValidBody);
+            var packetPath = GetPath("packet.json");
+
+            IssuePrepareCommand.TimestampFactory =
+                () => new DateTimeOffset(2026, 4, 28, 12, 0, 0, TimeSpan.Zero);
+
+            using var writer = new StringWriter();
+            var exit = IssuePrepareCommand.Execute(
+                Context,
+                ["--from-file", bodyPath, "--execution-unit", "G184", "--title", "G184 sample title", "--out", packetPath],
+                writer);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to prepare valid packet for test: exit={exit}, output={writer}");
+            }
+
+            return (bodyPath, packetPath);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds two new deterministic, provider-free `intent-cli` subcommands under the existing `issue` group:
  - `issue prepare --from-file <body.md> --execution-unit <id> --title <title> --out <packet.json>` — validates a standalone Markdown child issue body via the G183 `IssueValidateBodyValidator` and writes a stable JSON reviewed-publish packet on success. Refuses (exit 1, no packet) on missing/blank flags, nonexistent body file, or any G183 validation failure.
  - `issue publish-reviewed --from-file <packet.json> --repo <owner/repo>` — reads the reviewed packet and creates a single GitHub issue via `gh issue create --repo <repo> --title <title> --body-file <source_path>`, then writes the resulting issue number/URL back into the packet. **Never** passes `--label` of any kind; the host-owned `intent-target` boundary is preserved.
- Naming note: the spec recommends `issue publish`, but that name is already owned by the unrelated parent-driven YAML-artifact publish command (`IssuePublishCommand`). The G184 spec explicitly grants name adaptation, so the new command is `issue publish-reviewed`. The existing `IssuePublishCommand` is untouched.
- Refusal precedence in `publish-reviewed` (each path is a deterministic exit 1 BEFORE any `gh` call): missing flag → missing packet file → JSON parse failure → `reviewed != true` → `validation_status != "valid"` → `published == true` → source body file missing or no longer passes G183 validation.
- Packet shape (snake_case, stable order): `execution_unit`, `title`, `source_path`, `source_body_sha256`, `validation_status`, `reviewed`, `published`, `issue_number`, `issue_url`, `prepared_at_utc`, `published_at_utc`.
- Testability seam: a new `IGhIssueCreator { string CreateIssue(string repo, string title, string bodyFilePath); }` interface — three string parameters, no label parameter by construction. The default `GhIssueCreator` shells out to `gh issue create`. Tests inject a fake recorder.

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IssuePrepare|FullyQualifiedName~IssuePublishReviewed"` — **12/12 passing** (5 prepare + 7 publish-reviewed) covering every Acceptance-Criteria scenario: valid prepare, invalid body refusal, missing-flag refusal, missing-body-file refusal, JSON round-trip stability, reviewed-valid publish, missing-reviewed-marker refusal, already-published refusal, invalid-validation-status refusal, source-body-no-longer-valid refusal, never-passes-label-to-gh, missing-packet-file refusal.
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **964/964 passing** (CLI: 952 → 964 = +12 new G184 tests; no regressions).
- [ ] Manual smoke per issue Verification (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- issue prepare --from-file .intent-cli/issues/G184/github-body.md --execution-unit G184 --title "G184 ..." --out /tmp/g184-publish.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- issue publish-reviewed --from-file /tmp/g184-publish.json --repo J-Tech-Japan/intent-system`

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)