### PR TITLE
G185: add intent-cli next-slice classify continuation classifier

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -18,7 +18,8 @@ internal static class CommandRouter
         "clarify",
         "intake",
         "status",
-        "context"
+        "context",
+        "next-slice"
     ];
 
     private static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, CommandHandler>> ImplementedCommands =
@@ -106,6 +107,10 @@ internal static class CommandRouter
             ["context"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["collect"] = ContextCollectCommand.Execute
+            },
+            ["next-slice"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["classify"] = NextSliceClassifyCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/NextSliceClassifyAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceClassifyAnalyzer.cs
@@ -1,0 +1,301 @@
+using System.Text.Json;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Read-only continuation classifier for the AI tasking thread (G185). Inspects
+/// local <c>.intent-cli</c> state plus parent-host clarifications to decide which
+/// of <see cref="NextSliceClassification"/> applies. Never mutates queue state,
+/// runs, GitHub, packet files, or source. Reuses <see cref="StatusBriefAnalyzer"/>
+/// for the canonical WIP predicate and <see cref="ClarificationOpenDetector"/>
+/// for the structured open-blocker parser.
+/// </summary>
+internal static class NextSliceClassifyAnalyzer
+{
+    private const int ClarificationSummaryCharLimit = 240;
+
+    public static NextSliceClassifyResult Analyze(CliContext context, string? domainOverride)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride;
+
+        // (1) Required-but-corrupted artifact precedence.
+        var queueStatePath = context.GetQueueStatePath();
+        QueueState? queueState = null;
+        if (File.Exists(queueStatePath))
+        {
+            try
+            {
+                queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            }
+            catch (Exception exception) when (
+                exception is JsonException
+                or InvalidOperationException
+                or FormatException)
+            {
+                return new NextSliceClassifyResult
+                {
+                    Domain = domain,
+                    Classification = NextSliceClassification.InspectManually,
+                    Rationale = $"queue-state.json could not be parsed: {exception.Message}",
+                    WipRefs = Array.Empty<string>(),
+                    ClarificationSummary = null,
+                    CandidateExecutionUnit = null,
+                    CandidatePacketPath = null,
+                    RecommendedNextAction = "Inspect .intent-cli/queue-state.json manually before continuing.",
+                    Reason = $"corrupted artifact: {queueStatePath}"
+                };
+            }
+        }
+
+        // (2) WIP precedence — reuse StatusBriefAnalyzer's canonical predicate.
+        var wipRefs = new List<string>();
+        if (queueState is not null)
+        {
+            StatusBriefAnalyzer.CollectWipUnits(queueState, wipRefs, reviewUnits: null);
+        }
+
+        if (wipRefs.Count > 0)
+        {
+            return new NextSliceClassifyResult
+            {
+                Domain = domain,
+                Classification = NextSliceClassification.SkipDueToWip,
+                Rationale = $"queue-state.json shows in-flight WIP units: {string.Join(", ", wipRefs)}.",
+                WipRefs = wipRefs,
+                ClarificationSummary = null,
+                CandidateExecutionUnit = null,
+                CandidatePacketPath = null,
+                RecommendedNextAction = "Wait for in-flight units to clear before cutting another slice.",
+                Reason = null
+            };
+        }
+
+        // (3) Clarification precedence — reuse ClarificationOpenDetector.
+        var clarificationPath = ResolveClarificationPath(context, domain);
+        string? clarificationSummary = null;
+        var clarificationOpen = false;
+        if (clarificationPath is not null && File.Exists(clarificationPath))
+        {
+            var content = File.ReadAllText(clarificationPath);
+            clarificationOpen = ClarificationOpenDetector.HasOpenBlocker(content);
+            if (clarificationOpen)
+            {
+                clarificationSummary = ExtractFirstOpenBlockerSummary(content);
+            }
+        }
+
+        if (clarificationOpen)
+        {
+            return new NextSliceClassifyResult
+            {
+                Domain = domain,
+                Classification = NextSliceClassification.ClarificationRequired,
+                Rationale = "open clarification blocker detected under '## Current Open Blockers'.",
+                WipRefs = Array.Empty<string>(),
+                ClarificationSummary = clarificationSummary,
+                CandidateExecutionUnit = null,
+                CandidatePacketPath = null,
+                RecommendedNextAction = "Resolve or record clarification before cutting another slice.",
+                Reason = null
+            };
+        }
+
+        // (4) Issue-cut-ready precedence — find a deterministic packet candidate.
+        var (candidateUnit, candidatePath, ambiguous) = FindIssueCutCandidate(context, queueState);
+        if (ambiguous)
+        {
+            return new NextSliceClassifyResult
+            {
+                Domain = domain,
+                Classification = NextSliceClassification.InspectManually,
+                Rationale = "multiple unlinked issue packets visible; cannot deterministically pick one.",
+                WipRefs = Array.Empty<string>(),
+                ClarificationSummary = null,
+                CandidateExecutionUnit = null,
+                CandidatePacketPath = null,
+                RecommendedNextAction = "Inspect .intent-cli/issues/ to disambiguate the next candidate.",
+                Reason = "ambiguous candidate set under .intent-cli/issues/"
+            };
+        }
+
+        if (candidateUnit is not null && candidatePath is not null)
+        {
+            return new NextSliceClassifyResult
+            {
+                Domain = domain,
+                Classification = NextSliceClassification.IssueCutReady,
+                Rationale = $"issue packet for {candidateUnit} is present and not yet linked in queue-state.",
+                WipRefs = Array.Empty<string>(),
+                ClarificationSummary = null,
+                CandidateExecutionUnit = candidateUnit,
+                CandidatePacketPath = candidatePath,
+                RecommendedNextAction = $"Publish reviewed issue for {candidateUnit}.",
+                Reason = null
+            };
+        }
+
+        // (5) Default fallthrough.
+        return new NextSliceClassifyResult
+        {
+            Domain = domain,
+            Classification = NextSliceClassification.NoActionableItem,
+            Rationale = "no WIP, no open clarification, no unlinked issue packet candidate.",
+            WipRefs = Array.Empty<string>(),
+            ClarificationSummary = null,
+            CandidateExecutionUnit = null,
+            CandidatePacketPath = null,
+            RecommendedNextAction = "No deterministic next action; revisit parent intents to plan a new slice.",
+            Reason = null
+        };
+    }
+
+    private static string? ResolveClarificationPath(CliContext context, string domain)
+    {
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            return null;
+        }
+
+        var parentRoot = context.ResolveParentIntentRepoRootPath();
+        var baseRoot = string.IsNullOrWhiteSpace(parentRoot)
+            ? context.RepoRoot
+            : parentRoot;
+
+        return Path.Combine(baseRoot!, "intents", domain, "clarifications", "open.md");
+    }
+
+    private static string? ExtractFirstOpenBlockerSummary(string content)
+    {
+        var lines = content.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var inSection = false;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd();
+            if (line.StartsWith("## ", StringComparison.Ordinal))
+            {
+                var heading = line[3..].Trim();
+                inSection = string.Equals(heading, "Current Open Blockers", StringComparison.OrdinalIgnoreCase);
+                continue;
+            }
+
+            if (!inSection)
+            {
+                continue;
+            }
+
+            var trimmed = line.TrimStart();
+            if (!trimmed.StartsWith("- ", StringComparison.Ordinal)
+                && !trimmed.StartsWith("* ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var item = trimmed[2..].Trim();
+            if (item.Length == 0)
+            {
+                continue;
+            }
+
+            // Skip the no-blocker sentinel(s) — same shape as ClarificationOpenDetector
+            // but we deliberately re-use HasOpenBlocker for the boolean decision and
+            // only inspect items here for surface-level summary text.
+            if (item.Contains("現時点で child issue cut を要する root blocker はない", StringComparison.Ordinal)
+                || item.Contains("no root blocker requiring child issue cut", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            return item.Length > ClarificationSummaryCharLimit
+                ? item[..ClarificationSummaryCharLimit] + "…"
+                : item;
+        }
+
+        return null;
+    }
+
+    private static (string? Unit, string? Path, bool Ambiguous) FindIssueCutCandidate(
+        CliContext context,
+        QueueState? queueState)
+    {
+        var issuesRoot = Path.Combine(context.RepoRoot, ".intent-cli", "issues");
+        if (!Directory.Exists(issuesRoot))
+        {
+            return (null, null, false);
+        }
+
+        var linkedUnits = BuildLinkedUnitSet(queueState);
+
+        var candidates = new List<(string Unit, string Path)>();
+        foreach (var unitDir in Directory.EnumerateDirectories(issuesRoot))
+        {
+            var unit = Path.GetFileName(unitDir);
+            if (string.IsNullOrEmpty(unit))
+            {
+                continue;
+            }
+
+            var bodyPath = Path.Combine(unitDir, "github-body.md");
+            if (!File.Exists(bodyPath))
+            {
+                continue;
+            }
+
+            if (linkedUnits.Contains(unit))
+            {
+                continue;
+            }
+
+            candidates.Add((unit, bodyPath));
+        }
+
+        if (candidates.Count == 0)
+        {
+            return (null, null, false);
+        }
+
+        if (candidates.Count > 1)
+        {
+            return (null, null, true);
+        }
+
+        var only = candidates[0];
+        return (only.Unit, only.Path, false);
+    }
+
+    private static HashSet<string> BuildLinkedUnitSet(QueueState? queueState)
+    {
+        var linked = new HashSet<string>(StringComparer.Ordinal);
+        if (queueState is null)
+        {
+            return linked;
+        }
+
+        foreach (var item in queueState.Items)
+        {
+            // A queue item is treated as "already linked" when it carries either a
+            // GitHub issue reference or a PR reference. Anything else (queued only,
+            // no link yet) keeps its packet a candidate.
+            if (item.LinkedIssue is not null
+                && (item.LinkedIssue.Number is not null
+                    || !string.IsNullOrWhiteSpace(item.LinkedIssue.Url)))
+            {
+                linked.Add(item.ExecutionUnit);
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(item.LinkedPr))
+            {
+                linked.Add(item.ExecutionUnit);
+            }
+        }
+
+        return linked;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/NextSliceClassifyAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceClassifyAnalyzer.cs
@@ -107,8 +107,15 @@ internal static class NextSliceClassifyAnalyzer
         }
 
         // (4) Issue-cut-ready precedence — find a deterministic packet candidate.
-        var (candidateUnit, candidatePath, ambiguous) = FindIssueCutCandidate(context, queueState);
-        if (ambiguous)
+        // A complete packet requires BOTH github-body.md AND review-context.md
+        // (the canonical packet shape produced by the projection pipeline; see
+        // PacketPathResolver / IssueDraftCommand / QueueEnqueueCommand). Packets
+        // missing review-context.md are NOT publishable from intent-cli's
+        // existing issue prepare/publish-reviewed flow without operator
+        // intervention, so they degrade to `inspect-manually` rather than
+        // `issue-cut-ready`.
+        var candidate = FindIssueCutCandidate(context, queueState);
+        if (candidate.Kind == IssueCutCandidateKind.Ambiguous)
         {
             return new NextSliceClassifyResult
             {
@@ -124,18 +131,36 @@ internal static class NextSliceClassifyAnalyzer
             };
         }
 
-        if (candidateUnit is not null && candidatePath is not null)
+        if (candidate.Kind == IssueCutCandidateKind.Incomplete)
+        {
+            return new NextSliceClassifyResult
+            {
+                Domain = domain,
+                Classification = NextSliceClassification.InspectManually,
+                Rationale = $"unlinked issue packet for {candidate.Unit} is incomplete (missing review-context.md).",
+                WipRefs = Array.Empty<string>(),
+                ClarificationSummary = null,
+                CandidateExecutionUnit = null,
+                CandidatePacketPath = null,
+                RecommendedNextAction = $"Complete the packet under .intent-cli/issues/{candidate.Unit}/ before cutting.",
+                Reason = $"incomplete packet at .intent-cli/issues/{candidate.Unit}/ (missing review-context.md)"
+            };
+        }
+
+        if (candidate.Kind == IssueCutCandidateKind.Ready
+            && candidate.Unit is not null
+            && candidate.Path is not null)
         {
             return new NextSliceClassifyResult
             {
                 Domain = domain,
                 Classification = NextSliceClassification.IssueCutReady,
-                Rationale = $"issue packet for {candidateUnit} is present and not yet linked in queue-state.",
+                Rationale = $"issue packet for {candidate.Unit} is present and not yet linked in queue-state.",
                 WipRefs = Array.Empty<string>(),
                 ClarificationSummary = null,
-                CandidateExecutionUnit = candidateUnit,
-                CandidatePacketPath = candidatePath,
-                RecommendedNextAction = $"Publish reviewed issue for {candidateUnit}.",
+                CandidateExecutionUnit = candidate.Unit,
+                CandidatePacketPath = candidate.Path,
+                RecommendedNextAction = $"Publish reviewed issue for {candidate.Unit}.",
                 Reason = null
             };
         }
@@ -220,19 +245,33 @@ internal static class NextSliceClassifyAnalyzer
         return null;
     }
 
-    private static (string? Unit, string? Path, bool Ambiguous) FindIssueCutCandidate(
+    internal enum IssueCutCandidateKind
+    {
+        None,
+        Ready,
+        Ambiguous,
+        Incomplete
+    }
+
+    internal readonly record struct IssueCutCandidate(
+        IssueCutCandidateKind Kind,
+        string? Unit,
+        string? Path);
+
+    private static IssueCutCandidate FindIssueCutCandidate(
         CliContext context,
         QueueState? queueState)
     {
         var issuesRoot = Path.Combine(context.RepoRoot, ".intent-cli", "issues");
         if (!Directory.Exists(issuesRoot))
         {
-            return (null, null, false);
+            return new IssueCutCandidate(IssueCutCandidateKind.None, null, null);
         }
 
         var linkedUnits = BuildLinkedUnitSet(queueState);
 
-        var candidates = new List<(string Unit, string Path)>();
+        var complete = new List<(string Unit, string Path)>();
+        var incomplete = new List<string>();
         foreach (var unitDir in Directory.EnumerateDirectories(issuesRoot))
         {
             var unit = Path.GetFileName(unitDir);
@@ -244,6 +283,7 @@ internal static class NextSliceClassifyAnalyzer
             var bodyPath = Path.Combine(unitDir, "github-body.md");
             if (!File.Exists(bodyPath))
             {
+                // Not a packet directory at all — skip silently.
                 continue;
             }
 
@@ -252,21 +292,44 @@ internal static class NextSliceClassifyAnalyzer
                 continue;
             }
 
-            candidates.Add((unit, bodyPath));
+            // A complete packet requires the canonical companion artifact
+            // review-context.md (PacketPathResolver / IssueDraftCommand /
+                // QueueEnqueueCommand). Without it, the packet is not in a
+                // shape the existing issue prepare/publish-reviewed boundary
+                // can deterministically consume, so we degrade to Incomplete
+                // rather than reporting issue-cut-ready.
+            var reviewContextPath = Path.Combine(unitDir, "review-context.md");
+            if (!File.Exists(reviewContextPath))
+            {
+                incomplete.Add(unit);
+                continue;
+            }
+
+            complete.Add((unit, bodyPath));
         }
 
-        if (candidates.Count == 0)
+        if (complete.Count > 1)
         {
-            return (null, null, false);
+            return new IssueCutCandidate(IssueCutCandidateKind.Ambiguous, null, null);
         }
 
-        if (candidates.Count > 1)
+        if (complete.Count == 1)
         {
-            return (null, null, true);
+            // Prefer a complete unlinked candidate even if other directories
+            // happen to be incomplete — those are noise relative to the
+            // deterministic next slice.
+            var only = complete[0];
+            return new IssueCutCandidate(IssueCutCandidateKind.Ready, only.Unit, only.Path);
         }
 
-        var only = candidates[0];
-        return (only.Unit, only.Path, false);
+        if (incomplete.Count > 0)
+        {
+            // Sort for deterministic ordering across filesystems.
+            incomplete.Sort(StringComparer.Ordinal);
+            return new IssueCutCandidate(IssueCutCandidateKind.Incomplete, incomplete[0], null);
+        }
+
+        return new IssueCutCandidate(IssueCutCandidateKind.None, null, null);
     }
 
     private static HashSet<string> BuildLinkedUnitSet(QueueState? queueState)

--- a/src/IntentSystem.Cli/Commands/NextSliceClassifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceClassifyCommand.cs
@@ -1,0 +1,92 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G185: Read-only <c>intent-cli next-slice classify</c> command. Emits a single
+/// deterministic continuation classification for the AI tasking thread without
+/// mutating queue state, runs, GitHub, or source files.
+/// </summary>
+internal static class NextSliceClassifyCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var domainOverride, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var result = NextSliceClassifyAnalyzer.Analyze(context, domainOverride);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            NextSliceClassifyRenderer.WriteJson(writer, result);
+        }
+        else
+        {
+            NextSliceClassifyRenderer.WriteText(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? domainOverride,
+        out string format,
+        out string error)
+    {
+        domainOverride = null;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --domain <name> --format text|json.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/NextSliceClassifyRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceClassifyRenderer.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Output renderer for the read-only <c>next-slice classify</c> command (G185).
+/// </summary>
+internal static class NextSliceClassifyRenderer
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    public static void WriteText(TextWriter writer, NextSliceClassifyResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"domain: {result.Domain}");
+        writer.WriteLine($"classification: {result.Classification}");
+        writer.WriteLine($"rationale: {result.Rationale}");
+
+        writer.WriteLine("wip_refs:");
+        if (result.WipRefs.Count == 0)
+        {
+            writer.WriteLine("  - (none)");
+        }
+        else
+        {
+            foreach (var wipRef in result.WipRefs)
+            {
+                writer.WriteLine($"  - {wipRef}");
+            }
+        }
+
+        writer.WriteLine($"clarification_summary: {result.ClarificationSummary ?? "(none)"}");
+        writer.WriteLine($"candidate_execution_unit: {result.CandidateExecutionUnit ?? "(none)"}");
+        writer.WriteLine($"candidate_packet_path: {result.CandidatePacketPath ?? "(none)"}");
+        writer.WriteLine($"recommended_next_action: {result.RecommendedNextAction}");
+
+        if (!string.IsNullOrWhiteSpace(result.Reason))
+        {
+            writer.WriteLine($"reason: {result.Reason}");
+        }
+    }
+
+    public static void WriteJson(TextWriter writer, NextSliceClassifyResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+    }
+}

--- a/src/IntentSystem.Cli/Commands/NextSliceClassifyResult.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceClassifyResult.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Read-only continuation classification produced by
+/// <c>intent-cli next-slice classify</c> (G185). Field names are stable and
+/// snake_case-serialized for AI-thread JSON ingestion. Round-trippable via
+/// <see cref="System.Text.Json.JsonSerializer"/>.
+/// </summary>
+internal sealed record NextSliceClassifyResult
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("classification")]
+    public required string Classification { get; init; }
+
+    [JsonPropertyName("rationale")]
+    public required string Rationale { get; init; }
+
+    [JsonPropertyName("wip_refs")]
+    public required IReadOnlyList<string> WipRefs { get; init; }
+
+    [JsonPropertyName("clarification_summary")]
+    public string? ClarificationSummary { get; init; }
+
+    [JsonPropertyName("candidate_execution_unit")]
+    public string? CandidateExecutionUnit { get; init; }
+
+    [JsonPropertyName("candidate_packet_path")]
+    public string? CandidatePacketPath { get; init; }
+
+    [JsonPropertyName("recommended_next_action")]
+    public required string RecommendedNextAction { get; init; }
+
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+}
+
+/// <summary>
+/// Allowed classification values emitted by next-slice classify (G185).
+/// Two of these (<see cref="ExistingIssueNeedsRepair"/> and
+/// <see cref="ParentOnlyUpdate"/>) are reserved output values for future
+/// expansion: G185 does not yet ship a deterministic precedence rule that
+/// triggers them, but they are part of the stable enum surface so downstream
+/// AI-thread consumers can switch on them without breaking when later slices
+/// add the rules.
+/// </summary>
+internal static class NextSliceClassification
+{
+    public const string IssueCutReady = "issue-cut-ready";
+    public const string ClarificationRequired = "clarification-required";
+    public const string SkipDueToWip = "skip-due-to-wip";
+    public const string ExistingIssueNeedsRepair = "existing-issue-needs-repair";
+    public const string ParentOnlyUpdate = "parent-only-update";
+    public const string NoActionableItem = "no-actionable-item";
+    public const string InspectManually = "inspect-manually";
+}

