### PR TITLE
G197: add content-hash pinning to handoff-bundle-verify

### DIFF
--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyAnalyzer.cs
@@ -13,6 +13,12 @@ using CheckIds = TaskingHandoffBundleVerifyConstants.CheckIds;
 /// and <c>bundle_status</c> are read directly from the source bundle without
 /// inversion or rewriting. A G194 bundle whose contract fields drifted will be
 /// reported here as a failed check, never silently passed.
+///
+/// G197 — content-hash pinning checks (file_exists + hash_matches per
+/// referenced source artifact) are appended to the existing check list. The
+/// command pre-computes file observations via <see cref="SourceArtifactObservation"/>
+/// and hands them to <see cref="BuildChecks"/>; the analyzer itself still does
+/// no I/O.
 /// </summary>
 internal static class TaskingHandoffBundleVerifyAnalyzer
 {
@@ -21,9 +27,44 @@ internal static class TaskingHandoffBundleVerifyAnalyzer
     /// bundle. Checks appear in the stable order declared by
     /// <see cref="TaskingHandoffBundleVerifyConstants.CheckIds.All"/>.
     /// </summary>
-    public static IReadOnlyList<VerifyCheck> BuildChecks(TaskingHandoffBundleArtifact bundle)
+    public static IReadOnlyList<VerifyCheck> BuildChecks(
+        TaskingHandoffBundleArtifact bundle,
+        SourceArtifactObservations observations)
     {
         ArgumentNullException.ThrowIfNull(bundle);
+        ArgumentNullException.ThrowIfNull(observations);
+
+        var (taskPacketFileExists, taskPacketHashMatches) = BuildContentHashPair(
+            CheckIds.TaskPacketFileExists,
+            CheckIds.TaskPacketHashMatches,
+            "source_task_packet_path",
+            bundle.SourceTaskPacketPath,
+            bundle.SourceTaskPacketSha256,
+            observations.TaskPacket);
+
+        var (previewFileExists, previewHashMatches) = BuildContentHashPair(
+            CheckIds.PreviewFileExists,
+            CheckIds.PreviewHashMatches,
+            "source_preview_path",
+            bundle.SourcePreviewPath,
+            bundle.SourcePreviewSha256,
+            observations.Preview);
+
+        var (checklistFileExists, checklistHashMatches) = BuildContentHashPair(
+            CheckIds.ChecklistFileExists,
+            CheckIds.ChecklistHashMatches,
+            "source_checklist_path",
+            bundle.SourceChecklistPath,
+            bundle.SourceChecklistSha256,
+            observations.Checklist);
+
+        var (handoffFileExists, handoffHashMatches) = BuildContentHashPair(
+            CheckIds.HandoffFileExists,
+            CheckIds.HandoffHashMatches,
+            "source_handoff_path",
+            bundle.SourceHandoffPath,
+            bundle.SourceHandoffSha256,
+            observations.Handoff);
 
         return new[]
         {
@@ -83,7 +124,21 @@ internal static class TaskingHandoffBundleVerifyAnalyzer
             // schema cannot represent a launch directive in any field.
             Pass(
                 CheckIds.BundleArtifactOnlyNoProviderLaunchDirective,
-                "Bundle schema carries no provider-launch directive (G194 contract).")
+                "Bundle schema carries no provider-launch directive (G194 contract)."),
+
+            // G197 — content-hash pinning checks. Stable order:
+            // task-packet (file_exists, hash_matches),
+            // preview (file_exists, hash_matches),
+            // checklist (file_exists, hash_matches),
+            // handoff (file_exists, hash_matches).
+            taskPacketFileExists,
+            taskPacketHashMatches,
+            previewFileExists,
+            previewHashMatches,
+            checklistFileExists,
+            checklistHashMatches,
+            handoffFileExists,
+            handoffHashMatches
         };
     }
 
@@ -188,9 +243,117 @@ internal static class TaskingHandoffBundleVerifyAnalyzer
         };
     }
 
