### PR TITLE
G196: add intent-cli tasking handoff-bundle-verify deterministic preflight check

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -131,7 +131,8 @@ internal static class CommandRouter
                 ["task-packet-preview"] = TaskingTaskPacketPreviewCommand.Execute,
                 ["task-packet-checklist"] = TaskingTaskPacketChecklistCommand.Execute,
                 ["handoff-bundle"] = TaskingHandoffBundleCommand.Execute,
-                ["handoff-bundle-inspect"] = TaskingHandoffBundleInspectCommand.Execute
+                ["handoff-bundle-inspect"] = TaskingHandoffBundleInspectCommand.Execute,
+                ["handoff-bundle-verify"] = TaskingHandoffBundleVerifyCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyAnalyzer.cs
@@ -1,0 +1,196 @@
+namespace IntentSystem.Cli.Commands;
+
+using CheckIds = TaskingHandoffBundleVerifyConstants.CheckIds;
+
+/// <summary>
+/// G196 — pure logic that takes a deserialized G194
+/// <see cref="TaskingHandoffBundleArtifact"/> bundle (or null/parse-fail
+/// signal) and runs the fixed verification checklist. No file I/O, no network,
+/// and no process launches happen here — those concerns are owned by
+/// <see cref="TaskingHandoffBundleVerifyCommand"/>.
+///
+/// The analyzer is contract-locked: <c>is_published</c>, <c>is_automation_visible</c>,
+/// and <c>bundle_status</c> are read directly from the source bundle without
+/// inversion or rewriting. A G194 bundle whose contract fields drifted will be
+/// reported here as a failed check, never silently passed.
+/// </summary>
+internal static class TaskingHandoffBundleVerifyAnalyzer
+{
+    /// <summary>
+    /// Build the <see cref="VerifyCheck"/> list for a successfully parsed G194
+    /// bundle. Checks appear in the stable order declared by
+    /// <see cref="TaskingHandoffBundleVerifyConstants.CheckIds.All"/>.
+    /// </summary>
+    public static IReadOnlyList<VerifyCheck> BuildChecks(TaskingHandoffBundleArtifact bundle)
+    {
+        ArgumentNullException.ThrowIfNull(bundle);
+
+        return new[]
+        {
+            Pass(CheckIds.BundlePathPresentAndReadable, "Bundle path exists and was read."),
+            Pass(CheckIds.BundleJsonParses, "Bundle JSON parsed as TaskingHandoffBundleArtifact."),
+
+            CheckBundleStatusLocalOnly(bundle),
+            CheckIsPublishedFalse(bundle),
+            CheckIsAutomationVisibleFalse(bundle),
+
+            CheckNonEmpty(
+                CheckIds.TaskPacketPathPresent,
+                bundle.SourceTaskPacketPath,
+                "source_task_packet_path"),
+            CheckNonEmpty(
+                CheckIds.TaskPacketSha256Present,
+                bundle.SourceTaskPacketSha256,
+                "source_task_packet_sha256"),
+
+            CheckNonEmpty(
+                CheckIds.PreviewPathPresent,
+                bundle.SourcePreviewPath,
+                "source_preview_path"),
+            CheckNonEmpty(
+                CheckIds.PreviewSha256Present,
+                bundle.SourcePreviewSha256,
+                "source_preview_sha256"),
+
+            CheckNonEmpty(
+                CheckIds.HandoffPathPresent,
+                bundle.SourceHandoffPath,
+                "source_handoff_path"),
+            CheckNonEmpty(
+                CheckIds.HandoffSha256Present,
+                bundle.SourceHandoffSha256,
+                "source_handoff_sha256"),
+
+            CheckNonEmpty(
+                CheckIds.ChecklistPathPresent,
+                bundle.SourceChecklistPath,
+                "source_checklist_path"),
+            CheckNonEmpty(
+                CheckIds.ChecklistSha256Present,
+                bundle.SourceChecklistSha256,
+                "source_checklist_sha256"),
+
+            CheckChecklistNotEmpty(bundle),
+
+            CheckNonEmpty(
+                CheckIds.RecommendedWorkerActionNonEmpty,
+                bundle.RecommendedWorkerAction,
+                "recommended_worker_action"),
+
+            // Artifact-only invariant: the G194 bundle schema does NOT carry a
+            // provider-launch directive field. Confirming the parse-success
+            // path keeps the bundle artifact-only is a structural pass: the
+            // schema cannot represent a launch directive in any field.
+            Pass(
+                CheckIds.BundleArtifactOnlyNoProviderLaunchDirective,
+                "Bundle schema carries no provider-launch directive (G194 contract).")
+        };
+    }
+
+    /// <summary>
+    /// Build the (single-check) result for the case where <c>--from-bundle</c>
+    /// points at a non-existent path. Later checks are skipped — the path
+    /// pre-condition wasn't satisfied.
+    /// </summary>
+    public static IReadOnlyList<VerifyCheck> BuildPathMissingChecks(string pathDetail)
+    {
+        return new[]
+        {
+            Fail(
+                CheckIds.BundlePathPresentAndReadable,
+                $"Bundle path does not exist: {pathDetail}")
+        };
+    }
+
+    /// <summary>
+    /// Build the result for the case where the file exists but JSON parse
+    /// failed. Path-readable passes, JSON-parses fails, later checks skipped.
+    /// </summary>
+    public static IReadOnlyList<VerifyCheck> BuildJsonParseFailureChecks(string parseErrorDetail)
+    {
+        return new[]
+        {
+            Pass(CheckIds.BundlePathPresentAndReadable, "Bundle path exists and was read."),
+            Fail(
+                CheckIds.BundleJsonParses,
+                $"Failed to parse bundle JSON as TaskingHandoffBundleArtifact: {parseErrorDetail}")
+        };
+    }
+
+    private static VerifyCheck CheckBundleStatusLocalOnly(TaskingHandoffBundleArtifact bundle)
+    {
+        var actual = bundle.BundleStatus ?? string.Empty;
+        var passed = string.Equals(
+            actual,
+            TaskingHandoffBundleConstants.LocalOnlyStatus,
+            StringComparison.Ordinal);
+        return new VerifyCheck
+        {
+            Id = CheckIds.BundleStatusLocalOnly,
+            Passed = passed,
+            Detail = passed
+                ? $"bundle_status == '{TaskingHandoffBundleConstants.LocalOnlyStatus}'."
+                : $"bundle_status must be '{TaskingHandoffBundleConstants.LocalOnlyStatus}' (got '{actual}')."
+        };
+    }
+
+    private static VerifyCheck CheckIsPublishedFalse(TaskingHandoffBundleArtifact bundle)
+    {
+        var passed = bundle.IsPublished == false;
+        return new VerifyCheck
+        {
+            Id = CheckIds.BundleIsPublishedFalse,
+            Passed = passed,
+            Detail = passed
+                ? "is_published == false."
+                : "is_published must be literal false for a local-only bundle."
+        };
+    }
+
+    private static VerifyCheck CheckIsAutomationVisibleFalse(TaskingHandoffBundleArtifact bundle)
+    {
+        var passed = bundle.IsAutomationVisible == false;
+        return new VerifyCheck
+        {
+            Id = CheckIds.BundleIsAutomationVisibleFalse,
+            Passed = passed,
+            Detail = passed
+                ? "is_automation_visible == false."
+                : "is_automation_visible must be literal false for a local-only bundle."
+        };
+    }
+
+    private static VerifyCheck CheckNonEmpty(string id, string? value, string fieldName)
+    {
+        var passed = !string.IsNullOrWhiteSpace(value);
+        return new VerifyCheck
+        {
+            Id = id,
+            Passed = passed,
+            Detail = passed
+                ? $"{fieldName} is present."
+                : $"{fieldName} must be a non-empty string."
+        };
+    }
+
+    private static VerifyCheck CheckChecklistNotEmpty(TaskingHandoffBundleArtifact bundle)
+    {
+        var passedCount = bundle.ChecklistPassedCheckIds?.Count ?? 0;
+        var failedCount = bundle.ChecklistFailedCheckIds?.Count ?? 0;
+        var passed = (passedCount + failedCount) > 0;
+        return new VerifyCheck
+        {
+            Id = CheckIds.ChecklistPassedOrFailedCheckIdsPresent,
+            Passed = passed,
+            Detail = passed
+                ? $"checklist contains {passedCount} passed and {failedCount} failed check ids."
+                : "checklist_passed_check_ids and checklist_failed_check_ids are both empty."
+        };
+    }
+
+    private static VerifyCheck Pass(string id, string detail) =>
+        new() { Id = id, Passed = true, Detail = detail };
+
+    private static VerifyCheck Fail(string id, string detail) =>
+        new() { Id = id, Passed = false, Detail = detail };
+}

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyCommand.cs
@@ -1,0 +1,266 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G196: <c>intent-cli tasking handoff-bundle-verify</c>. A LOCAL deterministic
+/// preflight check command that consumes a G194
+/// <see cref="TaskingHandoffBundleArtifact"/> handoff bundle artifact (JSON)
+/// and prints a pass/fail verification result to STDOUT. The command performs
+/// no GitHub network calls, applies no labels, launches no provider processes,
+/// and does NOT touch <c>.intent-cli/queue-state.json</c> or
+/// <c>.intent-cli/runs.jsonl</c>. It also does NOT write any artifact file —
+/// verify is a read-only check that emits to STDOUT only.
+///
+/// Sits beside G190 <c>handoff</c>, G191 <c>task-packet</c>, G192
+/// <c>task-packet-preview</c>, G193 <c>task-packet-checklist</c>, G194
+/// <c>handoff-bundle</c>, and G195 <c>handoff-bundle-inspect</c> under the same
+/// <c>tasking</c> group. It does NOT replace any of those commands.
+///
+/// Network-mutation invariance: this command's hot path contains no
+/// <c>Process.Start</c>, no shell-out to <c>gh</c>, and no provider launcher.
+/// The associated tests validate the no-provider-launch invariant via the
+/// <see cref="NestedProviderLauncher"/> sentinel and a source-scan assertion.
+///
+/// Exit code: <c>0</c> iff every check in the verification list passes;
+/// <c>1</c> otherwise (including missing flag, missing file, parse failure).
+/// </summary>
+internal static class TaskingHandoffBundleVerifyCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private static readonly JsonSerializerOptions JsonOutputOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    /// <summary>
+    /// Test seam mirroring G190/G191/G192/G193/G194/G195 <c>NestedProviderLauncher</c>.
+    /// G196 must NEVER invoke this delegate. Tests register a sentinel that
+    /// flips a flag if invoked; the verify path leaves it untouched.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var fromBundle, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedFromBundle = Path.GetFullPath(fromBundle);
+
+        // Step 2: file existence — emit single check, do not parse.
+        if (!File.Exists(resolvedFromBundle))
+        {
+            var checks = TaskingHandoffBundleVerifyAnalyzer.BuildPathMissingChecks(fromBundle);
+            var result = new TaskingHandoffBundleVerifyResult
+            {
+                BundlePath = fromBundle,
+                BundleSha256 = null,
+                Domain = null,
+                Valid = false,
+                Errors = ExtractErrors(checks),
+                Checks = checks,
+                SummaryLine = TaskingHandoffBundleVerifyConstants.SummaryLineText
+            };
+            WriteResult(writer, result, format);
+            return 1;
+        }
+
+        byte[] bundleBytes;
+        try
+        {
+            bundleBytes = File.ReadAllBytes(resolvedFromBundle);
+        }
+        catch (Exception exception)
+        {
+            var checks = TaskingHandoffBundleVerifyAnalyzer.BuildPathMissingChecks(
+                $"{fromBundle} (read failure: {exception.Message})");
+            var result = new TaskingHandoffBundleVerifyResult
+            {
+                BundlePath = fromBundle,
+                BundleSha256 = null,
+                Domain = null,
+                Valid = false,
+                Errors = ExtractErrors(checks),
+                Checks = checks,
+                SummaryLine = TaskingHandoffBundleVerifyConstants.SummaryLineText
+            };
+            WriteResult(writer, result, format);
+            return 1;
+        }
+
+        var bundleSha256 = IssuePrepareCommand.ComputeSha256Hex(bundleBytes);
+
+        TaskingHandoffBundleArtifact? bundle;
+        try
+        {
+            bundle = JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(bundleBytes);
+        }
+        catch (JsonException exception)
+        {
+            var checks = TaskingHandoffBundleVerifyAnalyzer.BuildJsonParseFailureChecks(
+                exception.Message);
+            var result = new TaskingHandoffBundleVerifyResult
+            {
+                BundlePath = fromBundle,
+                BundleSha256 = bundleSha256,
+                Domain = null,
+                Valid = false,
+                Errors = ExtractErrors(checks),
+                Checks = checks,
+                SummaryLine = TaskingHandoffBundleVerifyConstants.SummaryLineText
+            };
+            WriteResult(writer, result, format);
+            return 1;
+        }
+
+        if (bundle is null)
+        {
+            var checks = TaskingHandoffBundleVerifyAnalyzer.BuildJsonParseFailureChecks(
+                "deserialized to a null bundle.");
+            var result = new TaskingHandoffBundleVerifyResult
+            {
+                BundlePath = fromBundle,
+                BundleSha256 = bundleSha256,
+                Domain = null,
+                Valid = false,
+                Errors = ExtractErrors(checks),
+                Checks = checks,
+                SummaryLine = TaskingHandoffBundleVerifyConstants.SummaryLineText
+            };
+            WriteResult(writer, result, format);
+            return 1;
+        }
+
+        var allChecks = TaskingHandoffBundleVerifyAnalyzer.BuildChecks(bundle);
+        var valid = allChecks.All(c => c.Passed);
+        var finalResult = new TaskingHandoffBundleVerifyResult
+        {
+            BundlePath = fromBundle,
+            BundleSha256 = bundleSha256,
+            Domain = bundle.Domain,
+            Valid = valid,
+            Errors = ExtractErrors(allChecks),
+            Checks = allChecks,
+            SummaryLine = TaskingHandoffBundleVerifyConstants.SummaryLineText
+        };
+
+        WriteResult(writer, finalResult, format);
+        return valid ? 0 : 1;
+    }
+
+    private static IReadOnlyList<string> ExtractErrors(IReadOnlyList<VerifyCheck> checks)
+    {
+        var errors = new List<string>();
+        foreach (var check in checks)
+        {
+            if (!check.Passed)
+            {
+                errors.Add($"{check.Id}: {check.Detail}");
+            }
+        }
+
+        return errors;
+    }
+
+    private static void WriteResult(
+        TextWriter writer,
+        TaskingHandoffBundleVerifyResult result,
+        string format)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOutputOptions));
+        }
+        else
+        {
+            WriteTextResult(writer, result);
+        }
+    }
+
+    private static void WriteTextResult(TextWriter writer, TaskingHandoffBundleVerifyResult result)
+    {
+        writer.WriteLine(result.SummaryLine);
+        writer.WriteLine();
+        writer.WriteLine($"Bundle path: {result.BundlePath}");
+        writer.WriteLine($"Bundle sha256: {result.BundleSha256 ?? "(unavailable)"}");
+        writer.WriteLine($"Domain: {result.Domain ?? "(unavailable)"}");
+        writer.WriteLine($"Valid: {result.Valid}");
+        writer.WriteLine();
+        writer.WriteLine("Checks:");
+        foreach (var check in result.Checks)
+        {
+            writer.WriteLine($"- {check.Id}: passed={check.Passed} (detail: {check.Detail})");
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string fromBundle,
+        out string format,
+        out string error)
+    {
+        fromBundle = string.Empty;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-bundle":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-bundle requires a non-empty value.";
+                        return false;
+                    }
+
+                    fromBundle = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error =
+                        $"Unknown argument '{argument}'. Supported: --from-bundle, --format.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromBundle))
+        {
+            error = "--from-bundle is required.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyResult.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyResult.cs
@@ -1,0 +1,119 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G196 verify result record. Snake_case JSON shape that
+/// <c>intent-cli tasking handoff-bundle-verify</c> emits to STDOUT when
+/// <c>--format json</c> is requested. The result is a deterministic, read-only
+/// preflight projection of a G194 <see cref="TaskingHandoffBundleArtifact"/>:
+/// the verify command does NOT write any artifact file.
+///
+/// <para>
+/// The <c>valid</c> flag is true iff every <see cref="VerifyCheck"/> in
+/// <see cref="Checks"/> has <c>passed == true</c>. <see cref="Errors"/> is a
+/// human-readable mirror of failed-check details for automation logs.
+/// </para>
+/// </summary>
+internal sealed record TaskingHandoffBundleVerifyResult
+{
+    [JsonPropertyName("bundle_path")]
+    public required string BundlePath { get; init; }
+
+    [JsonPropertyName("bundle_sha256")]
+    public required string? BundleSha256 { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string? Domain { get; init; }
+
+    [JsonPropertyName("valid")]
+    public required bool Valid { get; init; }
+
+    [JsonPropertyName("errors")]
+    public required IReadOnlyList<string> Errors { get; init; }
+
+    [JsonPropertyName("checks")]
+    public required IReadOnlyList<VerifyCheck> Checks { get; init; }
+
+    [JsonPropertyName("summary_line")]
+    public required string SummaryLine { get; init; }
+}
+
+/// <summary>
+/// G196 single-check record. Each <see cref="Id"/> matches a stable check id
+/// constant in <see cref="TaskingHandoffBundleVerifyConstants.CheckIds"/>.
+/// </summary>
+internal sealed record VerifyCheck
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("passed")]
+    public required bool Passed { get; init; }
+
+    [JsonPropertyName("detail")]
+    public required string Detail { get; init; }
+}
+
+/// <summary>
+/// G196 stable check id constants. The verify analyzer emits checks in the
+/// order declared in <see cref="CheckIds.All"/>; tests assert that every id
+/// appears exactly once in the output regardless of pass/fail status.
+/// </summary>
+internal static class TaskingHandoffBundleVerifyConstants
+{
+    /// <summary>
+    /// Stable status phrase appearing in both the text summary line and the
+    /// JSON <c>summary_line</c> field. Tests assert the literal substring.
+    /// </summary>
+    public const string UnpublishedStatusPhrase =
+        "UNPUBLISHED, local-only, not automation-visible";
+
+    /// <summary>
+    /// Stable summary line emitted at the top of both text and JSON outputs.
+    /// </summary>
+    public const string SummaryLineText =
+        "Tasking handoff bundle verify — UNPUBLISHED, local-only, not automation-visible.";
+
+    public static class CheckIds
+    {
+        public const string BundlePathPresentAndReadable = "bundle_path_present_and_readable";
+        public const string BundleJsonParses = "bundle_json_parses";
+        public const string BundleStatusLocalOnly = "bundle_status_local_only";
+        public const string BundleIsPublishedFalse = "bundle_is_published_false";
+        public const string BundleIsAutomationVisibleFalse = "bundle_is_automation_visible_false";
+        public const string TaskPacketPathPresent = "task_packet_path_present";
+        public const string TaskPacketSha256Present = "task_packet_sha256_present";
+        public const string PreviewPathPresent = "preview_path_present";
+        public const string PreviewSha256Present = "preview_sha256_present";
+        public const string HandoffPathPresent = "handoff_path_present";
+        public const string HandoffSha256Present = "handoff_sha256_present";
+        public const string ChecklistPathPresent = "checklist_path_present";
+        public const string ChecklistSha256Present = "checklist_sha256_present";
+        public const string ChecklistPassedOrFailedCheckIdsPresent =
+            "checklist_passed_check_ids_present_or_failed_check_ids_present";
+        public const string RecommendedWorkerActionNonEmpty = "recommended_worker_action_non_empty";
+        public const string BundleArtifactOnlyNoProviderLaunchDirective =
+            "bundle_artifact_only_no_provider_launch_directive";
+
+        public static readonly IReadOnlyList<string> All = new[]
+        {
+            BundlePathPresentAndReadable,
+            BundleJsonParses,
+            BundleStatusLocalOnly,
+            BundleIsPublishedFalse,
+            BundleIsAutomationVisibleFalse,
+            TaskPacketPathPresent,
+            TaskPacketSha256Present,
+            PreviewPathPresent,
+            PreviewSha256Present,
+            HandoffPathPresent,
+            HandoffSha256Present,
+            ChecklistPathPresent,
+            ChecklistSha256Present,
+            ChecklistPassedOrFailedCheckIdsPresent,
+            RecommendedWorkerActionNonEmpty,
+            BundleArtifactOnlyNoProviderLaunchDirective
+        };
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/TaskingHandoffBundleVerifyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskingHandoffBundleVerifyCommandTests.cs
@@ -1,0 +1,696 @@
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G196 — coverage for <c>intent-cli tasking handoff-bundle-verify</c>. Class
+/// name contains <c>Tasking</c>, <c>Handoff</c>, <c>Bundle</c>, and
+/// <c>Verify</c> so reviewers can match the issue's recommended
+/// <c>~Tasking|~Bundle|~Verify</c> filter.
+/// </summary>
+public sealed class TaskingHandoffBundleVerifyCommandTests : IDisposable
+{
+    private readonly Func<bool>? originalLauncher;
+
+    public TaskingHandoffBundleVerifyCommandTests()
+    {
+        originalLauncher = TaskingHandoffBundleVerifyCommand.NestedProviderLauncher;
+    }
+
+    public void Dispose()
+    {
+        TaskingHandoffBundleVerifyCommand.NestedProviderLauncher = originalLauncher;
+    }
+
+    [Fact]
+    public void Execute_GivenValidBundle_ReturnsZeroAndAllChecksPass()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("happy");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Valid: True", output, StringComparison.Ordinal);
+        foreach (var id in TaskingHandoffBundleVerifyConstants.CheckIds.All)
+        {
+            Assert.Contains($"- {id}: passed=True", output, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenValidBundle_TextOutputContainsLiteralStatusPhrase()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("phrase");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains(
+            "UNPUBLISHED, local-only, not automation-visible",
+            writer.ToString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenValidBundle_AllRequiredCheckIdsAppearExactlyOnce()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("once");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        foreach (var id in TaskingHandoffBundleVerifyConstants.CheckIds.All)
+        {
+            var marker = $"- {id}:";
+            var first = output.IndexOf(marker, StringComparison.Ordinal);
+            Assert.True(first >= 0, $"Required check id missing in output: {id}");
+            var second = output.IndexOf(marker, first + marker.Length, StringComparison.Ordinal);
+            Assert.True(second < 0, $"Required check id appeared more than once: {id}");
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_ResultRoundTripsStably()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("rt");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var result =
+            JsonSerializer.Deserialize<TaskingHandoffBundleVerifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.True(result!.Valid);
+        Assert.Empty(result.Errors);
+        Assert.Equal("intent-cli", result.Domain);
+        Assert.False(string.IsNullOrWhiteSpace(result.BundleSha256));
+        Assert.Equal(bundlePath, result.BundlePath);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_IncludesValidErrorsAndBundleIdentity()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("identity");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+
+        Assert.Equal(JsonValueKind.True, root.GetProperty("valid").ValueKind);
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("errors").ValueKind);
+        Assert.Equal(0, root.GetProperty("errors").GetArrayLength());
+
+        var bundlePathProp = root.GetProperty("bundle_path").GetString();
+        Assert.Equal(bundlePath, bundlePathProp);
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("bundle_sha256").GetString()));
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenMissingBundleFile_ReturnsNonZero_ActionableErrorMessage()
+    {
+        using var workspace = new VerifyWorkspace();
+        var missing = "/tmp/this-bundle-does-not-exist-g196.json";
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", missing },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains(missing, output, StringComparison.Ordinal);
+        Assert.True(
+            output.Contains("does not exist", StringComparison.Ordinal)
+                || output.Contains("not found", StringComparison.OrdinalIgnoreCase),
+            $"Expected actionable 'does not exist' or 'not found' message; got: {output}");
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedBundleJson_ReturnsNonZero_ActionableErrorMessage()
+    {
+        using var workspace = new VerifyWorkspace();
+        var malformed = workspace.GetPath("malformed-bundle.json");
+        File.WriteAllText(malformed, "{ this is not : valid json,");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", malformed, "--format", "json" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(JsonValueKind.False, doc.RootElement.GetProperty("valid").ValueKind);
+        var checks = doc.RootElement.GetProperty("checks");
+        var anyParseFailFailed = false;
+        foreach (var check in checks.EnumerateArray())
+        {
+            var id = check.GetProperty("id").GetString();
+            var passed = check.GetProperty("passed").GetBoolean();
+            if (id == TaskingHandoffBundleVerifyConstants.CheckIds.BundleJsonParses && !passed)
+            {
+                anyParseFailFailed = true;
+            }
+        }
+
+        Assert.True(anyParseFailFailed, "Expected bundle_json_parses to be reported as failed.");
+    }
+
+    [Fact]
+    public void Execute_GivenBundleMissingTaskPacketPath_ReturnsNonZero()
+    {
+        using var workspace = new VerifyWorkspace();
+        var tampered = workspace.GenerateTamperedBundle(
+            "missing-task-packet",
+            json => json.Replace(
+                "\"source_task_packet_path\":",
+                "\"source_task_packet_path\": \"\",\n  \"__orig_source_task_packet_path\":",
+                StringComparison.Ordinal));
+
+        var checkResult = RunVerify(workspace, tampered);
+        Assert.Equal(1, checkResult.ExitCode);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketPathPresent);
+    }
+
+    [Fact]
+    public void Execute_GivenBundleMissingPreviewPath_ReturnsNonZero()
+    {
+        using var workspace = new VerifyWorkspace();
+        var tampered = workspace.GenerateTamperedBundle(
+            "missing-preview",
+            json => json.Replace(
+                "\"source_preview_path\":",
+                "\"source_preview_path\": \"\",\n  \"__orig_source_preview_path\":",
+                StringComparison.Ordinal));
+
+        var checkResult = RunVerify(workspace, tampered);
+        Assert.Equal(1, checkResult.ExitCode);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.PreviewPathPresent);
+    }
+
+    [Fact]
+    public void Execute_GivenBundleMissingChecklistPath_ReturnsNonZero()
+    {
+        using var workspace = new VerifyWorkspace();
+        var tampered = workspace.GenerateTamperedBundle(
+            "missing-checklist",
+            json => json.Replace(
+                "\"source_checklist_path\":",
+                "\"source_checklist_path\": \"\",\n  \"__orig_source_checklist_path\":",
+                StringComparison.Ordinal));
+
+        var checkResult = RunVerify(workspace, tampered);
+        Assert.Equal(1, checkResult.ExitCode);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistPathPresent);
+    }
+
+    [Fact]
+    public void Execute_GivenBundleWithEmptyChecklist_ReturnsNonZero_ChecklistEmptyCheckFails()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("empty-cl");
+        var bundle = JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(
+            File.ReadAllText(bundlePath));
+        Assert.NotNull(bundle);
+
+        var emptied = bundle! with
+        {
+            ChecklistPassedCheckIds = Array.Empty<string>(),
+            ChecklistFailedCheckIds = Array.Empty<string>()
+        };
+        var emptiedPath = workspace.GetPath("bundle-empty-checklist.json");
+        File.WriteAllText(emptiedPath, JsonSerializer.Serialize(emptied));
+
+        var checkResult = RunVerify(workspace, emptiedPath);
+        Assert.Equal(1, checkResult.ExitCode);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistPassedOrFailedCheckIdsPresent);
+    }
+
+    [Fact]
+    public void Execute_GivenBundleWithWrongStatus_ReturnsNonZero_BundleStatusCheckFails()
+    {
+        using var workspace = new VerifyWorkspace();
+        var tampered = workspace.GenerateTamperedBundle(
+            "wrong-status",
+            json => json.Replace(
+                "\"bundle_status\": \"local_only\"",
+                "\"bundle_status\": \"published\"",
+                StringComparison.Ordinal));
+
+        var checkResult = RunVerify(workspace, tampered);
+        Assert.Equal(1, checkResult.ExitCode);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.BundleStatusLocalOnly);
+    }
+
+    [Fact]
+    public void Execute_GivenBundleIsPublishedTrue_ReturnsNonZero_IsPublishedCheckFails()
+    {
+        using var workspace = new VerifyWorkspace();
+        var tampered = workspace.GenerateTamperedBundle(
+            "published-true",
+            json => json.Replace(
+                "\"is_published\": false",
+                "\"is_published\": true",
+                StringComparison.Ordinal));
+
+        var checkResult = RunVerify(workspace, tampered);
+        Assert.Equal(1, checkResult.ExitCode);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.BundleIsPublishedFalse);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFlag_ReturnsNonZero()
+    {
+        using var workspace = new VerifyWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-bundle", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsNonZero()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("unknown");
+
+        var args = new[] { "--from-bundle", bundlePath, "--bogus", "value" };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesToQueueStateOrRunsLog()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("no-mut");
+
+        var queueStatePath = workspace.Context.GetQueueStatePath();
+        var runsLogPath = workspace.Context.GetRunLogPath();
+
+        var queueBytes = Encoding.UTF8.GetBytes("{\"schema_version\":\"1\",\"items\":[]}\n");
+        var runsBytes = Encoding.UTF8.GetBytes("{\"event\":\"sentinel\",\"ts\":\"2026-04-29T00:00:00Z\"}\n");
+        Directory.CreateDirectory(Path.GetDirectoryName(queueStatePath)!);
+        File.WriteAllBytes(queueStatePath, queueBytes);
+        File.WriteAllBytes(runsLogPath, runsBytes);
+
+        var queueBefore = File.ReadAllBytes(queueStatePath);
+        var runsBefore = File.ReadAllBytes(runsLogPath);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var queueAfter = File.ReadAllBytes(queueStatePath);
+        var runsAfter = File.ReadAllBytes(runsLogPath);
+        Assert.Equal(queueBefore, queueAfter);
+        Assert.Equal(runsBefore, runsAfter);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesAnyArtifactFile()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("no-artifact");
+
+        var bundleBytesBefore = File.ReadAllBytes(bundlePath);
+        var snapshotBefore = workspace.SnapshotAllFiles();
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var bundleBytesAfter = File.ReadAllBytes(bundlePath);
+        Assert.Equal(bundleBytesBefore, bundleBytesAfter);
+
+        var snapshotAfter = workspace.SnapshotAllFiles();
+        Assert.Equal(snapshotBefore.Count, snapshotAfter.Count);
+        foreach (var (path, contentBefore) in snapshotBefore)
+        {
+            Assert.True(snapshotAfter.ContainsKey(path), $"File disappeared: {path}");
+            Assert.Equal(contentBefore, snapshotAfter[path]);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesProvider_NoProcessStartInNewSurface()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("no-provider");
+
+        var launcherInvoked = false;
+        TaskingHandoffBundleVerifyCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(launcherInvoked);
+
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        var commandFile = Path.Combine(commandsDir, "TaskingHandoffBundleVerifyCommand.cs");
+        var analyzerFile = Path.Combine(commandsDir, "TaskingHandoffBundleVerifyAnalyzer.cs");
+        var resultFile = Path.Combine(commandsDir, "TaskingHandoffBundleVerifyResult.cs");
+        if (!File.Exists(commandFile) || !File.Exists(analyzerFile) || !File.Exists(resultFile))
+        {
+            return;
+        }
+
+        foreach (var path in new[] { commandFile, analyzerFile, resultFile })
+        {
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("Process.Start(", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_AlwaysReportsBundleStatusFromSourceWithoutInverting()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("contract");
+
+        // text format
+        using (var writer = new StringWriter())
+        {
+            var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+                workspace.Context,
+                new[] { "--from-bundle", bundlePath, "--format", "text" },
+                writer);
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains(
+                $"- {TaskingHandoffBundleVerifyConstants.CheckIds.BundleStatusLocalOnly}: passed=True",
+                output,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                $"- {TaskingHandoffBundleVerifyConstants.CheckIds.BundleIsPublishedFalse}: passed=True",
+                output,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                $"- {TaskingHandoffBundleVerifyConstants.CheckIds.BundleIsAutomationVisibleFalse}: passed=True",
+                output,
+                StringComparison.Ordinal);
+        }
+
+        // json format
+        using (var writer = new StringWriter())
+        {
+            var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+                workspace.Context,
+                new[] { "--from-bundle", bundlePath, "--format", "json" },
+                writer);
+            Assert.Equal(0, exitCode);
+
+            using var doc = JsonDocument.Parse(writer.ToString());
+            Assert.Equal(JsonValueKind.True, doc.RootElement.GetProperty("valid").ValueKind);
+        }
+
+        // The SOURCE bundle on disk really has these literal contract fields —
+        // verify propagates without inversion.
+        var sourceBundle =
+            JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(File.ReadAllText(bundlePath));
+        Assert.NotNull(sourceBundle);
+        Assert.Equal("local_only", sourceBundle!.BundleStatus);
+        Assert.False(sourceBundle.IsPublished);
+        Assert.False(sourceBundle.IsAutomationVisible);
+    }
+
+    private static (int ExitCode, string Output) RunVerify(VerifyWorkspace workspace, string bundlePath)
+    {
+        using var writer = new StringWriter();
+        var exit = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath, "--format", "json" },
+            writer);
+        return (exit, writer.ToString());
+    }
+
+    private static void AssertCheckFailed((int ExitCode, string Output) result, string checkId)
+    {
+        using var doc = JsonDocument.Parse(result.Output);
+        Assert.Equal(JsonValueKind.False, doc.RootElement.GetProperty("valid").ValueKind);
+
+        var found = false;
+        foreach (var check in doc.RootElement.GetProperty("checks").EnumerateArray())
+        {
+            if (check.GetProperty("id").GetString() == checkId)
+            {
+                Assert.False(
+                    check.GetProperty("passed").GetBoolean(),
+                    $"Expected check {checkId} to be passed=false but it was passed=true.");
+                found = true;
+                break;
+            }
+        }
+
+        Assert.True(found, $"Expected check id {checkId} to appear in output.");
+    }
+
+    private static bool TryResolveCommandsSourceDirectory(out string commandsDirectory)
+    {
+        commandsDirectory = string.Empty;
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, "src", "IntentSystem.Cli", "Commands");
+            if (Directory.Exists(candidate))
+            {
+                commandsDirectory = candidate;
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private sealed class VerifyWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("tasking-handoff-bundle-verify-tests-")
+            .FullName;
+
+        public VerifyWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string GetPath(string relative) => Path.Combine(rootPath, relative);
+
+        public IReadOnlyDictionary<string, byte[]> SnapshotAllFiles()
+        {
+            var map = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories))
+            {
+                map[path] = File.ReadAllBytes(path);
+            }
+
+            return map;
+        }
+
+        public string GenerateBundle(string tag)
+        {
+            var (previewPath, checklistPath) = GeneratePreviewAndChecklist(tag);
+            return BuildBundle(tag, previewPath, checklistPath);
+        }
+
+        public string GenerateTamperedBundle(string tag, Func<string, string> tamper)
+        {
+            var bundlePath = GenerateBundle($"{tag}-base");
+            var json = File.ReadAllText(bundlePath);
+            var tampered = tamper(json);
+            Assert.NotEqual(json, tampered);
+            var tamperedPath = GetPath($"bundle-{tag}-tampered.json");
+            File.WriteAllText(tamperedPath, tampered);
+            return tamperedPath;
+        }
+
+        private string BuildBundle(string tag, string previewPath, string checklistPath)
+        {
+            var bundlePath = GetPath($"bundle-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingHandoffBundleCommand.Execute(
+                Context,
+                new[]
+                {
+                    "--from-preview", previewPath,
+                    "--from-checklist", checklistPath,
+                    "--out", bundlePath
+                },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G194 bundle for tests: exit={exit}, stderr={sink}");
+            }
+
+            return bundlePath;
+        }
+
+        private (string previewPath, string checklistPath) GeneratePreviewAndChecklist(string tag)
+        {
+            var previewPath = GeneratePreview(tag);
+            var checklistPath = GetPath($"checklist-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingTaskPacketChecklistCommand.Execute(
+                Context,
+                new[] { "--from-preview", previewPath, "--out", checklistPath },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G193 checklist: exit={exit}, stderr={sink}");
+            }
+
+            return (previewPath, checklistPath);
+        }
+
+        private string GeneratePreview(string tag)
+        {
+            var handoffPath = GetPath($"__handoff_{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingHandoffCommand.Execute(
+                    Context,
+                    new[] { "--out", handoffPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G190 handoff: exit={exit}, stderr={sink}");
+                }
+            }
+
+            var taskPacketPath = GetPath($"__task_packet_{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingTaskPacketCommand.Execute(
+                    Context,
+                    new[] { "--from-handoff", handoffPath, "--out", taskPacketPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G191 task packet: exit={exit}, stderr={sink}");
+                }
+            }
+
+            var previewPath = GetPath($"preview-{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingTaskPacketPreviewCommand.Execute(
+                    Context,
+                    new[] { "--from-task-packet", taskPacketPath, "--out", previewPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G192 preview: exit={exit}, stderr={sink}");
+                }
+            }
+
+            return previewPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new subcommand `intent-cli tasking handoff-bundle-verify --from-bundle <bundle-artifact-path> [--format text|json]` under the existing `tasking` group. Seventh in the chain G190 → G191 → G192 → G193 → G194 → G195 → **G196 verify**. The verify command runs a deterministic preflight check that confirms a G194 handoff bundle is complete, internally consistent, and artifact-only — exactly what an outer AI tasking thread or automation loop needs before treating a bundle as trusted input. Exits 0 iff every check passes; non-zero otherwise. **No `--out` flag**: the command writes NO artifact file. No GitHub network. No provider/worker launch. No queue/runs mutation. No `intent-target` exposure.
- 16 stable check ids (defined as constants in `TaskingHandoffBundleVerifyConstants.CheckIds.All` so future drift breaks an explicit regression test). Each emitted check is `{id, passed, detail}` so test assertions can grep without depending on ordering. The check set covers: bundle path readability, JSON parses, `bundle_status == \"local_only\"`, `is_published == false`, `is_automation_visible == false`, all four (task-packet/preview/handoff/checklist) source paths and sha256s present, checklist non-empty, recommended worker action non-empty, and bundle stays artifact-only (no provider launch directive in schema).
- Validation precedence (each step before the next; first failure exits 1):
  1. `--from-bundle` flag missing/blank → exit 1, deterministic error message, no checks list.
  2. `--from-bundle` file not found → exit 1, single check `bundle_path_present_and_readable: passed=false`, `valid=false`. Don't try to parse.
  3. JSON parse failure → exit 1, two checks (`...path_present_and_readable: passed=true`, `bundle_json_parses: passed=false`), `valid=false`. Skip later checks.
  4. Otherwise: run every check; emit them all with `passed: bool`. `valid = checks.All(c => c.passed)`. Exit 0 iff `valid == true`.
- Output JSON shape (snake_case, stable, round-trippable through `JsonSerializer.Deserialize<TaskingHandoffBundleVerifyResult>`; satisfies issue's Acceptance Criterion that JSON \"includes at least `valid`, `errors`, and enough bundle identity/path information for automation logs\"):
  ```
  { \"bundle_path\": \"...\", \"bundle_sha256\": \"...\" | null, \"domain\": \"...\" | null,
    \"valid\": <bool>,
    \"errors\": [\"...\"],
    \"checks\": [ {\"id\": \"...\", \"passed\": <bool>, \"detail\": \"...\"}, ... 16 entries ... ],
    \"summary_line\": \"Tasking handoff bundle verify ... — UNPUBLISHED, local-only, not automation-visible.\" }
  ```
- No-mutation invariants:
  - Sentinel `TaskingHandoffBundleVerifyCommand.NestedProviderLauncher` (mirrors G187/G190/.../G195) — never invoked across any path.
  - Source-scan asserts the new command + analyzer files contain no `Process.Start(`.
  - Byte-equivalence test on `.intent-cli/queue-state.json` and `.intent-cli/runs.jsonl` before/after.
  - Whole-workspace byte-snapshot test (`Execute_NeverWritesAnyArtifactFile`) — no new file created and no existing file modified by the verify command.
- Reuse, not duplication:
  - `TaskingHandoffBundleArtifact` (G194) — deserialize the bundle.
  - `TaskingHandoffBundleConstants.LocalOnlyStatus` (G194) — for the status check.
  - `IssuePrepareCommand.ComputeSha256Hex(byte[])` — for `bundle_sha256` identity field.
  - No `private→internal` promotions needed.

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter \"FullyQualifiedName~TaskingHandoffBundleVerify\"` — **19/19 passing**. Issue-required scenarios covered: 1 passing-bundle scenario (`Execute_GivenValidBundle_ReturnsZeroAndAllChecksPass`) and >2 failing-bundle scenarios (missing-bundle-file, malformed-JSON, missing-task-packet-path, missing-preview-path, missing-checklist-path, empty-checklist, wrong-status, is-published-true, missing-flag, unknown-argument). Plus contract-locking regressions on the literal status phrase, all-required-check-ids-appear-exactly-once, JSON round-trip, JSON includes valid/errors/identity, no-queue-runs-write, no-artifact-written, no-provider-launch (sentinel + source-scan), and always-reports-status-from-source-without-inverting.
- [x] Issue's recommended broader filter (relevant tasks): `dotnet test ... --filter \"FullyQualifiedName~Tasking|FullyQualifiedName~Bundle|FullyQualifiedName~Verify\"` — passes (19 new G196 tests + every existing Tasking/Bundle/Verify test stays green).
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **1111/1111 passing + 1 skip** (the 1 skip is the pre-existing G190 `TolerantToSubAnalyzerFailure` `[Fact(Skip)]` not introduced by this slice; CLI: 1092 → 1111 = +19 new G196 tests; no regressions).
- Confirmation that no provider launch or GitHub mutation behavior was added: verified by source-scan + sentinel `NestedProviderLauncher` test + queue/runs byte-equivalence + whole-workspace byte-snapshot test (all asserted in the focused suite).
- [ ] Manual smoke (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff --domain intent-cli --out /tmp/g196-handoff.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet --from-handoff /tmp/g196-handoff.json --out /tmp/g196-task-packet.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet-preview --from-task-packet /tmp/g196-task-packet.json --out /tmp/g196-preview.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet-checklist --from-preview /tmp/g196-preview.json --out /tmp/g196-checklist.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff-bundle --from-preview /tmp/g196-preview.json --from-checklist /tmp/g196-checklist.json --out /tmp/g196-bundle.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff-bundle-verify --from-bundle /tmp/g196-bundle.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff-bundle-verify --from-bundle /tmp/g196-bundle.json --format json`

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)