### PR TITLE
G187: add intent-cli safety nested-provider-handoff artifact-only guard

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -20,7 +20,8 @@ internal static class CommandRouter
         "status",
         "context",
         "next-slice",
-        "automation"
+        "automation",
+        "safety"
     ];
 
     private static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, CommandHandler>> ImplementedCommands =
@@ -116,6 +117,10 @@ internal static class CommandRouter
             ["automation"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["summary"] = AutomationSummaryCommand.Execute
+            },
+            ["safety"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["nested-provider-handoff"] = SafetyNestedProviderHandoffCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/SafetyNestedProviderHandoffArtifact.cs
+++ b/src/IntentSystem.Cli/Commands/SafetyNestedProviderHandoffArtifact.cs
@@ -1,0 +1,56 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G187 nested-provider handoff artifact. Snake_case JSON shape that
+/// <c>intent-cli safety nested-provider-handoff</c> writes. The
+/// <c>NestedProviderLaunched</c> field is always literal <c>false</c> for the
+/// first accepted artifact-only slice — there is no path that sets it to
+/// <c>true</c>. The field exists so future tooling and tests can observe the
+/// no-launch invariant.
+/// </summary>
+internal sealed record SafetyNestedProviderHandoffArtifact
+{
+    /// <summary>
+    /// Stable prefix asserted by the no-launch tests. The full summary line
+    /// substitutes the concrete artifact path.
+    /// </summary>
+    public const string NotStartedMessagePrefix = "Nested provider execution was not started";
+
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("intended_role")]
+    public required string IntendedRole { get; init; }
+
+    [JsonPropertyName("intended_action")]
+    public required string IntendedAction { get; init; }
+
+    [JsonPropertyName("target_repo")]
+    public required string TargetRepo { get; init; }
+
+    [JsonPropertyName("target_path")]
+    public required string TargetPath { get; init; }
+
+    [JsonPropertyName("packet_path")]
+    public string? PacketPath { get; init; }
+
+    [JsonPropertyName("review_context_path")]
+    public string? ReviewContextPath { get; init; }
+
+    [JsonPropertyName("requested_command")]
+    public required string RequestedCommand { get; init; }
+
+    [JsonPropertyName("generated_at_utc")]
+    public required string GeneratedAtUtc { get; init; }
+
+    [JsonPropertyName("nested_provider_launched")]
+    public required bool NestedProviderLaunched { get; init; }
+
+    [JsonPropertyName("artifact_path")]
+    public required string ArtifactPath { get; init; }
+
+    [JsonPropertyName("summary_line")]
+    public required string SummaryLine { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/SafetyNestedProviderHandoffCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SafetyNestedProviderHandoffCommand.cs
@@ -1,0 +1,325 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G187: <c>intent-cli safety nested-provider-handoff</c>. First accepted
+/// behavior of the nested-provider safety guard. Produces a deterministic
+/// artifact-only handoff JSON file describing the requested nested-provider
+/// action and emits a human-facing summary stating that nested provider
+/// execution was NOT started. The command itself never spawns a process and
+/// never makes a GitHub network call. The artifact's
+/// <c>nested_provider_launched</c> field is always literal <c>false</c> for
+/// this slice.
+/// </summary>
+internal static class SafetyNestedProviderHandoffCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private static readonly JsonSerializerOptions ArtifactSerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    /// <summary>
+    /// Test seam. Always remains uncalled for this slice; tests assert the
+    /// invariant by registering a sentinel that flips a flag if invoked.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(
+                args,
+                out var executionUnit,
+                out var intendedRole,
+                out var intendedAction,
+                out var targetRepo,
+                out var targetPath,
+                out var packetPath,
+                out var reviewContextPath,
+                out var requestedCommand,
+                out var outPath,
+                out var format,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedOutPath = Path.GetFullPath(outPath);
+        var artifactDirectory = Path.GetDirectoryName(resolvedOutPath);
+        if (!string.IsNullOrEmpty(artifactDirectory))
+        {
+            Directory.CreateDirectory(artifactDirectory);
+        }
+
+        var summaryLine =
+            $"{SafetyNestedProviderHandoffArtifact.NotStartedMessagePrefix}; artifact written to {resolvedOutPath}.";
+
+        var artifact = new SafetyNestedProviderHandoffArtifact
+        {
+            ExecutionUnit = executionUnit,
+            IntendedRole = intendedRole,
+            IntendedAction = intendedAction,
+            TargetRepo = targetRepo,
+            TargetPath = targetPath,
+            PacketPath = string.IsNullOrEmpty(packetPath) ? null : packetPath,
+            ReviewContextPath = string.IsNullOrEmpty(reviewContextPath) ? null : reviewContextPath,
+            RequestedCommand = requestedCommand,
+            GeneratedAtUtc = FormatUtcTimestamp(TimestampFactory()),
+            NestedProviderLaunched = false,
+            ArtifactPath = resolvedOutPath,
+            SummaryLine = summaryLine
+        };
+
+        var serialized = JsonSerializer.Serialize(artifact, ArtifactSerializerOptions);
+        File.WriteAllText(resolvedOutPath, serialized);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(serialized);
+        }
+        else
+        {
+            WriteTextSummary(writer, artifact);
+        }
+
+        return 0;
+    }
+
+    private static void WriteTextSummary(TextWriter writer, SafetyNestedProviderHandoffArtifact artifact)
+    {
+        writer.WriteLine(
+            $"{SafetyNestedProviderHandoffArtifact.NotStartedMessagePrefix}. Artifact written to {artifact.ArtifactPath}.");
+        writer.WriteLine($"execution_unit: {artifact.ExecutionUnit}");
+        writer.WriteLine($"intended_role: {artifact.IntendedRole}");
+        writer.WriteLine($"intended_action: {artifact.IntendedAction}");
+        writer.WriteLine($"target_repo: {artifact.TargetRepo}");
+        writer.WriteLine($"target_path: {artifact.TargetPath}");
+        writer.WriteLine($"packet_path: {artifact.PacketPath ?? "(none)"}");
+        writer.WriteLine($"review_context_path: {artifact.ReviewContextPath ?? "(none)"}");
+        writer.WriteLine($"requested_command: {artifact.RequestedCommand}");
+        writer.WriteLine($"generated_at_utc: {artifact.GeneratedAtUtc}");
+        writer.WriteLine(
+            $"nested_provider_launched: {artifact.NestedProviderLaunched.ToString().ToLowerInvariant()}");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string executionUnit,
+        out string intendedRole,
+        out string intendedAction,
+        out string targetRepo,
+        out string targetPath,
+        out string packetPath,
+        out string reviewContextPath,
+        out string requestedCommand,
+        out string outPath,
+        out string format,
+        out string error)
+    {
+        executionUnit = string.Empty;
+        intendedRole = string.Empty;
+        intendedAction = string.Empty;
+        targetRepo = string.Empty;
+        targetPath = string.Empty;
+        packetPath = string.Empty;
+        reviewContextPath = string.Empty;
+        requestedCommand = string.Empty;
+        outPath = string.Empty;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--execution-unit":
+                    if (!TryReadValue(args, ref index, "--execution-unit", out executionUnit, out error))
+                    {
+                        return false;
+                    }
+
+                    break;
+
+                case "--intended-role":
+                    if (!TryReadValue(args, ref index, "--intended-role", out intendedRole, out error))
+                    {
+                        return false;
+                    }
+
+                    break;
+
+                case "--intended-action":
+                    if (!TryReadValue(args, ref index, "--intended-action", out intendedAction, out error))
+                    {
+                        return false;
+                    }
+
+                    break;
+
+                case "--target-repo":
+                    if (!TryReadValue(args, ref index, "--target-repo", out targetRepo, out error))
+                    {
+                        return false;
+                    }
+
+                    break;
+
+                case "--target-path":
+                    if (!TryReadValue(args, ref index, "--target-path", out targetPath, out error))
+                    {
+                        return false;
+                    }
+
+                    break;
+
+                case "--packet-path":
+                    if (!TryReadOptionalValue(args, ref index, "--packet-path", out packetPath, out error))
+                    {
+                        return false;
+                    }
+
+                    break;
+
+                case "--review-context-path":
+                    if (!TryReadOptionalValue(args, ref index, "--review-context-path", out reviewContextPath, out error))
+                    {
+                        return false;
+                    }
+
+                    break;
+
+                case "--requested-command":
+                    if (!TryReadValue(args, ref index, "--requested-command", out requestedCommand, out error))
+                    {
+                        return false;
+                    }
+
+                    break;
+
+                case "--out":
+                    if (!TryReadValue(args, ref index, "--out", out outPath, out error))
+                    {
+                        return false;
+                    }
+
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --execution-unit, --intended-role, --intended-action, --target-repo, --target-path, --packet-path, --review-context-path, --requested-command, --out, --format.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            error = "--execution-unit is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(intendedRole))
+        {
+            error = "--intended-role is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(intendedAction))
+        {
+            error = "--intended-action is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(targetRepo))
+        {
+            error = "--target-repo is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(targetPath))
+        {
+            error = "--target-path is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(requestedCommand))
+        {
+            error = "--requested-command is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(outPath))
+        {
+            error = "--out is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadValue(string[] args, ref int index, string flag, out string value, out string error)
+    {
+        value = string.Empty;
+        error = string.Empty;
+        if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+        {
+            error = $"{flag} requires a non-empty value.";
+            return false;
+        }
+
+        value = args[index + 1];
+        index++;
+        return true;
+    }
+
+    private static bool TryReadOptionalValue(string[] args, ref int index, string flag, out string value, out string error)
+    {
+        value = string.Empty;
+        error = string.Empty;
+        if (index + 1 >= args.Length)
+        {
+            error = $"{flag} requires a value.";
+            return false;
+        }
+
+        // Optional flags allow empty string to mean "treat as not provided".
+        value = args[index + 1];
+        index++;
+        return true;
+    }
+
+    internal static string FormatUtcTimestamp(DateTimeOffset timestamp)
+    {
+        return timestamp.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/SafetyNestedProviderHandoffCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/SafetyNestedProviderHandoffCommandTests.cs
@@ -1,0 +1,352 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class SafetyNestedProviderHandoffCommandTests : IDisposable
+{
+    private readonly Func<DateTimeOffset> originalTimestampFactory;
+    private readonly Func<bool>? originalLauncher;
+
+    public SafetyNestedProviderHandoffCommandTests()
+    {
+        originalTimestampFactory = SafetyNestedProviderHandoffCommand.TimestampFactory;
+        originalLauncher = SafetyNestedProviderHandoffCommand.NestedProviderLauncher;
+    }
+
+    public void Dispose()
+    {
+        SafetyNestedProviderHandoffCommand.TimestampFactory = originalTimestampFactory;
+        SafetyNestedProviderHandoffCommand.NestedProviderLauncher = originalLauncher;
+    }
+
+    [Fact]
+    public void Execute_GivenAllRequiredFlags_WritesArtifactAndStatesNoNestedLaunch()
+    {
+        using var workspace = new SafetyHandoffWorkspace();
+        SafetyNestedProviderHandoffCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 12, 34, 56, 789, TimeSpan.Zero);
+
+        var outPath = workspace.GetPath("artifact.json");
+
+        using var writer = new StringWriter();
+        var exitCode = SafetyNestedProviderHandoffCommand.Execute(
+            workspace.Context,
+            BuildSuccessArgs(outPath),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(outPath));
+
+        var doc = JsonDocument.Parse(File.ReadAllText(outPath));
+        var root = doc.RootElement;
+        Assert.Equal("G187", root.GetProperty("execution_unit").GetString());
+        Assert.Equal("worker", root.GetProperty("intended_role").GetString());
+        Assert.Equal("nested-provider-handoff", root.GetProperty("intended_action").GetString());
+        Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("target_repo").GetString());
+        Assert.Equal(".intent-cli/issues/G187/", root.GetProperty("target_path").GetString());
+        Assert.Equal("intent-cli safety nested-provider-handoff --execution-unit G187", root.GetProperty("requested_command").GetString());
+        Assert.Equal("2026-04-29T12:34:56.789Z", root.GetProperty("generated_at_utc").GetString());
+        Assert.False(root.GetProperty("nested_provider_launched").GetBoolean());
+        Assert.False(string.IsNullOrEmpty(root.GetProperty("artifact_path").GetString()));
+        Assert.Contains(
+            SafetyNestedProviderHandoffArtifact.NotStartedMessagePrefix,
+            root.GetProperty("summary_line").GetString(),
+            StringComparison.Ordinal);
+
+        Assert.Contains(
+            $"{SafetyNestedProviderHandoffArtifact.NotStartedMessagePrefix}. Artifact written to",
+            writer.ToString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenAllRequiredFlags_ArtifactJsonRoundTripsStably()
+    {
+        using var workspace = new SafetyHandoffWorkspace();
+        SafetyNestedProviderHandoffCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 12, 0, 0, TimeSpan.Zero);
+
+        var outPath = workspace.GetPath("artifact-roundtrip.json");
+        using var writer = new StringWriter();
+        var exitCode = SafetyNestedProviderHandoffCommand.Execute(
+            workspace.Context,
+            BuildSuccessArgs(outPath),
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var roundTripped = JsonSerializer.Deserialize<SafetyNestedProviderHandoffArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(roundTripped);
+        Assert.Equal("G187", roundTripped!.ExecutionUnit);
+        Assert.Equal("worker", roundTripped.IntendedRole);
+        Assert.Equal("nested-provider-handoff", roundTripped.IntendedAction);
+        Assert.Equal("J-Tech-Japan/intent-system", roundTripped.TargetRepo);
+        Assert.Equal(".intent-cli/issues/G187/", roundTripped.TargetPath);
+        Assert.Equal(".intent-cli/issues/G187/packet.yaml", roundTripped.PacketPath);
+        Assert.Equal(".intent-cli/issues/G187/review-context.md", roundTripped.ReviewContextPath);
+        Assert.Equal(
+            "intent-cli safety nested-provider-handoff --execution-unit G187",
+            roundTripped.RequestedCommand);
+        Assert.False(roundTripped.NestedProviderLaunched);
+        Assert.Equal(Path.GetFullPath(outPath), roundTripped.ArtifactPath);
+        Assert.Contains(
+            SafetyNestedProviderHandoffArtifact.NotStartedMessagePrefix,
+            roundTripped.SummaryLine,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_StdoutMatchesArtifact()
+    {
+        using var workspace = new SafetyHandoffWorkspace();
+        SafetyNestedProviderHandoffCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 1, 2, 3, TimeSpan.Zero);
+
+        var outPath = workspace.GetPath("artifact-json.json");
+        var args = BuildSuccessArgs(outPath).Concat(new[] { "--format", "json" }).ToArray();
+
+        using var writer = new StringWriter();
+        var exitCode = SafetyNestedProviderHandoffCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(0, exitCode);
+
+        var stdoutArtifact = JsonSerializer.Deserialize<SafetyNestedProviderHandoffArtifact>(writer.ToString());
+        var fileArtifact = JsonSerializer.Deserialize<SafetyNestedProviderHandoffArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(stdoutArtifact);
+        Assert.NotNull(fileArtifact);
+        Assert.Equal(fileArtifact, stdoutArtifact);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingRequiredFlag_ReturnsNonZero_NoArtifactWritten()
+    {
+        using var workspace = new SafetyHandoffWorkspace();
+        var outPath = workspace.GetPath("artifact-missing.json");
+
+        // Drop --execution-unit by not including it.
+        var args = new[]
+        {
+            "--intended-role", "worker",
+            "--intended-action", "nested-provider-handoff",
+            "--target-repo", "J-Tech-Japan/intent-system",
+            "--target-path", ".intent-cli/issues/G187/",
+            "--requested-command", "intent-cli safety nested-provider-handoff",
+            "--out", outPath
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = SafetyNestedProviderHandoffCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+        Assert.Contains("--execution-unit", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenBlankRequiredFlagValue_ReturnsNonZero_NoArtifactWritten()
+    {
+        using var workspace = new SafetyHandoffWorkspace();
+        var outPath = workspace.GetPath("artifact-blank.json");
+
+        var args = new[]
+        {
+            "--execution-unit", "",
+            "--intended-role", "worker",
+            "--intended-action", "nested-provider-handoff",
+            "--target-repo", "J-Tech-Japan/intent-system",
+            "--target-path", ".intent-cli/issues/G187/",
+            "--requested-command", "intent-cli safety nested-provider-handoff",
+            "--out", outPath
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = SafetyNestedProviderHandoffCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+        Assert.Contains("--execution-unit", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsNonZero()
+    {
+        using var workspace = new SafetyHandoffWorkspace();
+        var outPath = workspace.GetPath("artifact-unknown.json");
+
+        var args = BuildSuccessArgs(outPath).Concat(new[] { "--bogus-flag", "value" }).ToArray();
+
+        using var writer = new StringWriter();
+        var exitCode = SafetyNestedProviderHandoffCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus-flag", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesProcessStart_NoNestedProviderLaunched()
+    {
+        using var workspace = new SafetyHandoffWorkspace();
+        SafetyNestedProviderHandoffCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 0, 0, 0, TimeSpan.Zero);
+
+        var calledFlag = false;
+        SafetyNestedProviderHandoffCommand.NestedProviderLauncher = () =>
+        {
+            calledFlag = true;
+            return true;
+        };
+
+        var outPath = workspace.GetPath("artifact-sentinel.json");
+        using var writer = new StringWriter();
+        var exitCode = SafetyNestedProviderHandoffCommand.Execute(
+            workspace.Context,
+            BuildSuccessArgs(outPath),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(calledFlag);
+
+        var artifact = JsonSerializer.Deserialize<SafetyNestedProviderHandoffArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(artifact);
+        Assert.False(artifact!.NestedProviderLaunched);
+    }
+
+    [Fact]
+    public void Execute_OptionalPathsOmitted_AreEmittedAsNullInArtifact()
+    {
+        using var workspace = new SafetyHandoffWorkspace();
+        SafetyNestedProviderHandoffCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 0, 0, 0, TimeSpan.Zero);
+
+        var outPath = workspace.GetPath("artifact-no-optionals.json");
+        var args = new[]
+        {
+            "--execution-unit", "G187",
+            "--intended-role", "worker",
+            "--intended-action", "nested-provider-handoff",
+            "--target-repo", "J-Tech-Japan/intent-system",
+            "--target-path", ".intent-cli/issues/G187/",
+            "--requested-command", "intent-cli safety nested-provider-handoff --execution-unit G187",
+            "--out", outPath
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = SafetyNestedProviderHandoffCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(0, exitCode);
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(outPath));
+        var root = doc.RootElement;
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("packet_path").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("review_context_path").ValueKind);
+
+        var artifact = JsonSerializer.Deserialize<SafetyNestedProviderHandoffArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(artifact);
+        Assert.Null(artifact!.PacketPath);
+        Assert.Null(artifact.ReviewContextPath);
+    }
+
+    [Fact]
+    public void RunImplementAndRunFixSources_DoNotLaunchAnyNestedProviderBinary_ArtifactOnlyInvariant()
+    {
+        // Source-scan invariance test: the Run implement/fix command paths must
+        // not have introduced a Process.Start call against a hardcoded provider
+        // binary while this slice is artifact-only. If the resolver cannot
+        // locate the source files we skip — the per-command sentinel test
+        // covers the new surface deterministically.
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        var runImplement = Path.Combine(commandsDir, "RunImplementCommand.cs");
+        var runFix = Path.Combine(commandsDir, "RunFixCommand.cs");
+        if (!File.Exists(runImplement) || !File.Exists(runFix))
+        {
+            return;
+        }
+
+        foreach (var path in new[] { runImplement, runFix })
+        {
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("Process.Start(", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"codex\"", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"claude\"", text, StringComparison.Ordinal);
+        }
+    }
+
+    private static bool TryResolveCommandsSourceDirectory(out string commandsDirectory)
+    {
+        commandsDirectory = string.Empty;
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, "src", "IntentSystem.Cli", "Commands");
+            if (Directory.Exists(candidate))
+            {
+                commandsDirectory = candidate;
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private static string[] BuildSuccessArgs(string outPath)
+    {
+        return new[]
+        {
+            "--execution-unit", "G187",
+            "--intended-role", "worker",
+            "--intended-action", "nested-provider-handoff",
+            "--target-repo", "J-Tech-Japan/intent-system",
+            "--target-path", ".intent-cli/issues/G187/",
+            "--packet-path", ".intent-cli/issues/G187/packet.yaml",
+            "--review-context-path", ".intent-cli/issues/G187/review-context.md",
+            "--requested-command", "intent-cli safety nested-provider-handoff --execution-unit G187",
+            "--out", outPath
+        };
+    }
+
+    private sealed class SafetyHandoffWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("safety-nested-provider-handoff-tests-")
+            .FullName;
+
+        public SafetyHandoffWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string GetPath(string relative) => Path.Combine(rootPath, relative);
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the **first accepted behavior** for the G187 nested-provider safety guard: a new top-level `safety` command group with subcommand `intent-cli safety nested-provider-handoff`. The command produces a deterministic artifact-only handoff and emits a clear human-facing line stating that nested provider execution was NOT started. Exit 0 on success. The command itself never spawns a process and never makes a GitHub network call.
- Conservative scope (per "first accepted behavior" wording in the issue): existing `Run*` / `Fix*` / `BugIntent*` command path defaults are NOT modified in this slice — that is a follow-up. The slice introduces the artifact-only entry point and locks in a no-launch invariant; existing local read-only and artifact-producing tests continue to pass unchanged.
- Required flags: `--execution-unit`, `--intended-role`, `--intended-action`, `--target-repo`, `--target-path`, `--requested-command`, `--out`. Optional: `--packet-path`, `--review-context-path`. Format flag: `--format text|json` (text default; the artifact FILE is always written as JSON regardless of `--format`).
- Artifact JSON shape (snake_case, stable, round-trippable):
  ```
  {
    "execution_unit": "...",
    "intended_role": "...",
    "intended_action": "...",
    "target_repo": "owner/repo",
    "target_path": "...",
    "packet_path": "..." | null,
    "review_context_path": "..." | null,
    "requested_command": "...",
    "generated_at_utc": "<ISO8601 UTC>",
    "nested_provider_launched": false,
    "artifact_path": "<absolute path>",
    "summary_line": "Nested provider execution was not started; artifact written to <artifact_path>."
  }
  ```
  `nested_provider_launched` is ALWAYS the literal `false` for this slice — it's a contract field so future tooling can observe it. There is no path that sets it to `true`.
- No-launch invariant locked in via two complementary tests:
  - A per-command sentinel test injects `SafetyNestedProviderHandoffCommand.NestedProviderLauncher = () => { ... }` and asserts the sentinel is never invoked across the success path AND that the artifact's `nested_provider_launched` is `false`.
  - A source-scan invariance test (`RunImplementAndRunFixSources_DoNotLaunchAnyNestedProviderBinary_ArtifactOnlyInvariant`) walks up from the test bin to find `RunImplementCommand.cs` / `RunFixCommand.cs` and asserts neither file contains `Process.Start(` literal or hardcoded `\"codex\"`/`\"claude\"` provider binaries. If the source path cannot be resolved (e.g. packaged test bin), the test returns silently — the per-command sentinel still locks the new surface deterministically.

## Test plan

- [x] Focused (issue's recommended filter): `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter \"FullyQualifiedName~NestedProvider|FullyQualifiedName~ArtifactOnly|FullyQualifiedName~RunImplement|FullyQualifiedName~RunFix\"` — **87/87 passing** (9 new G187 tests + the existing RunImplement / RunFix tests this filter sweeps in).
- [x] Independent re-verify of just the G187 surface: `--filter \"FullyQualifiedName~NestedProvider|FullyQualifiedName~ArtifactOnly\"` — **9/9 passing**.
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **994/994 passing** (CLI: 985 → 994 = +9 new G187 tests; no regressions).
- [ ] Manual smoke per issue Verification (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- safety nested-provider-handoff --execution-unit G187 --intended-role implementer --intended-action implement --target-repo J-Tech-Japan/intent-system --target-path src/IntentSystem.Cli/ --requested-command \"intent-cli safety nested-provider-handoff ...\" --out /tmp/g187-handoff.json`

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)