+    /// <summary>
+    /// Build the (file_exists, hash_matches) check pair for one referenced
+    /// source artifact. Behavior precedence (G197):
+    /// <list type="bullet">
+    ///   <item>If the bundle's path field is empty/whitespace, both checks are
+    ///   <c>passed=false</c> with skipped detail (path-presence already
+    ///   reported the upstream cause).</item>
+    ///   <item>If file does not exist on disk, file_exists fails;
+    ///   hash_matches is <c>passed=false</c> with skipped detail.</item>
+    ///   <item>If the file was unreadable (locked, permission denied),
+    ///   file_exists is <c>passed=true</c> (we observed it) but hash_matches
+    ///   fails with the read error.</item>
+    ///   <item>Otherwise hash_matches compares actual sha256 to the
+    ///   bundle-recorded value.</item>
+    /// </list>
+    /// </summary>
+    private static (VerifyCheck FileExists, VerifyCheck HashMatches) BuildContentHashPair(
+        string fileExistsId,
+        string hashMatchesId,
+        string pathFieldName,
+        string? recordedPath,
+        string? recordedSha256,
+        SourceArtifactObservation observation)
+    {
+        if (string.IsNullOrWhiteSpace(recordedPath))
+        {
+            var skipped = $"skipped: {pathFieldName} is missing or empty";
+            return (
+                Fail(fileExistsId, skipped),
+                Fail(hashMatchesId, "skipped: " + pathFieldName + " is missing or empty"));
+        }
+
+        if (!observation.FileExists)
+        {
+            return (
+                Fail(fileExistsId, $"file does not exist: {recordedPath}"),
+                Fail(hashMatchesId, "skipped: file does not exist"));
+        }
+
+        // File observed on disk — file_exists passes regardless of read outcome.
+        var fileExistsCheck = Pass(fileExistsId, $"file exists: {recordedPath}");
+
+        if (!string.IsNullOrEmpty(observation.ReadErrorMessage))
+        {
+            return (
+                fileExistsCheck,
+                Fail(hashMatchesId, $"could not read file: {observation.ReadErrorMessage}"));
+        }
+
+        var actual = observation.ActualSha256 ?? string.Empty;
+        var recorded = recordedSha256 ?? string.Empty;
+        var passed = !string.IsNullOrEmpty(actual)
+            && !string.IsNullOrEmpty(recorded)
+            && string.Equals(actual, recorded, StringComparison.Ordinal);
+
+        var hashMatchesCheck = passed
+            ? Pass(hashMatchesId, $"sha256 matches: {actual}")
+            : Fail(
+                hashMatchesId,
+                $"sha256 mismatch — recorded: {recorded} actual: {actual}");
+
+        return (fileExistsCheck, hashMatchesCheck);
+    }
+
     private static VerifyCheck Pass(string id, string detail) =>
         new() { Id = id, Passed = true, Detail = detail };
 
     private static VerifyCheck Fail(string id, string detail) =>
         new() { Id = id, Passed = false, Detail = detail };
