### PR TITLE
G192: add intent-cli tasking task-packet-preview deterministic local renderer

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -127,7 +127,8 @@ internal static class CommandRouter
             ["tasking"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["handoff"] = TaskingHandoffCommand.Execute,
-                ["task-packet"] = TaskingTaskPacketCommand.Execute
+                ["task-packet"] = TaskingTaskPacketCommand.Execute,
+                ["task-packet-preview"] = TaskingTaskPacketPreviewCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/TaskingTaskPacketPreviewAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingTaskPacketPreviewAnalyzer.cs
@@ -1,0 +1,162 @@
+using System.Text;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G192 — pure logic that takes an already-deserialized G191
+/// <see cref="TaskingTaskPacketArtifact"/> and builds a deterministic
+/// <see cref="TaskingTaskPacketPreviewArtifact"/> plus the operator-facing
+/// rendered markdown. No file I/O, no network, and no process launches happen
+/// here — those concerns are owned by
+/// <see cref="TaskingTaskPacketPreviewCommand"/>.
+///
+/// The contract fields <see cref="TaskingTaskPacketPreviewArtifact.IsPublished"/>,
+/// <see cref="TaskingTaskPacketPreviewArtifact.IsAutomationVisible"/>, and
+/// <see cref="TaskingTaskPacketPreviewArtifact.PreviewStatus"/> are always
+/// literal false / false / "local_only" for this slice.
+/// </summary>
+internal static class TaskingTaskPacketPreviewAnalyzer
+{
+    /// <summary>
+    /// Stable UNPUBLISHED status phrase asserted by G192 tests. Any future
+    /// drift in this string deliberately breaks the contract test.
+    /// </summary>
+    public const string UnpublishedStatusPhrase =
+        "UNPUBLISHED, local-only, not automation-visible";
+
+    public static TaskingTaskPacketPreviewArtifact Build(
+        TaskingTaskPacketArtifact sourceTaskPacket,
+        string sourceTaskPacketPath,
+        string sourceTaskPacketSha256,
+        string generatedAtUtc,
+        string resolvedArtifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(sourceTaskPacket);
+        ArgumentNullException.ThrowIfNull(sourceTaskPacketPath);
+        ArgumentNullException.ThrowIfNull(sourceTaskPacketSha256);
+        ArgumentNullException.ThrowIfNull(generatedAtUtc);
+        ArgumentNullException.ThrowIfNull(resolvedArtifactPath);
+
+        var renderedMarkdown = RenderPreviewMarkdown(
+            sourceTaskPacket,
+            sourceTaskPacketPath,
+            sourceTaskPacketSha256);
+
+        var summaryLine =
+            $"Worker preview for {sourceTaskPacket.Domain} derived from {sourceTaskPacketPath} — {UnpublishedStatusPhrase}.";
+
+        return new TaskingTaskPacketPreviewArtifact
+        {
+            SourceTaskPacketPath = sourceTaskPacketPath,
+            SourceTaskPacketSha256 = sourceTaskPacketSha256,
+            SourceHandoffPath = sourceTaskPacket.SourceHandoffPath,
+            SourceHandoffSha256 = sourceTaskPacket.SourceHandoffSha256,
+            Domain = sourceTaskPacket.Domain,
+            IsPublished = false,
+            IsAutomationVisible = false,
+            PreviewStatus = TaskingTaskPacketPreviewConstants.LocalOnlyStatus,
+            EmbeddedStatusBrief = sourceTaskPacket.EmbeddedStatusBrief,
+            EmbeddedContextCollect = sourceTaskPacket.EmbeddedContextCollect,
+            EmbeddedNextSliceClassify = sourceTaskPacket.EmbeddedNextSliceClassify,
+            RecommendedWorkerAction = sourceTaskPacket.RecommendedWorkerAction,
+            RenderedPreviewMarkdown = renderedMarkdown,
+            GeneratedAtUtc = generatedAtUtc,
+            ArtifactPath = resolvedArtifactPath,
+            SummaryLine = summaryLine
+        };
+    }
+
+    private static string RenderPreviewMarkdown(
+        TaskingTaskPacketArtifact source,
+        string sourceTaskPacketPath,
+        string sourceTaskPacketSha256)
+    {
+        var builder = new StringBuilder();
+
+        builder.Append("# Worker task preview — ").Append(source.Domain).Append('\n');
+        builder.Append('\n');
+        builder.Append("**Status: ").Append(UnpublishedStatusPhrase).Append(".**").Append('\n');
+        builder.Append('\n');
+
+        builder.Append("## Source references").Append('\n');
+        builder.Append("- Task packet: ")
+            .Append(sourceTaskPacketPath)
+            .Append(" (sha256: ")
+            .Append(sourceTaskPacketSha256)
+            .Append(')')
+            .Append('\n');
+        builder.Append("- Handoff: ")
+            .Append(source.SourceHandoffPath)
+            .Append(" (sha256: ")
+            .Append(source.SourceHandoffSha256)
+            .Append(')')
+            .Append('\n');
+        builder.Append('\n');
+
+        builder.Append("## Recommended worker action").Append('\n');
+        builder.Append(source.RecommendedWorkerAction).Append('\n');
+        builder.Append('\n');
+
+        builder.Append("## Status brief").Append('\n');
+        builder.Append(SummarizeStatusBrief(source.EmbeddedStatusBrief)).Append('\n');
+        builder.Append('\n');
+
+        builder.Append("## Context collect").Append('\n');
+        builder.Append(SummarizeContextCollect(source.EmbeddedContextCollect)).Append('\n');
+        builder.Append('\n');
+
+        builder.Append("## Next-slice classify").Append('\n');
+        builder.Append(SummarizeNextSliceClassify(source.EmbeddedNextSliceClassify));
+
+        return builder.ToString();
+    }
+
+    private static string SummarizeStatusBrief(StatusBriefSummary? brief)
+    {
+        if (brief is null)
+        {
+            return "(none)";
+        }
+
+        return string.Format(
+            System.Globalization.CultureInfo.InvariantCulture,
+            "Domain {0}: queue_state_present={1}, wip_present={2}, in_flight={3}, review={4}, recommended_action: {5}",
+            brief.Domain,
+            brief.QueueStatePresent ? "true" : "false",
+            brief.WipPresent ? "true" : "false",
+            brief.InFlightUnits.Count,
+            brief.ReviewUnits.Count,
+            brief.RecommendedAction);
+    }
+
+    private static string SummarizeContextCollect(ContextCollectPacket? context)
+    {
+        if (context is null)
+        {
+            return "(none)";
+        }
+
+        return string.Format(
+            System.Globalization.CultureInfo.InvariantCulture,
+            "Domain {0}: queue_state_present={1}, in_flight={2}, review={3}, automation_bindings_present={4}.",
+            context.Domain,
+            context.QueueStatePresent ? "true" : "false",
+            context.InFlightUnits.Count,
+            context.ReviewUnits.Count,
+            context.AutomationBindingsPresent ? "true" : "false");
+    }
+
+    private static string SummarizeNextSliceClassify(NextSliceClassifyResult? classify)
+    {
+        if (classify is null)
+        {
+            return "(none)";
+        }
+
+        var builder = new StringBuilder();
+        builder.Append("- classification: ").Append(classify.Classification).Append('\n');
+        builder.Append("- rationale: ").Append(classify.Rationale).Append('\n');
+        builder.Append("- recommended_next_action: ").Append(classify.RecommendedNextAction);
+        return builder.ToString();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingTaskPacketPreviewArtifact.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingTaskPacketPreviewArtifact.cs
@@ -1,0 +1,70 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G192 worker-task preview artifact. Snake_case JSON shape that
+/// <c>intent-cli tasking task-packet-preview</c> writes by consuming a G191
+/// <see cref="TaskingTaskPacketArtifact"/>. The preview is explicitly
+/// local-only: it never publishes a GitHub issue, applies labels, mutates
+/// queue/runs state, or launches provider processes.
+///
+/// <see cref="IsPublished"/> and <see cref="IsAutomationVisible"/> are ALWAYS
+/// literal <c>false</c>; <see cref="PreviewStatus"/> is ALWAYS the literal
+/// value <see cref="TaskingTaskPacketPreviewConstants.LocalOnlyStatus"/>.
+/// </summary>
+internal sealed record TaskingTaskPacketPreviewArtifact
+{
+    [JsonPropertyName("source_task_packet_path")]
+    public required string SourceTaskPacketPath { get; init; }
+
+    [JsonPropertyName("source_task_packet_sha256")]
+    public required string SourceTaskPacketSha256 { get; init; }
+
+    [JsonPropertyName("source_handoff_path")]
+    public required string SourceHandoffPath { get; init; }
+
+    [JsonPropertyName("source_handoff_sha256")]
+    public required string SourceHandoffSha256 { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("is_published")]
+    public required bool IsPublished { get; init; }
+
+    [JsonPropertyName("is_automation_visible")]
+    public required bool IsAutomationVisible { get; init; }
+
+    [JsonPropertyName("preview_status")]
+    public required string PreviewStatus { get; init; }
+
+    [JsonPropertyName("embedded_status_brief")]
+    public StatusBriefSummary? EmbeddedStatusBrief { get; init; }
+
+    [JsonPropertyName("embedded_context_collect")]
+    public ContextCollectPacket? EmbeddedContextCollect { get; init; }
+
+    [JsonPropertyName("embedded_next_slice_classify")]
+    public NextSliceClassifyResult? EmbeddedNextSliceClassify { get; init; }
+
+    [JsonPropertyName("recommended_worker_action")]
+    public required string RecommendedWorkerAction { get; init; }
+
+    [JsonPropertyName("rendered_preview_markdown")]
+    public required string RenderedPreviewMarkdown { get; init; }
+
+    [JsonPropertyName("generated_at_utc")]
+    public required string GeneratedAtUtc { get; init; }
+
+    [JsonPropertyName("artifact_path")]
+    public required string ArtifactPath { get; init; }
+
+    [JsonPropertyName("summary_line")]
+    public required string SummaryLine { get; init; }
+}
+
+internal static class TaskingTaskPacketPreviewConstants
+{
+    public const string LocalOnlyStatus = "local_only";
+}

--- a/src/IntentSystem.Cli/Commands/TaskingTaskPacketPreviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingTaskPacketPreviewCommand.cs
@@ -1,0 +1,239 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G192: <c>intent-cli tasking task-packet-preview</c>. A LOCAL renderer that
+/// reads a G191 <see cref="TaskingTaskPacketArtifact"/> task packet artifact
+/// (JSON) and writes a deterministic operator-facing preview/worker-prompt
+/// artifact. The command performs no GitHub network calls, applies no labels,
+/// launches no provider processes, and does NOT touch
+/// <c>.intent-cli/queue-state.json</c> or <c>.intent-cli/runs.jsonl</c>.
+///
+/// This command is a pure consumer of the G191 task packet. It does NOT
+/// replace <c>tasking handoff</c>, <c>tasking task-packet</c>,
+/// <c>issue plan-candidate</c>, <c>issue prepare</c>, or
+/// <c>issue publish-reviewed</c>; it sits beside G190 <c>handoff</c> and G191
+/// <c>task-packet</c> under the same <c>tasking</c> group.
+///
+/// Network-mutation invariance: this command's hot path contains no
+/// <c>Process.Start</c>, no shell-out to <c>gh</c>, and no provider launcher.
+/// The associated tests validate the no-provider-launch invariant via the
+/// <see cref="NestedProviderLauncher"/> sentinel and a source-scan assertion.
+///
+/// Strict no-partial-output: on missing input file, malformed JSON, or a task
+/// packet whose <c>task_packet_status</c> is not <c>"local_only"</c>, the
+/// command exits 1 and does NOT write the output artifact.
+/// </summary>
+internal static class TaskingTaskPacketPreviewCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private static readonly JsonSerializerOptions ArtifactSerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    /// <summary>
+    /// Test seam mirroring G190/G191 <c>TimestampFactory</c>.
+    /// </summary>
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Test seam mirroring G190/G191 <c>NestedProviderLauncher</c>. G192 must
+    /// NEVER invoke this delegate. Tests register a sentinel that flips a flag
+    /// if invoked; the preview path leaves it untouched.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var fromTaskPacket, out var outPath, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedFromTaskPacket = Path.GetFullPath(fromTaskPacket);
+        if (!File.Exists(resolvedFromTaskPacket))
+        {
+            writer.WriteLine($"--from-task-packet path does not exist: {fromTaskPacket}");
+            return 1;
+        }
+
+        byte[] taskPacketBytes;
+        try
+        {
+            taskPacketBytes = File.ReadAllBytes(resolvedFromTaskPacket);
+        }
+        catch (Exception exception)
+        {
+            writer.WriteLine($"Failed to read --from-task-packet: {exception.Message}");
+            return 1;
+        }
+
+        TaskingTaskPacketArtifact? sourceTaskPacket;
+        try
+        {
+            sourceTaskPacket = JsonSerializer.Deserialize<TaskingTaskPacketArtifact>(taskPacketBytes);
+        }
+        catch (JsonException exception)
+        {
+            writer.WriteLine($"Failed to parse --from-task-packet as a G191 task packet: {exception.Message}");
+            return 1;
+        }
+
+        if (sourceTaskPacket is null)
+        {
+            writer.WriteLine("--from-task-packet parsed to a null packet; expected a G191 task packet JSON object.");
+            return 1;
+        }
+
+        if (!string.Equals(
+                sourceTaskPacket.TaskPacketStatus,
+                TaskingTaskPacketConstants.LocalOnlyStatus,
+                StringComparison.Ordinal))
+        {
+            writer.WriteLine(
+                $"--from-task-packet task_packet_status must be '{TaskingTaskPacketConstants.LocalOnlyStatus}' "
+                + $"(got '{sourceTaskPacket.TaskPacketStatus}'). Refusing to derive a preview from a non-local task packet.");
+            return 1;
+        }
+
+        // Reuse IssuePrepareCommand.ComputeSha256Hex for traceability hashing.
+        var sourceSha256 = IssuePrepareCommand.ComputeSha256Hex(taskPacketBytes);
+
+        // Reuse IssuePrepareCommand.FormatUtcTimestamp for ISO8601 UTC formatting.
+        var generatedAt = IssuePrepareCommand.FormatUtcTimestamp(TimestampFactory());
+
+        var resolvedOutPath = Path.GetFullPath(outPath);
+        var artifactDirectory = Path.GetDirectoryName(resolvedOutPath);
+        if (!string.IsNullOrEmpty(artifactDirectory))
+        {
+            Directory.CreateDirectory(artifactDirectory);
+        }
+
+        var preview = TaskingTaskPacketPreviewAnalyzer.Build(
+            sourceTaskPacket,
+            fromTaskPacket,
+            sourceSha256,
+            generatedAt,
+            resolvedOutPath);
+
+        var serialized = JsonSerializer.Serialize(preview, ArtifactSerializerOptions);
+        File.WriteAllText(resolvedOutPath, serialized);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(serialized);
+        }
+        else
+        {
+            WriteTextSummary(writer, preview);
+        }
+
+        return 0;
+    }
+
+    private static void WriteTextSummary(TextWriter writer, TaskingTaskPacketPreviewArtifact preview)
+    {
+        writer.WriteLine(preview.SummaryLine);
+        writer.WriteLine($"artifact_path: {preview.ArtifactPath}");
+        writer.WriteLine($"source_task_packet_path: {preview.SourceTaskPacketPath}");
+        writer.WriteLine($"source_task_packet_sha256: {preview.SourceTaskPacketSha256}");
+        writer.WriteLine($"source_handoff_path: {preview.SourceHandoffPath}");
+        writer.WriteLine($"source_handoff_sha256: {preview.SourceHandoffSha256}");
+        writer.WriteLine($"domain: {preview.Domain}");
+        writer.WriteLine($"is_published: {preview.IsPublished.ToString().ToLowerInvariant()}");
+        writer.WriteLine(
+            $"is_automation_visible: {preview.IsAutomationVisible.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"preview_status: {preview.PreviewStatus}");
+        writer.WriteLine($"recommended_worker_action: {preview.RecommendedWorkerAction}");
+        writer.WriteLine($"generated_at_utc: {preview.GeneratedAtUtc}");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string fromTaskPacket,
+        out string outPath,
+        out string format,
+        out string error)
+    {
+        fromTaskPacket = string.Empty;
+        outPath = string.Empty;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-task-packet":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-task-packet requires a non-empty value.";
+                        return false;
+                    }
+
+                    fromTaskPacket = args[index + 1];
+                    index++;
+                    break;
+
+                case "--out":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--out requires a non-empty value.";
+                        return false;
+                    }
+
+                    outPath = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --from-task-packet, --out, --format.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromTaskPacket))
+        {
+            error = "--from-task-packet is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(outPath))
+        {
+            error = "--out is required.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/TaskingTaskPacketPreviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskingTaskPacketPreviewCommandTests.cs
@@ -1,0 +1,573 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G192 — coverage for <c>intent-cli tasking task-packet-preview</c>. Class
+/// name contains <c>Tasking</c>, <c>TaskPacket</c>, and <c>Preview</c> so
+/// reviewers can match the issue's recommended
+/// <c>~Tasking|~TaskPacket|~Preview</c> filter.
+/// </summary>
+public sealed class TaskingTaskPacketPreviewCommandTests : IDisposable
+{
+    private readonly Func<DateTimeOffset> originalTimestampFactory;
+    private readonly Func<bool>? originalLauncher;
+
+    public TaskingTaskPacketPreviewCommandTests()
+    {
+        // Only snapshot the seams G192 actually mutates. Avoid clobbering
+        // G190 / G191 timestamp seams (the workspace helper invokes those
+        // commands but does not assert on their timestamps).
+        originalTimestampFactory = TaskingTaskPacketPreviewCommand.TimestampFactory;
+        originalLauncher = TaskingTaskPacketPreviewCommand.NestedProviderLauncher;
+    }
+
+    public void Dispose()
+    {
+        TaskingTaskPacketPreviewCommand.TimestampFactory = originalTimestampFactory;
+        TaskingTaskPacketPreviewCommand.NestedProviderLauncher = originalLauncher;
+    }
+
+    [Fact]
+    public void Execute_GivenValidTaskPacket_WritesUnpublishedPreviewArtifact()
+    {
+        using var workspace = new PreviewWorkspace();
+        var taskPacketPath = workspace.GenerateTaskPacket("task-packet.json");
+        var outPath = workspace.GetPath("preview.json");
+
+        TaskingTaskPacketPreviewCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 12, 34, 56, 789, TimeSpan.Zero);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(
+            workspace.Context,
+            new[] { "--from-task-packet", taskPacketPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(outPath));
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(outPath));
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("is_published").GetBoolean());
+        Assert.False(root.GetProperty("is_automation_visible").GetBoolean());
+        Assert.Equal("local_only", root.GetProperty("preview_status").GetString());
+        Assert.Equal("2026-04-29T12:34:56.789Z", root.GetProperty("generated_at_utc").GetString());
+
+        var summary = root.GetProperty("summary_line").GetString();
+        Assert.NotNull(summary);
+        Assert.Contains("UNPUBLISHED", summary, StringComparison.Ordinal);
+        Assert.Contains("not automation-visible", summary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenValidTaskPacket_PreviewJsonRoundTripsStably()
+    {
+        using var workspace = new PreviewWorkspace();
+        var taskPacketPath = workspace.GenerateTaskPacket("task-packet-rt.json");
+        var outPath = workspace.GetPath("preview-rt.json");
+
+        TaskingTaskPacketPreviewCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 1, 2, 3, TimeSpan.Zero);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(
+            workspace.Context,
+            new[] { "--from-task-packet", taskPacketPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var roundTripped =
+            JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(roundTripped);
+        Assert.Equal("intent-cli", roundTripped!.Domain);
+        Assert.False(roundTripped.IsPublished);
+        Assert.False(roundTripped.IsAutomationVisible);
+        Assert.Equal(TaskingTaskPacketPreviewConstants.LocalOnlyStatus, roundTripped.PreviewStatus);
+        Assert.Equal("local_only", roundTripped.PreviewStatus);
+        Assert.Equal("2026-04-29T01:02:03.000Z", roundTripped.GeneratedAtUtc);
+        Assert.Equal(Path.GetFullPath(outPath), roundTripped.ArtifactPath);
+        Assert.Equal(taskPacketPath, roundTripped.SourceTaskPacketPath);
+        Assert.Contains("UNPUBLISHED", roundTripped.SummaryLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenValidTaskPacket_RecordsAllSourceReferences()
+    {
+        using var workspace = new PreviewWorkspace();
+        var taskPacketPath = workspace.GenerateTaskPacket("task-packet-sha.json");
+        var outPath = workspace.GetPath("preview-sha.json");
+
+        var expectedBytes = File.ReadAllBytes(taskPacketPath);
+        var expectedSha = ComputeSha256HexLowercase(expectedBytes);
+
+        // Read the source task packet to compare its handoff fields.
+        var sourceTaskPacket =
+            JsonSerializer.Deserialize<TaskingTaskPacketArtifact>(expectedBytes);
+        Assert.NotNull(sourceTaskPacket);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(
+            workspace.Context,
+            new[] { "--from-task-packet", taskPacketPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var preview =
+            JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(preview);
+        Assert.Equal(taskPacketPath, preview!.SourceTaskPacketPath);
+        Assert.Equal(expectedSha, preview.SourceTaskPacketSha256);
+        Assert.Equal(expectedSha, preview.SourceTaskPacketSha256.ToLowerInvariant());
+        Assert.Equal(sourceTaskPacket!.SourceHandoffPath, preview.SourceHandoffPath);
+        Assert.Equal(sourceTaskPacket.SourceHandoffSha256, preview.SourceHandoffSha256);
+    }
+
+    [Fact]
+    public void Execute_GivenValidTaskPacket_EmbedsAllSubPacketsAndRecommendedAction()
+    {
+        using var workspace = new PreviewWorkspace();
+        var taskPacketPath = workspace.GenerateTaskPacket("task-packet-embed.json");
+        var outPath = workspace.GetPath("preview-embed.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(
+            workspace.Context,
+            new[] { "--from-task-packet", taskPacketPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var sourceTaskPacket =
+            JsonSerializer.Deserialize<TaskingTaskPacketArtifact>(File.ReadAllText(taskPacketPath));
+        var preview =
+            JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(File.ReadAllText(outPath));
+
+        Assert.NotNull(sourceTaskPacket);
+        Assert.NotNull(preview);
+        Assert.NotNull(preview!.EmbeddedStatusBrief);
+        Assert.NotNull(preview.EmbeddedContextCollect);
+        Assert.NotNull(preview.EmbeddedNextSliceClassify);
+
+        var canonical = new JsonSerializerOptions { WriteIndented = false };
+        Assert.Equal(
+            JsonSerializer.Serialize(sourceTaskPacket!.EmbeddedStatusBrief, canonical),
+            JsonSerializer.Serialize(preview.EmbeddedStatusBrief, canonical));
+        Assert.Equal(
+            JsonSerializer.Serialize(sourceTaskPacket.EmbeddedContextCollect, canonical),
+            JsonSerializer.Serialize(preview.EmbeddedContextCollect, canonical));
+        Assert.Equal(
+            JsonSerializer.Serialize(sourceTaskPacket.EmbeddedNextSliceClassify, canonical),
+            JsonSerializer.Serialize(preview.EmbeddedNextSliceClassify, canonical));
+
+        Assert.Equal(sourceTaskPacket.RecommendedWorkerAction, preview.RecommendedWorkerAction);
+    }
+
+    [Fact]
+    public void Execute_GivenValidTaskPacket_RenderedPreviewMarkdownContainsKeyHeadingsAndStatus()
+    {
+        using var workspace = new PreviewWorkspace();
+        var taskPacketPath = workspace.GenerateTaskPacket("task-packet-md.json");
+        var outPath = workspace.GetPath("preview-md.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(
+            workspace.Context,
+            new[] { "--from-task-packet", taskPacketPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var preview =
+            JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(preview);
+        var md = preview!.RenderedPreviewMarkdown;
+        Assert.Contains("# Worker task preview", md, StringComparison.Ordinal);
+        Assert.Contains("## Source references", md, StringComparison.Ordinal);
+        Assert.Contains("## Recommended worker action", md, StringComparison.Ordinal);
+        Assert.Contains("## Status brief", md, StringComparison.Ordinal);
+        Assert.Contains("## Context collect", md, StringComparison.Ordinal);
+        Assert.Contains("## Next-slice classify", md, StringComparison.Ordinal);
+        Assert.Contains("UNPUBLISHED, local-only, not automation-visible", md, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingTaskPacketFile_ReturnsNonZero_NoOutputArtifact()
+    {
+        using var workspace = new PreviewWorkspace();
+        var missing = workspace.GetPath("does-not-exist.json");
+        var outPath = workspace.GetPath("preview-missing.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(
+            workspace.Context,
+            new[] { "--from-task-packet", missing, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedTaskPacketJson_ReturnsNonZero_NoOutputArtifact()
+    {
+        using var workspace = new PreviewWorkspace();
+        var taskPacketPath = workspace.GetPath("malformed-task-packet.json");
+        File.WriteAllText(taskPacketPath, "{ this is not : valid json,");
+        var outPath = workspace.GetPath("preview-malformed.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(
+            workspace.Context,
+            new[] { "--from-task-packet", taskPacketPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenTaskPacketWithWrongStatus_ReturnsNonZero_NoOutputArtifact()
+    {
+        using var workspace = new PreviewWorkspace();
+        var validTaskPacket = workspace.GenerateTaskPacket("task-packet-source.json");
+        var json = File.ReadAllText(validTaskPacket);
+        var tampered = json.Replace(
+            "\"task_packet_status\": \"local_only\"",
+            "\"task_packet_status\": \"published\"",
+            StringComparison.Ordinal);
+        Assert.NotEqual(json, tampered);
+        var tamperedPath = workspace.GetPath("task-packet-tampered.json");
+        File.WriteAllText(tamperedPath, tampered);
+        var outPath = workspace.GetPath("preview-tampered.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(
+            workspace.Context,
+            new[] { "--from-task-packet", tamperedPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFlag_ReturnsNonZero()
+    {
+        using var workspace = new PreviewWorkspace();
+        var taskPacketPath = workspace.GenerateTaskPacket("task-packet-missing-flag.json");
+
+        // Drop --out entirely.
+        var args = new[] { "--from-task-packet", taskPacketPath };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--out", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsNonZero()
+    {
+        using var workspace = new PreviewWorkspace();
+        var taskPacketPath = workspace.GenerateTaskPacket("task-packet-unknown.json");
+        var outPath = workspace.GetPath("preview-unknown.json");
+
+        var args = new[]
+        {
+            "--from-task-packet", taskPacketPath,
+            "--out", outPath,
+            "--bogus", "value"
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesToQueueStateOrRunsLog()
+    {
+        using var workspace = new PreviewWorkspace();
+        var taskPacketPath = workspace.GenerateTaskPacket("task-packet-no-mut.json");
+
+        var queueStatePath = workspace.Context.GetQueueStatePath();
+        var runsLogPath = workspace.Context.GetRunLogPath();
+
+        var queueBytes = Encoding.UTF8.GetBytes("{\"schema_version\":\"1\",\"items\":[]}\n");
+        var runsBytes = Encoding.UTF8.GetBytes("{\"event\":\"sentinel\",\"ts\":\"2026-04-29T00:00:00Z\"}\n");
+        Directory.CreateDirectory(Path.GetDirectoryName(queueStatePath)!);
+        File.WriteAllBytes(queueStatePath, queueBytes);
+        File.WriteAllBytes(runsLogPath, runsBytes);
+
+        var queueBefore = File.ReadAllBytes(queueStatePath);
+        var runsBefore = File.ReadAllBytes(runsLogPath);
+
+        var outPath = workspace.GetPath("preview-no-mut.json");
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(
+            workspace.Context,
+            new[] { "--from-task-packet", taskPacketPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(outPath));
+
+        var queueAfter = File.ReadAllBytes(queueStatePath);
+        var runsAfter = File.ReadAllBytes(runsLogPath);
+        Assert.Equal(queueBefore, queueAfter);
+        Assert.Equal(runsBefore, runsAfter);
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesProvider_NoProcessStartInNewSurface()
+    {
+        using var workspace = new PreviewWorkspace();
+        var taskPacketPath = workspace.GenerateTaskPacket("task-packet-no-provider.json");
+
+        var launcherInvoked = false;
+        TaskingTaskPacketPreviewCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+
+        var outPath = workspace.GetPath("preview-no-provider.json");
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(
+            workspace.Context,
+            new[] { "--from-task-packet", taskPacketPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(launcherInvoked);
+
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        var commandFile = Path.Combine(commandsDir, "TaskingTaskPacketPreviewCommand.cs");
+        var analyzerFile = Path.Combine(commandsDir, "TaskingTaskPacketPreviewAnalyzer.cs");
+        var artifactFile = Path.Combine(commandsDir, "TaskingTaskPacketPreviewArtifact.cs");
+        if (!File.Exists(commandFile) || !File.Exists(analyzerFile) || !File.Exists(artifactFile))
+        {
+            return;
+        }
+
+        foreach (var path in new[] { commandFile, analyzerFile, artifactFile })
+        {
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("Process.Start(", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_AlwaysMarksContractFieldsLiteralFalseAndLocalOnly()
+    {
+        using var workspace = new PreviewWorkspace();
+        workspace.WriteQueueState("{\"schema_version\":\"1\",\"items\":[]}\n");
+        workspace.WriteClarificationOpen(
+            "## Current Open Blockers\n- 現時点で child issue cut を要する root blocker はない\n");
+        workspace.WriteAutomationBindings("# bindings\n");
+
+        var taskPacketPath = workspace.GenerateTaskPacket("task-packet-contract.json");
+        var outPath = workspace.GetPath("preview-contract.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-task-packet", taskPacketPath,
+                "--out", outPath,
+                "--format", "text"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var preview =
+            JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(preview);
+        Assert.False(preview!.IsPublished);
+        Assert.False(preview.IsAutomationVisible);
+        Assert.Equal("local_only", preview.PreviewStatus);
+        Assert.Equal(TaskingTaskPacketPreviewConstants.LocalOnlyStatus, preview.PreviewStatus);
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(outPath));
+        Assert.Equal(JsonValueKind.False, doc.RootElement.GetProperty("is_published").ValueKind);
+        Assert.Equal(JsonValueKind.False, doc.RootElement.GetProperty("is_automation_visible").ValueKind);
+        Assert.Equal("local_only", doc.RootElement.GetProperty("preview_status").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_StdoutContainsArtifactJson()
+    {
+        using var workspace = new PreviewWorkspace();
+        var taskPacketPath = workspace.GenerateTaskPacket("task-packet-json-fmt.json");
+        TaskingTaskPacketPreviewCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 5, 0, 0, TimeSpan.Zero);
+
+        var outPath = workspace.GetPath("preview-json-fmt.json");
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketPreviewCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-task-packet", taskPacketPath,
+                "--out", outPath,
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var stdoutPreview =
+            JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(writer.ToString());
+        var filePreview =
+            JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(stdoutPreview);
+        Assert.NotNull(filePreview);
+
+        var canonical = new JsonSerializerOptions { WriteIndented = false };
+        Assert.Equal(
+            JsonSerializer.Serialize(filePreview, canonical),
+            JsonSerializer.Serialize(stdoutPreview, canonical));
+    }
+
+    private static string ComputeSha256HexLowercase(byte[] bytes)
+    {
+        var hash = SHA256.HashData(bytes);
+        var builder = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash)
+        {
+            builder.Append(b.ToString("x2", System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool TryResolveCommandsSourceDirectory(out string commandsDirectory)
+    {
+        commandsDirectory = string.Empty;
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, "src", "IntentSystem.Cli", "Commands");
+            if (Directory.Exists(candidate))
+            {
+                commandsDirectory = candidate;
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private sealed class PreviewWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("tasking-task-packet-preview-tests-")
+            .FullName;
+
+        public PreviewWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string GetPath(string relative) => Path.Combine(rootPath, relative);
+
+        public void WriteQueueState(string content)
+        {
+            File.WriteAllText(Context.GetQueueStatePath(), content);
+        }
+
+        public void WriteClarificationOpen(string content)
+        {
+            var path = Path.Combine(rootPath, "intents", "intent-cli", "clarifications");
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "open.md"), content);
+        }
+
+        public void WriteAutomationBindings(string content)
+        {
+            var path = Path.Combine(rootPath, "intents", "intent-cli", "automation");
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "bindings.md"), content);
+        }
+
+        /// <summary>
+        /// Generate a real G190 handoff and a real G191 task packet derived
+        /// from it in this workspace by invoking the actual G190 / G191
+        /// commands. Returns the absolute path of the resulting task packet.
+        /// </summary>
+        public string GenerateTaskPacket(string filename)
+        {
+            var handoffPath = GetPath("__handoff_" + filename);
+            using (var sink = new StringWriter())
+            {
+                var handoffExit = TaskingHandoffCommand.Execute(
+                    Context,
+                    new[] { "--out", handoffPath },
+                    sink);
+                if (handoffExit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G190 handoff for tests: exit={handoffExit}, stderr={sink}");
+                }
+            }
+
+            var taskPacketPath = GetPath(filename);
+            using (var sink = new StringWriter())
+            {
+                var taskPacketExit = TaskingTaskPacketCommand.Execute(
+                    Context,
+                    new[] { "--from-handoff", handoffPath, "--out", taskPacketPath },
+                    sink);
+                if (taskPacketExit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G191 task packet for tests: exit={taskPacketExit}, stderr={sink}");
+                }
+            }
+
+            return taskPacketPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new subcommand `intent-cli tasking task-packet-preview --from-task-packet <task-packet-artifact-path> --out <preview-artifact-path> [--format text|json]` under the existing G190 `tasking` group. The renderer reads a G191 `tasking task-packet` JSON artifact, validates it, and writes a deterministic operator-facing preview/worker-prompt artifact (JSON shape with embedded markdown render). No GitHub network. No provider/worker launch. No queue/runs mutation. No `intent-target` exposure.
- Strict no-partial-output invariant on invalid input (explicit Acceptance Criterion):
  - missing `--from-task-packet` file → exit 1, output not written
  - JSON parse failure → exit 1, output not written
  - `task_packet_status != "local_only"` → exit 1, output not written
  - missing/blank required flag or unknown argument → exit 1, output not written
- Output JSON shape (snake_case, stable order, round-trippable through `JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>`):
  ```
  { "source_task_packet_path": "...", "source_task_packet_sha256": "<lowercase hex>",
    "source_handoff_path":     "...", "source_handoff_sha256":     "<copied from task packet>",
    "domain": "...",
    "is_published": false,
    "is_automation_visible": false,
    "preview_status": "local_only",
    "embedded_status_brief":        { ... } | null,
    "embedded_context_collect":     { ... } | null,
    "embedded_next_slice_classify": { ... } | null,
    "recommended_worker_action": "...",
    "rendered_preview_markdown": "<deterministic multi-section Markdown>",
    "generated_at_utc": "<ISO8601 UTC>",
    "artifact_path": "<absolute>",
    "summary_line": "Worker preview for <domain> derived from <source_task_packet_path> — UNPUBLISHED, local-only, not automation-visible." }
  ```
  Contract fields `is_published` / `is_automation_visible` are ALWAYS literal `false`; `preview_status` is ALWAYS literal `"local_only"`. Locked in by an explicit regression so future drift cannot accidentally flip these.
- `rendered_preview_markdown` is a stable, deterministic multi-section Markdown body: `# Worker task preview — <domain>` with sections `## Source references`, `## Recommended worker action`, `## Status brief`, `## Context collect`, `## Next-slice classify`, plus the literal status-line `**Status: UNPUBLISHED, local-only, not automation-visible.**`. Sections collapse to `(none)` when their sub-packet is null. Single `\n` separators, no trailing whitespace.
- No-mutation invariants:
  - Sentinel `TaskingTaskPacketPreviewCommand.NestedProviderLauncher` (mirrors G187/G190/G191) — never invoked.
  - Source-scan asserts `TaskingTaskPacketPreviewCommand.cs` and `TaskingTaskPacketPreviewAnalyzer.cs` contain no `Process.Start(`.
  - Byte-equivalence test on `.intent-cli/queue-state.json` and `.intent-cli/runs.jsonl` before/after.
- Reuse, not duplication:
  - `TaskingTaskPacketArtifact` (G191) — deserialized to validate the input
  - `TaskingTaskPacketConstants.LocalOnlyStatus` (G191) — status check
  - `IssuePrepareCommand.ComputeSha256Hex(byte[])` — for `source_task_packet_sha256`
  - `IssuePrepareCommand.FormatUtcTimestamp(DateTimeOffset)` — for `generated_at_utc`
  - No `private→internal` promotions needed.

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter \"FullyQualifiedName~TaskingTaskPacketPreview\"` — **14/14 passing**. Issue-required scenarios covered: WritesUnpublishedPreviewArtifact, PreviewJsonRoundTripsStably, RecordsAllSourceReferences (sha256 of bytes + copied handoff sha256), EmbedsAllSubPacketsAndRecommendedAction, RenderedPreviewMarkdownContainsKeyHeadingsAndStatus (locks every required heading + the literal "UNPUBLISHED, local-only, not automation-visible" phrase), MissingTaskPacketFileReturnsNonZero_NoOutputArtifact, MalformedTaskPacketJsonReturnsNonZero_NoOutputArtifact, GivenTaskPacketWithWrongStatusReturnsNonZero_NoOutputArtifact (contract-locking), MissingFlagReturnsNonZero, UnknownArgumentReturnsNonZero, NeverWritesToQueueStateOrRunsLog (byte-equivalence), NeverInvokesProvider_NoProcessStartInNewSurface (sentinel + source-scan), AlwaysMarksContractFieldsLiteralFalseAndLocalOnly (contract-locking regression).
- [x] Issue's recommended broader filter: `dotnet test ... --filter \"FullyQualifiedName~Tasking|FullyQualifiedName~TaskPacket|FullyQualifiedName~Preview|FullyQualifiedName~Handoff|FullyQualifiedName~IssuePlanCandidate|FullyQualifiedName~Publish\"` — passes (14 new G192 tests + every existing Tasking/TaskPacket/Handoff/IssuePlanCandidate/Publish test stays green).
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **1042/1042 passing + 1 skip** (the 1 skip is the pre-existing G190 `Execute_TolerantToSubAnalyzerFailure` `[Fact(Skip)]` not introduced by this slice; CLI: 1028 → 1042 = +14 new G192 tests; no regressions).
- [ ] Manual smoke (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff --domain intent-cli --out /tmp/g192-handoff.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet --from-handoff /tmp/g192-handoff.json --out /tmp/g192-task-packet.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet-preview --from-task-packet /tmp/g192-task-packet.json --out /tmp/g192-preview.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet-preview --from-task-packet /tmp/g192-task-packet.json --out /tmp/g192-preview.json --format json`

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)