--- a/src/IntentSystem.Cli/Commands/StatusBriefAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/StatusBriefAnalyzer.cs
@@ -60,20 +60,7 @@ internal static class StatusBriefAnalyzer
                     .Select(item => item.ExecutionUnit),
                 StringComparer.Ordinal);
 
-            foreach (var item in queueState.Items)
-            {
-                switch (item.State)
-                {
-                    case QueueItemState.Review:
-                        reviewUnits.Add(item.ExecutionUnit);
-                        inFlight.Add(item.ExecutionUnit);
-                        break;
-                    case QueueItemState.Active:
-                    case QueueItemState.Fixing:
-                        inFlight.Add(item.ExecutionUnit);
-                        break;
-                }
-            }
+            CollectWipUnits(queueState, inFlight, reviewUnits);
 
             // Deterministic next candidate: first Queued item whose dependencies
             // are all satisfied within the local queue. We keep queue-state's
@@ -120,6 +107,36 @@ internal static class StatusBriefAnalyzer
             RecommendedAction = recommended,
             Notes = notes
         };
+    }
+
+    /// <summary>
+    /// Canonical "WIP present" predicate for the local queue state. Treats Review,
+    /// Active, and Fixing items as in-flight WIP. G185 next-slice classify is the
+    /// second consumer (do not duplicate this logic). When <paramref name="reviewUnits"/>
+    /// is non-null, Review-state execution units are also collected into it.
+    /// </summary>
+    internal static void CollectWipUnits(
+        QueueState queueState,
+        List<string> inFlightSink,
+        List<string>? reviewUnits)
+    {
+        ArgumentNullException.ThrowIfNull(queueState);
+        ArgumentNullException.ThrowIfNull(inFlightSink);
+
+        foreach (var item in queueState.Items)
+        {
+            switch (item.State)
+            {
+                case QueueItemState.Review:
+                    reviewUnits?.Add(item.ExecutionUnit);
+                    inFlightSink.Add(item.ExecutionUnit);
+                    break;
+                case QueueItemState.Active:
+                case QueueItemState.Fixing:
+                    inFlightSink.Add(item.ExecutionUnit);
+                    break;
+            }
+        }
     }
 
     private static bool DependenciesSatisfied(QueueItem item, HashSet<string> completed)