+}
+
+/// <summary>
+/// G197 — pre-computed file observation for a single referenced source
+/// artifact. The verify command computes these in one pass (file existence,
+/// optional bytes, optional sha256, optional read error message) and passes
+/// the bag to <see cref="TaskingHandoffBundleVerifyAnalyzer.BuildChecks"/>.
+///
+/// Keeping I/O in the command and inspection in the analyzer preserves the
+/// G196 separation: the analyzer remains a pure function over a snapshot of
+/// observed state.
+/// </summary>
+internal sealed record SourceArtifactObservation
+{
+    /// <summary>True iff <c>File.Exists</c> returned true for the recorded path.</summary>
+    public required bool FileExists { get; init; }
+
+    /// <summary>
+    /// Hex sha256 of the file's bytes, or null when the file could not be
+    /// read (does not exist, locked, permission denied) or the path field
+    /// was empty.
+    /// </summary>
+    public string? ActualSha256 { get; init; }
+
+    /// <summary>
+    /// Non-null when <c>File.Exists</c> returned true but <c>File.ReadAllBytes</c>
+    /// threw. Carries the exception message for the hash-match check detail.
+    /// </summary>
+    public string? ReadErrorMessage { get; init; }
+
+    public static SourceArtifactObservation Skipped() =>
+        new() { FileExists = false };
+}
+
+/// <summary>
+/// Bundle of four <see cref="SourceArtifactObservation"/> records — one per
+/// referenced source artifact (task-packet, preview, checklist, handoff).
+/// </summary>
+internal sealed record SourceArtifactObservations
+{
+    public required SourceArtifactObservation TaskPacket { get; init; }
+    public required SourceArtifactObservation Preview { get; init; }
+    public required SourceArtifactObservation Checklist { get; init; }
+    public required SourceArtifactObservation Handoff { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyCommand.cs
@@ -141,7 +141,8 @@ internal static class TaskingHandoffBundleVerifyCommand
             return 1;
         }
 
-        var allChecks = TaskingHandoffBundleVerifyAnalyzer.BuildChecks(bundle);
+        var observations = ObserveReferencedSourceArtifacts(bundle);
+        var allChecks = TaskingHandoffBundleVerifyAnalyzer.BuildChecks(bundle, observations);
         var valid = allChecks.All(c => c.Passed);
         var finalResult = new TaskingHandoffBundleVerifyResult
         {
@@ -156,6 +157,59 @@ internal static class TaskingHandoffBundleVerifyCommand
 
         WriteResult(writer, finalResult, format);
         return valid ? 0 : 1;
+    }
+
+    /// <summary>
+    /// G197 — read the four referenced source artifact files (task-packet,
+    /// preview, checklist, handoff) and produce a snapshot for the analyzer.
+    /// Read-only: this method never writes any file. When the recorded path
+    /// field is missing/empty, the observation is "skipped" and the analyzer
+    /// will produce skipped check details. When the file exists but read
+    /// throws (locked, permission denied), the observation records the
+    /// message and the analyzer keeps file_exists=true while failing
+    /// hash_matches.
+    /// </summary>
+    private static SourceArtifactObservations ObserveReferencedSourceArtifacts(
+        TaskingHandoffBundleArtifact bundle)
+    {
+        return new SourceArtifactObservations
+        {
+            TaskPacket = ObserveOne(bundle.SourceTaskPacketPath),
+            Preview = ObserveOne(bundle.SourcePreviewPath),
+            Checklist = ObserveOne(bundle.SourceChecklistPath),
+            Handoff = ObserveOne(bundle.SourceHandoffPath)
+        };
+    }
+
+    private static SourceArtifactObservation ObserveOne(string? recordedPath)
+    {
+        if (string.IsNullOrWhiteSpace(recordedPath))
+        {
+            return SourceArtifactObservation.Skipped();
+        }
+
+        if (!File.Exists(recordedPath))
+        {
+            return new SourceArtifactObservation { FileExists = false };
+        }
+
+        try
+        {
+            var bytes = File.ReadAllBytes(recordedPath);
+            return new SourceArtifactObservation
+            {
+                FileExists = true,
+                ActualSha256 = IssuePrepareCommand.ComputeSha256Hex(bytes)
+            };
+        }
+        catch (Exception exception)
+        {
+            return new SourceArtifactObservation
+            {
+                FileExists = true,
+                ReadErrorMessage = exception.Message
+            };
+        }
     }
 
     private static IReadOnlyList<string> ExtractErrors(IReadOnlyList<VerifyCheck> checks)

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyResult.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyResult.cs
@@ -96,6 +96,21 @@ internal static class TaskingHandoffBundleVerifyConstants
         public const string BundleArtifactOnlyNoProviderLaunchDirective =
             "bundle_artifact_only_no_provider_launch_directive";
 
+        // G197 — content-hash pinning. New stable check ids appended to the end
+        // of <see cref="All"/> in the order: task-packet (file_exists then
+        // hash_matches), preview, checklist, handoff. The verify analyzer runs
+        // these AFTER the existing G196 path/sha256 field-presence checks so it
+        // can short-circuit deterministically when the path field itself is
+        // missing or empty.
+        public const string TaskPacketFileExists = "task_packet_file_exists";
+        public const string TaskPacketHashMatches = "task_packet_hash_matches";
+        public const string PreviewFileExists = "preview_file_exists";
+        public const string PreviewHashMatches = "preview_hash_matches";
+        public const string ChecklistFileExists = "checklist_file_exists";
+        public const string ChecklistHashMatches = "checklist_hash_matches";
+        public const string HandoffFileExists = "handoff_file_exists";
+        public const string HandoffHashMatches = "handoff_hash_matches";
+
         public static readonly IReadOnlyList<string> All = new[]
         {
             BundlePathPresentAndReadable,
@@ -113,7 +128,17 @@ internal static class TaskingHandoffBundleVerifyConstants
             ChecklistSha256Present,
             ChecklistPassedOrFailedCheckIdsPresent,
             RecommendedWorkerActionNonEmpty,
-            BundleArtifactOnlyNoProviderLaunchDirective
+            BundleArtifactOnlyNoProviderLaunchDirective,
+            // G197 content-hash pinning checks — task-packet, preview,
+            // checklist, handoff (file_exists then hash_matches per ref).
+            TaskPacketFileExists,
+            TaskPacketHashMatches,
+            PreviewFileExists,
+            PreviewHashMatches,
+            ChecklistFileExists,
+            ChecklistHashMatches,
+            HandoffFileExists,
+            HandoffHashMatches
         };
     }
 }

--- a/tests/IntentSystem.Cli.Tests/TaskingHandoffBundleVerifyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskingHandoffBundleVerifyCommandTests.cs
@@ -493,6 +493,488 @@ public sealed class TaskingHandoffBundleVerifyCommandTests : IDisposable
         Assert.False(sourceBundle.IsAutomationVisible);
     }
 
