### PR TITLE
G194: add intent-cli tasking handoff-bundle deterministic local export

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -129,7 +129,8 @@ internal static class CommandRouter
                 ["handoff"] = TaskingHandoffCommand.Execute,
                 ["task-packet"] = TaskingTaskPacketCommand.Execute,
                 ["task-packet-preview"] = TaskingTaskPacketPreviewCommand.Execute,
-                ["task-packet-checklist"] = TaskingTaskPacketChecklistCommand.Execute
+                ["task-packet-checklist"] = TaskingTaskPacketChecklistCommand.Execute,
+                ["handoff-bundle"] = TaskingHandoffBundleCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleAnalyzer.cs
@@ -1,0 +1,112 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G194 — pure logic that takes a deserialized G192
+/// <see cref="TaskingTaskPacketPreviewArtifact"/> preview and a G193
+/// <see cref="TaskingTaskPacketChecklistArtifact"/> checklist (already validated
+/// to belong together by the command layer via SHA256 match) and builds a
+/// deterministic <see cref="TaskingHandoffBundleArtifact"/>. No file I/O, no
+/// network, and no process launches happen here — those concerns are owned by
+/// <see cref="TaskingHandoffBundleCommand"/>.
+///
+/// The contract fields <see cref="TaskingHandoffBundleArtifact.IsPublished"/>,
+/// <see cref="TaskingHandoffBundleArtifact.IsAutomationVisible"/>, and
+/// <see cref="TaskingHandoffBundleArtifact.BundleStatus"/> are always literal
+/// false / false / "local_only" for this slice.
+/// </summary>
+internal static class TaskingHandoffBundleAnalyzer
+{
+    /// <summary>
+    /// Stable UNPUBLISHED status phrase asserted by G194 tests. Mirrors the
+    /// G192/G193 phrase so the worker handoff status is recognisable across the
+    /// chain.
+    /// </summary>
+    public const string UnpublishedStatusPhrase =
+        "UNPUBLISHED, local-only, not automation-visible";
+
+    private const int RenderedPreviewExcerptMaxLength = 240;
+
+    public static TaskingHandoffBundleArtifact Build(
+        TaskingTaskPacketPreviewArtifact sourcePreview,
+        TaskingTaskPacketChecklistArtifact sourceChecklist,
+        string sourcePreviewPath,
+        string sourcePreviewSha256,
+        string sourceChecklistPath,
+        string sourceChecklistSha256,
+        string generatedAtUtc,
+        string resolvedArtifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(sourcePreview);
+        ArgumentNullException.ThrowIfNull(sourceChecklist);
+        ArgumentNullException.ThrowIfNull(sourcePreviewPath);
+        ArgumentNullException.ThrowIfNull(sourcePreviewSha256);
+        ArgumentNullException.ThrowIfNull(sourceChecklistPath);
+        ArgumentNullException.ThrowIfNull(sourceChecklistSha256);
+        ArgumentNullException.ThrowIfNull(generatedAtUtc);
+        ArgumentNullException.ThrowIfNull(resolvedArtifactPath);
+
+        var passed = new List<string>();
+        var failed = new List<string>();
+        foreach (var check in sourceChecklist.Checks)
+        {
+            if (check.Passed)
+            {
+                passed.Add(check.Id);
+            }
+            else
+            {
+                failed.Add(check.Id);
+            }
+        }
+
+        var renderedExcerpt = !string.IsNullOrEmpty(sourceChecklist.RenderedPreviewExcerpt)
+            ? sourceChecklist.RenderedPreviewExcerpt
+            : BuildRenderedPreviewExcerpt(sourcePreview.RenderedPreviewMarkdown);
+
+        var summaryLine =
+            $"Worker handoff bundle for {sourcePreview.Domain} derived from preview "
+            + $"{sourcePreviewPath} + checklist {sourceChecklistPath} — "
+            + $"{UnpublishedStatusPhrase}. ready_for_handoff="
+            + (sourceChecklist.ReadyForHandoff ? "true" : "false")
+            + ".";
+
+        return new TaskingHandoffBundleArtifact
+        {
+            SourcePreviewPath = sourcePreviewPath,
+            SourcePreviewSha256 = sourcePreviewSha256,
+            SourceChecklistPath = sourceChecklistPath,
+            SourceChecklistSha256 = sourceChecklistSha256,
+            SourceTaskPacketPath = sourcePreview.SourceTaskPacketPath,
+            SourceTaskPacketSha256 = sourcePreview.SourceTaskPacketSha256,
+            SourceHandoffPath = sourcePreview.SourceHandoffPath,
+            SourceHandoffSha256 = sourcePreview.SourceHandoffSha256,
+            Domain = sourcePreview.Domain,
+            IsPublished = false,
+            IsAutomationVisible = false,
+            BundleStatus = TaskingHandoffBundleConstants.LocalOnlyStatus,
+            ChecklistReadyForHandoff = sourceChecklist.ReadyForHandoff,
+            ChecklistPassedCheckIds = passed,
+            ChecklistFailedCheckIds = failed,
+            RenderedPreviewExcerpt = renderedExcerpt,
+            RecommendedWorkerAction = sourcePreview.RecommendedWorkerAction,
+            GeneratedAtUtc = generatedAtUtc,
+            ArtifactPath = resolvedArtifactPath,
+            SummaryLine = summaryLine
+        };
+    }
+
+    private static string? BuildRenderedPreviewExcerpt(string? renderedMarkdown)
+    {
+        if (string.IsNullOrEmpty(renderedMarkdown))
+        {
+            return null;
+        }
+
+        if (renderedMarkdown.Length <= RenderedPreviewExcerptMaxLength)
+        {
+            return renderedMarkdown;
+        }
+
+        return renderedMarkdown.Substring(0, RenderedPreviewExcerptMaxLength) + "...";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleArtifact.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleArtifact.cs
@@ -1,0 +1,83 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G194 worker handoff bundle artifact. Snake_case JSON shape that
+/// <c>intent-cli tasking handoff-bundle</c> writes by consuming a G192
+/// <see cref="TaskingTaskPacketPreviewArtifact"/> preview and a G193
+/// <see cref="TaskingTaskPacketChecklistArtifact"/> checklist together. The
+/// bundle is explicitly local-only: it never publishes a GitHub issue, applies
+/// labels, mutates queue/runs state, or launches provider processes.
+///
+/// <see cref="IsPublished"/> and <see cref="IsAutomationVisible"/> are ALWAYS
+/// literal <c>false</c>; <see cref="BundleStatus"/> is ALWAYS the literal value
+/// <see cref="TaskingHandoffBundleConstants.LocalOnlyStatus"/>.
+/// </summary>
+internal sealed record TaskingHandoffBundleArtifact
+{
+    [JsonPropertyName("source_preview_path")]
+    public required string SourcePreviewPath { get; init; }
+
+    [JsonPropertyName("source_preview_sha256")]
+    public required string SourcePreviewSha256 { get; init; }
+
+    [JsonPropertyName("source_checklist_path")]
+    public required string SourceChecklistPath { get; init; }
+
+    [JsonPropertyName("source_checklist_sha256")]
+    public required string SourceChecklistSha256 { get; init; }
+
+    [JsonPropertyName("source_task_packet_path")]
+    public required string SourceTaskPacketPath { get; init; }
+
+    [JsonPropertyName("source_task_packet_sha256")]
+    public required string SourceTaskPacketSha256 { get; init; }
+
+    [JsonPropertyName("source_handoff_path")]
+    public required string SourceHandoffPath { get; init; }
+
+    [JsonPropertyName("source_handoff_sha256")]
+    public required string SourceHandoffSha256 { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("is_published")]
+    public required bool IsPublished { get; init; }
+
+    [JsonPropertyName("is_automation_visible")]
+    public required bool IsAutomationVisible { get; init; }
+
+    [JsonPropertyName("bundle_status")]
+    public required string BundleStatus { get; init; }
+
+    [JsonPropertyName("checklist_ready_for_handoff")]
+    public required bool ChecklistReadyForHandoff { get; init; }
+
+    [JsonPropertyName("checklist_passed_check_ids")]
+    public required IReadOnlyList<string> ChecklistPassedCheckIds { get; init; }
+
+    [JsonPropertyName("checklist_failed_check_ids")]
+    public required IReadOnlyList<string> ChecklistFailedCheckIds { get; init; }
+
+    [JsonPropertyName("rendered_preview_excerpt")]
+    public string? RenderedPreviewExcerpt { get; init; }
+
+    [JsonPropertyName("recommended_worker_action")]
+    public required string RecommendedWorkerAction { get; init; }
+
+    [JsonPropertyName("generated_at_utc")]
+    public required string GeneratedAtUtc { get; init; }
+
+    [JsonPropertyName("artifact_path")]
+    public required string ArtifactPath { get; init; }
+
+    [JsonPropertyName("summary_line")]
+    public required string SummaryLine { get; init; }
+}
+
+internal static class TaskingHandoffBundleConstants
+{
+    public const string LocalOnlyStatus = "local_only";
+}

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleCommand.cs
@@ -1,0 +1,353 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G194: <c>intent-cli tasking handoff-bundle</c>. A LOCAL bundle/export bridge
+/// that reads BOTH a G192 <see cref="TaskingTaskPacketPreviewArtifact"/> preview
+/// artifact (JSON) and a G193 <see cref="TaskingTaskPacketChecklistArtifact"/>
+/// checklist artifact (JSON), validates that they belong together (the
+/// checklist's <c>source_preview_sha256</c> MUST equal the actual SHA256 of the
+/// preview file's bytes), and writes one deterministic worker handoff bundle.
+/// The command performs no GitHub network calls, applies no labels, launches no
+/// provider processes, and does NOT touch <c>.intent-cli/queue-state.json</c>
+/// or <c>.intent-cli/runs.jsonl</c>.
+///
+/// Sits beside G190 <c>handoff</c>, G191 <c>task-packet</c>, G192
+/// <c>task-packet-preview</c>, and G193 <c>task-packet-checklist</c> under the
+/// same <c>tasking</c> group. It does NOT replace any of those commands, nor
+/// does it touch <c>issue plan-candidate</c>, <c>issue prepare</c>, or
+/// <c>issue publish-reviewed</c>.
+///
+/// Network-mutation invariance: this command's hot path contains no
+/// <c>Process.Start</c>, no shell-out to <c>gh</c>, and no provider launcher.
+/// The associated tests validate the no-provider-launch invariant via the
+/// <see cref="NestedProviderLauncher"/> sentinel and a source-scan assertion.
+///
+/// Strict no-partial-output: on missing input file, malformed JSON on either
+/// input, a preview/checklist whose status is not <c>"local_only"</c>, or a
+/// preview/checklist SHA256 mismatch, the command exits 1 and does NOT write
+/// the output artifact.
+/// </summary>
+internal static class TaskingHandoffBundleCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private static readonly JsonSerializerOptions ArtifactSerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    /// <summary>
+    /// Test seam mirroring G190/G191/G192/G193 <c>TimestampFactory</c>.
+    /// </summary>
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Test seam mirroring G190/G191/G192/G193 <c>NestedProviderLauncher</c>.
+    /// G194 must NEVER invoke this delegate. Tests register a sentinel that
+    /// flips a flag if invoked; the bundle path leaves it untouched.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(
+                args,
+                out var fromPreview,
+                out var fromChecklist,
+                out var outPath,
+                out var format,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedFromPreview = Path.GetFullPath(fromPreview);
+        if (!File.Exists(resolvedFromPreview))
+        {
+            writer.WriteLine($"--from-preview path does not exist: {fromPreview}");
+            return 1;
+        }
+
+        var resolvedFromChecklist = Path.GetFullPath(fromChecklist);
+        if (!File.Exists(resolvedFromChecklist))
+        {
+            writer.WriteLine($"--from-checklist path does not exist: {fromChecklist}");
+            return 1;
+        }
+
+        byte[] previewBytes;
+        try
+        {
+            previewBytes = File.ReadAllBytes(resolvedFromPreview);
+        }
+        catch (Exception exception)
+        {
+            writer.WriteLine($"Failed to read --from-preview: {exception.Message}");
+            return 1;
+        }
+
+        byte[] checklistBytes;
+        try
+        {
+            checklistBytes = File.ReadAllBytes(resolvedFromChecklist);
+        }
+        catch (Exception exception)
+        {
+            writer.WriteLine($"Failed to read --from-checklist: {exception.Message}");
+            return 1;
+        }
+
+        TaskingTaskPacketPreviewArtifact? sourcePreview;
+        try
+        {
+            sourcePreview = JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(previewBytes);
+        }
+        catch (JsonException exception)
+        {
+            writer.WriteLine($"Failed to parse --from-preview as a G192 task packet preview: {exception.Message}");
+            return 1;
+        }
+
+        if (sourcePreview is null)
+        {
+            writer.WriteLine("--from-preview parsed to a null preview; expected a G192 task packet preview JSON object.");
+            return 1;
+        }
+
+        TaskingTaskPacketChecklistArtifact? sourceChecklist;
+        try
+        {
+            sourceChecklist =
+                JsonSerializer.Deserialize<TaskingTaskPacketChecklistArtifact>(checklistBytes);
+        }
+        catch (JsonException exception)
+        {
+            writer.WriteLine($"Failed to parse --from-checklist as a G193 task packet checklist: {exception.Message}");
+            return 1;
+        }
+
+        if (sourceChecklist is null)
+        {
+            writer.WriteLine("--from-checklist parsed to a null checklist; expected a G193 task packet checklist JSON object.");
+            return 1;
+        }
+
+        if (!string.Equals(
+                sourcePreview.PreviewStatus,
+                TaskingTaskPacketPreviewConstants.LocalOnlyStatus,
+                StringComparison.Ordinal))
+        {
+            writer.WriteLine(
+                $"--from-preview preview_status must be '{TaskingTaskPacketPreviewConstants.LocalOnlyStatus}' "
+                + $"(got '{sourcePreview.PreviewStatus}'). Refusing to derive a bundle from a non-local preview.");
+            return 1;
+        }
+
+        if (!string.Equals(
+                sourceChecklist.ChecklistStatus,
+                TaskingTaskPacketChecklistConstants.LocalOnlyStatus,
+                StringComparison.Ordinal))
+        {
+            writer.WriteLine(
+                $"--from-checklist checklist_status must be '{TaskingTaskPacketChecklistConstants.LocalOnlyStatus}' "
+                + $"(got '{sourceChecklist.ChecklistStatus}'). Refusing to derive a bundle from a non-local checklist.");
+            return 1;
+        }
+
+        // Reuse IssuePrepareCommand.ComputeSha256Hex for traceability hashing.
+        var sourcePreviewSha256 = IssuePrepareCommand.ComputeSha256Hex(previewBytes);
+        var sourceChecklistSha256 = IssuePrepareCommand.ComputeSha256Hex(checklistBytes);
+
+        // Mismatch acceptance criterion: the checklist must have been derived
+        // from the supplied preview, asserted by SHA256 equality of the preview
+        // file bytes vs the checklist's recorded source_preview_sha256.
+        if (!string.Equals(
+                sourceChecklist.SourcePreviewSha256,
+                sourcePreviewSha256,
+                StringComparison.Ordinal))
+        {
+            writer.WriteLine(
+                "--from-checklist source_preview_sha256 does not match --from-preview file SHA256. "
+                + $"checklist.source_preview_sha256={sourceChecklist.SourcePreviewSha256} "
+                + $"preview_file_sha256={sourcePreviewSha256}. "
+                + "Refusing to bundle a checklist that was not derived from the supplied preview.");
+            return 1;
+        }
+
+        // Reuse IssuePrepareCommand.FormatUtcTimestamp for ISO8601 UTC formatting.
+        var generatedAt = IssuePrepareCommand.FormatUtcTimestamp(TimestampFactory());
+
+        var resolvedOutPath = Path.GetFullPath(outPath);
+        var artifactDirectory = Path.GetDirectoryName(resolvedOutPath);
+        if (!string.IsNullOrEmpty(artifactDirectory))
+        {
+            Directory.CreateDirectory(artifactDirectory);
+        }
+
+        var bundle = TaskingHandoffBundleAnalyzer.Build(
+            sourcePreview,
+            sourceChecklist,
+            fromPreview,
+            sourcePreviewSha256,
+            fromChecklist,
+            sourceChecklistSha256,
+            generatedAt,
+            resolvedOutPath);
+
+        var serialized = JsonSerializer.Serialize(bundle, ArtifactSerializerOptions);
+        File.WriteAllText(resolvedOutPath, serialized);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(serialized);
+        }
+        else
+        {
+            WriteTextSummary(writer, bundle);
+        }
+
+        return 0;
+    }
+
+    private static void WriteTextSummary(TextWriter writer, TaskingHandoffBundleArtifact bundle)
+    {
+        writer.WriteLine(bundle.SummaryLine);
+        writer.WriteLine($"artifact_path: {bundle.ArtifactPath}");
+        writer.WriteLine($"source_preview_path: {bundle.SourcePreviewPath}");
+        writer.WriteLine($"source_preview_sha256: {bundle.SourcePreviewSha256}");
+        writer.WriteLine($"source_checklist_path: {bundle.SourceChecklistPath}");
+        writer.WriteLine($"source_checklist_sha256: {bundle.SourceChecklistSha256}");
+        writer.WriteLine($"source_task_packet_path: {bundle.SourceTaskPacketPath}");
+        writer.WriteLine($"source_task_packet_sha256: {bundle.SourceTaskPacketSha256}");
+        writer.WriteLine($"source_handoff_path: {bundle.SourceHandoffPath}");
+        writer.WriteLine($"source_handoff_sha256: {bundle.SourceHandoffSha256}");
+        writer.WriteLine($"domain: {bundle.Domain}");
+        writer.WriteLine($"is_published: {bundle.IsPublished.ToString().ToLowerInvariant()}");
+        writer.WriteLine(
+            $"is_automation_visible: {bundle.IsAutomationVisible.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"bundle_status: {bundle.BundleStatus}");
+        writer.WriteLine(
+            $"checklist_ready_for_handoff: {bundle.ChecklistReadyForHandoff.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"recommended_worker_action: {bundle.RecommendedWorkerAction}");
+        writer.WriteLine($"generated_at_utc: {bundle.GeneratedAtUtc}");
+
+        writer.WriteLine($"checklist_passed_check_ids ({bundle.ChecklistPassedCheckIds.Count}):");
+        foreach (var id in bundle.ChecklistPassedCheckIds)
+        {
+            writer.WriteLine($"- {id}");
+        }
+
+        writer.WriteLine($"checklist_failed_check_ids ({bundle.ChecklistFailedCheckIds.Count}):");
+        foreach (var id in bundle.ChecklistFailedCheckIds)
+        {
+            writer.WriteLine($"- {id}");
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string fromPreview,
+        out string fromChecklist,
+        out string outPath,
+        out string format,
+        out string error)
+    {
+        fromPreview = string.Empty;
+        fromChecklist = string.Empty;
+        outPath = string.Empty;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-preview":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-preview requires a non-empty value.";
+                        return false;
+                    }
+
+                    fromPreview = args[index + 1];
+                    index++;
+                    break;
+
+                case "--from-checklist":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-checklist requires a non-empty value.";
+                        return false;
+                    }
+
+                    fromChecklist = args[index + 1];
+                    index++;
+                    break;
+
+                case "--out":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--out requires a non-empty value.";
+                        return false;
+                    }
+
+                    outPath = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --from-preview, --from-checklist, --out, --format.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromPreview))
+        {
+            error = "--from-preview is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(fromChecklist))
+        {
+            error = "--from-checklist is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(outPath))
+        {
+            error = "--out is required.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/TaskingHandoffBundleCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskingHandoffBundleCommandTests.cs
@@ -1,0 +1,757 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G194 — coverage for <c>intent-cli tasking handoff-bundle</c>. Class name
+/// contains <c>Tasking</c>, <c>Handoff</c>, and <c>Bundle</c> so reviewers can
+/// match the issue's recommended <c>~Bundle|~Handoff|~Tasking</c> filter.
+/// </summary>
+public sealed class TaskingHandoffBundleCommandTests : IDisposable
+{
+    private readonly Func<DateTimeOffset> originalTimestampFactory;
+    private readonly Func<bool>? originalLauncher;
+
+    public TaskingHandoffBundleCommandTests()
+    {
+        originalTimestampFactory = TaskingHandoffBundleCommand.TimestampFactory;
+        originalLauncher = TaskingHandoffBundleCommand.NestedProviderLauncher;
+    }
+
+    public void Dispose()
+    {
+        TaskingHandoffBundleCommand.TimestampFactory = originalTimestampFactory;
+        TaskingHandoffBundleCommand.NestedProviderLauncher = originalLauncher;
+    }
+
+    [Fact]
+    public void Execute_GivenMatchedPreviewAndChecklist_WritesUnpublishedBundleArtifact()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, checklistPath) = workspace.GeneratePreviewAndChecklist("matched");
+        var outPath = workspace.GetPath("bundle-matched.json");
+
+        TaskingHandoffBundleCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 12, 34, 56, 789, TimeSpan.Zero);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--from-checklist", checklistPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(outPath));
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(outPath));
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("is_published").GetBoolean());
+        Assert.False(root.GetProperty("is_automation_visible").GetBoolean());
+        Assert.Equal("local_only", root.GetProperty("bundle_status").GetString());
+        Assert.Equal("2026-04-29T12:34:56.789Z", root.GetProperty("generated_at_utc").GetString());
+
+        var summary = root.GetProperty("summary_line").GetString();
+        Assert.NotNull(summary);
+        Assert.Contains("UNPUBLISHED", summary, StringComparison.Ordinal);
+        Assert.Contains("not automation-visible", summary, StringComparison.Ordinal);
+        Assert.Contains("ready_for_handoff=true", summary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMatchedInputs_BundleJsonRoundTripsStably()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, checklistPath) = workspace.GeneratePreviewAndChecklist("rt");
+        var outPath = workspace.GetPath("bundle-rt.json");
+
+        TaskingHandoffBundleCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 1, 2, 3, TimeSpan.Zero);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--from-checklist", checklistPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var roundTripped =
+            JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(roundTripped);
+        Assert.Equal("intent-cli", roundTripped!.Domain);
+        Assert.False(roundTripped.IsPublished);
+        Assert.False(roundTripped.IsAutomationVisible);
+        Assert.Equal(TaskingHandoffBundleConstants.LocalOnlyStatus, roundTripped.BundleStatus);
+        Assert.Equal("local_only", roundTripped.BundleStatus);
+        Assert.Equal("2026-04-29T01:02:03.000Z", roundTripped.GeneratedAtUtc);
+        Assert.Equal(Path.GetFullPath(outPath), roundTripped.ArtifactPath);
+        Assert.Equal(previewPath, roundTripped.SourcePreviewPath);
+        Assert.Equal(checklistPath, roundTripped.SourceChecklistPath);
+        Assert.Contains("UNPUBLISHED", roundTripped.SummaryLine, StringComparison.Ordinal);
+        Assert.True(roundTripped.ChecklistReadyForHandoff);
+    }
+
+    [Fact]
+    public void Execute_GivenMatchedInputs_RecordsAllSourceReferencesAndSha256s()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, checklistPath) = workspace.GeneratePreviewAndChecklist("sha");
+        var outPath = workspace.GetPath("bundle-sha.json");
+
+        var expectedPreviewBytes = File.ReadAllBytes(previewPath);
+        var expectedChecklistBytes = File.ReadAllBytes(checklistPath);
+        var expectedPreviewSha = ComputeSha256HexLowercase(expectedPreviewBytes);
+        var expectedChecklistSha = ComputeSha256HexLowercase(expectedChecklistBytes);
+
+        var sourcePreview =
+            JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(expectedPreviewBytes);
+        Assert.NotNull(sourcePreview);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--from-checklist", checklistPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var bundle =
+            JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(bundle);
+        Assert.Equal(previewPath, bundle!.SourcePreviewPath);
+        Assert.Equal(expectedPreviewSha, bundle.SourcePreviewSha256);
+        Assert.Equal(checklistPath, bundle.SourceChecklistPath);
+        Assert.Equal(expectedChecklistSha, bundle.SourceChecklistSha256);
+
+        Assert.Equal(sourcePreview!.SourceTaskPacketPath, bundle.SourceTaskPacketPath);
+        Assert.Equal(sourcePreview.SourceTaskPacketSha256, bundle.SourceTaskPacketSha256);
+        Assert.Equal(sourcePreview.SourceHandoffPath, bundle.SourceHandoffPath);
+        Assert.Equal(sourcePreview.SourceHandoffSha256, bundle.SourceHandoffSha256);
+
+        Assert.False(string.IsNullOrWhiteSpace(bundle.SourcePreviewSha256));
+        Assert.False(string.IsNullOrWhiteSpace(bundle.SourceChecklistSha256));
+        Assert.False(string.IsNullOrWhiteSpace(bundle.SourceTaskPacketSha256));
+        Assert.False(string.IsNullOrWhiteSpace(bundle.SourceHandoffSha256));
+    }
+
+    [Fact]
+    public void Execute_GivenMatchedInputs_RecordsPassedAndFailedCheckIds()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, checklistPath) = workspace.GeneratePreviewAndChecklist("ids");
+        var outPath = workspace.GetPath("bundle-ids.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--from-checklist", checklistPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var bundle =
+            JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(bundle);
+
+        var expectedIds = TaskingTaskPacketChecklistConstants.CheckIds.All;
+        Assert.Equal(10, expectedIds.Count);
+        Assert.Equal(expectedIds.Count, bundle!.ChecklistPassedCheckIds.Count);
+        Assert.Empty(bundle.ChecklistFailedCheckIds);
+
+        foreach (var expected in expectedIds)
+        {
+            Assert.Contains(expected, bundle.ChecklistPassedCheckIds);
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMatchedInputs_ChecklistReadyForHandoffPropagated()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, checklistPath) = workspace.GeneratePreviewAndChecklist("ready");
+        var outPath = workspace.GetPath("bundle-ready.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--from-checklist", checklistPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var bundle =
+            JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(bundle);
+        Assert.True(bundle!.ChecklistReadyForHandoff);
+    }
+
+    [Fact]
+    public void Execute_GivenChecklistWithFailedChecks_PropagatesFailedCheckIdsAndReadyFalse()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, checklistPath) =
+            workspace.GeneratePreviewAndChecklistWithEmptyRecommendedAction("failed");
+        var outPath = workspace.GetPath("bundle-failed.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--from-checklist", checklistPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var bundle =
+            JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(bundle);
+        Assert.False(bundle!.ChecklistReadyForHandoff);
+        Assert.Contains(
+            TaskingTaskPacketChecklistConstants.CheckIds.RecommendedWorkerActionNonEmpty,
+            bundle.ChecklistFailedCheckIds);
+        Assert.Contains("ready_for_handoff=false", bundle.SummaryLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenPreviewChecklistMismatch_ReturnsNonZero_NoOutputArtifact()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewA, _) = workspace.GeneratePreviewAndChecklist("pairA");
+        var (_, checklistB) = workspace.GeneratePreviewAndChecklist("pairB");
+        var outPath = workspace.GetPath("bundle-mismatch.json");
+
+        var previewABytes = File.ReadAllBytes(previewA);
+        var previewASha = ComputeSha256HexLowercase(previewABytes);
+
+        var checklistBJson = File.ReadAllText(checklistB);
+        var checklistBObj =
+            JsonSerializer.Deserialize<TaskingTaskPacketChecklistArtifact>(checklistBJson);
+        Assert.NotNull(checklistBObj);
+        Assert.NotEqual(previewASha, checklistBObj!.SourcePreviewSha256);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewA, "--from-checklist", checklistB, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+
+        var output = writer.ToString();
+        Assert.Contains(checklistBObj.SourcePreviewSha256, output, StringComparison.Ordinal);
+        Assert.Contains(previewASha, output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPreviewFile_ReturnsNonZero_NoOutputArtifact()
+    {
+        using var workspace = new BundleWorkspace();
+        var (_, checklistPath) = workspace.GeneratePreviewAndChecklist("missing-preview");
+        var missing = workspace.GetPath("does-not-exist-preview.json");
+        var outPath = workspace.GetPath("bundle-missing-preview.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", missing, "--from-checklist", checklistPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingChecklistFile_ReturnsNonZero_NoOutputArtifact()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, _) = workspace.GeneratePreviewAndChecklist("missing-checklist");
+        var missing = workspace.GetPath("does-not-exist-checklist.json");
+        var outPath = workspace.GetPath("bundle-missing-checklist.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--from-checklist", missing, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedPreviewJson_ReturnsNonZero_NoOutputArtifact()
+    {
+        using var workspace = new BundleWorkspace();
+        var (_, checklistPath) = workspace.GeneratePreviewAndChecklist("malformed-prev");
+        var malformed = workspace.GetPath("malformed-preview.json");
+        File.WriteAllText(malformed, "{ this is not : valid json,");
+        var outPath = workspace.GetPath("bundle-malformed-prev.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", malformed, "--from-checklist", checklistPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedChecklistJson_ReturnsNonZero_NoOutputArtifact()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, _) = workspace.GeneratePreviewAndChecklist("malformed-chk");
+        var malformed = workspace.GetPath("malformed-checklist.json");
+        File.WriteAllText(malformed, "{ this is not : valid json,");
+        var outPath = workspace.GetPath("bundle-malformed-chk.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--from-checklist", malformed, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenPreviewWithWrongStatus_ReturnsNonZero_NoOutputArtifact()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, checklistPath) = workspace.GeneratePreviewAndChecklist("wrong-prev");
+        var json = File.ReadAllText(previewPath);
+        var tampered = json.Replace(
+            "\"preview_status\": \"local_only\"",
+            "\"preview_status\": \"published\"",
+            StringComparison.Ordinal);
+        Assert.NotEqual(json, tampered);
+        var tamperedPath = workspace.GetPath("preview-tampered-status.json");
+        File.WriteAllText(tamperedPath, tampered);
+        var outPath = workspace.GetPath("bundle-wrong-prev-status.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", tamperedPath, "--from-checklist", checklistPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenChecklistWithWrongStatus_ReturnsNonZero_NoOutputArtifact()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, checklistPath) = workspace.GeneratePreviewAndChecklist("wrong-chk");
+        var json = File.ReadAllText(checklistPath);
+        var tampered = json.Replace(
+            "\"checklist_status\": \"local_only\"",
+            "\"checklist_status\": \"published\"",
+            StringComparison.Ordinal);
+        Assert.NotEqual(json, tampered);
+        var tamperedPath = workspace.GetPath("checklist-tampered-status.json");
+        File.WriteAllText(tamperedPath, tampered);
+        var outPath = workspace.GetPath("bundle-wrong-chk-status.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--from-checklist", tamperedPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFlag_ReturnsNonZero()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, checklistPath) = workspace.GeneratePreviewAndChecklist("missing-flag");
+
+        // Drop --out entirely.
+        var args = new[] { "--from-preview", previewPath, "--from-checklist", checklistPath };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--out", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsNonZero()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, checklistPath) = workspace.GeneratePreviewAndChecklist("unknown");
+        var outPath = workspace.GetPath("bundle-unknown.json");
+
+        var args = new[]
+        {
+            "--from-preview", previewPath,
+            "--from-checklist", checklistPath,
+            "--out", outPath,
+            "--bogus", "value"
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesToQueueStateOrRunsLog()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, checklistPath) = workspace.GeneratePreviewAndChecklist("no-mut");
+
+        var queueStatePath = workspace.Context.GetQueueStatePath();
+        var runsLogPath = workspace.Context.GetRunLogPath();
+
+        var queueBytes = Encoding.UTF8.GetBytes("{\"schema_version\":\"1\",\"items\":[]}\n");
+        var runsBytes = Encoding.UTF8.GetBytes("{\"event\":\"sentinel\",\"ts\":\"2026-04-29T00:00:00Z\"}\n");
+        Directory.CreateDirectory(Path.GetDirectoryName(queueStatePath)!);
+        File.WriteAllBytes(queueStatePath, queueBytes);
+        File.WriteAllBytes(runsLogPath, runsBytes);
+
+        var queueBefore = File.ReadAllBytes(queueStatePath);
+        var runsBefore = File.ReadAllBytes(runsLogPath);
+
+        var outPath = workspace.GetPath("bundle-no-mut.json");
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--from-checklist", checklistPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(outPath));
+
+        var queueAfter = File.ReadAllBytes(queueStatePath);
+        var runsAfter = File.ReadAllBytes(runsLogPath);
+        Assert.Equal(queueBefore, queueAfter);
+        Assert.Equal(runsBefore, runsAfter);
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesProvider_NoProcessStartInNewSurface()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, checklistPath) = workspace.GeneratePreviewAndChecklist("no-provider");
+
+        var launcherInvoked = false;
+        TaskingHandoffBundleCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+
+        var outPath = workspace.GetPath("bundle-no-provider.json");
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[] { "--from-preview", previewPath, "--from-checklist", checklistPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(launcherInvoked);
+
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        var commandFile = Path.Combine(commandsDir, "TaskingHandoffBundleCommand.cs");
+        var analyzerFile = Path.Combine(commandsDir, "TaskingHandoffBundleAnalyzer.cs");
+        var artifactFile = Path.Combine(commandsDir, "TaskingHandoffBundleArtifact.cs");
+        if (!File.Exists(commandFile) || !File.Exists(analyzerFile) || !File.Exists(artifactFile))
+        {
+            return;
+        }
+
+        foreach (var path in new[] { commandFile, analyzerFile, artifactFile })
+        {
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("Process.Start(", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_AlwaysMarksContractFieldsLiteralFalseAndLocalOnly()
+    {
+        using var workspace = new BundleWorkspace();
+        workspace.WriteQueueState("{\"schema_version\":\"1\",\"items\":[]}\n");
+        workspace.WriteClarificationOpen(
+            "## Current Open Blockers\n- 現時点で child issue cut を要する root blocker はない\n");
+        workspace.WriteAutomationBindings("# bindings\n");
+
+        var (previewPath, checklistPath) = workspace.GeneratePreviewAndChecklist("contract");
+        var outPath = workspace.GetPath("bundle-contract.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-preview", previewPath,
+                "--from-checklist", checklistPath,
+                "--out", outPath,
+                "--format", "text"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var bundle =
+            JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(bundle);
+        Assert.False(bundle!.IsPublished);
+        Assert.False(bundle.IsAutomationVisible);
+        Assert.Equal("local_only", bundle.BundleStatus);
+        Assert.Equal(TaskingHandoffBundleConstants.LocalOnlyStatus, bundle.BundleStatus);
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(outPath));
+        Assert.Equal(JsonValueKind.False, doc.RootElement.GetProperty("is_published").ValueKind);
+        Assert.Equal(JsonValueKind.False, doc.RootElement.GetProperty("is_automation_visible").ValueKind);
+        Assert.Equal("local_only", doc.RootElement.GetProperty("bundle_status").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_StdoutContainsArtifactJson()
+    {
+        using var workspace = new BundleWorkspace();
+        var (previewPath, checklistPath) = workspace.GeneratePreviewAndChecklist("json-fmt");
+        TaskingHandoffBundleCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 5, 0, 0, TimeSpan.Zero);
+
+        var outPath = workspace.GetPath("bundle-json-fmt.json");
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-preview", previewPath,
+                "--from-checklist", checklistPath,
+                "--out", outPath,
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var stdoutBundle =
+            JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(writer.ToString());
+        var fileBundle =
+            JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(File.ReadAllText(outPath));
+        Assert.NotNull(stdoutBundle);
+        Assert.NotNull(fileBundle);
+
+        var canonical = new JsonSerializerOptions { WriteIndented = false };
+        Assert.Equal(
+            JsonSerializer.Serialize(fileBundle, canonical),
+            JsonSerializer.Serialize(stdoutBundle, canonical));
+    }
+
+    private static string ComputeSha256HexLowercase(byte[] bytes)
+    {
+        var hash = SHA256.HashData(bytes);
+        var builder = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash)
+        {
+            builder.Append(b.ToString("x2", System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool TryResolveCommandsSourceDirectory(out string commandsDirectory)
+    {
+        commandsDirectory = string.Empty;
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, "src", "IntentSystem.Cli", "Commands");
+            if (Directory.Exists(candidate))
+            {
+                commandsDirectory = candidate;
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private sealed class BundleWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("tasking-handoff-bundle-tests-")
+            .FullName;
+
+        public BundleWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string GetPath(string relative) => Path.Combine(rootPath, relative);
+
+        public void WriteQueueState(string content)
+        {
+            File.WriteAllText(Context.GetQueueStatePath(), content);
+        }
+
+        public void WriteClarificationOpen(string content)
+        {
+            var path = Path.Combine(rootPath, "intents", "intent-cli", "clarifications");
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "open.md"), content);
+        }
+
+        public void WriteAutomationBindings(string content)
+        {
+            var path = Path.Combine(rootPath, "intents", "intent-cli", "automation");
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "bindings.md"), content);
+        }
+
+        /// <summary>
+        /// Generate a real G190 handoff, G191 task packet, G192 preview, and
+        /// a real G193 checklist derived from that preview. Returns the
+        /// (preview path, checklist path) pair.
+        /// </summary>
+        public (string previewPath, string checklistPath) GeneratePreviewAndChecklist(string tag)
+        {
+            var previewPath = GeneratePreview(tag);
+            var checklistPath = GetPath($"checklist-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingTaskPacketChecklistCommand.Execute(
+                Context,
+                new[] { "--from-preview", previewPath, "--out", checklistPath },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G193 checklist for tests: exit={exit}, stderr={sink}");
+            }
+
+            return (previewPath, checklistPath);
+        }
+
+        /// <summary>
+        /// Like <see cref="GeneratePreviewAndChecklist"/>, but mutates the
+        /// preview to set <c>recommended_worker_action</c> to whitespace before
+        /// running the checklist. The resulting checklist will fail
+        /// <c>recommended_worker_action_non_empty</c>.
+        /// </summary>
+        public (string previewPath, string checklistPath)
+            GeneratePreviewAndChecklistWithEmptyRecommendedAction(string tag)
+        {
+            var basePreviewPath = GeneratePreview($"{tag}-base");
+            var preview = JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(
+                File.ReadAllText(basePreviewPath));
+            if (preview is null)
+            {
+                throw new InvalidOperationException("Generated preview deserialized to null.");
+            }
+
+            var mutated = preview with { RecommendedWorkerAction = "   " };
+            var mutatedPreviewPath = GetPath($"preview-{tag}-empty-action.json");
+            File.WriteAllText(mutatedPreviewPath, JsonSerializer.Serialize(mutated));
+
+            var checklistPath = GetPath($"checklist-{tag}-empty-action.json");
+            using var sink = new StringWriter();
+            var exit = TaskingTaskPacketChecklistCommand.Execute(
+                Context,
+                new[] { "--from-preview", mutatedPreviewPath, "--out", checklistPath },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G193 checklist (empty action) for tests: exit={exit}, stderr={sink}");
+            }
+
+            return (mutatedPreviewPath, checklistPath);
+        }
+
+        private string GeneratePreview(string tag)
+        {
+            var handoffPath = GetPath($"__handoff_{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var handoffExit = TaskingHandoffCommand.Execute(
+                    Context,
+                    new[] { "--out", handoffPath },
+                    sink);
+                if (handoffExit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G190 handoff for tests: exit={handoffExit}, stderr={sink}");
+                }
+            }
+
+            var taskPacketPath = GetPath($"__task_packet_{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var taskPacketExit = TaskingTaskPacketCommand.Execute(
+                    Context,
+                    new[] { "--from-handoff", handoffPath, "--out", taskPacketPath },
+                    sink);
+                if (taskPacketExit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G191 task packet for tests: exit={taskPacketExit}, stderr={sink}");
+                }
+            }
+
+            var previewPath = GetPath($"preview-{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var previewExit = TaskingTaskPacketPreviewCommand.Execute(
+                    Context,
+                    new[] { "--from-task-packet", taskPacketPath, "--out", previewPath },
+                    sink);
+                if (previewExit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G192 preview for tests: exit={previewExit}, stderr={sink}");
+                }
+            }
+
+            return previewPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new subcommand `intent-cli tasking handoff-bundle --from-preview <preview-artifact-path> --from-checklist <checklist-artifact-path> --out <bundle-artifact-path> [--format text|json]` under the existing `tasking` group. Fifth in the chain G190 handoff → G191 task-packet → G192 preview → G193 checklist → **G194 bundle**. The bundle reads BOTH a G192 preview AND a G193 checklist, validates they belong together (sha256 cross-check), and writes one deterministic combined bundle artifact. No GitHub network. No provider/worker launch. No queue/runs mutation. No `intent-target` exposure.
- Mismatch check (the issue's explicit acceptance criterion): the checklist's `source_preview_sha256` MUST equal the actual sha256 of the supplied preview file's bytes. Mismatch → exit 1 with deterministic message naming BOTH hashes inline (so test searches against either hash succeed regardless of ordering); output artifact NOT written.
- Strict no-partial-output invariant on invalid input (explicit Acceptance Criterion):
  - either input file missing → exit 1, output not written
  - JSON parse failure on EITHER input → exit 1, output not written
  - `preview_status != "local_only"` → exit 1
  - `checklist_status != "local_only"` → exit 1
  - sha256 mismatch (above) → exit 1
  - missing/blank required flag or unknown argument → exit 1, output not written
- Output JSON shape (snake_case, stable order, round-trippable through `JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>`):
  ```
  { "source_preview_path":   "...", "source_preview_sha256":   "<lowercase hex>",
    "source_checklist_path": "...", "source_checklist_sha256": "<lowercase hex>",
    "source_task_packet_path": "...", "source_task_packet_sha256": "...",
    "source_handoff_path":     "...", "source_handoff_sha256":     "...",
    "domain": "...",
    "is_published": false,
    "is_automation_visible": false,
    "bundle_status": "local_only",
    "checklist_ready_for_handoff": <bool>,
    "checklist_passed_check_ids": ["..."],
    "checklist_failed_check_ids": ["..."],
    "rendered_preview_excerpt": "...",
    "recommended_worker_action": "...",
    "generated_at_utc": "<ISO8601 UTC>",
    "artifact_path": "<absolute>",
    "summary_line": "Worker handoff bundle for <domain> derived from preview <source_preview_path> + checklist <source_checklist_path> — UNPUBLISHED, local-only, not automation-visible. ready_for_handoff=<true/false>." }
  ```
  Contract fields `is_published` / `is_automation_visible` are ALWAYS literal `false`; `bundle_status` is ALWAYS literal `"local_only"`. Locked in by an explicit regression so future drift cannot accidentally flip these.
- `checklist_passed_check_ids` / `checklist_failed_check_ids` partition every check id from the source G193 checklist by `passed`. Tests assert (a) the happy path has all 10 ids in passed and 0 in failed, and (b) a deliberately-broken preview path (empty `recommended_worker_action`) propagates `recommended_worker_action_non_empty` into failed.
- No-mutation invariants:
  - Sentinel `TaskingHandoffBundleCommand.NestedProviderLauncher` (mirrors G187/G190/G191/G192/G193) — never invoked across the success path.
  - Source-scan asserts the new command + analyzer files contain no `Process.Start(`.
  - Byte-equivalence test snapshots `.intent-cli/queue-state.json` and `.intent-cli/runs.jsonl` before/after — must be byte-identical.
- Reuse, not duplication:
  - `TaskingTaskPacketPreviewArtifact` (G192) + `TaskingTaskPacketPreviewConstants.LocalOnlyStatus`
  - `TaskingTaskPacketChecklistArtifact` (G193) + `TaskingTaskPacketChecklistConstants.LocalOnlyStatus`
  - `IssuePrepareCommand.ComputeSha256Hex(byte[])` — for both source sha256 fields
  - `IssuePrepareCommand.FormatUtcTimestamp(DateTimeOffset)` — for `generated_at_utc`
  - No `private→internal` promotions needed.

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter \"FullyQualifiedName~TaskingHandoffBundle\"` — **19/19 passing**. Issue-required scenarios covered: WritesUnpublishedBundleArtifact, BundleJsonRoundTripsStably, RecordsAllSourceReferencesAndSha256s (4 sha256 fields), RecordsPassedAndFailedCheckIds (happy path: 10 passed / 0 failed), ChecklistReadyForHandoffPropagated (true/false propagation), ChecklistWithFailedChecks_PropagatesFailedCheckIdsAndReadyFalse, **PreviewChecklistMismatch_ReturnsNonZero_NoOutputArtifact** (the explicit mismatch criterion, deterministic error mentioning both hashes), MissingPreviewFileReturnsNonZero_NoOutputArtifact, MissingChecklistFileReturnsNonZero_NoOutputArtifact, MalformedPreviewJsonReturnsNonZero_NoOutputArtifact, MalformedChecklistJsonReturnsNonZero_NoOutputArtifact, GivenPreviewWithWrongStatusReturnsNonZero_NoOutputArtifact (contract-locking), GivenChecklistWithWrongStatusReturnsNonZero_NoOutputArtifact (contract-locking), MissingFlagReturnsNonZero, UnknownArgumentReturnsNonZero, NeverWritesToQueueStateOrRunsLog (byte-equivalence), NeverInvokesProvider_NoProcessStartInNewSurface (sentinel + source-scan), AlwaysMarksContractFieldsLiteralFalseAndLocalOnly (contract-locking regression).
- [x] Issue's recommended broader filter `~Tasking|~TaskPacket|~Checklist|~Bundle|~Preview|~Publish` — passes (19 new G194 tests + every existing surface stays green).
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **1077/1077 passing + 1 skip** (the 1 skip is the pre-existing G190 `TolerantToSubAnalyzerFailure` `[Fact(Skip)]` not introduced by this slice; CLI: 1058 → 1077 = +19 new G194 tests; no regressions).
- [ ] Manual smoke (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff --domain intent-cli --out /tmp/g194-handoff.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet --from-handoff /tmp/g194-handoff.json --out /tmp/g194-task-packet.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet-preview --from-task-packet /tmp/g194-task-packet.json --out /tmp/g194-preview.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet-checklist --from-preview /tmp/g194-preview.json --out /tmp/g194-checklist.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff-bundle --from-preview /tmp/g194-preview.json --from-checklist /tmp/g194-checklist.json --out /tmp/g194-bundle.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff-bundle --from-preview /tmp/g194-preview.json --from-checklist /tmp/g194-checklist.json --out /tmp/g194-bundle.json --format json`

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)