### PR TITLE
G195: add intent-cli tasking handoff-bundle-inspect operator read command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -130,7 +130,8 @@ internal static class CommandRouter
                 ["task-packet"] = TaskingTaskPacketCommand.Execute,
                 ["task-packet-preview"] = TaskingTaskPacketPreviewCommand.Execute,
                 ["task-packet-checklist"] = TaskingTaskPacketChecklistCommand.Execute,
-                ["handoff-bundle"] = TaskingHandoffBundleCommand.Execute
+                ["handoff-bundle"] = TaskingHandoffBundleCommand.Execute,
+                ["handoff-bundle-inspect"] = TaskingHandoffBundleInspectCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleInspectAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleInspectAnalyzer.cs
@@ -1,0 +1,61 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G195 — pure logic that takes a deserialized G194
+/// <see cref="TaskingHandoffBundleArtifact"/> bundle and builds a deterministic
+/// <see cref="TaskingHandoffBundleInspectSummary"/>. No file I/O, no network,
+/// and no process launches happen here — those concerns are owned by
+/// <see cref="TaskingHandoffBundleInspectCommand"/>.
+///
+/// The fields <see cref="TaskingHandoffBundleInspectSummary.IsPublished"/>,
+/// <see cref="TaskingHandoffBundleInspectSummary.IsAutomationVisible"/>, and
+/// <see cref="TaskingHandoffBundleInspectSummary.BundleStatus"/> are propagated
+/// verbatim from the source bundle. The command layer asserts the source bundle
+/// has <c>bundle_status == "local_only"</c> before calling this analyzer; G194
+/// contract makes that imply <c>is_published == false</c> and
+/// <c>is_automation_visible == false</c>.
+/// </summary>
+internal static class TaskingHandoffBundleInspectAnalyzer
+{
+    /// <summary>
+    /// Stable UNPUBLISHED status phrase asserted by G195 tests. Identical to the
+    /// G194 phrase so an operator scanning either output can recognise it.
+    /// </summary>
+    public const string UnpublishedStatusPhrase =
+        "UNPUBLISHED, local-only, not automation-visible";
+
+    /// <summary>
+    /// Stable summary line emitted at the top of both text and JSON outputs.
+    /// Locked by tests so the wording cannot drift silently.
+    /// </summary>
+    public const string SummaryLineText =
+        "Tasking handoff bundle inspect — UNPUBLISHED, local-only, not automation-visible.";
+
+    public static TaskingHandoffBundleInspectSummary Build(TaskingHandoffBundleArtifact bundle)
+    {
+        ArgumentNullException.ThrowIfNull(bundle);
+
+        return new TaskingHandoffBundleInspectSummary
+        {
+            Domain = bundle.Domain,
+            BundleStatus = bundle.BundleStatus,
+            IsPublished = bundle.IsPublished,
+            IsAutomationVisible = bundle.IsAutomationVisible,
+            ChecklistReadyForHandoff = bundle.ChecklistReadyForHandoff,
+            PassedCheckCount = bundle.ChecklistPassedCheckIds.Count,
+            FailedCheckCount = bundle.ChecklistFailedCheckIds.Count,
+            PassedCheckIds = bundle.ChecklistPassedCheckIds,
+            FailedCheckIds = bundle.ChecklistFailedCheckIds,
+            SourcePreviewPath = bundle.SourcePreviewPath,
+            SourcePreviewSha256 = bundle.SourcePreviewSha256,
+            SourceChecklistPath = bundle.SourceChecklistPath,
+            SourceChecklistSha256 = bundle.SourceChecklistSha256,
+            SourceTaskPacketPath = bundle.SourceTaskPacketPath,
+            SourceTaskPacketSha256 = bundle.SourceTaskPacketSha256,
+            SourceHandoffPath = bundle.SourceHandoffPath,
+            SourceHandoffSha256 = bundle.SourceHandoffSha256,
+            RecommendedWorkerAction = bundle.RecommendedWorkerAction,
+            SummaryLine = SummaryLineText
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleInspectCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleInspectCommand.cs
@@ -1,0 +1,220 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G195: <c>intent-cli tasking handoff-bundle-inspect</c>. A LOCAL operator
+/// read/inspect command that consumes a G194
+/// <see cref="TaskingHandoffBundleArtifact"/> handoff bundle artifact (JSON) and
+/// renders a deterministic concise terminal summary to STDOUT. The command
+/// performs no GitHub network calls, applies no labels, launches no provider
+/// processes, and does NOT touch <c>.intent-cli/queue-state.json</c> or
+/// <c>.intent-cli/runs.jsonl</c>. It also does NOT write any artifact file —
+/// inspect renders to STDOUT only.
+///
+/// Sits beside G190 <c>handoff</c>, G191 <c>task-packet</c>, G192
+/// <c>task-packet-preview</c>, G193 <c>task-packet-checklist</c>, and G194
+/// <c>handoff-bundle</c> under the same <c>tasking</c> group. It does NOT
+/// replace any of those commands, nor does it touch <c>issue plan-candidate</c>,
+/// <c>issue prepare</c>, or <c>issue publish-reviewed</c>.
+///
+/// Network-mutation invariance: this command's hot path contains no
+/// <c>Process.Start</c>, no shell-out to <c>gh</c>, and no provider launcher.
+/// The associated tests validate the no-provider-launch invariant via the
+/// <see cref="NestedProviderLauncher"/> sentinel and a source-scan assertion.
+///
+/// Strict no-output: on missing input file, malformed JSON, or a bundle whose
+/// status is not <c>"local_only"</c>, the command exits 1.
+/// </summary>
+internal static class TaskingHandoffBundleInspectCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private static readonly JsonSerializerOptions JsonOutputOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    /// <summary>
+    /// Test seam mirroring G190/G191/G192/G193/G194 <c>NestedProviderLauncher</c>.
+    /// G195 must NEVER invoke this delegate. Tests register a sentinel that
+    /// flips a flag if invoked; the inspect path leaves it untouched.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var fromBundle, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedFromBundle = Path.GetFullPath(fromBundle);
+        if (!File.Exists(resolvedFromBundle))
+        {
+            writer.WriteLine($"--from-bundle path does not exist: {fromBundle}");
+            return 1;
+        }
+
+        byte[] bundleBytes;
+        try
+        {
+            bundleBytes = File.ReadAllBytes(resolvedFromBundle);
+        }
+        catch (Exception exception)
+        {
+            writer.WriteLine($"Failed to read --from-bundle: {exception.Message}");
+            return 1;
+        }
+
+        TaskingHandoffBundleArtifact? sourceBundle;
+        try
+        {
+            sourceBundle = JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(bundleBytes);
+        }
+        catch (JsonException exception)
+        {
+            writer.WriteLine(
+                $"Failed to parse --from-bundle as a G194 handoff bundle: {exception.Message}");
+            return 1;
+        }
+
+        if (sourceBundle is null)
+        {
+            writer.WriteLine(
+                "--from-bundle parsed to a null bundle; expected a G194 handoff bundle JSON object.");
+            return 1;
+        }
+
+        if (!string.Equals(
+                sourceBundle.BundleStatus,
+                TaskingHandoffBundleConstants.LocalOnlyStatus,
+                StringComparison.Ordinal))
+        {
+            writer.WriteLine(
+                $"--from-bundle bundle_status must be '{TaskingHandoffBundleConstants.LocalOnlyStatus}' "
+                + $"(got '{sourceBundle.BundleStatus}'). Refusing to inspect a non-local bundle.");
+            return 1;
+        }
+
+        var summary = TaskingHandoffBundleInspectAnalyzer.Build(sourceBundle);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(summary, JsonOutputOptions));
+        }
+        else
+        {
+            WriteTextSummary(writer, summary);
+        }
+
+        return 0;
+    }
+
+    private static void WriteTextSummary(TextWriter writer, TaskingHandoffBundleInspectSummary summary)
+    {
+        writer.WriteLine(summary.SummaryLine);
+        writer.WriteLine();
+        writer.WriteLine($"Domain: {summary.Domain}");
+        writer.WriteLine($"Bundle status: {summary.BundleStatus}");
+        writer.WriteLine($"Is published: {summary.IsPublished}");
+        writer.WriteLine($"Is automation visible: {summary.IsAutomationVisible}");
+        writer.WriteLine($"Ready for handoff: {summary.ChecklistReadyForHandoff}");
+        writer.WriteLine();
+        writer.WriteLine("Source references:");
+        writer.WriteLine(
+            $"- Preview:    {summary.SourcePreviewPath}     (sha256: {summary.SourcePreviewSha256})");
+        writer.WriteLine(
+            $"- Checklist:  {summary.SourceChecklistPath}   (sha256: {summary.SourceChecklistSha256})");
+        writer.WriteLine(
+            $"- Task packet: {summary.SourceTaskPacketPath} (sha256: {summary.SourceTaskPacketSha256})");
+        writer.WriteLine(
+            $"- Handoff:    {summary.SourceHandoffPath}     (sha256: {summary.SourceHandoffSha256})");
+        writer.WriteLine();
+        writer.WriteLine("Checklist:");
+        writer.WriteLine(
+            $"- Passed ({summary.PassedCheckCount}): {FormatCheckIds(summary.PassedCheckIds)}");
+        writer.WriteLine(
+            $"- Failed ({summary.FailedCheckCount}): {FormatCheckIds(summary.FailedCheckIds)}");
+        writer.WriteLine();
+        writer.WriteLine($"Recommended worker action: {summary.RecommendedWorkerAction}");
+    }
+
+    private static string FormatCheckIds(IReadOnlyList<string> ids)
+    {
+        if (ids.Count == 0)
+        {
+            return "(none)";
+        }
+
+        return string.Join(", ", ids);
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string fromBundle,
+        out string format,
+        out string error)
+    {
+        fromBundle = string.Empty;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-bundle":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-bundle requires a non-empty value.";
+                        return false;
+                    }
+
+                    fromBundle = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error =
+                        $"Unknown argument '{argument}'. Supported: --from-bundle, --format.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromBundle))
+        {
+            error = "--from-bundle is required.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleInspectSummary.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleInspectSummary.cs
@@ -1,0 +1,74 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G195 inspect summary record. Snake_case JSON shape that
+/// <c>intent-cli tasking handoff-bundle-inspect</c> emits to STDOUT when
+/// <c>--format json</c> is requested. The summary is a read-only projection of a
+/// G194 <see cref="TaskingHandoffBundleArtifact"/> — the inspect command does NOT
+/// write any artifact file. <see cref="IsPublished"/> and
+/// <see cref="IsAutomationVisible"/> propagate verbatim from the source bundle
+/// (which by G194 contract are always literal <c>false</c>);
+/// <see cref="BundleStatus"/> propagates verbatim and is always
+/// <c>"local_only"</c> for any bundle that passes the G195 status validation.
+/// </summary>
+internal sealed record TaskingHandoffBundleInspectSummary
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("bundle_status")]
+    public required string BundleStatus { get; init; }
+
+    [JsonPropertyName("is_published")]
+    public required bool IsPublished { get; init; }
+
+    [JsonPropertyName("is_automation_visible")]
+    public required bool IsAutomationVisible { get; init; }
+
+    [JsonPropertyName("checklist_ready_for_handoff")]
+    public required bool ChecklistReadyForHandoff { get; init; }
+
+    [JsonPropertyName("passed_check_count")]
+    public required int PassedCheckCount { get; init; }
+
+    [JsonPropertyName("failed_check_count")]
+    public required int FailedCheckCount { get; init; }
+
+    [JsonPropertyName("passed_check_ids")]
+    public required IReadOnlyList<string> PassedCheckIds { get; init; }
+
+    [JsonPropertyName("failed_check_ids")]
+    public required IReadOnlyList<string> FailedCheckIds { get; init; }
+
+    [JsonPropertyName("source_preview_path")]
+    public required string SourcePreviewPath { get; init; }
+
+    [JsonPropertyName("source_preview_sha256")]
+    public required string SourcePreviewSha256 { get; init; }
+
+    [JsonPropertyName("source_checklist_path")]
+    public required string SourceChecklistPath { get; init; }
+
+    [JsonPropertyName("source_checklist_sha256")]
+    public required string SourceChecklistSha256 { get; init; }
+
+    [JsonPropertyName("source_task_packet_path")]
+    public required string SourceTaskPacketPath { get; init; }
+
+    [JsonPropertyName("source_task_packet_sha256")]
+    public required string SourceTaskPacketSha256 { get; init; }
+
+    [JsonPropertyName("source_handoff_path")]
+    public required string SourceHandoffPath { get; init; }
+
+    [JsonPropertyName("source_handoff_sha256")]
+    public required string SourceHandoffSha256 { get; init; }
+
+    [JsonPropertyName("recommended_worker_action")]
+    public required string RecommendedWorkerAction { get; init; }
+
+    [JsonPropertyName("summary_line")]
+    public required string SummaryLine { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/TaskingHandoffBundleInspectCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskingHandoffBundleInspectCommandTests.cs
@@ -1,0 +1,636 @@
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G195 — coverage for <c>intent-cli tasking handoff-bundle-inspect</c>. Class
+/// name contains <c>Tasking</c>, <c>Handoff</c>, <c>Bundle</c>, and
+/// <c>Inspect</c> so reviewers can match the issue's recommended
+/// <c>~Inspect|~Bundle</c> filter.
+/// </summary>
+public sealed class TaskingHandoffBundleInspectCommandTests : IDisposable
+{
+    private readonly Func<bool>? originalLauncher;
+
+    public TaskingHandoffBundleInspectCommandTests()
+    {
+        originalLauncher = TaskingHandoffBundleInspectCommand.NestedProviderLauncher;
+    }
+
+    public void Dispose()
+    {
+        TaskingHandoffBundleInspectCommand.NestedProviderLauncher = originalLauncher;
+    }
+
+    [Fact]
+    public void Execute_GivenValidBundle_RendersConciseTextSummary()
+    {
+        using var workspace = new InspectWorkspace();
+        var bundlePath = workspace.GenerateBundle("text");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("UNPUBLISHED, local-only, not automation-visible", output, StringComparison.Ordinal);
+        Assert.Contains("Domain: intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("Ready for handoff: True", output, StringComparison.Ordinal);
+        Assert.Contains("Source references:", output, StringComparison.Ordinal);
+        Assert.Contains("Checklist:", output, StringComparison.Ordinal);
+        Assert.Contains("Recommended worker action:", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenValidBundle_TextSummaryListsAllSourceReferences()
+    {
+        using var workspace = new InspectWorkspace();
+        var bundlePath = workspace.GenerateBundle("srcs");
+        var bundle =
+            JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(File.ReadAllText(bundlePath));
+        Assert.NotNull(bundle);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+
+        Assert.Contains(bundle!.SourcePreviewPath, output, StringComparison.Ordinal);
+        Assert.Contains(bundle.SourceChecklistPath, output, StringComparison.Ordinal);
+        Assert.Contains(bundle.SourceTaskPacketPath, output, StringComparison.Ordinal);
+        Assert.Contains(bundle.SourceHandoffPath, output, StringComparison.Ordinal);
+
+        Assert.Contains(bundle.SourcePreviewSha256, output, StringComparison.Ordinal);
+        Assert.Contains(bundle.SourceChecklistSha256, output, StringComparison.Ordinal);
+        Assert.Contains(bundle.SourceTaskPacketSha256, output, StringComparison.Ordinal);
+        Assert.Contains(bundle.SourceHandoffSha256, output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenValidBundle_TextSummaryListsPassedAndFailedCheckCounts()
+    {
+        using var workspace = new InspectWorkspace();
+        var bundlePath = workspace.GenerateBundle("counts");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+
+        Assert.Contains("Passed (10):", output, StringComparison.Ordinal);
+        foreach (var id in TaskingTaskPacketChecklistConstants.CheckIds.All)
+        {
+            Assert.Contains(id, output, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("Failed (0): (none)", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_EmitsRoundTrippableSummary()
+    {
+        using var workspace = new InspectWorkspace();
+        var bundlePath = workspace.GenerateBundle("json-rt");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var summary =
+            JsonSerializer.Deserialize<TaskingHandoffBundleInspectSummary>(writer.ToString());
+        Assert.NotNull(summary);
+        Assert.Equal("intent-cli", summary!.Domain);
+        Assert.Equal("local_only", summary.BundleStatus);
+        Assert.False(summary.IsPublished);
+        Assert.False(summary.IsAutomationVisible);
+        Assert.True(summary.ChecklistReadyForHandoff);
+        Assert.Equal(10, summary.PassedCheckCount);
+        Assert.Equal(0, summary.FailedCheckCount);
+        Assert.Contains(
+            "UNPUBLISHED, local-only, not automation-visible",
+            summary.SummaryLine,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_FieldsMatchSourceBundle()
+    {
+        using var workspace = new InspectWorkspace();
+        var bundlePath = workspace.GenerateBundle("json-match");
+        var sourceBundle =
+            JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(File.ReadAllText(bundlePath));
+        Assert.NotNull(sourceBundle);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var summary =
+            JsonSerializer.Deserialize<TaskingHandoffBundleInspectSummary>(writer.ToString());
+        Assert.NotNull(summary);
+
+        Assert.Equal("local_only", summary!.BundleStatus);
+        Assert.False(summary.IsPublished);
+        Assert.False(summary.IsAutomationVisible);
+        Assert.Equal(10, summary.PassedCheckCount);
+        Assert.Equal(0, summary.FailedCheckCount);
+
+        Assert.Equal(sourceBundle!.SourcePreviewPath, summary.SourcePreviewPath);
+        Assert.Equal(sourceBundle.SourcePreviewSha256, summary.SourcePreviewSha256);
+        Assert.Equal(sourceBundle.SourceChecklistPath, summary.SourceChecklistPath);
+        Assert.Equal(sourceBundle.SourceChecklistSha256, summary.SourceChecklistSha256);
+        Assert.Equal(sourceBundle.SourceTaskPacketPath, summary.SourceTaskPacketPath);
+        Assert.Equal(sourceBundle.SourceTaskPacketSha256, summary.SourceTaskPacketSha256);
+        Assert.Equal(sourceBundle.SourceHandoffPath, summary.SourceHandoffPath);
+        Assert.Equal(sourceBundle.SourceHandoffSha256, summary.SourceHandoffSha256);
+        Assert.Equal(sourceBundle.RecommendedWorkerAction, summary.RecommendedWorkerAction);
+    }
+
+    [Fact]
+    public void Execute_GivenBundleWithFailedChecks_PropagatesCounts()
+    {
+        using var workspace = new InspectWorkspace();
+        var bundlePath = workspace.GenerateBundleWithFailedCheck("failed");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+
+        Assert.Contains("Ready for handoff: False", output, StringComparison.Ordinal);
+        Assert.Contains("Failed (1):", output, StringComparison.Ordinal);
+        Assert.Contains(
+            TaskingTaskPacketChecklistConstants.CheckIds.RecommendedWorkerActionNonEmpty,
+            output,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingBundleFile_ReturnsNonZero()
+    {
+        using var workspace = new InspectWorkspace();
+        var missing = workspace.GetPath("does-not-exist-bundle.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", missing },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-bundle", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedBundleJson_ReturnsNonZero()
+    {
+        using var workspace = new InspectWorkspace();
+        var malformed = workspace.GetPath("malformed-bundle.json");
+        File.WriteAllText(malformed, "{ this is not : valid json,");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", malformed },
+            writer);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public void Execute_GivenBundleWithWrongStatus_ReturnsNonZero()
+    {
+        using var workspace = new InspectWorkspace();
+        var bundlePath = workspace.GenerateBundle("wrong-status");
+        var json = File.ReadAllText(bundlePath);
+        var tampered = json.Replace(
+            "\"bundle_status\": \"local_only\"",
+            "\"bundle_status\": \"published\"",
+            StringComparison.Ordinal);
+        Assert.NotEqual(json, tampered);
+        var tamperedPath = workspace.GetPath("bundle-tampered-status.json");
+        File.WriteAllText(tamperedPath, tampered);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", tamperedPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("local_only", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFlag_ReturnsNonZero()
+    {
+        using var workspace = new InspectWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+            workspace.Context,
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-bundle", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsNonZero()
+    {
+        using var workspace = new InspectWorkspace();
+        var bundlePath = workspace.GenerateBundle("unknown");
+
+        var args = new[] { "--from-bundle", bundlePath, "--bogus", "value" };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesToQueueStateOrRunsLog()
+    {
+        using var workspace = new InspectWorkspace();
+        var bundlePath = workspace.GenerateBundle("no-mut");
+
+        var queueStatePath = workspace.Context.GetQueueStatePath();
+        var runsLogPath = workspace.Context.GetRunLogPath();
+
+        var queueBytes = Encoding.UTF8.GetBytes("{\"schema_version\":\"1\",\"items\":[]}\n");
+        var runsBytes = Encoding.UTF8.GetBytes("{\"event\":\"sentinel\",\"ts\":\"2026-04-29T00:00:00Z\"}\n");
+        Directory.CreateDirectory(Path.GetDirectoryName(queueStatePath)!);
+        File.WriteAllBytes(queueStatePath, queueBytes);
+        File.WriteAllBytes(runsLogPath, runsBytes);
+
+        var queueBefore = File.ReadAllBytes(queueStatePath);
+        var runsBefore = File.ReadAllBytes(runsLogPath);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var queueAfter = File.ReadAllBytes(queueStatePath);
+        var runsAfter = File.ReadAllBytes(runsLogPath);
+        Assert.Equal(queueBefore, queueAfter);
+        Assert.Equal(runsBefore, runsAfter);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesAnyArtifactFile()
+    {
+        using var workspace = new InspectWorkspace();
+        var bundlePath = workspace.GenerateBundle("no-artifact");
+
+        var bundleBytesBefore = File.ReadAllBytes(bundlePath);
+        var snapshotBefore = workspace.SnapshotAllFiles();
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var bundleBytesAfter = File.ReadAllBytes(bundlePath);
+        Assert.Equal(bundleBytesBefore, bundleBytesAfter);
+
+        var snapshotAfter = workspace.SnapshotAllFiles();
+        Assert.Equal(snapshotBefore.Count, snapshotAfter.Count);
+        foreach (var (path, contentBefore) in snapshotBefore)
+        {
+            Assert.True(snapshotAfter.ContainsKey(path), $"File disappeared: {path}");
+            Assert.Equal(contentBefore, snapshotAfter[path]);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesProvider_NoProcessStartInNewSurface()
+    {
+        using var workspace = new InspectWorkspace();
+        var bundlePath = workspace.GenerateBundle("no-provider");
+
+        var launcherInvoked = false;
+        TaskingHandoffBundleInspectCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(launcherInvoked);
+
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        var commandFile = Path.Combine(commandsDir, "TaskingHandoffBundleInspectCommand.cs");
+        var analyzerFile = Path.Combine(commandsDir, "TaskingHandoffBundleInspectAnalyzer.cs");
+        var summaryFile = Path.Combine(commandsDir, "TaskingHandoffBundleInspectSummary.cs");
+        if (!File.Exists(commandFile) || !File.Exists(analyzerFile) || !File.Exists(summaryFile))
+        {
+            return;
+        }
+
+        foreach (var path in new[] { commandFile, analyzerFile, summaryFile })
+        {
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("Process.Start(", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_AlwaysReportsLiteralFalseAndLocalOnlyFromSourceBundle()
+    {
+        using var workspace = new InspectWorkspace();
+        var bundlePath = workspace.GenerateBundle("contract");
+
+        // text format
+        using (var writer = new StringWriter())
+        {
+            var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+                workspace.Context,
+                new[] { "--from-bundle", bundlePath, "--format", "text" },
+                writer);
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Bundle status: local_only", output, StringComparison.Ordinal);
+            Assert.Contains("Is published: False", output, StringComparison.Ordinal);
+            Assert.Contains("Is automation visible: False", output, StringComparison.Ordinal);
+        }
+
+        // json format
+        using (var writer = new StringWriter())
+        {
+            var exitCode = TaskingHandoffBundleInspectCommand.Execute(
+                workspace.Context,
+                new[] { "--from-bundle", bundlePath, "--format", "json" },
+                writer);
+            Assert.Equal(0, exitCode);
+
+            var summary =
+                JsonSerializer.Deserialize<TaskingHandoffBundleInspectSummary>(writer.ToString());
+            Assert.NotNull(summary);
+            Assert.Equal("local_only", summary!.BundleStatus);
+            Assert.False(summary.IsPublished);
+            Assert.False(summary.IsAutomationVisible);
+
+            using var doc = JsonDocument.Parse(writer.ToString());
+            Assert.Equal(JsonValueKind.False, doc.RootElement.GetProperty("is_published").ValueKind);
+            Assert.Equal(
+                JsonValueKind.False,
+                doc.RootElement.GetProperty("is_automation_visible").ValueKind);
+            Assert.Equal("local_only", doc.RootElement.GetProperty("bundle_status").GetString());
+        }
+
+        // Confirm the SOURCE bundle on disk really had these literal contract
+        // fields — the inspect command propagates without inversion.
+        var sourceBundle =
+            JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(File.ReadAllText(bundlePath));
+        Assert.NotNull(sourceBundle);
+        Assert.Equal("local_only", sourceBundle!.BundleStatus);
+        Assert.False(sourceBundle.IsPublished);
+        Assert.False(sourceBundle.IsAutomationVisible);
+    }
+
+    private static bool TryResolveCommandsSourceDirectory(out string commandsDirectory)
+    {
+        commandsDirectory = string.Empty;
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, "src", "IntentSystem.Cli", "Commands");
+            if (Directory.Exists(candidate))
+            {
+                commandsDirectory = candidate;
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private sealed class InspectWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("tasking-handoff-bundle-inspect-tests-")
+            .FullName;
+
+        public InspectWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string GetPath(string relative) => Path.Combine(rootPath, relative);
+
+        public IReadOnlyDictionary<string, byte[]> SnapshotAllFiles()
+        {
+            var map = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories))
+            {
+                map[path] = File.ReadAllBytes(path);
+            }
+
+            return map;
+        }
+
+        /// <summary>
+        /// Generate the full G190 → G191 → G192 → G193 → G194 chain and return
+        /// the bundle path. The bundle's checks all pass.
+        /// </summary>
+        public string GenerateBundle(string tag)
+        {
+            var (previewPath, checklistPath) = GeneratePreviewAndChecklist(tag);
+            return BuildBundle(tag, previewPath, checklistPath);
+        }
+
+        /// <summary>
+        /// Generate a chain whose checklist contains a failed check (the
+        /// preview's recommended_worker_action is whitespace), then build a
+        /// bundle on top.
+        /// </summary>
+        public string GenerateBundleWithFailedCheck(string tag)
+        {
+            var basePreviewPath = GeneratePreview($"{tag}-base");
+            var preview = JsonSerializer.Deserialize<TaskingTaskPacketPreviewArtifact>(
+                File.ReadAllText(basePreviewPath));
+            if (preview is null)
+            {
+                throw new InvalidOperationException("Generated preview deserialized to null.");
+            }
+
+            var mutated = preview with { RecommendedWorkerAction = "   " };
+            var mutatedPreviewPath = GetPath($"preview-{tag}-empty-action.json");
+            File.WriteAllText(mutatedPreviewPath, JsonSerializer.Serialize(mutated));
+
+            var checklistPath = GetPath($"checklist-{tag}-empty-action.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingTaskPacketChecklistCommand.Execute(
+                    Context,
+                    new[] { "--from-preview", mutatedPreviewPath, "--out", checklistPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G193 checklist (empty action): exit={exit}, stderr={sink}");
+                }
+            }
+
+            return BuildBundle(tag, mutatedPreviewPath, checklistPath);
+        }
+
+        private string BuildBundle(string tag, string previewPath, string checklistPath)
+        {
+            var bundlePath = GetPath($"bundle-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingHandoffBundleCommand.Execute(
+                Context,
+                new[]
+                {
+                    "--from-preview", previewPath,
+                    "--from-checklist", checklistPath,
+                    "--out", bundlePath
+                },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G194 bundle for tests: exit={exit}, stderr={sink}");
+            }
+
+            return bundlePath;
+        }
+
+        private (string previewPath, string checklistPath) GeneratePreviewAndChecklist(string tag)
+        {
+            var previewPath = GeneratePreview(tag);
+            var checklistPath = GetPath($"checklist-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingTaskPacketChecklistCommand.Execute(
+                Context,
+                new[] { "--from-preview", previewPath, "--out", checklistPath },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G193 checklist: exit={exit}, stderr={sink}");
+            }
+
+            return (previewPath, checklistPath);
+        }
+
+        private string GeneratePreview(string tag)
+        {
+            var handoffPath = GetPath($"__handoff_{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingHandoffCommand.Execute(
+                    Context,
+                    new[] { "--out", handoffPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G190 handoff: exit={exit}, stderr={sink}");
+                }
+            }
+
+            var taskPacketPath = GetPath($"__task_packet_{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingTaskPacketCommand.Execute(
+                    Context,
+                    new[] { "--from-handoff", handoffPath, "--out", taskPacketPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G191 task packet: exit={exit}, stderr={sink}");
+                }
+            }
+
+            var previewPath = GetPath($"preview-{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingTaskPacketPreviewCommand.Execute(
+                    Context,
+                    new[] { "--from-task-packet", taskPacketPath, "--out", previewPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G192 preview: exit={exit}, stderr={sink}");
+                }
+            }
+
+            return previewPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new subcommand `intent-cli tasking handoff-bundle-inspect --from-bundle <bundle-artifact-path> [--format text|json]` under the existing `tasking` group. Sixth in the chain G190 handoff → G191 task-packet → G192 preview → G193 checklist → G194 bundle → **G195 inspect**. The inspect command reads a G194 bundle JSON artifact, validates it, and renders a concise deterministic operator-facing summary to STDOUT only. **No `--out` flag**: this is a read-only inspector — it writes NO artifact file. No GitHub network. No provider/worker launch. No queue/runs mutation. No `intent-target` exposure.
- Output: stable multi-line text (default) or stable round-trippable snake_case JSON (`--format json`). Text format includes the literal status phrase `UNPUBLISHED, local-only, not automation-visible.`, then `Domain:` / `Bundle status:` / `Is published:` / `Is automation visible:` / `Ready for handoff:` lines, followed by `Source references:` (all 4 paths + sha256), `Checklist:` (passed/failed counts and id lists), and `Recommended worker action:`. JSON `TaskingHandoffBundleInspectSummary` shape mirrors the same fields plus `passed_check_count` / `failed_check_count` / `passed_check_ids` / `failed_check_ids` arrays.
- Strict validation; `bundle_status`, `is_published`, `is_automation_visible` propagate VERBATIM from the source bundle (which by G194 contract are always `local_only`/false/false). The inspector NEVER inverts them — locked by an explicit regression test.
- Failure paths (each → exit 1):
  - `--from-bundle` file missing
  - JSON parse failure
  - `bundle_status != "local_only"` (contract-locking)
  - missing/blank required flag or unknown argument
- No-mutation invariants:
  - Sentinel `TaskingHandoffBundleInspectCommand.NestedProviderLauncher` (mirrors G187/G190/G191/G192/G193/G194) — never invoked.
  - Source-scan asserts the new command + analyzer files contain no `Process.Start(`.
  - Byte-equivalence test on `.intent-cli/queue-state.json` and `.intent-cli/runs.jsonl` before/after.
  - Dedicated `Execute_NeverWritesAnyArtifactFile` test snapshots ALL files in the workspace before/after — assert NO new file created and NO existing file modified.
- Reuse, not duplication:
  - `TaskingHandoffBundleArtifact` (G194) — deserialize the input bundle
  - `TaskingHandoffBundleConstants.LocalOnlyStatus` (G194) — status validation
  - No `private→internal` promotions needed — the analyzer reads only public properties of the already-`internal` G194 record.
  - No `TimestampFactory` (the inspect command writes no timestamp into any artifact).

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter \"FullyQualifiedName~TaskingHandoffBundleInspect\"` — **15/15 passing**. Issue-required scenarios covered: RendersConciseTextSummary, TextSummaryListsAllSourceReferences (4 paths + 4 sha256), TextSummaryListsPassedAndFailedCheckCounts (10/0 happy path), JsonFormat_EmitsRoundTrippableSummary, JsonFormat_FieldsMatchSourceBundle, BundleWithFailedChecks_PropagatesCounts (1 failed: `recommended_worker_action_non_empty`), MissingBundleFileReturnsNonZero, MalformedBundleJsonReturnsNonZero, GivenBundleWithWrongStatusReturnsNonZero (contract-locking), MissingFlagReturnsNonZero, UnknownArgumentReturnsNonZero, NeverWritesToQueueStateOrRunsLog (byte-equivalence), NeverWritesAnyArtifactFile (whole-workspace byte snapshot), NeverInvokesProvider_NoProcessStartInNewSurface (sentinel + source-scan), AlwaysReportsLiteralFalseAndLocalOnlyFromSourceBundle (contract-locking regression).
- [x] Issue's recommended broader filter `~Tasking|~Handoff|~Bundle|~Inspect|~Publish` — passes (15 new G195 tests + every existing surface stays green).
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **1092/1092 passing + 1 skip** (the 1 skip is the pre-existing G190 `TolerantToSubAnalyzerFailure` `[Fact(Skip)]` not introduced by this slice; CLI: 1077 → 1092 = +15 new G195 tests; no regressions).
- [ ] Manual smoke (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff --domain intent-cli --out /tmp/g195-handoff.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet --from-handoff /tmp/g195-handoff.json --out /tmp/g195-task-packet.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet-preview --from-task-packet /tmp/g195-task-packet.json --out /tmp/g195-preview.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet-checklist --from-preview /tmp/g195-preview.json --out /tmp/g195-checklist.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff-bundle --from-preview /tmp/g195-preview.json --from-checklist /tmp/g195-checklist.json --out /tmp/g195-bundle.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff-bundle-inspect --from-bundle /tmp/g195-bundle.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff-bundle-inspect --from-bundle /tmp/g195-bundle.json --format json`

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)