### PR TITLE
G193: add intent-cli tasking task-packet-checklist deterministic local acceptance artifact

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -128,7 +128,8 @@ internal static class CommandRouter
             {
                 ["handoff"] = TaskingHandoffCommand.Execute,
                 ["task-packet"] = TaskingTaskPacketCommand.Execute,
-                ["task-packet-preview"] = TaskingTaskPacketPreviewCommand.Execute
+                ["task-packet-preview"] = TaskingTaskPacketPreviewCommand.Execute,
+                ["task-packet-checklist"] = TaskingTaskPacketChecklistCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/TaskingTaskPacketChecklistAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingTaskPacketChecklistAnalyzer.cs
@@ -1,0 +1,190 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G193 — pure logic that takes an already-deserialized G192
+/// <see cref="TaskingTaskPacketPreviewArtifact"/> and builds a deterministic
+/// <see cref="TaskingTaskPacketChecklistArtifact"/>. No file I/O, no network,
+/// and no process launches happen here — those concerns are owned by
+/// <see cref="TaskingTaskPacketChecklistCommand"/>.
+///
+/// The contract fields <see cref="TaskingTaskPacketChecklistArtifact.IsPublished"/>,
+/// <see cref="TaskingTaskPacketChecklistArtifact.IsAutomationVisible"/>, and
+/// <see cref="TaskingTaskPacketChecklistArtifact.ChecklistStatus"/> are always
+/// literal false / false / "local_only" for this slice.
+/// </summary>
+internal static class TaskingTaskPacketChecklistAnalyzer
+{
+    /// <summary>
+    /// Stable UNPUBLISHED status phrase asserted by G193 tests. Mirrors the
+    /// G192 phrase so the worker handoff status is recognisable across the
+    /// chain.
+    /// </summary>
+    public const string UnpublishedStatusPhrase =
+        "UNPUBLISHED, local-only, not automation-visible";
+
+    private const int RenderedPreviewExcerptMaxLength = 240;
+
+    public static TaskingTaskPacketChecklistArtifact Build(
+        TaskingTaskPacketPreviewArtifact sourcePreview,
+        string sourcePreviewPath,
+        string sourcePreviewSha256,
+        string generatedAtUtc,
+        string resolvedArtifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(sourcePreview);
+        ArgumentNullException.ThrowIfNull(sourcePreviewPath);
+        ArgumentNullException.ThrowIfNull(sourcePreviewSha256);
+        ArgumentNullException.ThrowIfNull(generatedAtUtc);
+        ArgumentNullException.ThrowIfNull(resolvedArtifactPath);
+
+        var checks = BuildChecks(sourcePreview);
+        var readyForHandoff = checks.All(c => c.Passed);
+
+        var summaryLine =
+            $"Worker handoff checklist for {sourcePreview.Domain} derived from {sourcePreviewPath} — "
+            + $"{UnpublishedStatusPhrase}. ready_for_handoff="
+            + (readyForHandoff ? "true" : "false")
+            + ".";
+
+        return new TaskingTaskPacketChecklistArtifact
+        {
+            SourcePreviewPath = sourcePreviewPath,
+            SourcePreviewSha256 = sourcePreviewSha256,
+            SourceTaskPacketPath = sourcePreview.SourceTaskPacketPath,
+            SourceTaskPacketSha256 = sourcePreview.SourceTaskPacketSha256,
+            SourceHandoffPath = sourcePreview.SourceHandoffPath,
+            SourceHandoffSha256 = sourcePreview.SourceHandoffSha256,
+            Domain = sourcePreview.Domain,
+            IsPublished = false,
+            IsAutomationVisible = false,
+            ChecklistStatus = TaskingTaskPacketChecklistConstants.LocalOnlyStatus,
+            ReadyForHandoff = readyForHandoff,
+            Checks = checks,
+            RecommendedWorkerAction = sourcePreview.RecommendedWorkerAction,
+            RenderedPreviewExcerpt = BuildRenderedPreviewExcerpt(sourcePreview.RenderedPreviewMarkdown),
+            GeneratedAtUtc = generatedAtUtc,
+            ArtifactPath = resolvedArtifactPath,
+            SummaryLine = summaryLine
+        };
+    }
+
+    private static IReadOnlyList<ChecklistCheck> BuildChecks(TaskingTaskPacketPreviewArtifact preview)
+    {
+        var checks = new List<ChecklistCheck>(TaskingTaskPacketChecklistConstants.CheckIds.All.Count);
+
+        var statusLocalOnly = string.Equals(
+            preview.PreviewStatus,
+            TaskingTaskPacketPreviewConstants.LocalOnlyStatus,
+            StringComparison.Ordinal);
+        checks.Add(new ChecklistCheck
+        {
+            Id = TaskingTaskPacketChecklistConstants.CheckIds.PreviewStatusLocalOnly,
+            Passed = statusLocalOnly,
+            Detail = statusLocalOnly
+                ? $"preview_status == '{TaskingTaskPacketPreviewConstants.LocalOnlyStatus}'."
+                : $"preview_status was '{preview.PreviewStatus}', expected '{TaskingTaskPacketPreviewConstants.LocalOnlyStatus}'."
+        });
+
+        var publishedFalse = !preview.IsPublished;
+        checks.Add(new ChecklistCheck
+        {
+            Id = TaskingTaskPacketChecklistConstants.CheckIds.PreviewIsPublishedFalse,
+            Passed = publishedFalse,
+            Detail = publishedFalse
+                ? "preview is_published == false (unpublished)."
+                : "preview is_published == true; expected false for local-only handoff."
+        });
+
+        var automationFalse = !preview.IsAutomationVisible;
+        checks.Add(new ChecklistCheck
+        {
+            Id = TaskingTaskPacketChecklistConstants.CheckIds.PreviewIsAutomationVisibleFalse,
+            Passed = automationFalse,
+            Detail = automationFalse
+                ? "preview is_automation_visible == false (not automation-visible)."
+                : "preview is_automation_visible == true; expected false for local-only handoff."
+        });
+
+        checks.Add(BuildPresenceCheck(
+            TaskingTaskPacketChecklistConstants.CheckIds.SourceTaskPacketPathPresent,
+            "source_task_packet_path",
+            preview.SourceTaskPacketPath));
+
+        checks.Add(BuildPresenceCheck(
+            TaskingTaskPacketChecklistConstants.CheckIds.SourceTaskPacketSha256Present,
+            "source_task_packet_sha256",
+            preview.SourceTaskPacketSha256));
+
+        checks.Add(BuildPresenceCheck(
+            TaskingTaskPacketChecklistConstants.CheckIds.SourceHandoffPathPresent,
+            "source_handoff_path",
+            preview.SourceHandoffPath));
+
+        checks.Add(BuildPresenceCheck(
+            TaskingTaskPacketChecklistConstants.CheckIds.SourceHandoffSha256Present,
+            "source_handoff_sha256",
+            preview.SourceHandoffSha256));
+
+        var markdown = preview.RenderedPreviewMarkdown;
+        var markdownPresent = !string.IsNullOrWhiteSpace(markdown);
+        checks.Add(new ChecklistCheck
+        {
+            Id = TaskingTaskPacketChecklistConstants.CheckIds.RenderedPreviewMarkdownNonEmpty,
+            Passed = markdownPresent,
+            Detail = markdownPresent
+                ? "rendered_preview_markdown is non-empty."
+                : "rendered_preview_markdown is null or whitespace; expected operator-facing markdown."
+        });
+
+        var marksUnpublished = markdownPresent
+            && markdown.Contains("UNPUBLISHED", StringComparison.Ordinal);
+        checks.Add(new ChecklistCheck
+        {
+            Id = TaskingTaskPacketChecklistConstants.CheckIds.RenderedPreviewMarksUnpublished,
+            Passed = marksUnpublished,
+            Detail = marksUnpublished
+                ? "rendered_preview_markdown contains the literal 'UNPUBLISHED'."
+                : "rendered_preview_markdown does not contain the literal 'UNPUBLISHED'."
+        });
+
+        var recommendedActionPresent = !string.IsNullOrWhiteSpace(preview.RecommendedWorkerAction);
+        checks.Add(new ChecklistCheck
+        {
+            Id = TaskingTaskPacketChecklistConstants.CheckIds.RecommendedWorkerActionNonEmpty,
+            Passed = recommendedActionPresent,
+            Detail = recommendedActionPresent
+                ? "recommended_worker_action is non-empty."
+                : "recommended_worker_action is null or whitespace; expected a worker action statement."
+        });
+
+        return checks;
+    }
+
+    private static ChecklistCheck BuildPresenceCheck(string id, string fieldName, string? value)
+    {
+        var present = !string.IsNullOrWhiteSpace(value);
+        return new ChecklistCheck
+        {
+            Id = id,
+            Passed = present,
+            Detail = present
+                ? $"{fieldName} is present."
+                : $"{fieldName} is null or whitespace; expected a non-empty value from the source preview."
+        };
+    }
+
+    private static string? BuildRenderedPreviewExcerpt(string? renderedMarkdown)
+    {
+        if (string.IsNullOrEmpty(renderedMarkdown))
+        {
+            return null;
+        }
+
+        if (renderedMarkdown.Length <= RenderedPreviewExcerptMaxLength)
+        {
+            return renderedMarkdown;
+        }
+
+        return renderedMarkdown.Substring(0, RenderedPreviewExcerptMaxLength) + "...";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingTaskPacketChecklistArtifact.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingTaskPacketChecklistArtifact.cs
@@ -1,0 +1,122 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G193 worker-task acceptance checklist artifact. Snake_case JSON shape that
+/// <c>intent-cli tasking task-packet-checklist</c> writes by consuming a G192
+/// <see cref="TaskingTaskPacketPreviewArtifact"/>. The checklist is explicitly
+/// local-only: it never publishes a GitHub issue, applies labels, mutates
+/// queue/runs state, or launches provider processes.
+///
+/// <see cref="IsPublished"/> and <see cref="IsAutomationVisible"/> are ALWAYS
+/// literal <c>false</c>; <see cref="ChecklistStatus"/> is ALWAYS the literal
+/// value <see cref="TaskingTaskPacketChecklistConstants.LocalOnlyStatus"/>.
+/// </summary>
+internal sealed record TaskingTaskPacketChecklistArtifact
+{
+    [JsonPropertyName("source_preview_path")]
+    public required string SourcePreviewPath { get; init; }
+
+    [JsonPropertyName("source_preview_sha256")]
+    public required string SourcePreviewSha256 { get; init; }
+
+    [JsonPropertyName("source_task_packet_path")]
+    public required string SourceTaskPacketPath { get; init; }
+
+    [JsonPropertyName("source_task_packet_sha256")]
+    public required string SourceTaskPacketSha256 { get; init; }
+
+    [JsonPropertyName("source_handoff_path")]
+    public required string SourceHandoffPath { get; init; }
+
+    [JsonPropertyName("source_handoff_sha256")]
+    public required string SourceHandoffSha256 { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("is_published")]
+    public required bool IsPublished { get; init; }
+
+    [JsonPropertyName("is_automation_visible")]
+    public required bool IsAutomationVisible { get; init; }
+
+    [JsonPropertyName("checklist_status")]
+    public required string ChecklistStatus { get; init; }
+
+    [JsonPropertyName("ready_for_handoff")]
+    public required bool ReadyForHandoff { get; init; }
+
+    [JsonPropertyName("checks")]
+    public required IReadOnlyList<ChecklistCheck> Checks { get; init; }
+
+    [JsonPropertyName("recommended_worker_action")]
+    public required string RecommendedWorkerAction { get; init; }
+
+    [JsonPropertyName("rendered_preview_excerpt")]
+    public string? RenderedPreviewExcerpt { get; init; }
+
+    [JsonPropertyName("generated_at_utc")]
+    public required string GeneratedAtUtc { get; init; }
+
+    [JsonPropertyName("artifact_path")]
+    public required string ArtifactPath { get; init; }
+
+    [JsonPropertyName("summary_line")]
+    public required string SummaryLine { get; init; }
+}
+
+/// <summary>
+/// Single check entry in the G193 checklist. <see cref="Id"/> is a stable
+/// constant string from <see cref="TaskingTaskPacketChecklistConstants.CheckIds"/>
+/// — tests grep on these without relying on ordering.
+/// </summary>
+internal sealed record ChecklistCheck
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("passed")]
+    public required bool Passed { get; init; }
+
+    [JsonPropertyName("detail")]
+    public required string Detail { get; init; }
+}
+
+internal static class TaskingTaskPacketChecklistConstants
+{
+    public const string LocalOnlyStatus = "local_only";
+
+    /// <summary>
+    /// Stable check ids. Tests assert each constant appears exactly once in
+    /// the produced checklist so the check set cannot drift silently.
+    /// </summary>
+    public static class CheckIds
+    {
+        public const string PreviewStatusLocalOnly = "preview_status_local_only";
+        public const string PreviewIsPublishedFalse = "preview_is_published_false";
+        public const string PreviewIsAutomationVisibleFalse = "preview_is_automation_visible_false";
+        public const string SourceTaskPacketPathPresent = "source_task_packet_path_present";
+        public const string SourceTaskPacketSha256Present = "source_task_packet_sha256_present";
+        public const string SourceHandoffPathPresent = "source_handoff_path_present";
+        public const string SourceHandoffSha256Present = "source_handoff_sha256_present";
+        public const string RenderedPreviewMarkdownNonEmpty = "rendered_preview_markdown_non_empty";
+        public const string RenderedPreviewMarksUnpublished = "rendered_preview_marks_unpublished";
+        public const string RecommendedWorkerActionNonEmpty = "recommended_worker_action_non_empty";
+
+        public static IReadOnlyList<string> All { get; } =
+        [
+            PreviewStatusLocalOnly,
+            PreviewIsPublishedFalse,
+            PreviewIsAutomationVisibleFalse,
+            SourceTaskPacketPathPresent,
+            SourceTaskPacketSha256Present,
+            SourceHandoffPathPresent,
+            SourceHandoffSha256Present,
+            RenderedPreviewMarkdownNonEmpty,
+            RenderedPreviewMarksUnpublished,
+            RecommendedWorkerActionNonEmpty
+        ];
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingTaskPacketChecklistCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingTaskPacketChecklistCommand.cs
@@ -1,0 +1,251 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G193: <c>intent-cli tasking task-packet-checklist</c>. A LOCAL acceptance
+/// checklist that reads a G192 <see cref="TaskingTaskPacketPreviewArtifact"/>
+/// preview artifact (JSON) and writes a deterministic operator-facing checklist
+/// describing whether the preview is ready for worker handoff. The command
+/// performs no GitHub network calls, applies no labels, launches no provider
+/// processes, and does NOT touch <c>.intent-cli/queue-state.json</c> or
+/// <c>.intent-cli/runs.jsonl</c>.
+///
+/// Sits beside G190 <c>handoff</c>, G191 <c>task-packet</c>, and G192
+/// <c>task-packet-preview</c> under the same <c>tasking</c> group. It does NOT
+/// replace any of those commands, nor does it touch
+/// <c>issue plan-candidate</c>, <c>issue prepare</c>, or
+/// <c>issue publish-reviewed</c>.
+///
+/// Network-mutation invariance: this command's hot path contains no
+/// <c>Process.Start</c>, no shell-out to <c>gh</c>, and no provider launcher.
+/// The associated tests validate the no-provider-launch invariant via the
+/// <see cref="NestedProviderLauncher"/> sentinel and a source-scan assertion.
+///
+/// Strict no-partial-output: on missing input file, malformed JSON, or a
+/// preview whose <c>preview_status</c> is not <c>"local_only"</c>, the command
+/// exits 1 and does NOT write the output artifact.
+/// </summary>
+internal static class TaskingTaskPacketChecklistCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private static readonly JsonSerializerOptions ArtifactSerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    /// <summary>
+    /// Test seam mirroring G190/G191/G192 <c>TimestampFactory</c>.
+    /// </summary>
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Test seam mirroring G190/G191/G192 <c>NestedProviderLauncher</c>. G193
+    /// must NEVER invoke this delegate. Tests register a sentinel that flips a
+    /// flag if invoked; the checklist path leaves it untouched.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var fromPreview, out var outPath, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedFromPreview = Path.GetFullPath(fromPreview);
+        if (!File.Exists(resolvedFromPreview))
+        {
+            writer.WriteLine($"--from-preview path does not exist: {fromPreview}");
+            return 1;
+        }
+
+        byte[] previewBytes;
+        try
+        {
+            previewBytes = File.ReadAllBytes(resolvedFromPreview);
+        }
+        catch (Exception exception)
+        {
+            writer.WriteLine($"Failed to read --from-preview: {exception.Message}");
+            return 1;
+        }
+
+        TaskingTaskPacketPreviewArtifact? sourcePreview;
+        try
+        {
+            sourcePreview = JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(previewBytes);
+        }
+        catch (JsonException exception)
+        {
+            writer.WriteLine($"Failed to parse --from-preview as a G192 task packet preview: {exception.Message}");
+            return 1;
+        }
+
+        if (sourcePreview is null)
+        {
+            writer.WriteLine("--from-preview parsed to a null preview; expected a G192 task packet preview JSON object.");
+            return 1;
+        }
+
+        if (!string.Equals(
+                sourcePreview.PreviewStatus,
+                TaskingTaskPacketPreviewConstants.LocalOnlyStatus,
+                StringComparison.Ordinal))
+        {
+            writer.WriteLine(
+                $"--from-preview preview_status must be '{TaskingTaskPacketPreviewConstants.LocalOnlyStatus}' "
+                + $"(got '{sourcePreview.PreviewStatus}'). Refusing to derive a checklist from a non-local preview.");
+            return 1;
+        }
+
+        // Reuse IssuePrepareCommand.ComputeSha256Hex for traceability hashing.
+        var sourceSha256 = IssuePrepareCommand.ComputeSha256Hex(previewBytes);
+
+        // Reuse IssuePrepareCommand.FormatUtcTimestamp for ISO8601 UTC formatting.
+        var generatedAt = IssuePrepareCommand.FormatUtcTimestamp(TimestampFactory());
+
+        var resolvedOutPath = Path.GetFullPath(outPath);
+        var artifactDirectory = Path.GetDirectoryName(resolvedOutPath);
+        if (!string.IsNullOrEmpty(artifactDirectory))
+        {
+            Directory.CreateDirectory(artifactDirectory);
+        }
+
+        var checklist = TaskingTaskPacketChecklistAnalyzer.Build(
+            sourcePreview,
+            fromPreview,
+            sourceSha256,
+            generatedAt,
+            resolvedOutPath);
+
+        var serialized = JsonSerializer.Serialize(checklist, ArtifactSerializerOptions);
+        File.WriteAllText(resolvedOutPath, serialized);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(serialized);
+        }
+        else
+        {
+            WriteTextSummary(writer, checklist);
+        }
+
+        return 0;
+    }
+
+    private static void WriteTextSummary(TextWriter writer, TaskingTaskPacketChecklistArtifact checklist)
+    {
+        writer.WriteLine(checklist.SummaryLine);
+        writer.WriteLine($"artifact_path: {checklist.ArtifactPath}");
+        writer.WriteLine($"source_preview_path: {checklist.SourcePreviewPath}");
+        writer.WriteLine($"source_preview_sha256: {checklist.SourcePreviewSha256}");
+        writer.WriteLine($"source_task_packet_path: {checklist.SourceTaskPacketPath}");
+        writer.WriteLine($"source_task_packet_sha256: {checklist.SourceTaskPacketSha256}");
+        writer.WriteLine($"source_handoff_path: {checklist.SourceHandoffPath}");
+        writer.WriteLine($"source_handoff_sha256: {checklist.SourceHandoffSha256}");
+        writer.WriteLine($"domain: {checklist.Domain}");
+        writer.WriteLine($"is_published: {checklist.IsPublished.ToString().ToLowerInvariant()}");
+        writer.WriteLine(
+            $"is_automation_visible: {checklist.IsAutomationVisible.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"checklist_status: {checklist.ChecklistStatus}");
+        writer.WriteLine(
+            $"ready_for_handoff: {checklist.ReadyForHandoff.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"recommended_worker_action: {checklist.RecommendedWorkerAction}");
+        writer.WriteLine($"generated_at_utc: {checklist.GeneratedAtUtc}");
+
+        writer.WriteLine("checks:");
+        foreach (var check in checklist.Checks)
+        {
+            writer.WriteLine(
+                $"- {check.Id}: passed={check.Passed.ToString().ToLowerInvariant()} — {check.Detail}");
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string fromPreview,
+        out string outPath,
+        out string format,
+        out string error)
+    {
+        fromPreview = string.Empty;
+        outPath = string.Empty;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-preview":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-preview requires a non-empty value.";
+                        return false;
+                    }
+
+                    fromPreview = args[index + 1];
+                    index++;
+                    break;
+
+                case "--out":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--out requires a non-empty value.";
+                        return false;
+                    }
+
+                    outPath = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --from-preview, --out, --format.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromPreview))
+        {
+            error = "--from-preview is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(outPath))
+        {
+            error = "--out is required.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/TaskingTaskPacketChecklistCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskingTaskPacketChecklistCommandTests.cs
@@ -1,0 +1,660 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G193 — coverage for <c>intent-cli tasking task-packet-checklist</c>. Class
+/// name contains <c>Tasking</c>, <c>TaskPacket</c>, and <c>Checklist</c> so
+/// reviewers can match the issue's recommended
+/// <c>~Tasking|~TaskPacket|~Checklist</c> filter.
+/// </summary>
+public sealed class TaskingTaskPacketChecklistCommandTests : IDisposable
+{
+    private readonly Func<DateTimeOffset> originalTimestampFactory;
+    private readonly Func<bool>? originalLauncher;
+
+    public TaskingTaskPacketChecklistCommandTests()
+    {
+        // Snapshot only the seams G193 actually mutates. Avoid clobbering
+        // upstream G190 / G191 / G192 timestamp seams (the workspace helper
+        // invokes those commands but the assertions live on the G193 output).
+        originalTimestampFactory = TaskingTaskPacketChecklistCommand.TimestampFactory;
+        originalLauncher = TaskingTaskPacketChecklistCommand.NestedProviderLauncher;
+    }
+
+    public void Dispose()
+    {
+        TaskingTaskPacketChecklistCommand.TimestampFactory = originalTimestampFactory;
+        TaskingTaskPacketChecklistCommand.NestedProviderLauncher = originalLauncher;
+    }
+
+    [Fact]
+    public void Execute_GivenValidPreview_WritesUnpublishedChecklistArtifact()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var previewPath = workspace.GeneratePreview("preview.json");
+        var outPath = workspace.GetPath("checklist.json");
+
+        TaskingTaskPacketChecklistCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 12, 34, 56, 789, TimeSpan.Zero);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(outPath));
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(outPath));
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("is_published").GetBoolean());
+        Assert.False(root.GetProperty("is_automation_visible").GetBoolean());
+        Assert.Equal("local_only", root.GetProperty("checklist_status").GetString());
+        Assert.Equal("2026-04-29T12:34:56.789Z", root.GetProperty("generated_at_utc").GetString());
+
+        var summary = root.GetProperty("summary_line").GetString();
+        Assert.NotNull(summary);
+        Assert.Contains("UNPUBLISHED", summary, StringComparison.Ordinal);
+        Assert.Contains("not automation-visible", summary, StringComparison.Ordinal);
+        Assert.Contains("ready_for_handoff=true", summary, StringComparison.Ordinal);
+
+        Assert.True(root.GetProperty("ready_for_handoff").GetBoolean());
+    }
+
+    [Fact]
+    public void Execute_GivenValidPreview_ChecklistJsonRoundTripsStably()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var previewPath = workspace.GeneratePreview("preview-rt.json");
+        var outPath = workspace.GetPath("checklist-rt.json");
+
+        TaskingTaskPacketChecklistCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 1, 2, 3, TimeSpan.Zero);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var roundTripped =
+            JsonSerializer.Deserialize<TaskingTaskPacketChecklistArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(roundTripped);
+        Assert.Equal("intent-cli", roundTripped!.Domain);
+        Assert.False(roundTripped.IsPublished);
+        Assert.False(roundTripped.IsAutomationVisible);
+        Assert.Equal(TaskingTaskPacketChecklistConstants.LocalOnlyStatus, roundTripped.ChecklistStatus);
+        Assert.Equal("local_only", roundTripped.ChecklistStatus);
+        Assert.Equal("2026-04-29T01:02:03.000Z", roundTripped.GeneratedAtUtc);
+        Assert.Equal(Path.GetFullPath(outPath), roundTripped.ArtifactPath);
+        Assert.Equal(previewPath, roundTripped.SourcePreviewPath);
+        Assert.Contains("UNPUBLISHED", roundTripped.SummaryLine, StringComparison.Ordinal);
+        Assert.True(roundTripped.ReadyForHandoff);
+        Assert.Equal(
+            TaskingTaskPacketChecklistConstants.CheckIds.All.Count,
+            roundTripped.Checks.Count);
+    }
+
+    [Fact]
+    public void Execute_GivenValidPreview_RecordsAllSourceReferencesAndSha256s()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var previewPath = workspace.GeneratePreview("preview-sha.json");
+        var outPath = workspace.GetPath("checklist-sha.json");
+
+        var expectedPreviewBytes = File.ReadAllBytes(previewPath);
+        var expectedPreviewSha = ComputeSha256HexLowercase(expectedPreviewBytes);
+
+        var sourcePreview =
+            JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(expectedPreviewBytes);
+        Assert.NotNull(sourcePreview);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var checklist =
+            JsonSerializer.Deserialize<TaskingTaskPacketChecklistArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(checklist);
+        Assert.Equal(previewPath, checklist!.SourcePreviewPath);
+        Assert.Equal(expectedPreviewSha, checklist.SourcePreviewSha256);
+        Assert.Equal(expectedPreviewSha, checklist.SourcePreviewSha256.ToLowerInvariant());
+        Assert.Equal(sourcePreview!.SourceTaskPacketPath, checklist.SourceTaskPacketPath);
+        Assert.Equal(sourcePreview.SourceTaskPacketSha256, checklist.SourceTaskPacketSha256);
+        Assert.Equal(sourcePreview.SourceHandoffPath, checklist.SourceHandoffPath);
+        Assert.Equal(sourcePreview.SourceHandoffSha256, checklist.SourceHandoffSha256);
+
+        Assert.False(string.IsNullOrWhiteSpace(checklist.SourceTaskPacketPath));
+        Assert.False(string.IsNullOrWhiteSpace(checklist.SourceTaskPacketSha256));
+        Assert.False(string.IsNullOrWhiteSpace(checklist.SourceHandoffPath));
+        Assert.False(string.IsNullOrWhiteSpace(checklist.SourceHandoffSha256));
+    }
+
+    [Fact]
+    public void Execute_GivenValidPreview_AllTenChecksPresentByStableId()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var previewPath = workspace.GeneratePreview("preview-checks.json");
+        var outPath = workspace.GetPath("checklist-checks.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var checklist =
+            JsonSerializer.Deserialize<TaskingTaskPacketChecklistArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(checklist);
+
+        var expectedIds = TaskingTaskPacketChecklistConstants.CheckIds.All;
+        Assert.Equal(10, expectedIds.Count);
+        Assert.Equal(expectedIds.Count, checklist!.Checks.Count);
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var check in checklist.Checks)
+        {
+            Assert.True(seen.Add(check.Id), $"Duplicate check id: {check.Id}");
+        }
+
+        foreach (var expected in expectedIds)
+        {
+            Assert.Contains(expected, seen);
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenValidPreview_ReadyForHandoffTrueIffAllChecksPass()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var previewPath = workspace.GeneratePreview("preview-ready.json");
+        var outPath = workspace.GetPath("checklist-ready.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var checklist =
+            JsonSerializer.Deserialize<TaskingTaskPacketChecklistArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(checklist);
+        Assert.True(checklist!.ReadyForHandoff);
+        foreach (var check in checklist.Checks)
+        {
+            Assert.True(check.Passed, $"Expected check '{check.Id}' to pass: {check.Detail}");
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenPreviewWithEmptyRecommendedAction_FailsRecommendedActionCheck()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var previewPath = workspace.GeneratePreview("preview-empty-action-src.json");
+        var modifiedPreviewPath = workspace.GetPath("preview-empty-action.json");
+        var preview = JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(
+            File.ReadAllText(previewPath));
+        Assert.NotNull(preview);
+        var mutated = preview! with { RecommendedWorkerAction = "   " };
+        File.WriteAllText(modifiedPreviewPath, JsonSerializer.Serialize(mutated));
+
+        var outPath = workspace.GetPath("checklist-empty-action.json");
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", modifiedPreviewPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var checklist =
+            JsonSerializer.Deserialize<TaskingTaskPacketChecklistArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(checklist);
+        Assert.False(checklist!.ReadyForHandoff);
+
+        var actionCheck = checklist.Checks.Single(
+            c => c.Id == TaskingTaskPacketChecklistConstants.CheckIds.RecommendedWorkerActionNonEmpty);
+        Assert.False(actionCheck.Passed);
+    }
+
+    [Fact]
+    public void Execute_GivenPreviewWithEmptyMarkdown_FailsMarkdownChecks()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var previewPath = workspace.GeneratePreview("preview-empty-md-src.json");
+        var modifiedPreviewPath = workspace.GetPath("preview-empty-md.json");
+        var preview = JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(
+            File.ReadAllText(previewPath));
+        Assert.NotNull(preview);
+        var mutated = preview! with { RenderedPreviewMarkdown = string.Empty };
+        File.WriteAllText(modifiedPreviewPath, JsonSerializer.Serialize(mutated));
+
+        var outPath = workspace.GetPath("checklist-empty-md.json");
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", modifiedPreviewPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var checklist =
+            JsonSerializer.Deserialize<TaskingTaskPacketChecklistArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(checklist);
+        Assert.False(checklist!.ReadyForHandoff);
+
+        var nonEmpty = checklist.Checks.Single(
+            c => c.Id == TaskingTaskPacketChecklistConstants.CheckIds.RenderedPreviewMarkdownNonEmpty);
+        var marksUnpublished = checklist.Checks.Single(
+            c => c.Id == TaskingTaskPacketChecklistConstants.CheckIds.RenderedPreviewMarksUnpublished);
+        Assert.False(nonEmpty.Passed);
+        Assert.False(marksUnpublished.Passed);
+
+        Assert.Null(checklist.RenderedPreviewExcerpt);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPreviewFile_ReturnsNonZero_NoOutputArtifact()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var missing = workspace.GetPath("does-not-exist.json");
+        var outPath = workspace.GetPath("checklist-missing.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", missing, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedPreviewJson_ReturnsNonZero_NoOutputArtifact()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var previewPath = workspace.GetPath("malformed-preview.json");
+        File.WriteAllText(previewPath, "{ this is not : valid json,");
+        var outPath = workspace.GetPath("checklist-malformed.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenPreviewWithWrongStatus_ReturnsNonZero_NoOutputArtifact()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var validPreview = workspace.GeneratePreview("preview-source.json");
+        var json = File.ReadAllText(validPreview);
+        var tampered = json.Replace(
+            "\"preview_status\": \"local_only\"",
+            "\"preview_status\": \"published\"",
+            StringComparison.Ordinal);
+        Assert.NotEqual(json, tampered);
+        var tamperedPath = workspace.GetPath("preview-tampered.json");
+        File.WriteAllText(tamperedPath, tampered);
+        var outPath = workspace.GetPath("checklist-tampered.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", tamperedPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFlag_ReturnsNonZero()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var previewPath = workspace.GeneratePreview("preview-missing-flag.json");
+
+        // Drop --out entirely.
+        var args = new[] { "--from-preview", previewPath };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--out", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsNonZero()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var previewPath = workspace.GeneratePreview("preview-unknown.json");
+        var outPath = workspace.GetPath("checklist-unknown.json");
+
+        var args = new[]
+        {
+            "--from-preview", previewPath,
+            "--out", outPath,
+            "--bogus", "value"
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesToQueueStateOrRunsLog()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var previewPath = workspace.GeneratePreview("preview-no-mut.json");
+
+        var queueStatePath = workspace.Context.GetQueueStatePath();
+        var runsLogPath = workspace.Context.GetRunLogPath();
+
+        var queueBytes = Encoding.UTF8.GetBytes("{\"schema_version\":\"1\",\"items\":[]}\n");
+        var runsBytes = Encoding.UTF8.GetBytes("{\"event\":\"sentinel\",\"ts\":\"2026-04-29T00:00:00Z\"}\n");
+        Directory.CreateDirectory(Path.GetDirectoryName(queueStatePath)!);
+        File.WriteAllBytes(queueStatePath, queueBytes);
+        File.WriteAllBytes(runsLogPath, runsBytes);
+
+        var queueBefore = File.ReadAllBytes(queueStatePath);
+        var runsBefore = File.ReadAllBytes(runsLogPath);
+
+        var outPath = workspace.GetPath("checklist-no-mut.json");
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(outPath));
+
+        var queueAfter = File.ReadAllBytes(queueStatePath);
+        var runsAfter = File.ReadAllBytes(runsLogPath);
+        Assert.Equal(queueBefore, queueAfter);
+        Assert.Equal(runsBefore, runsAfter);
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesProvider_NoProcessStartInNewSurface()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var previewPath = workspace.GeneratePreview("preview-no-provider.json");
+
+        var launcherInvoked = false;
+        TaskingTaskPacketChecklistCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+
+        var outPath = workspace.GetPath("checklist-no-provider.json");
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(launcherInvoked);
+
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        var commandFile = Path.Combine(commandsDir, "TaskingTaskPacketChecklistCommand.cs");
+        var analyzerFile = Path.Combine(commandsDir, "TaskingTaskPacketChecklistAnalyzer.cs");
+        var artifactFile = Path.Combine(commandsDir, "TaskingTaskPacketChecklistArtifact.cs");
+        if (!File.Exists(commandFile) || !File.Exists(analyzerFile) || !File.Exists(artifactFile))
+        {
+            return;
+        }
+
+        foreach (var path in new[] { commandFile, analyzerFile, artifactFile })
+        {
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("Process.Start(", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_AlwaysMarksContractFieldsLiteralFalseAndLocalOnly()
+    {
+        using var workspace = new ChecklistWorkspace();
+        workspace.WriteQueueState("{\"schema_version\":\"1\",\"items\":[]}\n");
+        workspace.WriteClarificationOpen(
+            "## Current Open Blockers\n- 現時点で child issue cut を要する root blocker はない\n");
+        workspace.WriteAutomationBindings("# bindings\n");
+
+        var previewPath = workspace.GeneratePreview("preview-contract.json");
+        var outPath = workspace.GetPath("checklist-contract.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-preview", previewPath,
+                "--out", outPath,
+                "--format", "text"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var checklist =
+            JsonSerializer.Deserialize<TaskingTaskPacketChecklistArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(checklist);
+        Assert.False(checklist!.IsPublished);
+        Assert.False(checklist.IsAutomationVisible);
+        Assert.Equal("local_only", checklist.ChecklistStatus);
+        Assert.Equal(TaskingTaskPacketChecklistConstants.LocalOnlyStatus, checklist.ChecklistStatus);
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(outPath));
+        Assert.Equal(JsonValueKind.False, doc.RootElement.GetProperty("is_published").ValueKind);
+        Assert.Equal(JsonValueKind.False, doc.RootElement.GetProperty("is_automation_visible").ValueKind);
+        Assert.Equal("local_only", doc.RootElement.GetProperty("checklist_status").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_StdoutContainsArtifactJson()
+    {
+        using var workspace = new ChecklistWorkspace();
+        var previewPath = workspace.GeneratePreview("preview-json-fmt.json");
+        TaskingTaskPacketChecklistCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 5, 0, 0, TimeSpan.Zero);
+
+        var outPath = workspace.GetPath("checklist-json-fmt.json");
+        using var writer = new StringWriter();
+        var exitCode = TaskingTaskPacketChecklistCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-preview", previewPath,
+                "--out", outPath,
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var stdoutChecklist =
+            JsonSerializer.Deserialize<TaskingTaskPacketChecklistArtifact>(writer.ToString());
+        var fileChecklist =
+            JsonSerializer.Deserialize<TaskingTaskPacketChecklistArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(stdoutChecklist);
+        Assert.NotNull(fileChecklist);
+
+        var canonical = new JsonSerializerOptions { WriteIndented = false };
+        Assert.Equal(
+            JsonSerializer.Serialize(fileChecklist, canonical),
+            JsonSerializer.Serialize(stdoutChecklist, canonical));
+    }
+
+    private static string ComputeSha256HexLowercase(byte[] bytes)
+    {
+        var hash = SHA256.HashData(bytes);
+        var builder = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash)
+        {
+            builder.Append(b.ToString("x2", System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool TryResolveCommandsSourceDirectory(out string commandsDirectory)
+    {
+        commandsDirectory = string.Empty;
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, "src", "IntentSystem.Cli", "Commands");
+            if (Directory.Exists(candidate))
+            {
+                commandsDirectory = candidate;
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private sealed class ChecklistWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("tasking-task-packet-checklist-tests-")
+            .FullName;
+
+        public ChecklistWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string GetPath(string relative) => Path.Combine(rootPath, relative);
+
+        public void WriteQueueState(string content)
+        {
+            File.WriteAllText(Context.GetQueueStatePath(), content);
+        }
+
+        public void WriteClarificationOpen(string content)
+        {
+            var path = Path.Combine(rootPath, "intents", "intent-cli", "clarifications");
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "open.md"), content);
+        }
+
+        public void WriteAutomationBindings(string content)
+        {
+            var path = Path.Combine(rootPath, "intents", "intent-cli", "automation");
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "bindings.md"), content);
+        }
+
+        /// <summary>
+        /// Generate a real G190 handoff, a real G191 task packet, and a real
+        /// G192 preview derived from them in this workspace by invoking the
+        /// actual upstream commands. Returns the absolute path of the resulting
+        /// preview artifact.
+        /// </summary>
+        public string GeneratePreview(string filename)
+        {
+            var handoffPath = GetPath("__handoff_" + filename);
+            using (var sink = new StringWriter())
+            {
+                var handoffExit = TaskingHandoffCommand.Execute(
+                    Context,
+                    new[] { "--out", handoffPath },
+                    sink);
+                if (handoffExit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G190 handoff for tests: exit={handoffExit}, stderr={sink}");
+                }
+            }
+
+            var taskPacketPath = GetPath("__task_packet_" + filename);
+            using (var sink = new StringWriter())
+            {
+                var taskPacketExit = TaskingTaskPacketCommand.Execute(
+                    Context,
+                    new[] { "--from-handoff", handoffPath, "--out", taskPacketPath },
+                    sink);
+                if (taskPacketExit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G191 task packet for tests: exit={taskPacketExit}, stderr={sink}");
+                }
+            }
+
+            var previewPath = GetPath(filename);
+            using (var sink = new StringWriter())
+            {
+                var previewExit = TaskingTaskPacketPreviewCommand.Execute(
+                    Context,
+                    new[] { "--from-task-packet", taskPacketPath, "--out", previewPath },
+                    sink);
+                if (previewExit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G192 preview for tests: exit={previewExit}, stderr={sink}");
+                }
+            }
+
+            return previewPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new subcommand `intent-cli tasking task-packet-checklist --from-preview <preview-artifact-path> --out <checklist-artifact-path> [--format text|json]` under the existing `tasking` group. Fourth in the chain G190 handoff → G191 task-packet → G192 preview → **G193 checklist**. The bridge reads a G192 preview JSON artifact, validates it, runs 10 stable acceptance checks, and writes a deterministic local-only checklist artifact. No GitHub network. No provider/worker launch. No queue/runs mutation. No `intent-target` exposure.
- Strict no-partial-output invariant on invalid input (explicit Acceptance Criterion):
  - missing `--from-preview` file → exit 1, output not written
  - JSON parse failure → exit 1, output not written
  - `preview_status != "local_only"` → exit 1, output not written
  - missing/blank required flag or unknown argument → exit 1, output not written
- 10 stable check ids (defined as constants in `TaskingTaskPacketChecklistConstants.CheckIds`):
  `preview_status_local_only`, `preview_is_published_false`, `preview_is_automation_visible_false`, `source_task_packet_path_present`, `source_task_packet_sha256_present`, `source_handoff_path_present`, `source_handoff_sha256_present`, `rendered_preview_markdown_non_empty`, `rendered_preview_marks_unpublished`, `recommended_worker_action_non_empty`. Each emitted check is `{id, passed, detail}` so test assertions can grep without depending on ordering. `ready_for_handoff = checks.All(c => c.passed)`. The check-id list is locked by an explicit regression so future drift breaks the test.
- Output JSON shape (snake_case, stable order, round-trippable through `JsonSerializer.Deserialize<TaskingTaskPacketChecklistArtifact>`):
  ```
  { "source_preview_path": "...", "source_preview_sha256": "<lowercase hex>",
    "source_task_packet_path": "...", "source_task_packet_sha256": "...",
    "source_handoff_path":     "...", "source_handoff_sha256":     "...",
    "domain": "...",
    "is_published": false,
    "is_automation_visible": false,
    "checklist_status": "local_only",
    "ready_for_handoff": <bool>,
    "checks": [ {"id":"...", "passed":<bool>, "detail":"..."}, ... 10 entries ... ],
    "recommended_worker_action": "...",
    "rendered_preview_excerpt": "<first 240 chars + '...' if truncated, or null if empty>",
    "generated_at_utc": "<ISO8601 UTC>",
    "artifact_path": "<absolute>",
    "summary_line": "Worker handoff checklist for <domain> derived from <source_preview_path> — UNPUBLISHED, local-only, not automation-visible. ready_for_handoff=<true/false>." }
  ```
  Contract fields `is_published` / `is_automation_visible` are ALWAYS literal `false`; `checklist_status` is ALWAYS literal `"local_only"`. Locked in by an explicit regression so future drift cannot accidentally flip these.
- No-mutation invariants:
  - Sentinel `TaskingTaskPacketChecklistCommand.NestedProviderLauncher` (mirrors G187/G190/G191/G192) — never invoked across the success path.
  - Source-scan asserts the new command + analyzer files contain no `Process.Start(`.
  - Byte-equivalence test snapshots `.intent-cli/queue-state.json` and `.intent-cli/runs.jsonl` before/after — must be byte-identical.
- Reuse, not duplication:
  - `TaskingTaskPacketPreviewArtifact` (G192) — deserialize the input preview
  - `TaskingTaskPacketPreviewConstants.LocalOnlyStatus` (G192) — status validation
  - `IssuePrepareCommand.ComputeSha256Hex(byte[])` — for `source_preview_sha256`
  - `IssuePrepareCommand.FormatUtcTimestamp(DateTimeOffset)` — for `generated_at_utc`
  - No `private→internal` promotions needed.

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter \"FullyQualifiedName~TaskingTaskPacketChecklist\"` — **16/16 passing**. Issue-required scenarios covered: WritesUnpublishedChecklistArtifact, ChecklistJsonRoundTripsStably, RecordsAllSourceReferencesAndSha256s (full upstream chain), AllTenChecksPresentByStableId (locks the check set), ReadyForHandoffTrueIffAllChecksPass (happy path), GivenPreviewWithEmptyRecommendedAction_FailsRecommendedActionCheck (exit 0, ready_for_handoff=false, specific check fails), GivenPreviewWithEmptyMarkdown_FailsMarkdownChecks (markdown checks fail), MissingPreviewFileReturnsNonZero_NoOutputArtifact, MalformedPreviewJsonReturnsNonZero_NoOutputArtifact, GivenPreviewWithWrongStatusReturnsNonZero_NoOutputArtifact (contract-locking), MissingFlagReturnsNonZero, UnknownArgumentReturnsNonZero, NeverWritesToQueueStateOrRunsLog (byte-equivalence), NeverInvokesProvider_NoProcessStartInNewSurface (sentinel + source-scan), AlwaysMarksContractFieldsLiteralFalseAndLocalOnly (contract-locking regression), plus a JSON-format stdout-mirrors-artifact test.
- [x] Issue's recommended broader filter `~Tasking|~TaskPacket|~Checklist|~Preview|~Publish` — passes (16 new G193 tests + every existing surface stays green).
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **1058/1058 passing + 1 skip** (the 1 skip is the pre-existing G190 `TolerantToSubAnalyzerFailure` `[Fact(Skip)]` not introduced by this slice; CLI: 1042 → 1058 = +16 new G193 tests; no regressions).
- [ ] Manual smoke (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff --domain intent-cli --out /tmp/g193-handoff.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet --from-handoff /tmp/g193-handoff.json --out /tmp/g193-task-packet.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet-preview --from-task-packet /tmp/g193-task-packet.json --out /tmp/g193-preview.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet-checklist --from-preview /tmp/g193-preview.json --out /tmp/g193-checklist.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet-checklist --from-preview /tmp/g193-preview.json --out /tmp/g193-checklist.json --format json`

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)