### PR TITLE
G198: add intent-cli tasking handoff-bundle-import-dry-run plan emitter

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -132,7 +132,8 @@ internal static class CommandRouter
                 ["task-packet-checklist"] = TaskingTaskPacketChecklistCommand.Execute,
                 ["handoff-bundle"] = TaskingHandoffBundleCommand.Execute,
                 ["handoff-bundle-inspect"] = TaskingHandoffBundleInspectCommand.Execute,
-                ["handoff-bundle-verify"] = TaskingHandoffBundleVerifyCommand.Execute
+                ["handoff-bundle-verify"] = TaskingHandoffBundleVerifyCommand.Execute,
+                ["handoff-bundle-import-dry-run"] = TaskingHandoffBundleImportDryRunCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleImportDryRunAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleImportDryRunAnalyzer.cs
@@ -1,0 +1,144 @@
+namespace IntentSystem.Cli.Commands;
+
+using Actions = TaskingHandoffBundleImportDryRunConstants.Actions;
+using CurrentStatuses = TaskingHandoffBundleImportDryRunConstants.CurrentStatuses;
+using Roles = TaskingHandoffBundleImportDryRunConstants.Roles;
+using VerifyCheckIds = TaskingHandoffBundleVerifyConstants.CheckIds;
+
+/// <summary>
+/// G198 — pure logic that turns a deserialized G194 bundle plus a G196/G197
+/// verify check list into a deterministic restore plan. No I/O, no network,
+/// no process launches. The command layer is responsible for reading the
+/// bundle, observing referenced files, and dispatching to
+/// <see cref="TaskingHandoffBundleVerifyAnalyzer.BuildChecks"/>; this analyzer
+/// then projects those check results into the per-role plan entries.
+///
+/// The restore plan is descriptive: it never performs the listed actions and
+/// the bundle does not carry artifact bytes, only paths and sha256 values.
+/// See <see cref="TaskingHandoffBundleImportDryRunConstants.RestorePlanDisclaimer"/>.
+/// </summary>
+internal static class TaskingHandoffBundleImportDryRunAnalyzer
+{
+    /// <summary>
+    /// Build the four-entry restore plan in the canonical order
+    /// (task_packet, preview, checklist, handoff). Caller is responsible for
+    /// only invoking this when the verify result is <c>valid == true</c>;
+    /// when verify failed, the command layer emits an empty plan instead.
+    /// </summary>
+    public static IReadOnlyList<RestorePlanEntry> BuildRestorePlan(
+        TaskingHandoffBundleArtifact bundle,
+        IReadOnlyList<VerifyCheck> verifyChecks)
+    {
+        ArgumentNullException.ThrowIfNull(bundle);
+        ArgumentNullException.ThrowIfNull(verifyChecks);
+
+        return new[]
+        {
+            BuildEntry(
+                Roles.TaskPacket,
+                bundle.SourceTaskPacketPath,
+                bundle.SourceTaskPacketSha256,
+                verifyChecks,
+                VerifyCheckIds.TaskPacketFileExists,
+                VerifyCheckIds.TaskPacketHashMatches),
+            BuildEntry(
+                Roles.Preview,
+                bundle.SourcePreviewPath,
+                bundle.SourcePreviewSha256,
+                verifyChecks,
+                VerifyCheckIds.PreviewFileExists,
+                VerifyCheckIds.PreviewHashMatches),
+            BuildEntry(
+                Roles.Checklist,
+                bundle.SourceChecklistPath,
+                bundle.SourceChecklistSha256,
+                verifyChecks,
+                VerifyCheckIds.ChecklistFileExists,
+                VerifyCheckIds.ChecklistHashMatches),
+            BuildEntry(
+                Roles.Handoff,
+                bundle.SourceHandoffPath,
+                bundle.SourceHandoffSha256,
+                verifyChecks,
+                VerifyCheckIds.HandoffFileExists,
+                VerifyCheckIds.HandoffHashMatches)
+        };
+    }
+
+    /// <summary>
+    /// Project the failing-check ids out of a verify check list, preserving
+    /// the analyzer's stable order. Used both for the
+    /// <see cref="TaskingHandoffBundleImportDryRunVerifySummary.FailedCheckIds"/>
+    /// projection and for the human-readable error list.
+    /// </summary>
+    public static IReadOnlyList<string> ExtractFailedCheckIds(IReadOnlyList<VerifyCheck> checks)
+    {
+        ArgumentNullException.ThrowIfNull(checks);
+        var ids = new List<string>();
+        foreach (var check in checks)
+        {
+            if (!check.Passed)
+            {
+                ids.Add(check.Id);
+            }
+        }
+
+        return ids;
+    }
+
+    private static RestorePlanEntry BuildEntry(
+        string role,
+        string? recordedPath,
+        string? recordedSha256,
+        IReadOnlyList<VerifyCheck> verifyChecks,
+        string fileExistsId,
+        string hashMatchesId)
+    {
+        var fileExistsCheck = FindCheck(verifyChecks, fileExistsId);
+        var hashMatchesCheck = FindCheck(verifyChecks, hashMatchesId);
+
+        var (currentStatus, action) = ResolveStatusAndAction(fileExistsCheck, hashMatchesCheck);
+
+        return new RestorePlanEntry
+        {
+            Role = role,
+            RecordedPath = recordedPath ?? string.Empty,
+            RecordedSha256 = recordedSha256 ?? string.Empty,
+            CurrentStatus = currentStatus,
+            DryRunAction = action
+        };
+    }
+
+    private static (string currentStatus, string action) ResolveStatusAndAction(
+        VerifyCheck? fileExistsCheck,
+        VerifyCheck? hashMatchesCheck)
+    {
+        var fileExists = fileExistsCheck?.Passed ?? false;
+        var hashMatches = hashMatchesCheck?.Passed ?? false;
+
+        if (fileExists && hashMatches)
+        {
+            return (CurrentStatuses.AlreadyPresentAndMatching, Actions.NoOpAlreadyMatches);
+        }
+
+        if (fileExists && !hashMatches)
+        {
+            return (CurrentStatuses.PresentButHashDiffers, Actions.WouldOverwriteWithRecordedContent);
+        }
+
+        return (CurrentStatuses.Missing, Actions.WouldRecreateFromRecordedContent);
+    }
+
+    private static VerifyCheck? FindCheck(IReadOnlyList<VerifyCheck> checks, string id)
+    {
+        foreach (var check in checks)
+        {
+            if (string.Equals(check.Id, id, StringComparison.Ordinal))
+            {
+                return check;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleImportDryRunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleImportDryRunCommand.cs
@@ -1,0 +1,417 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+using DryRunConstants = TaskingHandoffBundleImportDryRunConstants;
+
+/// <summary>
+/// G198: <c>intent-cli tasking handoff-bundle-import-dry-run</c>. A LOCAL
+/// dry-run import/restore plan emitter that consumes a G194
+/// <see cref="TaskingHandoffBundleArtifact"/> handoff bundle artifact (JSON),
+/// runs the existing G196/G197
+/// <see cref="TaskingHandoffBundleVerifyAnalyzer"/> verification, and prints
+/// either a deterministic restore plan (status=ok) or a verify-failure status
+/// (status=verify_failed/missing_bundle/malformed_bundle) to STDOUT.
+///
+/// <para>
+/// The command performs no GitHub network calls, applies no labels, launches
+/// no provider processes, does NOT touch <c>.intent-cli/queue-state.json</c>
+/// or <c>.intent-cli/runs.jsonl</c>, does NOT create branches or worktrees,
+/// and does NOT write any artifact file — even on the valid restore-plan
+/// path. The restore plan is descriptive only; the bundle does not carry
+/// artifact bytes, only paths and sha256 values, so the listed dry-run
+/// actions are a contractual placeholder for a future real restore
+/// (out-of-scope this slice). See
+/// <see cref="DryRunConstants.RestorePlanDisclaimer"/>.
+/// </para>
+///
+/// Sits beside G190 <c>handoff</c>, G191 <c>task-packet</c>, G192
+/// <c>task-packet-preview</c>, G193 <c>task-packet-checklist</c>, G194
+/// <c>handoff-bundle</c>, G195 <c>handoff-bundle-inspect</c>, and G196/G197
+/// <c>handoff-bundle-verify</c> under the same <c>tasking</c> group. It does
+/// NOT replace any of those commands.
+///
+/// Network-mutation invariance: this command's hot path contains no
+/// <c>Process.Start</c>, no shell-out to <c>gh</c>, no <c>git</c> shell-out,
+/// and no provider launcher. The associated tests validate the
+/// no-provider-launch invariant via the <see cref="NestedProviderLauncher"/>
+/// sentinel and a source-scan assertion.
+///
+/// Exit code: <c>0</c> iff the bundle parses, verify reports
+/// <c>valid == true</c>, and the restore plan was successfully built;
+/// <c>1</c> otherwise (including missing flag, missing file, parse failure,
+/// any verify check failure).
+/// </summary>
+internal static class TaskingHandoffBundleImportDryRunCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private static readonly JsonSerializerOptions JsonOutputOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    /// <summary>
+    /// Test seam mirroring G190/G191/G192/G193/G194/G195/G196 <c>NestedProviderLauncher</c>.
+    /// G198 must NEVER invoke this delegate. Tests register a sentinel that
+    /// flips a flag if invoked; the dry-run path leaves it untouched.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var fromBundle, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedFromBundle = Path.GetFullPath(fromBundle);
+
+        if (!File.Exists(resolvedFromBundle))
+        {
+            var missingResult = new TaskingHandoffBundleImportDryRunResult
+            {
+                BundlePath = fromBundle,
+                BundleSha256 = null,
+                Domain = null,
+                Status = DryRunConstants.Statuses.MissingBundle,
+                Errors = new[]
+                {
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Bundle path does not exist: {0}",
+                        fromBundle)
+                },
+                VerifySummary = new TaskingHandoffBundleImportDryRunVerifySummary
+                {
+                    Valid = false,
+                    FailedCheckIds = new[]
+                    {
+                        TaskingHandoffBundleVerifyConstants.CheckIds.BundlePathPresentAndReadable
+                    }
+                },
+                RestorePlan = Array.Empty<RestorePlanEntry>(),
+                RestorePlanDisclaimer = DryRunConstants.RestorePlanDisclaimer,
+                SummaryLine = BuildSummaryLine(domain: null, status: DryRunConstants.Statuses.MissingBundle)
+            };
+            WriteResult(writer, missingResult, format);
+            return 1;
+        }
+
+        byte[] bundleBytes;
+        try
+        {
+            bundleBytes = File.ReadAllBytes(resolvedFromBundle);
+        }
+        catch (Exception exception)
+        {
+            var readFailResult = new TaskingHandoffBundleImportDryRunResult
+            {
+                BundlePath = fromBundle,
+                BundleSha256 = null,
+                Domain = null,
+                Status = DryRunConstants.Statuses.MissingBundle,
+                Errors = new[]
+                {
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Bundle path could not be read: {0} ({1})",
+                        fromBundle,
+                        exception.Message)
+                },
+                VerifySummary = new TaskingHandoffBundleImportDryRunVerifySummary
+                {
+                    Valid = false,
+                    FailedCheckIds = new[]
+                    {
+                        TaskingHandoffBundleVerifyConstants.CheckIds.BundlePathPresentAndReadable
+                    }
+                },
+                RestorePlan = Array.Empty<RestorePlanEntry>(),
+                RestorePlanDisclaimer = DryRunConstants.RestorePlanDisclaimer,
+                SummaryLine = BuildSummaryLine(domain: null, status: DryRunConstants.Statuses.MissingBundle)
+            };
+            WriteResult(writer, readFailResult, format);
+            return 1;
+        }
+
+        var bundleSha256 = IssuePrepareCommand.ComputeSha256Hex(bundleBytes);
+
+        TaskingHandoffBundleArtifact? bundle;
+        try
+        {
+            bundle = JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(bundleBytes);
+        }
+        catch (JsonException exception)
+        {
+            var malformedResult = new TaskingHandoffBundleImportDryRunResult
+            {
+                BundlePath = fromBundle,
+                BundleSha256 = bundleSha256,
+                Domain = null,
+                Status = DryRunConstants.Statuses.MalformedBundle,
+                Errors = new[]
+                {
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Failed to parse bundle JSON as TaskingHandoffBundleArtifact: {0}",
+                        exception.Message)
+                },
+                VerifySummary = new TaskingHandoffBundleImportDryRunVerifySummary
+                {
+                    Valid = false,
+                    FailedCheckIds = new[]
+                    {
+                        TaskingHandoffBundleVerifyConstants.CheckIds.BundleJsonParses
+                    }
+                },
+                RestorePlan = Array.Empty<RestorePlanEntry>(),
+                RestorePlanDisclaimer = DryRunConstants.RestorePlanDisclaimer,
+                SummaryLine = BuildSummaryLine(domain: null, status: DryRunConstants.Statuses.MalformedBundle)
+            };
+            WriteResult(writer, malformedResult, format);
+            return 1;
+        }
+
+        if (bundle is null)
+        {
+            var nullResult = new TaskingHandoffBundleImportDryRunResult
+            {
+                BundlePath = fromBundle,
+                BundleSha256 = bundleSha256,
+                Domain = null,
+                Status = DryRunConstants.Statuses.MalformedBundle,
+                Errors = new[] { "Bundle JSON deserialized to a null bundle." },
+                VerifySummary = new TaskingHandoffBundleImportDryRunVerifySummary
+                {
+                    Valid = false,
+                    FailedCheckIds = new[]
+                    {
+                        TaskingHandoffBundleVerifyConstants.CheckIds.BundleJsonParses
+                    }
+                },
+                RestorePlan = Array.Empty<RestorePlanEntry>(),
+                RestorePlanDisclaimer = DryRunConstants.RestorePlanDisclaimer,
+                SummaryLine = BuildSummaryLine(domain: null, status: DryRunConstants.Statuses.MalformedBundle)
+            };
+            WriteResult(writer, nullResult, format);
+            return 1;
+        }
+
+        // Reuse G197 file observation + G196/G197 analyzer, same as
+        // TaskingHandoffBundleVerifyCommand.
+        var observations =
+            TaskingHandoffBundleVerifyCommand.ObserveReferencedSourceArtifacts(bundle);
+        var verifyChecks = TaskingHandoffBundleVerifyAnalyzer.BuildChecks(bundle, observations);
+        var valid = verifyChecks.All(c => c.Passed);
+
+        var failedCheckIds =
+            TaskingHandoffBundleImportDryRunAnalyzer.ExtractFailedCheckIds(verifyChecks);
+
+        if (!valid)
+        {
+            var verifyFailedResult = new TaskingHandoffBundleImportDryRunResult
+            {
+                BundlePath = fromBundle,
+                BundleSha256 = bundleSha256,
+                Domain = bundle.Domain,
+                Status = DryRunConstants.Statuses.VerifyFailed,
+                Errors = ExtractErrorMessages(verifyChecks),
+                VerifySummary = new TaskingHandoffBundleImportDryRunVerifySummary
+                {
+                    Valid = false,
+                    FailedCheckIds = failedCheckIds
+                },
+                RestorePlan = Array.Empty<RestorePlanEntry>(),
+                RestorePlanDisclaimer = DryRunConstants.RestorePlanDisclaimer,
+                SummaryLine = BuildSummaryLine(bundle.Domain, DryRunConstants.Statuses.VerifyFailed)
+            };
+            WriteResult(writer, verifyFailedResult, format);
+            return 1;
+        }
+
+        var restorePlan = TaskingHandoffBundleImportDryRunAnalyzer.BuildRestorePlan(
+            bundle,
+            verifyChecks);
+
+        var okResult = new TaskingHandoffBundleImportDryRunResult
+        {
+            BundlePath = fromBundle,
+            BundleSha256 = bundleSha256,
+            Domain = bundle.Domain,
+            Status = DryRunConstants.Statuses.Ok,
+            Errors = Array.Empty<string>(),
+            VerifySummary = new TaskingHandoffBundleImportDryRunVerifySummary
+            {
+                Valid = true,
+                FailedCheckIds = Array.Empty<string>()
+            },
+            RestorePlan = restorePlan,
+            RestorePlanDisclaimer = DryRunConstants.RestorePlanDisclaimer,
+            SummaryLine = BuildSummaryLine(bundle.Domain, DryRunConstants.Statuses.Ok)
+        };
+
+        WriteResult(writer, okResult, format);
+        return 0;
+    }
+
+    private static IReadOnlyList<string> ExtractErrorMessages(IReadOnlyList<VerifyCheck> checks)
+    {
+        var errors = new List<string>();
+        foreach (var check in checks)
+        {
+            if (!check.Passed)
+            {
+                errors.Add($"{check.Id}: {check.Detail}");
+            }
+        }
+
+        return errors;
+    }
+
+    private static string BuildSummaryLine(string? domain, string status)
+    {
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            DryRunConstants.SummaryLineFormat,
+            domain ?? "(unavailable)",
+            status);
+    }
+
+    private static void WriteResult(
+        TextWriter writer,
+        TaskingHandoffBundleImportDryRunResult result,
+        string format)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOutputOptions));
+        }
+        else
+        {
+            WriteTextResult(writer, result);
+        }
+    }
+
+    private static void WriteTextResult(
+        TextWriter writer,
+        TaskingHandoffBundleImportDryRunResult result)
+    {
+        writer.WriteLine(result.SummaryLine);
+        writer.WriteLine();
+        writer.WriteLine($"Bundle path: {result.BundlePath}");
+        writer.WriteLine($"Bundle sha256: {result.BundleSha256 ?? "(unavailable)"}");
+        writer.WriteLine($"Domain: {result.Domain ?? "(unavailable)"}");
+        writer.WriteLine($"Status: {result.Status}");
+        writer.WriteLine($"Verify valid: {result.VerifySummary.Valid}");
+
+        if (result.VerifySummary.FailedCheckIds.Count > 0)
+        {
+            writer.WriteLine("Failed verify check ids:");
+            foreach (var id in result.VerifySummary.FailedCheckIds)
+            {
+                writer.WriteLine($"- {id}");
+            }
+        }
+
+        if (result.Errors.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("Errors:");
+            foreach (var err in result.Errors)
+            {
+                writer.WriteLine($"- {err}");
+            }
+        }
+
+        writer.WriteLine();
+        if (result.RestorePlan.Count > 0)
+        {
+            writer.WriteLine("Restore plan (DRY-RUN — no action performed):");
+            foreach (var entry in result.RestorePlan)
+            {
+                writer.WriteLine($"- role: {entry.Role}");
+                writer.WriteLine($"  recorded_path: {entry.RecordedPath}");
+                writer.WriteLine($"  recorded_sha256: {entry.RecordedSha256}");
+                writer.WriteLine($"  current_status: {entry.CurrentStatus}");
+                writer.WriteLine($"  dry_run_action: {entry.DryRunAction}");
+            }
+        }
+        else
+        {
+            writer.WriteLine("Restore plan: (empty — bundle did not pass verify)");
+        }
+
+        writer.WriteLine();
+        writer.WriteLine(result.RestorePlanDisclaimer);
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string fromBundle,
+        out string format,
+        out string error)
+    {
+        fromBundle = string.Empty;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-bundle":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-bundle requires a non-empty value.";
+                        return false;
+                    }
+
+                    fromBundle = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error =
+                        $"Unknown argument '{argument}'. Supported: --from-bundle, --format.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromBundle))
+        {
+            error = "--from-bundle is required.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleImportDryRunResult.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleImportDryRunResult.cs
@@ -1,0 +1,153 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G198 dry-run import/restore result. Snake_case JSON shape that
+/// <c>intent-cli tasking handoff-bundle-import-dry-run</c> emits to STDOUT when
+/// <c>--format json</c> is requested. Round-trippable through
+/// <see cref="System.Text.Json.JsonSerializer"/>.
+///
+/// <para>
+/// This command is a DRY-RUN only — the result describes what a future real
+/// restore would do, but the command itself never overwrites any file, never
+/// publishes any GitHub issue, never mutates queue/runs state, never launches
+/// providers, and never creates branches/worktrees. See
+/// <see cref="TaskingHandoffBundleImportDryRunConstants.RestorePlanDisclaimer"/>.
+/// </para>
+/// </summary>
+internal sealed record TaskingHandoffBundleImportDryRunResult
+{
+    [JsonPropertyName("bundle_path")]
+    public required string BundlePath { get; init; }
+
+    [JsonPropertyName("bundle_sha256")]
+    public required string? BundleSha256 { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string? Domain { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("errors")]
+    public required IReadOnlyList<string> Errors { get; init; }
+
+    [JsonPropertyName("verify_summary")]
+    public required TaskingHandoffBundleImportDryRunVerifySummary VerifySummary { get; init; }
+
+    [JsonPropertyName("restore_plan")]
+    public required IReadOnlyList<RestorePlanEntry> RestorePlan { get; init; }
+
+    [JsonPropertyName("restore_plan_disclaimer")]
+    public required string RestorePlanDisclaimer { get; init; }
+
+    [JsonPropertyName("summary_line")]
+    public required string SummaryLine { get; init; }
+}
+
+/// <summary>
+/// G198 — derived projection of the G196/G197 verify result. Mirrors the
+/// minimum fields automation logs need without re-emitting the full verify
+/// check list.
+/// </summary>
+internal sealed record TaskingHandoffBundleImportDryRunVerifySummary
+{
+    [JsonPropertyName("valid")]
+    public required bool Valid { get; init; }
+
+    [JsonPropertyName("failed_check_ids")]
+    public required IReadOnlyList<string> FailedCheckIds { get; init; }
+}
+
+/// <summary>
+/// G198 single restore-plan entry. One per referenced source artifact in the
+/// bundle (task_packet, preview, checklist, handoff). All three string fields
+/// are drawn from <see cref="TaskingHandoffBundleImportDryRunConstants"/> to
+/// lock the contract against drift.
+/// </summary>
+internal sealed record RestorePlanEntry
+{
+    [JsonPropertyName("role")]
+    public required string Role { get; init; }
+
+    [JsonPropertyName("recorded_path")]
+    public required string RecordedPath { get; init; }
+
+    [JsonPropertyName("recorded_sha256")]
+    public required string RecordedSha256 { get; init; }
+
+    [JsonPropertyName("current_status")]
+    public required string CurrentStatus { get; init; }
+
+    [JsonPropertyName("dry_run_action")]
+    public required string DryRunAction { get; init; }
+}
+
+/// <summary>
+/// G198 stable constants for the dry-run command's output contract. Status
+/// values, role names, current-status enums, dry-run-action enums, and the
+/// disclaimer text are all centralized here so future drift breaks the
+/// regression test deterministically.
+/// </summary>
+internal static class TaskingHandoffBundleImportDryRunConstants
+{
+    /// <summary>
+    /// Stable disclaimer string emitted both in the text output and in the
+    /// JSON <c>restore_plan_disclaimer</c> field. Tests assert the literal
+    /// "DRY-RUN ONLY: this is a restore plan preview" substring.
+    /// </summary>
+    public const string RestorePlanDisclaimer =
+        "DRY-RUN ONLY: this is a restore plan preview. The handoff bundle records artifact paths and sha256 values, not artifact bytes; a future real restore would need access to the original referenced files (or a separate content store) to perform the listed actions. This command performs none of them.";
+
+    /// <summary>
+    /// Stable summary line — same structural shape as the G196 verify
+    /// summary. The <c>{0}</c> placeholder is the bundle's domain (or
+    /// <c>(unavailable)</c> when not parseable) and <c>{1}</c> is the status
+    /// enum value. Tests assert the literal phrase
+    /// "UNPUBLISHED, local-only, not automation-visible".
+    /// </summary>
+    public const string SummaryLineFormat =
+        "Tasking handoff bundle import dry-run for {0} — UNPUBLISHED, local-only, not automation-visible. status={1}.";
+
+    public const string UnpublishedStatusPhrase =
+        "UNPUBLISHED, local-only, not automation-visible";
+
+    public static class Statuses
+    {
+        public const string Ok = "ok";
+        public const string VerifyFailed = "verify_failed";
+        public const string MissingBundle = "missing_bundle";
+        public const string MalformedBundle = "malformed_bundle";
+    }
+
+    public static class Roles
+    {
+        public const string TaskPacket = "task_packet";
+        public const string Preview = "preview";
+        public const string Checklist = "checklist";
+        public const string Handoff = "handoff";
+
+        public static readonly IReadOnlyList<string> InOrder = new[]
+        {
+            TaskPacket,
+            Preview,
+            Checklist,
+            Handoff
+        };
+    }
+
+    public static class CurrentStatuses
+    {
+        public const string AlreadyPresentAndMatching = "already_present_and_matching";
+        public const string PresentButHashDiffers = "present_but_hash_differs";
+        public const string Missing = "missing";
+    }
+
+    public static class Actions
+    {
+        public const string NoOpAlreadyMatches = "no_op_already_matches";
+        public const string WouldOverwriteWithRecordedContent = "would_overwrite_with_recorded_content";
+        public const string WouldRecreateFromRecordedContent = "would_recreate_from_recorded_content";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleVerifyCommand.cs
@@ -168,8 +168,12 @@ internal static class TaskingHandoffBundleVerifyCommand
     /// throws (locked, permission denied), the observation records the
     /// message and the analyzer keeps file_exists=true while failing
     /// hash_matches.
+    ///
+    /// G198 — promoted from <c>private</c> to <c>internal</c> so the dry-run
+    /// import command can reuse the same observation pipeline before reusing
+    /// <see cref="TaskingHandoffBundleVerifyAnalyzer.BuildChecks"/>.
     /// </summary>
-    private static SourceArtifactObservations ObserveReferencedSourceArtifacts(
+    internal static SourceArtifactObservations ObserveReferencedSourceArtifacts(
         TaskingHandoffBundleArtifact bundle)
     {
         return new SourceArtifactObservations

--- a/tests/IntentSystem.Cli.Tests/TaskingHandoffBundleImportDryRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskingHandoffBundleImportDryRunCommandTests.cs
@@ -1,0 +1,724 @@
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G198 — coverage for <c>intent-cli tasking handoff-bundle-import-dry-run</c>.
+/// Class name contains <c>Tasking</c>, <c>Handoff</c>, <c>Bundle</c>,
+/// <c>Import</c>, and <c>DryRun</c> so reviewers can match the issue's
+/// recommended <c>~TaskingHandoffBundle</c> filter.
+/// </summary>
+public sealed class TaskingHandoffBundleImportDryRunCommandTests : IDisposable
+{
+    private readonly Func<bool>? originalLauncher;
+
+    public TaskingHandoffBundleImportDryRunCommandTests()
+    {
+        originalLauncher = TaskingHandoffBundleImportDryRunCommand.NestedProviderLauncher;
+    }
+
+    public void Dispose()
+    {
+        TaskingHandoffBundleImportDryRunCommand.NestedProviderLauncher = originalLauncher;
+    }
+
+    [Fact]
+    public void Execute_GivenValidBundle_ReturnsZeroAndEmitsRestorePlan()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("happy");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleImportDryRunCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains(
+            "UNPUBLISHED, local-only, not automation-visible",
+            output,
+            StringComparison.Ordinal);
+        Assert.Contains("status=ok", output, StringComparison.Ordinal);
+
+        Assert.Contains($"role: {TaskingHandoffBundleImportDryRunConstants.Roles.TaskPacket}", output, StringComparison.Ordinal);
+        Assert.Contains($"role: {TaskingHandoffBundleImportDryRunConstants.Roles.Preview}", output, StringComparison.Ordinal);
+        Assert.Contains($"role: {TaskingHandoffBundleImportDryRunConstants.Roles.Checklist}", output, StringComparison.Ordinal);
+        Assert.Contains($"role: {TaskingHandoffBundleImportDryRunConstants.Roles.Handoff}", output, StringComparison.Ordinal);
+
+        Assert.Contains(
+            $"current_status: {TaskingHandoffBundleImportDryRunConstants.CurrentStatuses.AlreadyPresentAndMatching}",
+            output,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            $"dry_run_action: {TaskingHandoffBundleImportDryRunConstants.Actions.NoOpAlreadyMatches}",
+            output,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenValidBundle_RestorePlanContainsAllFourRolesInOrder()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("order");
+
+        var (exit, output) = RunJson(workspace, bundlePath);
+        Assert.Equal(0, exit);
+
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleImportDryRunResult>(output);
+        Assert.NotNull(result);
+        var plan = result!.RestorePlan;
+        Assert.Equal(4, plan.Count);
+        Assert.Equal(TaskingHandoffBundleImportDryRunConstants.Roles.TaskPacket, plan[0].Role);
+        Assert.Equal(TaskingHandoffBundleImportDryRunConstants.Roles.Preview, plan[1].Role);
+        Assert.Equal(TaskingHandoffBundleImportDryRunConstants.Roles.Checklist, plan[2].Role);
+        Assert.Equal(TaskingHandoffBundleImportDryRunConstants.Roles.Handoff, plan[3].Role);
+    }
+
+    [Fact]
+    public void Execute_GivenValidBundle_DisclaimerIsPresentInTextAndJson()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("disclaimer");
+
+        using (var textWriter = new StringWriter())
+        {
+            var textExit = TaskingHandoffBundleImportDryRunCommand.Execute(
+                workspace.Context,
+                new[] { "--from-bundle", bundlePath, "--format", "text" },
+                textWriter);
+            Assert.Equal(0, textExit);
+            Assert.Contains(
+                "DRY-RUN ONLY: this is a restore plan preview",
+                textWriter.ToString(),
+                StringComparison.Ordinal);
+        }
+
+        var (exit, output) = RunJson(workspace, bundlePath);
+        Assert.Equal(0, exit);
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleImportDryRunResult>(output);
+        Assert.NotNull(result);
+        Assert.Contains(
+            "DRY-RUN ONLY: this is a restore plan preview",
+            result!.RestorePlanDisclaimer,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenValidBundle_JsonResultRoundTripsStably()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("rt");
+
+        var (exit, output) = RunJson(workspace, bundlePath);
+        Assert.Equal(0, exit);
+
+        var first = JsonSerializer.Deserialize<TaskingHandoffBundleImportDryRunResult>(output);
+        Assert.NotNull(first);
+        var reserialized = JsonSerializer.Serialize(first);
+        var second = JsonSerializer.Deserialize<TaskingHandoffBundleImportDryRunResult>(reserialized);
+        Assert.NotNull(second);
+
+        Assert.Equal(first!.BundlePath, second!.BundlePath);
+        Assert.Equal(first.BundleSha256, second.BundleSha256);
+        Assert.Equal(first.Domain, second.Domain);
+        Assert.Equal(first.Status, second.Status);
+        Assert.Equal(first.Errors, second.Errors);
+        Assert.Equal(first.VerifySummary.Valid, second.VerifySummary.Valid);
+        Assert.Equal(first.VerifySummary.FailedCheckIds, second.VerifySummary.FailedCheckIds);
+        Assert.Equal(first.RestorePlan.Count, second.RestorePlan.Count);
+        for (var i = 0; i < first.RestorePlan.Count; i++)
+        {
+            Assert.Equal(first.RestorePlan[i].Role, second.RestorePlan[i].Role);
+            Assert.Equal(first.RestorePlan[i].RecordedPath, second.RestorePlan[i].RecordedPath);
+            Assert.Equal(first.RestorePlan[i].RecordedSha256, second.RestorePlan[i].RecordedSha256);
+            Assert.Equal(first.RestorePlan[i].CurrentStatus, second.RestorePlan[i].CurrentStatus);
+            Assert.Equal(first.RestorePlan[i].DryRunAction, second.RestorePlan[i].DryRunAction);
+        }
+
+        Assert.Equal(first.RestorePlanDisclaimer, second.RestorePlanDisclaimer);
+        Assert.Equal(first.SummaryLine, second.SummaryLine);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_IncludesStatusAndArtifactPathsForAutomation()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("automation");
+        var bundle = ReadBundle(bundlePath);
+
+        var (exit, output) = RunJson(workspace, bundlePath);
+        Assert.Equal(0, exit);
+
+        using var doc = JsonDocument.Parse(output);
+        var root = doc.RootElement;
+
+        Assert.Equal(
+            TaskingHandoffBundleImportDryRunConstants.Statuses.Ok,
+            root.GetProperty("status").GetString());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("errors").ValueKind);
+        Assert.Equal(bundlePath, root.GetProperty("bundle_path").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("bundle_sha256").GetString()));
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+
+        var plan = root.GetProperty("restore_plan");
+        Assert.Equal(4, plan.GetArrayLength());
+
+        var paths = new List<string>();
+        foreach (var entry in plan.EnumerateArray())
+        {
+            paths.Add(entry.GetProperty("recorded_path").GetString() ?? string.Empty);
+        }
+
+        Assert.Contains(bundle.SourceTaskPacketPath, paths);
+        Assert.Contains(bundle.SourcePreviewPath, paths);
+        Assert.Contains(bundle.SourceChecklistPath, paths);
+        Assert.Contains(bundle.SourceHandoffPath, paths);
+    }
+
+    [Fact]
+    public void Execute_GivenReferencedTaskPacketDeleted_FailsVerifyAndExitsNonZero()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("del-tp");
+        var bundle = ReadBundle(bundlePath);
+        File.Delete(bundle.SourceTaskPacketPath);
+
+        var (exit, output) = RunJson(workspace, bundlePath);
+        Assert.Equal(1, exit);
+
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleImportDryRunResult>(output);
+        Assert.NotNull(result);
+        Assert.Equal(TaskingHandoffBundleImportDryRunConstants.Statuses.VerifyFailed, result!.Status);
+        Assert.Empty(result.RestorePlan);
+        Assert.False(result.VerifySummary.Valid);
+
+        var failedIds = result.VerifySummary.FailedCheckIds;
+        Assert.Contains(
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketFileExists,
+            failedIds);
+        Assert.Contains(
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches,
+            failedIds);
+
+        var anyHashErr = result.Errors.Any(e =>
+            e.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketFileExists, StringComparison.Ordinal)
+            || e.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches, StringComparison.Ordinal));
+        Assert.True(anyHashErr, "Expected errors to mention task_packet hash/exists check id.");
+
+        Assert.DoesNotContain("\"role\":", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenReferencedPreviewEdited_FailsVerifyAndExitsNonZero()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("edit-pv");
+        var bundle = ReadBundle(bundlePath);
+        AppendByte(bundle.SourcePreviewPath);
+
+        var (exit, output) = RunJson(workspace, bundlePath);
+        Assert.Equal(1, exit);
+
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleImportDryRunResult>(output);
+        Assert.NotNull(result);
+        Assert.Equal(TaskingHandoffBundleImportDryRunConstants.Statuses.VerifyFailed, result!.Status);
+        Assert.Empty(result.RestorePlan);
+        Assert.False(result.VerifySummary.Valid);
+        Assert.Contains(
+            TaskingHandoffBundleVerifyConstants.CheckIds.PreviewHashMatches,
+            result.VerifySummary.FailedCheckIds);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingBundleFile_ReturnsNonZero_StatusMissingBundle()
+    {
+        using var workspace = new DryRunWorkspace();
+        var missing = "/tmp/this-bundle-does-not-exist-g198.json";
+
+        var (exit, output) = RunJson(workspace, missing);
+        Assert.Equal(1, exit);
+
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleImportDryRunResult>(output);
+        Assert.NotNull(result);
+        Assert.Equal(
+            TaskingHandoffBundleImportDryRunConstants.Statuses.MissingBundle,
+            result!.Status);
+        Assert.Empty(result.RestorePlan);
+        Assert.Contains(result.Errors, e => e.Contains(missing, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedBundleJson_ReturnsNonZero_StatusMalformedBundle()
+    {
+        using var workspace = new DryRunWorkspace();
+        var malformed = workspace.GetPath("garbage-bundle.json");
+        File.WriteAllText(malformed, "{ this is not : valid json,");
+
+        var (exit, output) = RunJson(workspace, malformed);
+        Assert.Equal(1, exit);
+
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleImportDryRunResult>(output);
+        Assert.NotNull(result);
+        Assert.Equal(
+            TaskingHandoffBundleImportDryRunConstants.Statuses.MalformedBundle,
+            result!.Status);
+        Assert.Empty(result.RestorePlan);
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e =>
+            e.Contains("parse", StringComparison.OrdinalIgnoreCase)
+            || e.Contains("JSON", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Execute_GivenBundleWithWrongStatus_FailsVerify_NoRestorePlan()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("wrong-status-base");
+        var json = File.ReadAllText(bundlePath);
+        var tampered = json.Replace(
+            "\"bundle_status\": \"local_only\"",
+            "\"bundle_status\": \"published\"",
+            StringComparison.Ordinal);
+        Assert.NotEqual(json, tampered);
+        var tamperedPath = workspace.GetPath("bundle-wrong-status.json");
+        File.WriteAllText(tamperedPath, tampered);
+
+        var (exit, output) = RunJson(workspace, tamperedPath);
+        Assert.Equal(1, exit);
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleImportDryRunResult>(output);
+        Assert.NotNull(result);
+        Assert.Equal(
+            TaskingHandoffBundleImportDryRunConstants.Statuses.VerifyFailed,
+            result!.Status);
+        Assert.Empty(result.RestorePlan);
+        Assert.Contains(
+            TaskingHandoffBundleVerifyConstants.CheckIds.BundleStatusLocalOnly,
+            result.VerifySummary.FailedCheckIds);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFlag_ReturnsNonZero()
+    {
+        using var workspace = new DryRunWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleImportDryRunCommand.Execute(
+            workspace.Context,
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-bundle", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsNonZero()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("unknown");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleImportDryRunCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath, "--bogus", "value" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesToQueueStateOrRunsLog()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("no-mut");
+
+        var queueStatePath = workspace.Context.GetQueueStatePath();
+        var runsLogPath = workspace.Context.GetRunLogPath();
+
+        var queueBytes = Encoding.UTF8.GetBytes("{\"schema_version\":\"1\",\"items\":[]}\n");
+        var runsBytes = Encoding.UTF8.GetBytes("{\"event\":\"sentinel\",\"ts\":\"2026-04-29T00:00:00Z\"}\n");
+        Directory.CreateDirectory(Path.GetDirectoryName(queueStatePath)!);
+        File.WriteAllBytes(queueStatePath, queueBytes);
+        File.WriteAllBytes(runsLogPath, runsBytes);
+
+        var queueBefore = File.ReadAllBytes(queueStatePath);
+        var runsBefore = File.ReadAllBytes(runsLogPath);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleImportDryRunCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var queueAfter = File.ReadAllBytes(queueStatePath);
+        var runsAfter = File.ReadAllBytes(runsLogPath);
+        Assert.Equal(queueBefore, queueAfter);
+        Assert.Equal(runsBefore, runsAfter);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesAnyArtifactFile_NeverOverwritesAnything()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("no-write");
+
+        var snapshotBefore = workspace.SnapshotAllFiles();
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleImportDryRunCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var snapshotAfter = workspace.SnapshotAllFiles();
+        Assert.Equal(snapshotBefore.Count, snapshotAfter.Count);
+        foreach (var (path, contentBefore) in snapshotBefore)
+        {
+            Assert.True(snapshotAfter.ContainsKey(path), $"File disappeared: {path}");
+            Assert.Equal(contentBefore, snapshotAfter[path]);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesProvider_NoProcessStartInNewSurface()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("no-provider");
+
+        var launcherInvoked = false;
+        TaskingHandoffBundleImportDryRunCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleImportDryRunCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(launcherInvoked);
+
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        var commandFile = Path.Combine(commandsDir, "TaskingHandoffBundleImportDryRunCommand.cs");
+        var analyzerFile = Path.Combine(commandsDir, "TaskingHandoffBundleImportDryRunAnalyzer.cs");
+        var resultFile = Path.Combine(commandsDir, "TaskingHandoffBundleImportDryRunResult.cs");
+        if (!File.Exists(commandFile) || !File.Exists(analyzerFile) || !File.Exists(resultFile))
+        {
+            return;
+        }
+
+        foreach (var path in new[] { commandFile, analyzerFile, resultFile })
+        {
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("Process.Start(", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverCreatesBranchOrWorktree_NoGitInvocationInNewSurface()
+    {
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        var commandFile = Path.Combine(commandsDir, "TaskingHandoffBundleImportDryRunCommand.cs");
+        var analyzerFile = Path.Combine(commandsDir, "TaskingHandoffBundleImportDryRunAnalyzer.cs");
+        var resultFile = Path.Combine(commandsDir, "TaskingHandoffBundleImportDryRunResult.cs");
+
+        Assert.True(File.Exists(commandFile), $"Missing command file at {commandFile}");
+        Assert.True(File.Exists(analyzerFile), $"Missing analyzer file at {analyzerFile}");
+        Assert.True(File.Exists(resultFile), $"Missing result file at {resultFile}");
+
+        foreach (var path in new[] { commandFile, analyzerFile, resultFile })
+        {
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("Process.Start(\"git", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("git checkout", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("git worktree", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_RestorePlanEntryFieldsAreStableConstants_RoleStatusActionLockedAgainstDrift()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("locked");
+
+        var (exit, output) = RunJson(workspace, bundlePath);
+        Assert.Equal(0, exit);
+
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleImportDryRunResult>(output);
+        Assert.NotNull(result);
+
+        var allowedRoles = new HashSet<string>(StringComparer.Ordinal)
+        {
+            TaskingHandoffBundleImportDryRunConstants.Roles.TaskPacket,
+            TaskingHandoffBundleImportDryRunConstants.Roles.Preview,
+            TaskingHandoffBundleImportDryRunConstants.Roles.Checklist,
+            TaskingHandoffBundleImportDryRunConstants.Roles.Handoff
+        };
+        var allowedStatuses = new HashSet<string>(StringComparer.Ordinal)
+        {
+            TaskingHandoffBundleImportDryRunConstants.CurrentStatuses.AlreadyPresentAndMatching,
+            TaskingHandoffBundleImportDryRunConstants.CurrentStatuses.PresentButHashDiffers,
+            TaskingHandoffBundleImportDryRunConstants.CurrentStatuses.Missing
+        };
+        var allowedActions = new HashSet<string>(StringComparer.Ordinal)
+        {
+            TaskingHandoffBundleImportDryRunConstants.Actions.NoOpAlreadyMatches,
+            TaskingHandoffBundleImportDryRunConstants.Actions.WouldOverwriteWithRecordedContent,
+            TaskingHandoffBundleImportDryRunConstants.Actions.WouldRecreateFromRecordedContent
+        };
+
+        Assert.Equal(4, result!.RestorePlan.Count);
+        foreach (var entry in result.RestorePlan)
+        {
+            Assert.Contains(entry.Role, allowedRoles);
+            Assert.Contains(entry.CurrentStatus, allowedStatuses);
+            Assert.Contains(entry.DryRunAction, allowedActions);
+        }
+
+        // Lock the canonical order in <c>Roles.InOrder</c> too.
+        Assert.Equal(
+            new[]
+            {
+                TaskingHandoffBundleImportDryRunConstants.Roles.TaskPacket,
+                TaskingHandoffBundleImportDryRunConstants.Roles.Preview,
+                TaskingHandoffBundleImportDryRunConstants.Roles.Checklist,
+                TaskingHandoffBundleImportDryRunConstants.Roles.Handoff
+            },
+            TaskingHandoffBundleImportDryRunConstants.Roles.InOrder);
+    }
+
+    [Fact]
+    public void Execute_GivenValidBundle_RecordedShaInPlanMatchesBundleSha()
+    {
+        using var workspace = new DryRunWorkspace();
+        var bundlePath = workspace.GenerateBundle("sha");
+        var bundle = ReadBundle(bundlePath);
+
+        var (exit, output) = RunJson(workspace, bundlePath);
+        Assert.Equal(0, exit);
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleImportDryRunResult>(output);
+        Assert.NotNull(result);
+
+        var byRole = result!.RestorePlan.ToDictionary(e => e.Role, StringComparer.Ordinal);
+        Assert.Equal(
+            bundle.SourceTaskPacketSha256,
+            byRole[TaskingHandoffBundleImportDryRunConstants.Roles.TaskPacket].RecordedSha256);
+        Assert.Equal(
+            bundle.SourcePreviewSha256,
+            byRole[TaskingHandoffBundleImportDryRunConstants.Roles.Preview].RecordedSha256);
+        Assert.Equal(
+            bundle.SourceChecklistSha256,
+            byRole[TaskingHandoffBundleImportDryRunConstants.Roles.Checklist].RecordedSha256);
+        Assert.Equal(
+            bundle.SourceHandoffSha256,
+            byRole[TaskingHandoffBundleImportDryRunConstants.Roles.Handoff].RecordedSha256);
+    }
+
+    // --------- helpers ---------
+
+    private static TaskingHandoffBundleArtifact ReadBundle(string bundlePath)
+    {
+        var bundle = JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(
+            File.ReadAllText(bundlePath));
+        Assert.NotNull(bundle);
+        return bundle!;
+    }
+
+    private static void AppendByte(string path)
+    {
+        using var stream = new FileStream(path, FileMode.Append, FileAccess.Write);
+        stream.WriteByte((byte)' ');
+    }
+
+    private static (int ExitCode, string Output) RunJson(DryRunWorkspace workspace, string bundlePath)
+    {
+        using var writer = new StringWriter();
+        var exit = TaskingHandoffBundleImportDryRunCommand.Execute(
+            workspace.Context,
+            new[] { "--from-bundle", bundlePath, "--format", "json" },
+            writer);
+        return (exit, writer.ToString());
+    }
+
+    private static bool TryResolveCommandsSourceDirectory(out string commandsDirectory)
+    {
+        commandsDirectory = string.Empty;
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, "src", "IntentSystem.Cli", "Commands");
+            if (Directory.Exists(candidate))
+            {
+                commandsDirectory = candidate;
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private sealed class DryRunWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("tasking-handoff-bundle-import-dry-run-tests-")
+            .FullName;
+
+        public DryRunWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string GetPath(string relative) => Path.Combine(rootPath, relative);
+
+        public IReadOnlyDictionary<string, byte[]> SnapshotAllFiles()
+        {
+            var map = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories))
+            {
+                map[path] = File.ReadAllBytes(path);
+            }
+
+            return map;
+        }
+
+        public string GenerateBundle(string tag)
+        {
+            var (previewPath, checklistPath) = GeneratePreviewAndChecklist(tag);
+            return BuildBundle(tag, previewPath, checklistPath);
+        }
+
+        private string BuildBundle(string tag, string previewPath, string checklistPath)
+        {
+            var bundlePath = GetPath($"bundle-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingHandoffBundleCommand.Execute(
+                Context,
+                new[]
+                {
+                    "--from-preview", previewPath,
+                    "--from-checklist", checklistPath,
+                    "--out", bundlePath
+                },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G194 bundle for tests: exit={exit}, stderr={sink}");
+            }
+
+            return bundlePath;
+        }
+
+        private (string previewPath, string checklistPath) GeneratePreviewAndChecklist(string tag)
+        {
+            var previewPath = GeneratePreview(tag);
+            var checklistPath = GetPath($"checklist-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingTaskPacketChecklistCommand.Execute(
+                Context,
+                new[] { "--from-preview", previewPath, "--out", checklistPath },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G193 checklist: exit={exit}, stderr={sink}");
+            }
+
+            return (previewPath, checklistPath);
+        }
+
+        private string GeneratePreview(string tag)
+        {
+            var handoffPath = GetPath($"__handoff_{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingHandoffCommand.Execute(
+                    Context,
+                    new[] { "--out", handoffPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G190 handoff: exit={exit}, stderr={sink}");
+                }
+            }
+
+            var taskPacketPath = GetPath($"__task_packet_{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingTaskPacketCommand.Execute(
+                    Context,
+                    new[] { "--from-handoff", handoffPath, "--out", taskPacketPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G191 task packet: exit={exit}, stderr={sink}");
+                }
+            }
+
+            var previewPath = GetPath($"preview-{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingTaskPacketPreviewCommand.Execute(
+                    Context,
+                    new[] { "--from-task-packet", taskPacketPath, "--out", previewPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G192 preview: exit={exit}, stderr={sink}");
+                }
+            }
+
+            return previewPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new subcommand `intent-cli tasking handoff-bundle-import-dry-run --from-bundle <bundle-artifact-path> [--format text|json]` under the existing `tasking` group. Eighth in the chain G190 → G191 → G192 → G193 → G194 → G195 → G196 → G197 → **G198 dry-run import/restore**. The command consumes a G194 handoff bundle, runs the existing G196/G197 verify analyzer on it, and — only when verify is valid — emits a deterministic restore plan to STDOUT for the four referenced source artifacts (task-packet, preview, checklist, handoff in that order). **No `--out` flag**: the dry-run command emits a plan to STDOUT only and writes nothing.
- Strict precedence (each step before the next; first failure exits 1, NO restore plan emitted):
  - `--from-bundle` flag missing/blank → exit 1, deterministic error message.
  - `--from-bundle` file not found → exit 1, JSON `status: "missing_bundle"`.
  - JSON parse failure → exit 1, JSON `status: "malformed_bundle"`.
  - G196/G197 verify reports `valid == false` (any failed check id, including G197's hash mismatch / file-missing) → exit 1, JSON `status: "verify_failed"`, restore_plan empty, errors mentions failed check ids. **Restore plan is never built when verify fails** (issue's "Missing, malformed, or hash-mismatched bundles fail deterministically before a restore plan is accepted" criterion).
  - Otherwise: build the restore plan, exit 0, JSON `status: "ok"`.
- Each restore plan entry uses constants locked in `TaskingHandoffBundleImportDryRunConstants.{Roles,Statuses,Actions}` so future drift breaks an explicit regression. Schema:
  - `role`: `task_packet` | `preview` | `checklist` | `handoff`
  - `recorded_path`: from bundle's `source_<role>_path`
  - `recorded_sha256`: from bundle's `source_<role>_sha256`
  - `current_status`: `already_present_and_matching` | `present_but_hash_differs` | `missing` (computed from G196/G197 verify's referenced-file observations)
  - `dry_run_action`: `no_op_already_matches` | `would_overwrite_with_recorded_content` | `would_recreate_from_recorded_content` (descriptive intent only — see disclaimer below)
- **Contractual placeholder disclaimer** (in both text output and a `restore_plan_disclaimer` JSON field, asserted by tests):
  > DRY-RUN ONLY: this is a restore plan preview. The handoff bundle records artifact paths and sha256 values, not artifact bytes; a future real restore would need access to the original referenced files (or a separate content store) to perform the listed actions. This command performs none of them.
- Output JSON shape (snake_case, stable, round-trippable through `JsonSerializer.Deserialize<TaskingHandoffBundleImportDryRunResult>`; satisfies issue's automation-log criterion of including `status`, `errors`, and artifact path identity):
  ```
  { \"bundle_path\": \"...\", \"bundle_sha256\": \"...\" | null, \"domain\": \"...\" | null,
    \"status\": \"ok\" | \"verify_failed\" | \"missing_bundle\" | \"malformed_bundle\",
    \"errors\": [\"...\"],
    \"verify_summary\": { \"valid\": <bool>, \"failed_check_ids\": [\"...\"] },
    \"restore_plan\": [ {role, recorded_path, recorded_sha256, current_status, dry_run_action}, ... 4 entries when status=ok, [] otherwise ],
    \"restore_plan_disclaimer\": \"DRY-RUN ONLY: ...\",
    \"summary_line\": \"Tasking handoff bundle import dry-run for <domain> — UNPUBLISHED, local-only, not automation-visible. status=<status>.\" }
  ```
- No-mutation invariants (all asserted by focused tests):
  - Sentinel `TaskingHandoffBundleImportDryRunCommand.NestedProviderLauncher` (mirrors G187/G190/.../G197) — never invoked.
  - Source-scan asserts the new command + analyzer files contain no `Process.Start(`.
  - Source-scan asserts the new files contain no `git checkout`/`git worktree` invocations (issue's no-branch/no-worktree criterion).
  - Byte-equivalence test on `.intent-cli/queue-state.json` and `.intent-cli/runs.jsonl` before/after.
  - Whole-workspace byte-snapshot test (`Execute_NeverWritesAnyArtifactFile_NeverOverwritesAnything`) — even on the valid restore-plan path, NO new file is created and NO existing file is modified.
- Reuse, not duplication:
  - `TaskingHandoffBundleVerifyAnalyzer.BuildChecks` (G196/G197) — reused for verify result.
  - `TaskingHandoffBundleVerifyCommand.ObserveReferencedSourceArtifacts` (G197) — promoted from `private` to `internal` for reuse; documented in the source. No other promotions needed.
  - `TaskingHandoffBundleArtifact` (G194) — deserialize the bundle.
  - `IssuePrepareCommand.ComputeSha256Hex(byte[])` — for `bundle_sha256`.

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter \"FullyQualifiedName~TaskingHandoffBundleImportDryRun\"` — **18/18 passing**. Issue-required scenarios covered:
  - **valid dry-run**: `Execute_GivenValidBundle_ReturnsZeroAndEmitsRestorePlan` (chain → bundle → dry-run; assert exit 0, status=ok, all 4 entries `current_status: already_present_and_matching` + `dry_run_action: no_op_already_matches`), plus `RestorePlanContainsAllFourRolesInOrder` (locks the role ordering), `DisclaimerIsPresentInTextAndJson`, `JsonResultRoundTripsStably`, `JsonFormat_IncludesStatusAndArtifactPathsForAutomation`, `RecordedShaInPlanMatchesBundleSha`.
  - **failed verification**: `Execute_GivenReferencedTaskPacketDeleted_FailsVerifyAndExitsNonZero` (deletes the referenced task packet, asserts exit 1, status=`verify_failed`, restore_plan empty, errors names a G196/G197 check id), `Execute_GivenReferencedPreviewEdited_FailsVerifyAndExitsNonZero` (appends byte to preview, asserts hash-mismatch path → no restore plan).
  - **malformed input**: `Execute_GivenMissingBundleFile_ReturnsNonZero_StatusMissingBundle`, `Execute_GivenMalformedBundleJson_ReturnsNonZero_StatusMalformedBundle`, `Execute_GivenBundleWithWrongStatus_FailsVerify_NoRestorePlan` (flips bundle_status away from local_only).
  - **CLI plumbing**: `Execute_GivenMissingFlag_ReturnsNonZero`, `Execute_GivenUnknownArgument_ReturnsNonZero`.
  - **no-mutation behavior**: `Execute_NeverWritesToQueueStateOrRunsLog`, `Execute_NeverWritesAnyArtifactFile_NeverOverwritesAnything` (whole-workspace byte snapshot — covers issue's no-overwrite criterion explicitly), `Execute_NeverInvokesProvider_NoProcessStartInNewSurface`, `Execute_NeverCreatesBranchOrWorktree_NoGitInvocationInNewSurface`.
  - **contract-locking regression**: `Execute_RestorePlanEntryFieldsAreStableConstants_RoleStatusActionLockedAgainstDrift` (Roles/Statuses/Actions constants + the canonical role ordering).
- [x] Issue's recommended broader filter `~TaskingHandoffBundle` — passes (18 new G198 tests + every existing TaskingHandoffBundle* surface stays green).
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **1143/1143 passing + 1 skip** (the 1 skip is the pre-existing G190 `TolerantToSubAnalyzerFailure` `[Fact(Skip)]` not introduced by this slice; CLI: 1125 → 1143 = +18 new G198 tests; no regressions).
- Confirmation that no provider launch or GitHub mutation behavior was added: verified by sentinel + source-scan (Process.Start + git invocation patterns) + queue/runs byte-equivalence + whole-workspace byte-snapshot.
- [ ] Manual smoke (recommended after merge):
  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- tasking handoff --domain intent-cli --out /tmp/g198-handoff.json`
  - `... -- tasking task-packet --from-handoff /tmp/g198-handoff.json --out /tmp/g198-task-packet.json`
  - `... -- tasking task-packet-preview --from-task-packet /tmp/g198-task-packet.json --out /tmp/g198-preview.json`
  - `... -- tasking task-packet-checklist --from-preview /tmp/g198-preview.json --out /tmp/g198-checklist.json`
  - `... -- tasking handoff-bundle --from-preview /tmp/g198-preview.json --from-checklist /tmp/g198-checklist.json --out /tmp/g198-bundle.json`
  - `... -- tasking handoff-bundle-import-dry-run --from-bundle /tmp/g198-bundle.json --format json` (assert `status: \"ok\"`, 4 plan entries with `current_status: already_present_and_matching`)
  - `echo extra >> /tmp/g198-task-packet.json && ... -- tasking handoff-bundle-import-dry-run --from-bundle /tmp/g198-bundle.json --format json` (assert `status: \"verify_failed\"`, `restore_plan: []`)

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)