--- a/tests/IntentSystem.Cli.Tests/NextSliceClassifyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NextSliceClassifyCommandTests.cs
@@ -99,6 +99,36 @@ public sealed class NextSliceClassifyCommandTests
     }
 
     [Fact]
+    public void Execute_GivenIncompletePacketMissingReviewContext_ClassifiesAsInspectManually()
+    {
+        // Regression for the G185 review note: a directory containing only
+        // github-body.md (no review-context.md) is a partial packet that
+        // intent-cli's existing issue prepare/publish-reviewed boundary
+        // cannot deterministically consume. The classifier must NOT report
+        // such a state as `issue-cut-ready`; it must degrade to
+        // `inspect-manually` with a reason naming the incomplete packet.
+        using var workspace = new NextSliceWorkspace();
+        workspace.WriteIncompleteIssuePacket("G998", "# G998 partial body only\n");
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(NextSliceClassification.InspectManually, result!.Classification);
+        Assert.Null(result.CandidateExecutionUnit);
+        Assert.Null(result.CandidatePacketPath);
+        Assert.NotNull(result.Reason);
+        Assert.Contains("incomplete", result.Reason!, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("review-context.md", result.Reason!, StringComparison.Ordinal);
+        Assert.Contains("G998", result.Reason!, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenEmptyState_ClassifiesAsNoActionableItem()
     {
         using var workspace = new NextSliceWorkspace();
@@ -308,6 +338,23 @@ public sealed class NextSliceClassifyCommandTests
 
         public void WriteIssuePacket(string executionUnit, string body)
         {
+            // A complete packet has BOTH github-body.md AND review-context.md
+            // (the canonical packet shape produced by the projection pipeline).
+            // Tests that want an INCOMPLETE packet should use
+            // WriteIncompleteIssuePacket instead.
+            var path = Path.Combine(rootPath, ".intent-cli", "issues", executionUnit);
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "github-body.md"), body);
+            File.WriteAllText(
+                Path.Combine(path, "review-context.md"),
+                $"# Review context for {executionUnit}\n\nGenerated for next-slice classify tests.\n");
+        }
+
+        public void WriteIncompleteIssuePacket(string executionUnit, string body)
+        {
+            // Writes only github-body.md (no review-context.md) to simulate a
+            // partial packet that the issue prepare/publish-reviewed boundary
+            // cannot deterministically consume.
             var path = Path.Combine(rootPath, ".intent-cli", "issues", executionUnit);
             Directory.CreateDirectory(path);
             File.WriteAllText(Path.Combine(path, "github-body.md"), body);

--- a/tests/IntentSystem.Cli.Tests/NextSliceClassifyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NextSliceClassifyCommandTests.cs
@@ -1,0 +1,324 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class NextSliceClassifyCommandTests
+{
+    [Fact]
+    public void Execute_GivenWipPresent_ClassifiesAsSkipDueToWip()
+    {
+        using var workspace = new NextSliceWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G180",
+                  "title": "context collect command",
+                  "state": "active",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {
+                    "implementation": ".intent-cli/issues/G180/implementation.md",
+                    "review_context": ".intent-cli/issues/G180/review-context.md",
+                    "yaml": ".intent-cli/issues/G180/packet.yaml"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(NextSliceClassification.SkipDueToWip, result!.Classification);
+        Assert.NotEmpty(result.WipRefs);
+        Assert.Contains("G180", result.WipRefs);
+    }
+
+    [Fact]
+    public void Execute_GivenOpenClarificationBlocker_ClassifiesAsClarificationRequired()
+    {
+        using var workspace = new NextSliceWorkspace();
+        workspace.WriteClarificationOpen(
+            """
+            # intent-cli clarifications
+
+            ## Current Open Blockers
+
+            - Should we use plain text format by default for `next-slice classify`?
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(NextSliceClassification.ClarificationRequired, result!.Classification);
+        Assert.False(string.IsNullOrWhiteSpace(result.ClarificationSummary));
+    }
+
+    [Fact]
+    public void Execute_GivenIssuePacketCandidate_ClassifiesAsIssueCutReady()
+    {
+        using var workspace = new NextSliceWorkspace();
+        workspace.WriteIssuePacket("G999", "# G999 sample issue body\n");
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(NextSliceClassification.IssueCutReady, result!.Classification);
+        Assert.Equal("G999", result.CandidateExecutionUnit);
+        Assert.False(string.IsNullOrWhiteSpace(result.CandidatePacketPath));
+        Assert.Contains("G999", result.CandidatePacketPath!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenEmptyState_ClassifiesAsNoActionableItem()
+    {
+        using var workspace = new NextSliceWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(NextSliceClassification.NoActionableItem, result!.Classification);
+        Assert.Empty(result.WipRefs);
+        Assert.Null(result.CandidateExecutionUnit);
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedQueueState_ClassifiesAsInspectManually()
+    {
+        using var workspace = new NextSliceWorkspace();
+        workspace.WriteQueueState("{ this is not valid json at all");
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(NextSliceClassification.InspectManually, result!.Classification);
+        Assert.False(string.IsNullOrWhiteSpace(result.Reason));
+        Assert.Contains("queue-state", result.Reason!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_RoundTripsStably()
+    {
+        using var workspace = new NextSliceWorkspace();
+        workspace.WriteIssuePacket("G555", "# packet body\n");
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json", "--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        // Stable snake_case fields are present and round-trip.
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        Assert.Equal(NextSliceClassification.IssueCutReady, root.GetProperty("classification").GetString());
+        Assert.True(root.TryGetProperty("rationale", out _));
+        Assert.True(root.TryGetProperty("wip_refs", out _));
+        Assert.True(root.TryGetProperty("clarification_summary", out _));
+        Assert.True(root.TryGetProperty("candidate_execution_unit", out _));
+        Assert.True(root.TryGetProperty("candidate_packet_path", out _));
+        Assert.True(root.TryGetProperty("recommended_next_action", out _));
+        Assert.True(root.TryGetProperty("reason", out _));
+
+        var roundTripped = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(roundTripped);
+        Assert.Equal("intent-cli", roundTripped!.Domain);
+        Assert.Equal(NextSliceClassification.IssueCutReady, roundTripped.Classification);
+        Assert.Equal("G555", roundTripped.CandidateExecutionUnit);
+    }
+
+    [Fact]
+    public void Execute_GivenSentinelOnlyClarifications_DoesNotClassifyAsClarificationRequired()
+    {
+        // Same-shape regression that bit G179: the durable Japanese no-blocker
+        // sentinel under "## Current Open Blockers" must NOT trigger
+        // clarification-required. This verifies the shared
+        // ClarificationOpenDetector is being used.
+        using var workspace = new NextSliceWorkspace();
+        workspace.WriteClarificationOpen(
+            """
+            # intent-cli clarifications
+
+            このファイルは durable な markdown artifact として残し続ける。
+
+            ## Current Open Blockers
+
+            - 現時点で child issue cut を要する root blocker はない。
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.NotEqual(NextSliceClassification.ClarificationRequired, result!.Classification);
+        // With nothing else actionable, this should fall through to no-actionable-item.
+        Assert.Equal(NextSliceClassification.NoActionableItem, result.Classification);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownFormat_ReturnsNonZero()
+    {
+        using var workspace = new NextSliceWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenLinkedIssuePacket_ClassifiesAsNoActionableItem()
+    {
+        // A packet for a unit that is already linked in queue-state should NOT
+        // be reported as issue-cut-ready.
+        using var workspace = new NextSliceWorkspace();
+        workspace.WriteIssuePacket("G900", "# already linked\n");
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G900",
+                  "title": "already linked",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {
+                    "implementation": ".intent-cli/issues/G900/implementation.md",
+                    "review_context": ".intent-cli/issues/G900/review-context.md",
+                    "yaml": ".intent-cli/issues/G900/packet.yaml"
+                  },
+                  "linked_issue": {
+                    "repo": "owner/repo",
+                    "number": 123,
+                    "url": "https://github.com/owner/repo/issues/123"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(NextSliceClassification.NoActionableItem, result!.Classification);
+    }
+
+    private sealed class NextSliceWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("next-slice-classify-tests-")
+            .FullName;
+
+        public NextSliceWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public void WriteQueueState(string content)
+        {
+            File.WriteAllText(Context.GetQueueStatePath(), content);
+        }
+
+        public void WriteClarificationOpen(string content)
+        {
+            var path = Path.Combine(rootPath, "intents", "intent-cli", "clarifications");
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "open.md"), content);
+        }
+
+        public void WriteIssuePacket(string executionUnit, string body)
+        {
+            var path = Path.Combine(rootPath, ".intent-cli", "issues", executionUnit);
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "github-body.md"), body);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new top-level command group `next-slice` with one read-only subcommand: `intent-cli next-slice classify [--domain <domain>] [--format text|json]`. The command answers the deterministic continuation question (cut an issue, ask/record clarification, wait for WIP, or stop) by reading local artifacts only — no GitHub network call, no AI provider call, no mutation of `.intent-cli/queue-state.json` / `.intent-cli/runs.jsonl` / source files / GitHub objects / labels.
- Outputs exactly one classification from the allowed set: `issue-cut-ready` / `clarification-required` / `skip-due-to-wip` / `existing-issue-needs-repair` / `parent-only-update` / `no-actionable-item` / `inspect-manually`. Deterministic precedence: malformed-state → WIP → open-clarification → issue-packet-candidate → no-actionable-item. The two classifications `existing-issue-needs-repair` / `parent-only-update` are reserved in the constants for future expansion (the analyzer does not currently produce them; consumers can already switch on the constants safely).
- Reuse, not duplication:
  - WIP predicate: extracted `StatusBriefAnalyzer.CollectWipUnits` from a previously-inline private loop into `internal static` so G185 calls into the same canonical "WIP present" semantics G179 established.
  - Open-clarification parser: calls the existing shared `ClarificationOpenDetector.HasOpenBlocker` (no fork of the Japanese-sentinel handling that G179's review fix added).
  - Queue state: reuses `QueueStateSerializer.Deserialize`.
- Conservative `inspect-manually` paths (over guessing): malformed `queue-state.json`, multiple unlinked packet directories present (cannot deterministically pick one).
- Output: deterministic multi-line text (default) or stable snake_case JSON (`{domain, classification, rationale, wip_refs, clarification_summary, candidate_execution_unit, candidate_packet_path, recommended_next_action, reason}`) for AI-thread ingestion. JSON round-trips through `JsonSerializer.Deserialize<NextSliceClassifyResult>`.
- `--format` accepts `text` (default) or `json`; anything else exits 1 with a deterministic message.

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~NextSliceClassify"` — **9/9 passing** covering all required scenarios + a sentinel-only-clarifications regression that proves the shared `ClarificationOpenDetector` is wired in (so the G179-style false-positive on the Japanese no-blocker sentinel cannot recur).
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **974/974 passing** (CLI: 965 → 974 = +9 new G185 tests; no regressions).
- [ ] Manual smoke per issue Verification (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- next-slice classify --domain intent-cli`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- next-slice classify --domain intent-cli --format json`

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)