### PR TITLE
G188: document intent-cli run as integration smoke / replay, not primary orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,28 @@ Equivalent `dnx` path:
 ```bash
 (cd .artifacts/smoke-repo && dnx --yes --source ../packages --version 0.1.0 intent-cli project status)
 ```
+
+## CLI command roles
+
+The accepted production automation boundary lives in the parent host-side
+review/next-slice loop, which uses provider-neutral GitHub labels
+(`intent-target`, `intent-pr-reviewing`, `intent-pr-request-update`, etc.),
+durable parent state, and explicit handoff artifacts. The child CLI is a tasking
+companion to that loop, not a replacement.
+
+| Surface | Role |
+|---------|------|
+| `intent-cli status brief` / `context collect` | Compact / richer AI-thread inputs |
+| `intent-cli clarify draft` / `clarify record` | Owner clarification flow |
+| `intent-cli issue validate-body` | Standalone Child Issue Contract enforcement |
+| `intent-cli issue prepare` / `issue publish-reviewed` | Reviewed issue body publish boundary (never applies `intent-target`) |
+| `intent-cli next-slice classify` | Local read-only continuation classifier |
+| `intent-cli automation summary` | Provider-neutral label-driven automation contract emitter |
+| `intent-cli safety nested-provider-handoff` | Artifact-only nested-provider safety guard (never spawns providers) |
+| `intent-cli run …` | **Integration smoke, deterministic replay, and local dogfooding only** — not the primary production orchestrator |
+
+For ongoing production automation, drive work through the host-side
+review/next-slice loop and the provider-neutral label set described by
+`intent-cli automation summary`. For nested-provider handoff steps, use
+`intent-cli safety nested-provider-handoff` to emit a deterministic artifact
+instead of recursively launching providers from inside `run`.

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -201,5 +201,32 @@ internal static class CommandRouter
 
         writer.WriteLine("Additional top-level commands:");
         writer.WriteLine($"- {GenerateFromCurrentCommandName}");
+
+        writer.WriteLine();
+        foreach (var line in RunRoleNote)
+        {
+            writer.WriteLine(line);
+        }
     }
+
+    /// <summary>
+    /// G188 — clarifies the accepted role of <c>intent-cli run</c>. The command
+    /// family is for integration smoke, deterministic replay, and local
+    /// dogfooding; production automation uses the host-side review/next-slice
+    /// loop, provider-neutral GitHub labels, durable parent state, and
+    /// explicit handoff artifacts (see <c>automation summary</c> and
+    /// <c>safety nested-provider-handoff</c>). Exposed as <c>internal</c> so
+    /// focused help-surface tests can assert against the canonical wording
+    /// without re-deriving it.
+    /// </summary>
+    internal static readonly IReadOnlyList<string> RunRoleNote =
+    [
+        "Notes:",
+        "- `intent-cli run` is for integration smoke, deterministic replay, and local dogfooding;",
+        "  it is not the primary production orchestrator.",
+        "- Production automation lives in the host-side review/next-slice loop with",
+        "  provider-neutral GitHub labels, durable parent state, and explicit handoff",
+        "  artifacts. See `automation summary` for the label-driven contract and",
+        "  `safety nested-provider-handoff` for artifact-only nested-provider handoffs."
+    ];
 }

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -36,6 +36,39 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_GivenNoArguments_HelpDescribesRunAsIntegrationSmokeNotPrimaryOrchestrator()
+    {
+        // G188 — `intent-cli run` is for integration smoke, deterministic
+        // replay, and local dogfooding; production automation lives in the
+        // host-side review/next-slice loop with provider-neutral labels and
+        // durable parent state. The root help output must say so explicitly,
+        // and the canonical wording must come from the shared
+        // CommandRouter.RunRoleNote constant so the docs/help surface cannot
+        // drift from the test assertion.
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(Array.Empty<string>(), CreateContext("/tmp/intent-system"), writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+
+        Assert.Contains("integration smoke", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("deterministic replay", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("local dogfooding", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("not the primary production orchestrator", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("host-side review/next-slice loop", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("automation summary", output, StringComparison.Ordinal);
+        Assert.Contains("safety nested-provider-handoff", output, StringComparison.Ordinal);
+
+        // The shared constant must be the single source of truth for this
+        // wording so future changes flow through one place.
+        foreach (var line in CommandRouter.RunRoleNote)
+        {
+            Assert.Contains(line, output, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
     public void Execute_GivenKnownGroupAndUnknownSubcommand_WritesNotYetImplementedMessage()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

- Clarifies the accepted role of `intent-cli run`: it is integration smoke, deterministic replay, and local dogfooding — NOT the primary production orchestrator. Production automation lives in the host-side review/next-slice loop with provider-neutral GitHub labels, durable parent state, and explicit handoff artifacts.
- README.md: adds a new "## CLI command roles" section with a table enumerating every accepted AI-thread support surface (status brief / context collect / clarify draft+record / issue validate-body / issue prepare+publish-reviewed / next-slice classify / automation summary / safety nested-provider-handoff) and explicitly describes `intent-cli run` as integration smoke / replay / local dogfooding only. Points production automation guidance to the host-side review/next-slice loop and cross-references both `automation summary` (label-driven contract) and `safety nested-provider-handoff` (G187 nested-provider safety boundary).
- `CommandRouter.WriteHelp`: the root `intent-cli` help output now appends a Notes block with the same wording, sourced from a single shared `CommandRouter.RunRoleNote` constant so docs and help can never drift.
- No `run` execution semantics changed. No provider-specific labels or workflow states introduced. The G187 nested-provider safety boundary is intact (`safety nested-provider-handoff` still produces artifact-only handoffs and never spawns providers).

## Test plan

- [x] Focused (issue's filter hint): `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~CommandRouter|FullyQualifiedName~Run|FullyQualifiedName~Help|FullyQualifiedName~Automation"` — **465/465 passing** (1 new G188 test + every existing CommandRouter / Run / Automation test in the suite, confirming no regression).
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **995/995 passing** (CLI: 994 → 995 = +1 new G188 test; no regressions).
- New regression `Execute_GivenNoArguments_HelpDescribesRunAsIntegrationSmokeNotPrimaryOrchestrator` asserts the canonical wording (`integration smoke`, `deterministic replay`, `local dogfooding`, `not the primary production orchestrator`, `host-side review/next-slice loop`, `automation summary`, `safety nested-provider-handoff`) appears in root help output, AND that every line of `CommandRouter.RunRoleNote` is present verbatim — locking the constant as the single source of truth so any future drift between docs and help breaks the test.
- [ ] Manual smoke (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj` — root help output now includes the Notes block describing run's role.

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)