+    // -------------------------------------------------------------------
+    // G197 — content-hash pinning for referenced source artifacts.
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void Execute_GivenValidBundle_AllReferencedArtifactsExistAndHashesMatch()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("g197-happy");
+
+        var checkResult = RunVerify(workspace, bundlePath);
+        Assert.Equal(0, checkResult.ExitCode);
+
+        var passedIds = ExtractPassedCheckIds(checkResult);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.PreviewFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.PreviewHashMatches, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistHashMatches, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.HandoffFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.HandoffHashMatches, passedIds);
+    }
+
+    [Fact]
+    public void Execute_GivenReferencedTaskPacketDeleted_TaskPacketFileExistsCheckFails()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("g197-del-tp");
+        var bundle = ReadBundle(bundlePath);
+        File.Delete(bundle.SourceTaskPacketPath);
+
+        var checkResult = RunVerify(workspace, bundlePath);
+        Assert.Equal(1, checkResult.ExitCode);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketFileExists);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches);
+
+        var passedIds = ExtractPassedCheckIds(checkResult);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.PreviewFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.PreviewHashMatches, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistHashMatches, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.HandoffFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.HandoffHashMatches, passedIds);
+    }
+
+    [Fact]
+    public void Execute_GivenReferencedPreviewDeleted_PreviewFileExistsCheckFails()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("g197-del-pv");
+        var bundle = ReadBundle(bundlePath);
+        File.Delete(bundle.SourcePreviewPath);
+
+        var checkResult = RunVerify(workspace, bundlePath);
+        Assert.Equal(1, checkResult.ExitCode);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.PreviewFileExists);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.PreviewHashMatches);
+
+        var passedIds = ExtractPassedCheckIds(checkResult);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistHashMatches, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.HandoffFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.HandoffHashMatches, passedIds);
+    }
+
+    [Fact]
+    public void Execute_GivenReferencedChecklistDeleted_ChecklistFileExistsCheckFails()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("g197-del-cl");
+        var bundle = ReadBundle(bundlePath);
+        File.Delete(bundle.SourceChecklistPath);
+
+        var checkResult = RunVerify(workspace, bundlePath);
+        Assert.Equal(1, checkResult.ExitCode);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistFileExists);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistHashMatches);
+
+        var passedIds = ExtractPassedCheckIds(checkResult);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.PreviewFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.PreviewHashMatches, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.HandoffFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.HandoffHashMatches, passedIds);
+    }
+
+    [Fact]
+    public void Execute_GivenReferencedHandoffDeleted_HandoffFileExistsCheckFails()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("g197-del-ho");
+        var bundle = ReadBundle(bundlePath);
+        File.Delete(bundle.SourceHandoffPath);
+
+        var checkResult = RunVerify(workspace, bundlePath);
+        Assert.Equal(1, checkResult.ExitCode);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.HandoffFileExists);
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.HandoffHashMatches);
+
+        var passedIds = ExtractPassedCheckIds(checkResult);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.PreviewFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.PreviewHashMatches, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistFileExists, passedIds);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistHashMatches, passedIds);
+    }
+
+    [Fact]
+    public void Execute_GivenReferencedTaskPacketEdited_TaskPacketHashMismatchFails()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("g197-edit-tp");
+        var bundle = ReadBundle(bundlePath);
+        AppendByte(bundle.SourceTaskPacketPath);
+
+        var checkResult = RunVerify(workspace, bundlePath);
+        Assert.Equal(1, checkResult.ExitCode);
+
+        var passedIds = ExtractPassedCheckIds(checkResult);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketFileExists, passedIds);
+
+        var failedDetail = GetFailedCheckDetail(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches);
+        Assert.Contains("recorded:", failedDetail, StringComparison.Ordinal);
+        Assert.Contains("actual:", failedDetail, StringComparison.Ordinal);
+        Assert.Contains(bundle.SourceTaskPacketSha256, failedDetail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenReferencedPreviewEdited_PreviewHashMismatchFails()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("g197-edit-pv");
+        var bundle = ReadBundle(bundlePath);
+        AppendByte(bundle.SourcePreviewPath);
+
+        var checkResult = RunVerify(workspace, bundlePath);
+        Assert.Equal(1, checkResult.ExitCode);
+
+        var passedIds = ExtractPassedCheckIds(checkResult);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.PreviewFileExists, passedIds);
+
+        var failedDetail = GetFailedCheckDetail(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.PreviewHashMatches);
+        Assert.Contains("recorded:", failedDetail, StringComparison.Ordinal);
+        Assert.Contains("actual:", failedDetail, StringComparison.Ordinal);
+        Assert.Contains(bundle.SourcePreviewSha256, failedDetail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenReferencedChecklistEdited_ChecklistHashMismatchFails()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("g197-edit-cl");
+        var bundle = ReadBundle(bundlePath);
+        AppendByte(bundle.SourceChecklistPath);
+
+        var checkResult = RunVerify(workspace, bundlePath);
+        Assert.Equal(1, checkResult.ExitCode);
+
+        var passedIds = ExtractPassedCheckIds(checkResult);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistFileExists, passedIds);
+
+        var failedDetail = GetFailedCheckDetail(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistHashMatches);
+        Assert.Contains("recorded:", failedDetail, StringComparison.Ordinal);
+        Assert.Contains("actual:", failedDetail, StringComparison.Ordinal);
+        Assert.Contains(bundle.SourceChecklistSha256, failedDetail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenReferencedHandoffEdited_HandoffHashMismatchFails()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("g197-edit-ho");
+        var bundle = ReadBundle(bundlePath);
+        AppendByte(bundle.SourceHandoffPath);
+
+        var checkResult = RunVerify(workspace, bundlePath);
+        Assert.Equal(1, checkResult.ExitCode);
+
+        var passedIds = ExtractPassedCheckIds(checkResult);
+        Assert.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.HandoffFileExists, passedIds);
+
+        var failedDetail = GetFailedCheckDetail(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.HandoffHashMatches);
+        Assert.Contains("recorded:", failedDetail, StringComparison.Ordinal);
+        Assert.Contains("actual:", failedDetail, StringComparison.Ordinal);
+        Assert.Contains(bundle.SourceHandoffSha256, failedDetail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_HashMismatchAppearsInErrorsArrayWithBothHashes()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("g197-json-mm");
+        var bundle = ReadBundle(bundlePath);
+        AppendByte(bundle.SourceTaskPacketPath);
+
+        var checkResult = RunVerify(workspace, bundlePath);
+        Assert.Equal(1, checkResult.ExitCode);
+
+        using var doc = JsonDocument.Parse(checkResult.Output);
+        Assert.Equal(JsonValueKind.False, doc.RootElement.GetProperty("valid").ValueKind);
+
+        var actualBytes = File.ReadAllBytes(bundle.SourceTaskPacketPath);
+        var actualSha = ComputeSha256HexLocal(actualBytes);
+
+        var errors = doc.RootElement.GetProperty("errors");
+        var foundMismatchEntry = false;
+        foreach (var err in errors.EnumerateArray())
+        {
+            var entry = err.GetString() ?? string.Empty;
+            if (entry.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches, StringComparison.Ordinal)
+                && entry.Contains(bundle.SourceTaskPacketSha256, StringComparison.Ordinal)
+                && entry.Contains(actualSha, StringComparison.Ordinal))
+            {
+                foundMismatchEntry = true;
+                break;
+            }
+        }
+
+        Assert.True(
+            foundMismatchEntry,
+            $"Expected errors[] to include task_packet_hash_matches with both recorded and actual sha256 hex. Output: {checkResult.Output}");
+    }
+
+    [Fact]
+    public void Execute_GivenAllChecksPass_NewCheckIdsAppearInStableOrderAfterPathSha256Checks()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("g197-order");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath, "--format", "json" },
+            writer);
+        Assert.Equal(0, exitCode);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var idsInOrder = new List<string>();
+        foreach (var check in doc.RootElement.GetProperty("checks").EnumerateArray())
+        {
+            idsInOrder.Add(check.GetProperty("id").GetString()!);
+        }
+
+        // The eight new G197 ids must appear in the documented stable order
+        // and they must come AFTER the field-presence (path/sha256) tier and
+        // AFTER the artifact-only invariant check, i.e. at the end.
+        var expectedTail = new[]
+        {
+            TaskingHandoffBundleVerifyConstants.CheckIds.BundleArtifactOnlyNoProviderLaunchDirective,
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketFileExists,
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches,
+            TaskingHandoffBundleVerifyConstants.CheckIds.PreviewFileExists,
+            TaskingHandoffBundleVerifyConstants.CheckIds.PreviewHashMatches,
+            TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistFileExists,
+            TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistHashMatches,
+            TaskingHandoffBundleVerifyConstants.CheckIds.HandoffFileExists,
+            TaskingHandoffBundleVerifyConstants.CheckIds.HandoffHashMatches
+        };
+
+        Assert.True(idsInOrder.Count >= expectedTail.Length);
+        var tail = idsInOrder.GetRange(idsInOrder.Count - expectedTail.Length, expectedTail.Length);
+        Assert.Equal(expectedTail, tail);
+
+        // Each new file_exists must come AFTER its path-presence sibling, and
+        // each hash_matches must come AFTER its sha256-presence sibling.
+        AssertOrder(idsInOrder,
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketPathPresent,
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketFileExists);
+        AssertOrder(idsInOrder,
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketSha256Present,
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches);
+        AssertOrder(idsInOrder,
+            TaskingHandoffBundleVerifyConstants.CheckIds.PreviewPathPresent,
+            TaskingHandoffBundleVerifyConstants.CheckIds.PreviewFileExists);
+        AssertOrder(idsInOrder,
+            TaskingHandoffBundleVerifyConstants.CheckIds.PreviewSha256Present,
+            TaskingHandoffBundleVerifyConstants.CheckIds.PreviewHashMatches);
+        AssertOrder(idsInOrder,
+            TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistPathPresent,
+            TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistFileExists);
+        AssertOrder(idsInOrder,
+            TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistSha256Present,
+            TaskingHandoffBundleVerifyConstants.CheckIds.ChecklistHashMatches);
+        AssertOrder(idsInOrder,
+            TaskingHandoffBundleVerifyConstants.CheckIds.HandoffPathPresent,
+            TaskingHandoffBundleVerifyConstants.CheckIds.HandoffFileExists);
+        AssertOrder(idsInOrder,
+            TaskingHandoffBundleVerifyConstants.CheckIds.HandoffSha256Present,
+            TaskingHandoffBundleVerifyConstants.CheckIds.HandoffHashMatches);
+    }
+
+    [Fact]
+    public void Execute_GivenSourcePathFieldEmpty_FileExistsCheckSkippedDeterministically()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("g197-empty-path");
+
+        // Mutate the bundle JSON to set source_task_packet_path to "" without
+        // any artifact removal, simulating an upstream G194 path-missing case.
+        var bundle = ReadBundle(bundlePath);
+        var emptied = bundle with { SourceTaskPacketPath = string.Empty };
+        var emptiedPath = workspace.GetPath("bundle-g197-empty-path-tampered.json");
+        File.WriteAllText(emptiedPath, JsonSerializer.Serialize(emptied));
+
+        var checkResult = RunVerify(workspace, emptiedPath);
+        Assert.Equal(1, checkResult.ExitCode);
+
+        AssertCheckFailed(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketPathPresent);
+
+        var fileExistsDetail = GetFailedCheckDetail(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketFileExists);
+        Assert.True(
+            fileExistsDetail.Contains("skipped", StringComparison.OrdinalIgnoreCase)
+                || fileExistsDetail.Contains("missing or empty", StringComparison.OrdinalIgnoreCase),
+            $"Expected file_exists detail to mention 'skipped' or 'missing or empty path'; got: {fileExistsDetail}");
+
+        var hashDetail = GetFailedCheckDetail(
+            checkResult,
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches);
+        Assert.Contains("skipped", hashDetail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_PreservesAllExistingG196Checks_NoIdRemovedOrRenamed()
+    {
+        // The 16 ids accepted at the close of G196. If any of them ever
+        // disappears or is renamed, this test is the canary.
+        var g196Ids = new[]
+        {
+            "bundle_path_present_and_readable",
+            "bundle_json_parses",
+            "bundle_status_local_only",
+            "bundle_is_published_false",
+            "bundle_is_automation_visible_false",
+            "task_packet_path_present",
+            "task_packet_sha256_present",
+            "preview_path_present",
+            "preview_sha256_present",
+            "handoff_path_present",
+            "handoff_sha256_present",
+            "checklist_path_present",
+            "checklist_sha256_present",
+            "checklist_passed_check_ids_present_or_failed_check_ids_present",
+            "recommended_worker_action_non_empty",
+            "bundle_artifact_only_no_provider_launch_directive"
+        };
+
+        foreach (var id in g196Ids)
+        {
+            Assert.Contains(id, TaskingHandoffBundleVerifyConstants.CheckIds.All);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverWritesAnyArtifactFile_AfterReadingReferencedArtifacts()
+    {
+        using var workspace = new VerifyWorkspace();
+        var bundlePath = workspace.GenerateBundle("g197-no-write");
+
+        var snapshotBefore = workspace.SnapshotAllFiles();
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleVerifyCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+        Assert.Equal(0, exitCode);
+
+        var snapshotAfter = workspace.SnapshotAllFiles();
+        Assert.Equal(snapshotBefore.Count, snapshotAfter.Count);
+        foreach (var (path, contentBefore) in snapshotBefore)
+        {
+            Assert.True(snapshotAfter.ContainsKey(path), $"File disappeared: {path}");
+            Assert.Equal(contentBefore, snapshotAfter[path]);
+        }
+    }
+
+    private static TaskingHandoffBundleArtifact ReadBundle(string bundlePath)
+    {
+        var bundle = JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(
+            File.ReadAllText(bundlePath));
+        Assert.NotNull(bundle);
+        return bundle!;
+    }
+
+    private static void AppendByte(string path)
+    {
+        // Adding a single byte changes the file's sha256. ASCII space is
+        // typically harmless to JSON-decoding tools but the analyzer never
+        // re-parses these source artifacts; only the byte hash is compared.
+        using var stream = new FileStream(path, FileMode.Append, FileAccess.Write);
+        stream.WriteByte((byte)' ');
+    }
+
+    private static IReadOnlyList<string> ExtractPassedCheckIds((int ExitCode, string Output) result)
+    {
+        var ids = new List<string>();
+        using var doc = JsonDocument.Parse(result.Output);
+        foreach (var check in doc.RootElement.GetProperty("checks").EnumerateArray())
+        {
+            if (check.GetProperty("passed").GetBoolean())
+            {
+                ids.Add(check.GetProperty("id").GetString()!);
+            }
+        }
+
+        return ids;
+    }
+
+    private static string GetFailedCheckDetail((int ExitCode, string Output) result, string checkId)
+    {
+        using var doc = JsonDocument.Parse(result.Output);
+        foreach (var check in doc.RootElement.GetProperty("checks").EnumerateArray())
+        {
+            if (check.GetProperty("id").GetString() == checkId)
+            {
+                Assert.False(
+                    check.GetProperty("passed").GetBoolean(),
+                    $"Expected {checkId} to be passed=false.");
+                return check.GetProperty("detail").GetString() ?? string.Empty;
+            }
+        }
+
+        Assert.Fail($"Check id {checkId} not found in output.");
+        return string.Empty;
+    }
+
+    private static void AssertOrder(IReadOnlyList<string> ids, string before, string after)
+    {
+        var beforeIndex = ids.ToList().IndexOf(before);
+        var afterIndex = ids.ToList().IndexOf(after);
+        Assert.True(beforeIndex >= 0, $"{before} not found");
+        Assert.True(afterIndex >= 0, $"{after} not found");
+        Assert.True(
+            beforeIndex < afterIndex,
+            $"Expected {before} (index {beforeIndex}) to come before {after} (index {afterIndex}).");
+    }
+
+    private static string ComputeSha256HexLocal(byte[] bytes)
+    {
+        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+        var sb = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash)
+        {
+            sb.Append(b.ToString("x2", System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        return sb.ToString();
+    }
+
     private static (int ExitCode, string Output) RunVerify(VerifyWorkspace workspace, string bundlePath)
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

- Extends the existing G196 `intent-cli tasking handoff-bundle-verify --from-bundle <path>` command with content-hash pinning for the four referenced source artifacts (task-packet, preview, checklist, handoff). **No command-surface change**, **no JSON shape change** — the `checks` array simply gains 8 new entries with stable ids, and `errors` may include the new failure details when an artifact is missing or edited.
- 8 new stable check ids appended to `TaskingHandoffBundleVerifyConstants.CheckIds.All` (in pairs, after the existing path/sha256 field-presence checks):
  - `task_packet_file_exists`, `task_packet_hash_matches`
  - `preview_file_exists`, `preview_hash_matches`
  - `checklist_file_exists`, `checklist_hash_matches`
  - `handoff_file_exists`, `handoff_hash_matches`
- Deterministic skip semantics so we never emit spurious file-not-found errors when the upstream path field itself is missing:
  - If the corresponding `<ref>_path_present` (G196) check is `passed=false`, then `<ref>_file_exists` is `passed=false` with `detail = "skipped: source_<ref>_path is missing or empty"` AND `<ref>_hash_matches` is `passed=false` with `detail = "skipped: ..."`.
  - If `<ref>_file_exists` is `passed=false`, then `<ref>_hash_matches` is `passed=false` with `detail = "skipped: file does not exist"`.
  - If reading the file throws (locked / permission denied), `<ref>_file_exists` is `passed=true` (we observed it) but `<ref>_hash_matches` is `passed=false` with `detail = "could not read file: <message>"`.
  - Otherwise: compute sha256 of the file's bytes and compare to the recorded value. On mismatch, the failed check's `detail` includes BOTH the recorded full hex sha256 AND the actual full hex sha256, so JSON `errors` automation logs are debuggable.
- `valid = checks.All(c => c.passed)` continues unchanged. Exit 0 iff valid; non-zero otherwise.
- All existing G196 invariants intact: read-only, no GitHub network, no labels, no queue/runs writes, no provider/worker launch, no artifact file writes (verified by the `Execute_NeverWritesAnyArtifactFile_AfterReadingReferencedArtifacts` whole-workspace byte-snapshot test even though the new code now reads referenced files).
- Reuse, not duplication: `IssuePrepareCommand.ComputeSha256Hex(byte[])` is reused for the actual file-bytes hash. Analyzer remains I/O-free; the I/O (`File.ReadAllBytes`) lives in the command, which feeds a `SourceArtifactObservation` record into the analyzer (matches G196's separation).

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter \"FullyQualifiedName~TaskingHandoffBundleVerify\"` — **33/33 passing** (19 prior G196 tests + 14 new G197 regressions, all passing in a single run).
- [x] Issue's required scenarios covered:
  - **valid hash**: `Execute_GivenValidBundle_AllReferencedArtifactsExistAndHashesMatch` — chain handoff → task-packet → preview → checklist → bundle, then verify; assert all 8 new checks `passed=True`.
  - **missing referenced artifact**: separate tests for each of the 4 references (`Execute_GivenReferencedTaskPacketDeleted_TaskPacketFileExistsCheckFails`, `..PreviewDeleted..`, `..ChecklistDeleted..`, `..HandoffDeleted..`); each deletes the corresponding file from disk, asserts exit 1, the `<ref>_file_exists` and `<ref>_hash_matches` checks are `passed=False`, and other refs still pass.
  - **edited referenced artifact / hash mismatch**: separate tests for each of the 4 references (`..TaskPacketEdited..`, `..PreviewEdited..`, `..ChecklistEdited..`, `..HandoffEdited..`); each appends a single byte to the corresponding file, asserts exit 1, `<ref>_file_exists: passed=True`, `<ref>_hash_matches: passed=False`, and the failed check's `detail` mentions BOTH the recorded hash and the actual hash.
- [x] Other regressions covered: `Execute_GivenJsonFormat_HashMismatchAppearsInErrorsArrayWithBothHashes` (JSON automation-log debuggability), `Execute_GivenAllChecksPass_NewCheckIdsAppearInStableOrderAfterPathSha256Checks` (locks the new id ordering against drift), `Execute_GivenSourcePathFieldEmpty_FileExistsCheckSkippedDeterministically` (empty path → deterministic skip cascade), `Execute_PreservesAllExistingG196Checks_NoIdRemovedOrRenamed` (locks all 16 existing G196 ids against accidental rename/removal), `Execute_NeverWritesAnyArtifactFile_AfterReadingReferencedArtifacts` (whole-workspace byte snapshot — even now that new code reads referenced files, the verify command still writes nothing).
- [x] Existing G196 missing-bundle / malformed-bundle / wrong-status / etc. behavior remains intact (all 19 prior tests pass unchanged).
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **1125/1125 passing + 1 skip** (the 1 skip is the pre-existing G190 `TolerantToSubAnalyzerFailure` `[Fact(Skip)]` not introduced by this slice; CLI: 1111 → 1125 = +14 new G197 tests; no regressions).
- Confirmation that no provider launch or GitHub mutation behavior was added: verified by the no-write workspace snapshot + queue/runs byte-equivalence + sentinel `NestedProviderLauncher` (G196 tests retained) + source-scan (G196 tests retained).
- [ ] Manual smoke (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff --domain intent-cli --out /tmp/g197-handoff.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet --from-handoff /tmp/g197-handoff.json --out /tmp/g197-task-packet.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet-preview --from-task-packet /tmp/g197-task-packet.json --out /tmp/g197-preview.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking task-packet-checklist --from-preview /tmp/g197-preview.json --out /tmp/g197-checklist.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff-bundle --from-preview /tmp/g197-preview.json --from-checklist /tmp/g197-checklist.json --out /tmp/g197-bundle.json`
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff-bundle-verify --from-bundle /tmp/g197-bundle.json --format json` (assert `valid: true`, all 24 checks pass)
  - `echo extra >> /tmp/g197-task-packet.json && dotnet run ... -- tasking handoff-bundle-verify --from-bundle /tmp/g197-bundle.json --format json` (assert `valid: false`, `task_packet_hash_matches: false` with both hashes in `errors[]`)

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)