### PR TITLE
G199: add intent-cli tasking publish-reviewed-bridge for verified+approved task packets

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -133,7 +133,8 @@ internal static class CommandRouter
                 ["handoff-bundle"] = TaskingHandoffBundleCommand.Execute,
                 ["handoff-bundle-inspect"] = TaskingHandoffBundleInspectCommand.Execute,
                 ["handoff-bundle-verify"] = TaskingHandoffBundleVerifyCommand.Execute,
-                ["handoff-bundle-import-dry-run"] = TaskingHandoffBundleImportDryRunCommand.Execute
+                ["handoff-bundle-import-dry-run"] = TaskingHandoffBundleImportDryRunCommand.Execute,
+                ["publish-reviewed-bridge"] = TaskingPublishReviewedBridgeCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/TaskingPublishReviewedBridgeAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingPublishReviewedBridgeAnalyzer.cs
@@ -1,0 +1,172 @@
+using System.Globalization;
+
+namespace IntentSystem.Cli.Commands;
+
+using ApprovalMarkerKinds = TaskingPublishReviewedBridgeConstants.ApprovalMarkerKinds;
+using BridgeConstants = TaskingPublishReviewedBridgeConstants;
+using BridgeStatuses = TaskingPublishReviewedBridgeConstants.Statuses;
+
+/// <summary>
+/// G199 — pure logic. Takes the deserialized G194 bundle, the G196/G197 verify
+/// check list, the body content, the body sha256, and the operator-supplied
+/// approval marker, and builds the reviewed-ready artifact record (or the
+/// failure projections used by the command layer). No I/O, no network, no
+/// process launches; the command layer handles file reads/writes and verify
+/// dispatch.
+///
+/// Reuses <see cref="IssueValidateBodyValidator.Validate"/> for body contract
+/// validation.
+/// </summary>
+internal static class TaskingPublishReviewedBridgeAnalyzer
+{
+    /// <summary>
+    /// Classify the operator-supplied approval marker into one of the three
+    /// stable shapes. Returns <c>null</c> when the marker is blank or does not
+    /// match any accepted shape; the command layer treats <c>null</c> as
+    /// <see cref="BridgeStatuses.ApprovalMarkerInvalid"/>.
+    /// </summary>
+    public static string? ClassifyApprovalMarker(string? approvalMarker)
+    {
+        if (string.IsNullOrWhiteSpace(approvalMarker))
+        {
+            return null;
+        }
+
+        if (string.Equals(approvalMarker, BridgeConstants.ApprovedLiteral, StringComparison.Ordinal))
+        {
+            return ApprovalMarkerKinds.Approved;
+        }
+
+        if (string.Equals(approvalMarker, BridgeConstants.ReviewedByOperatorLiteral, StringComparison.Ordinal))
+        {
+            return ApprovalMarkerKinds.ReviewedByOperator;
+        }
+
+        if (approvalMarker.StartsWith(BridgeConstants.ApprovedWithTagPrefix, StringComparison.Ordinal)
+            && approvalMarker.Length > BridgeConstants.ApprovedWithTagPrefix.Length)
+        {
+            return ApprovalMarkerKinds.ApprovedWithTag;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Project the failing-check ids out of a verify check list, preserving
+    /// the analyzer's stable order. Mirrors the G198 projection so both
+    /// commands surface the same identifiers for automation logs.
+    /// </summary>
+    public static IReadOnlyList<string> ExtractFailedCheckIds(IReadOnlyList<VerifyCheck> checks)
+    {
+        ArgumentNullException.ThrowIfNull(checks);
+        var ids = new List<string>();
+        foreach (var check in checks)
+        {
+            if (!check.Passed)
+            {
+                ids.Add(check.Id);
+            }
+        }
+
+        return ids;
+    }
+
+    /// <summary>
+    /// Build the human-readable error messages for a verify-failed projection,
+    /// using the same <c>{id}: {detail}</c> shape the G198 dry-run uses.
+    /// </summary>
+    public static IReadOnlyList<string> ExtractErrorMessages(IReadOnlyList<VerifyCheck> checks)
+    {
+        ArgumentNullException.ThrowIfNull(checks);
+        var errors = new List<string>();
+        foreach (var check in checks)
+        {
+            if (!check.Passed)
+            {
+                errors.Add($"{check.Id}: {check.Detail}");
+            }
+        }
+
+        return errors;
+    }
+
+    /// <summary>
+    /// Project an <see cref="IssueValidateBodyResult"/> into the artifact's
+    /// body-contract sub-record.
+    /// </summary>
+    public static TaskingPublishReviewedBridgeBodyValidation ProjectBodyValidation(
+        IssueValidateBodyResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        return new TaskingPublishReviewedBridgeBodyValidation
+        {
+            IsValid = result.IsValid,
+            MissingHeadings = result.MissingHeadings,
+            RelatedLinksInvalid = result.RelatedLinksInvalid,
+            RelatedLinksReason = result.RelatedLinksReason
+        };
+    }
+
+    /// <summary>
+    /// Build the reviewed-ready artifact for the success path. Caller must
+    /// have already confirmed verify is valid, body contract is valid, and the
+    /// approval marker classification is non-null.
+    /// </summary>
+    public static TaskingPublishReviewedBridgeArtifact BuildArtifact(
+        string sourceBundlePath,
+        string sourceBundleSha256,
+        string sourceBodyPath,
+        string sourceBodySha256,
+        string domain,
+        string approvalMarker,
+        string approvalMarkerKind,
+        IssueValidateBodyResult bodyValidation,
+        string generatedAtUtc,
+        string artifactPath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sourceBundlePath);
+        ArgumentException.ThrowIfNullOrEmpty(sourceBundleSha256);
+        ArgumentException.ThrowIfNullOrEmpty(sourceBodyPath);
+        ArgumentException.ThrowIfNullOrEmpty(sourceBodySha256);
+        ArgumentException.ThrowIfNullOrEmpty(domain);
+        ArgumentException.ThrowIfNullOrEmpty(approvalMarker);
+        ArgumentException.ThrowIfNullOrEmpty(approvalMarkerKind);
+        ArgumentException.ThrowIfNullOrEmpty(generatedAtUtc);
+        ArgumentException.ThrowIfNullOrEmpty(artifactPath);
+        ArgumentNullException.ThrowIfNull(bodyValidation);
+
+        return new TaskingPublishReviewedBridgeArtifact
+        {
+            SourceBundlePath = sourceBundlePath,
+            SourceBundleSha256 = sourceBundleSha256,
+            SourceBodyPath = sourceBodyPath,
+            SourceBodySha256 = sourceBodySha256,
+            Domain = domain,
+            IsPublished = false,
+            IsAutomationVisible = false,
+            ReviewedBridgeStatus = BridgeConstants.LocalOnlyStatus,
+            ApprovalMarker = approvalMarker,
+            ApprovalMarkerKind = approvalMarkerKind,
+            VerifySummary = new TaskingPublishReviewedBridgeVerifySummary
+            {
+                Valid = true,
+                FailedCheckIds = Array.Empty<string>()
+            },
+            BodyContractValidation = ProjectBodyValidation(bodyValidation),
+            GeneratedAtUtc = generatedAtUtc,
+            ArtifactPath = artifactPath,
+            SummaryLine = BuildSummaryLine(domain, BridgeStatuses.Ok)
+        };
+    }
+
+    /// <summary>
+    /// Build the canonical summary line shared by the artifact's
+    /// <c>summary_line</c> field and the text-format stdout header.
+    /// </summary>
+    public static string BuildSummaryLine(string? domain, string status) =>
+        string.Format(
+            CultureInfo.InvariantCulture,
+            BridgeConstants.SummaryLineFormat,
+            domain ?? "(unavailable)",
+            status);
+}

--- a/src/IntentSystem.Cli/Commands/TaskingPublishReviewedBridgeArtifact.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingPublishReviewedBridgeArtifact.cs
@@ -1,0 +1,180 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G199 reviewed task packet publish bridge artifact. Snake_case JSON shape
+/// emitted by <c>intent-cli tasking publish-reviewed-bridge</c> when a verified
+/// G194 handoff bundle plus an operator-supplied G183-valid Markdown body plus
+/// an explicit approval marker have all passed local checks. The artifact is
+/// the "ready-for-real-publish" handoff that a future operator (or G184
+/// <c>issue publish-reviewed</c>) can consume.
+///
+/// <para>
+/// The artifact is local-only by contract:
+/// <see cref="IsPublished"/> and <see cref="IsAutomationVisible"/> are ALWAYS
+/// literal <c>false</c>; <see cref="ReviewedBridgeStatus"/> is ALWAYS the
+/// literal value
+/// <see cref="TaskingPublishReviewedBridgeConstants.LocalOnlyStatus"/>. The
+/// command performs no GitHub network calls, applies no labels, does not
+/// mutate queue/runs state, does not launch providers, and does not create
+/// branches/worktrees.
+/// </para>
+/// </summary>
+internal sealed record TaskingPublishReviewedBridgeArtifact
+{
+    [JsonPropertyName("source_bundle_path")]
+    public required string SourceBundlePath { get; init; }
+
+    [JsonPropertyName("source_bundle_sha256")]
+    public required string SourceBundleSha256 { get; init; }
+
+    [JsonPropertyName("source_body_path")]
+    public required string SourceBodyPath { get; init; }
+
+    [JsonPropertyName("source_body_sha256")]
+    public required string SourceBodySha256 { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("is_published")]
+    public required bool IsPublished { get; init; }
+
+    [JsonPropertyName("is_automation_visible")]
+    public required bool IsAutomationVisible { get; init; }
+
+    [JsonPropertyName("reviewed_bridge_status")]
+    public required string ReviewedBridgeStatus { get; init; }
+
+    [JsonPropertyName("approval_marker")]
+    public required string ApprovalMarker { get; init; }
+
+    [JsonPropertyName("approval_marker_kind")]
+    public required string ApprovalMarkerKind { get; init; }
+
+    [JsonPropertyName("verify_summary")]
+    public required TaskingPublishReviewedBridgeVerifySummary VerifySummary { get; init; }
+
+    [JsonPropertyName("body_contract_validation")]
+    public required TaskingPublishReviewedBridgeBodyValidation BodyContractValidation { get; init; }
+
+    [JsonPropertyName("generated_at_utc")]
+    public required string GeneratedAtUtc { get; init; }
+
+    [JsonPropertyName("artifact_path")]
+    public required string ArtifactPath { get; init; }
+
+    [JsonPropertyName("summary_line")]
+    public required string SummaryLine { get; init; }
+}
+
+/// <summary>
+/// G199 — minimal projection of the G196/G197 verify check list. Only carries
+/// the boolean validity and the failed check ids, mirroring the dry-run
+/// import projection.
+/// </summary>
+internal sealed record TaskingPublishReviewedBridgeVerifySummary
+{
+    [JsonPropertyName("valid")]
+    public required bool Valid { get; init; }
+
+    [JsonPropertyName("failed_check_ids")]
+    public required IReadOnlyList<string> FailedCheckIds { get; init; }
+}
+
+/// <summary>
+/// G199 — Child Issue Contract validation projection. Mirrors
+/// <see cref="IssueValidateBodyResult"/> but only the fields the operator
+/// needs from the artifact: validity, missing-heading list, related-links
+/// invalid flag, and reason.
+/// </summary>
+internal sealed record TaskingPublishReviewedBridgeBodyValidation
+{
+    [JsonPropertyName("is_valid")]
+    public required bool IsValid { get; init; }
+
+    [JsonPropertyName("missing_headings")]
+    public required IReadOnlyList<string> MissingHeadings { get; init; }
+
+    [JsonPropertyName("related_links_invalid")]
+    public required bool RelatedLinksInvalid { get; init; }
+
+    [JsonPropertyName("related_links_reason")]
+    public string? RelatedLinksReason { get; init; }
+}
+
+/// <summary>
+/// G199 stable constants for the reviewed publish bridge command's output
+/// contract. Status values, approval-marker shapes, and the canonical
+/// "local_only" status are centralized here so future drift breaks the
+/// regression tests deterministically.
+/// </summary>
+internal static class TaskingPublishReviewedBridgeConstants
+{
+    /// <summary>
+    /// Stable literal value of <c>reviewed_bridge_status</c>. ALWAYS this
+    /// value when the bridge succeeds; never overridden by operator input.
+    /// </summary>
+    public const string LocalOnlyStatus = "local_only";
+
+    /// <summary>
+    /// Stable summary line. <c>{0}</c> is the bundle's domain (or
+    /// <c>(unavailable)</c> when not parseable), <c>{1}</c> is the status
+    /// enum value. Tests assert the literal phrase
+    /// "UNPUBLISHED, local-only, not automation-visible".
+    /// </summary>
+    public const string SummaryLineFormat =
+        "Reviewed task packet publish bridge for {0} — UNPUBLISHED, local-only, not automation-visible. status={1}.";
+
+    public const string UnpublishedStatusPhrase =
+        "UNPUBLISHED, local-only, not automation-visible";
+
+    public static class Statuses
+    {
+        public const string Ok = "ok";
+        public const string VerifyFailed = "verify_failed";
+        public const string MissingBundle = "missing_bundle";
+        public const string MalformedBundle = "malformed_bundle";
+        public const string MissingBody = "missing_body";
+        public const string BodyContractInvalid = "body_contract_invalid";
+        public const string ApprovalMarkerInvalid = "approval_marker_invalid";
+    }
+
+    /// <summary>
+    /// Stable approval marker kinds emitted into the artifact's
+    /// <c>approval_marker_kind</c> field. The operator-supplied marker is
+    /// classified into exactly one of these three forms before the artifact is
+    /// written.
+    /// </summary>
+    public static class ApprovalMarkerKinds
+    {
+        public const string Approved = "approved";
+        public const string ReviewedByOperator = "reviewed_by_operator";
+        public const string ApprovedWithTag = "approved_with_tag";
+    }
+
+    /// <summary>
+    /// Stable approval marker shapes accepted by the bridge. Anything not
+    /// matching one of these shapes (case-sensitive) — including blank,
+    /// <c>"yes"</c>, <c>"ok"</c>, <c>"true"</c> — is rejected as
+    /// <c>approval_marker_invalid</c>. The accepted shapes are:
+    /// <list type="bullet">
+    ///   <item><description>literal <c>"approved"</c></description></item>
+    ///   <item><description>literal <c>"reviewed-by-operator"</c></description></item>
+    ///   <item><description>any string starting with <c>"approved:"</c>
+    ///   (e.g. <c>"approved:tomohisa-2026-04-29"</c> for human traceability)
+    ///   </description></item>
+    /// </list>
+    /// </summary>
+    public static readonly IReadOnlyList<string> AcceptedApprovalShapes = new[]
+    {
+        "approved",
+        "reviewed-by-operator",
+        "approved:<tag>"
+    };
+
+    public const string ApprovedLiteral = "approved";
+    public const string ReviewedByOperatorLiteral = "reviewed-by-operator";
+    public const string ApprovedWithTagPrefix = "approved:";
+}

--- a/src/IntentSystem.Cli/Commands/TaskingPublishReviewedBridgeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingPublishReviewedBridgeCommand.cs
@@ -1,0 +1,695 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+using BridgeConstants = TaskingPublishReviewedBridgeConstants;
+using BridgeStatuses = TaskingPublishReviewedBridgeConstants.Statuses;
+
+/// <summary>
+/// G199: <c>intent-cli tasking publish-reviewed-bridge</c>. A LOCAL
+/// pre-publish artifact builder that bundles a verified G194
+/// <see cref="TaskingHandoffBundleArtifact"/>, an operator-supplied
+/// G183-valid Markdown body, and an explicit approval marker into a
+/// reviewed-ready packet at <c>--out</c>. Sits beside the existing
+/// <c>handoff</c>, <c>task-packet</c>, <c>task-packet-preview</c>,
+/// <c>task-packet-checklist</c>, <c>handoff-bundle</c>,
+/// <c>handoff-bundle-inspect</c>, <c>handoff-bundle-verify</c>, and
+/// <c>handoff-bundle-import-dry-run</c> commands under the same
+/// <c>tasking</c> group.
+///
+/// <para>
+/// Distinct from G184 <c>issue publish-reviewed</c>: this G199 bridge is
+/// purely local and never publishes a GitHub issue, applies labels, mutates
+/// queue/runs state, launches providers, creates branches/worktrees, or
+/// overwrites unrelated artifacts. The artifact JSON it writes is a
+/// "ready-for-real-publish" handoff that a future operator (or the G184
+/// command) can consume.
+/// </para>
+///
+/// Network-mutation invariance: the hot path contains no
+/// <c>Process.Start</c>, no shell-out to <c>gh</c>, no <c>git</c> shell-out,
+/// and no provider launcher. Tests validate this via the
+/// <see cref="NestedProviderLauncher"/> sentinel and source-scan assertions.
+///
+/// Exit code: <c>0</c> iff all four checks pass (bundle parses, verify
+/// reports <c>valid == true</c>, body file exists and passes G183, approval
+/// marker is one of the accepted shapes); <c>1</c> otherwise. On failure no
+/// artifact is written.
+/// </summary>
+internal static class TaskingPublishReviewedBridgeCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private static readonly JsonSerializerOptions JsonOutputOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    /// <summary>
+    /// Test seam mirroring the timestamp pattern used by
+    /// <see cref="IssuePrepareCommand.TimestampFactory"/>. Defaults to
+    /// <see cref="DateTimeOffset.UtcNow"/>; tests can pin a deterministic
+    /// timestamp for round-trip and stability assertions.
+    /// </summary>
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Test seam mirroring G190/G191/G192/G193/G194/G195/G196/G198
+    /// <c>NestedProviderLauncher</c>. G199 must NEVER invoke this delegate.
+    /// Tests register a sentinel that flips a flag if invoked; the bridge
+    /// path leaves it untouched.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(
+                args,
+                out var fromBundle,
+                out var fromBody,
+                out var approval,
+                out var outPath,
+                out var format,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        // Step 2: read bundle file.
+        var resolvedFromBundle = Path.GetFullPath(fromBundle);
+
+        if (!File.Exists(resolvedFromBundle))
+        {
+            WriteFailure(
+                writer,
+                format,
+                BridgeStatuses.MissingBundle,
+                domain: null,
+                bundlePath: fromBundle,
+                bundleSha256: null,
+                bodyPath: fromBody,
+                bodySha256: null,
+                approvalMarker: approval,
+                approvalMarkerKind: null,
+                errors: new[]
+                {
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Bundle path does not exist: {0}",
+                        fromBundle)
+                },
+                verifyValid: false,
+                failedCheckIds: new[]
+                {
+                    TaskingHandoffBundleVerifyConstants.CheckIds.BundlePathPresentAndReadable
+                });
+            return 1;
+        }
+
+        byte[] bundleBytes;
+        try
+        {
+            bundleBytes = File.ReadAllBytes(resolvedFromBundle);
+        }
+        catch (Exception exception)
+        {
+            WriteFailure(
+                writer,
+                format,
+                BridgeStatuses.MissingBundle,
+                domain: null,
+                bundlePath: fromBundle,
+                bundleSha256: null,
+                bodyPath: fromBody,
+                bodySha256: null,
+                approvalMarker: approval,
+                approvalMarkerKind: null,
+                errors: new[]
+                {
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Bundle path could not be read: {0} ({1})",
+                        fromBundle,
+                        exception.Message)
+                },
+                verifyValid: false,
+                failedCheckIds: new[]
+                {
+                    TaskingHandoffBundleVerifyConstants.CheckIds.BundlePathPresentAndReadable
+                });
+            return 1;
+        }
+
+        var bundleSha256 = IssuePrepareCommand.ComputeSha256Hex(bundleBytes);
+
+        TaskingHandoffBundleArtifact? bundle;
+        try
+        {
+            bundle = JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(bundleBytes);
+        }
+        catch (JsonException exception)
+        {
+            WriteFailure(
+                writer,
+                format,
+                BridgeStatuses.MalformedBundle,
+                domain: null,
+                bundlePath: fromBundle,
+                bundleSha256: bundleSha256,
+                bodyPath: fromBody,
+                bodySha256: null,
+                approvalMarker: approval,
+                approvalMarkerKind: null,
+                errors: new[]
+                {
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Failed to parse bundle JSON as TaskingHandoffBundleArtifact: {0}",
+                        exception.Message)
+                },
+                verifyValid: false,
+                failedCheckIds: new[]
+                {
+                    TaskingHandoffBundleVerifyConstants.CheckIds.BundleJsonParses
+                });
+            return 1;
+        }
+
+        if (bundle is null)
+        {
+            WriteFailure(
+                writer,
+                format,
+                BridgeStatuses.MalformedBundle,
+                domain: null,
+                bundlePath: fromBundle,
+                bundleSha256: bundleSha256,
+                bodyPath: fromBody,
+                bodySha256: null,
+                approvalMarker: approval,
+                approvalMarkerKind: null,
+                errors: new[] { "Bundle JSON deserialized to a null bundle." },
+                verifyValid: false,
+                failedCheckIds: new[]
+                {
+                    TaskingHandoffBundleVerifyConstants.CheckIds.BundleJsonParses
+                });
+            return 1;
+        }
+
+        // Step 3: reuse G196/G197 verify.
+        var observations =
+            TaskingHandoffBundleVerifyCommand.ObserveReferencedSourceArtifacts(bundle);
+        var verifyChecks = TaskingHandoffBundleVerifyAnalyzer.BuildChecks(bundle, observations);
+        var verifyValid = verifyChecks.All(c => c.Passed);
+
+        if (!verifyValid)
+        {
+            WriteFailure(
+                writer,
+                format,
+                BridgeStatuses.VerifyFailed,
+                domain: bundle.Domain,
+                bundlePath: fromBundle,
+                bundleSha256: bundleSha256,
+                bodyPath: fromBody,
+                bodySha256: null,
+                approvalMarker: approval,
+                approvalMarkerKind: null,
+                errors: TaskingPublishReviewedBridgeAnalyzer.ExtractErrorMessages(verifyChecks),
+                verifyValid: false,
+                failedCheckIds: TaskingPublishReviewedBridgeAnalyzer.ExtractFailedCheckIds(verifyChecks));
+            return 1;
+        }
+
+        // Step 4: read body file.
+        var resolvedFromBody = Path.GetFullPath(fromBody);
+        if (!File.Exists(resolvedFromBody))
+        {
+            WriteFailure(
+                writer,
+                format,
+                BridgeStatuses.MissingBody,
+                domain: bundle.Domain,
+                bundlePath: fromBundle,
+                bundleSha256: bundleSha256,
+                bodyPath: fromBody,
+                bodySha256: null,
+                approvalMarker: approval,
+                approvalMarkerKind: null,
+                errors: new[]
+                {
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Body path does not exist: {0}",
+                        fromBody)
+                },
+                verifyValid: true,
+                failedCheckIds: Array.Empty<string>());
+            return 1;
+        }
+
+        byte[] bodyBytes;
+        try
+        {
+            bodyBytes = File.ReadAllBytes(resolvedFromBody);
+        }
+        catch (Exception exception)
+        {
+            WriteFailure(
+                writer,
+                format,
+                BridgeStatuses.MissingBody,
+                domain: bundle.Domain,
+                bundlePath: fromBundle,
+                bundleSha256: bundleSha256,
+                bodyPath: fromBody,
+                bodySha256: null,
+                approvalMarker: approval,
+                approvalMarkerKind: null,
+                errors: new[]
+                {
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Body path could not be read: {0} ({1})",
+                        fromBody,
+                        exception.Message)
+                },
+                verifyValid: true,
+                failedCheckIds: Array.Empty<string>());
+            return 1;
+        }
+
+        var bodySha256 = IssuePrepareCommand.ComputeSha256Hex(bodyBytes);
+        var bodyContent = Encoding.UTF8.GetString(bodyBytes);
+
+        // Step 5: reuse G183 body validator.
+        var bodyValidation = IssueValidateBodyValidator.Validate(fromBody, bodyContent);
+        if (!bodyValidation.IsValid)
+        {
+            var errors = new List<string>();
+            foreach (var missing in bodyValidation.MissingHeadings)
+            {
+                errors.Add(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Missing required heading: {0}",
+                    missing));
+            }
+
+            if (bodyValidation.RelatedLinksInvalid && bodyValidation.RelatedLinksReason is not null)
+            {
+                errors.Add(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Related Links invalid: {0}",
+                    bodyValidation.RelatedLinksReason));
+            }
+
+            WriteFailure(
+                writer,
+                format,
+                BridgeStatuses.BodyContractInvalid,
+                domain: bundle.Domain,
+                bundlePath: fromBundle,
+                bundleSha256: bundleSha256,
+                bodyPath: fromBody,
+                bodySha256: bodySha256,
+                approvalMarker: approval,
+                approvalMarkerKind: null,
+                errors: errors,
+                verifyValid: true,
+                failedCheckIds: Array.Empty<string>(),
+                bodyValidation: bodyValidation);
+            return 1;
+        }
+
+        // Step 6: validate approval marker.
+        var approvalKind = TaskingPublishReviewedBridgeAnalyzer.ClassifyApprovalMarker(approval);
+        if (approvalKind is null)
+        {
+            WriteFailure(
+                writer,
+                format,
+                BridgeStatuses.ApprovalMarkerInvalid,
+                domain: bundle.Domain,
+                bundlePath: fromBundle,
+                bundleSha256: bundleSha256,
+                bodyPath: fromBody,
+                bodySha256: bodySha256,
+                approvalMarker: approval,
+                approvalMarkerKind: null,
+                errors: new[]
+                {
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Approval marker '{0}' is not one of the accepted shapes (literal 'approved', literal 'reviewed-by-operator', or any string starting with 'approved:').",
+                        approval)
+                },
+                verifyValid: true,
+                failedCheckIds: Array.Empty<string>(),
+                bodyValidation: bodyValidation);
+            return 1;
+        }
+
+        // Step 7: build artifact + write.
+        var resolvedOut = Path.GetFullPath(outPath);
+        var generatedAt = IssuePrepareCommand.FormatUtcTimestamp(TimestampFactory());
+
+        var artifact = TaskingPublishReviewedBridgeAnalyzer.BuildArtifact(
+            sourceBundlePath: fromBundle,
+            sourceBundleSha256: bundleSha256,
+            sourceBodyPath: fromBody,
+            sourceBodySha256: bodySha256,
+            domain: bundle.Domain,
+            approvalMarker: approval,
+            approvalMarkerKind: approvalKind,
+            bodyValidation: bodyValidation,
+            generatedAtUtc: generatedAt,
+            artifactPath: resolvedOut);
+
+        var artifactJson = JsonSerializer.Serialize(artifact, JsonOutputOptions);
+        var outDir = Path.GetDirectoryName(resolvedOut);
+        if (!string.IsNullOrEmpty(outDir))
+        {
+            Directory.CreateDirectory(outDir);
+        }
+
+        File.WriteAllText(resolvedOut, artifactJson);
+
+        WriteSuccess(writer, artifact, format);
+        return 0;
+    }
+
+    private static void WriteFailure(
+        TextWriter writer,
+        string format,
+        string status,
+        string? domain,
+        string bundlePath,
+        string? bundleSha256,
+        string bodyPath,
+        string? bodySha256,
+        string approvalMarker,
+        string? approvalMarkerKind,
+        IReadOnlyList<string> errors,
+        bool verifyValid,
+        IReadOnlyList<string> failedCheckIds,
+        IssueValidateBodyResult? bodyValidation = null)
+    {
+        // Build a "failure projection" of the artifact JSON. We deliberately
+        // do not write the artifact to disk on the failure path — only emit
+        // it to stdout so callers can parse status and error fields.
+        var failureBodyValidation = bodyValidation is null
+            ? new TaskingPublishReviewedBridgeBodyValidation
+            {
+                IsValid = false,
+                MissingHeadings = Array.Empty<string>(),
+                RelatedLinksInvalid = false,
+                RelatedLinksReason = null
+            }
+            : TaskingPublishReviewedBridgeAnalyzer.ProjectBodyValidation(bodyValidation);
+
+        var summaryLine = TaskingPublishReviewedBridgeAnalyzer.BuildSummaryLine(domain, status);
+
+        var projection = new FailureProjection
+        {
+            Status = status,
+            SourceBundlePath = bundlePath,
+            SourceBundleSha256 = bundleSha256,
+            SourceBodyPath = bodyPath,
+            SourceBodySha256 = bodySha256,
+            Domain = domain,
+            ApprovalMarker = approvalMarker,
+            ApprovalMarkerKind = approvalMarkerKind,
+            Errors = errors,
+            VerifySummary = new TaskingPublishReviewedBridgeVerifySummary
+            {
+                Valid = verifyValid,
+                FailedCheckIds = failedCheckIds
+            },
+            BodyContractValidation = failureBodyValidation,
+            SummaryLine = summaryLine
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(projection, JsonOutputOptions));
+        }
+        else
+        {
+            WriteFailureText(writer, projection);
+        }
+    }
+
+    private static void WriteFailureText(TextWriter writer, FailureProjection projection)
+    {
+        writer.WriteLine(projection.SummaryLine);
+        writer.WriteLine();
+        writer.WriteLine($"Bundle path: {projection.SourceBundlePath}");
+        writer.WriteLine($"Bundle sha256: {projection.SourceBundleSha256 ?? "(unavailable)"}");
+        writer.WriteLine($"Body path: {projection.SourceBodyPath}");
+        writer.WriteLine($"Body sha256: {projection.SourceBodySha256 ?? "(unavailable)"}");
+        writer.WriteLine($"Domain: {projection.Domain ?? "(unavailable)"}");
+        writer.WriteLine($"Status: {projection.Status}");
+        writer.WriteLine($"Approval marker: {projection.ApprovalMarker}");
+        writer.WriteLine($"Approval marker kind: {projection.ApprovalMarkerKind ?? "(unavailable)"}");
+        writer.WriteLine($"Verify valid: {projection.VerifySummary.Valid}");
+
+        if (projection.VerifySummary.FailedCheckIds.Count > 0)
+        {
+            writer.WriteLine("Failed verify check ids:");
+            foreach (var id in projection.VerifySummary.FailedCheckIds)
+            {
+                writer.WriteLine($"- {id}");
+            }
+        }
+
+        writer.WriteLine($"Body valid: {projection.BodyContractValidation.IsValid}");
+        if (projection.BodyContractValidation.MissingHeadings.Count > 0)
+        {
+            writer.WriteLine("Missing headings:");
+            foreach (var heading in projection.BodyContractValidation.MissingHeadings)
+            {
+                writer.WriteLine($"- {heading}");
+            }
+        }
+
+        if (projection.BodyContractValidation.RelatedLinksInvalid)
+        {
+            writer.WriteLine($"Related links invalid: {projection.BodyContractValidation.RelatedLinksReason ?? "(unspecified)"}");
+        }
+
+        if (projection.Errors.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("Errors:");
+            foreach (var err in projection.Errors)
+            {
+                writer.WriteLine($"- {err}");
+            }
+        }
+    }
+
+    private static void WriteSuccess(
+        TextWriter writer,
+        TaskingPublishReviewedBridgeArtifact artifact,
+        string format)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(artifact, JsonOutputOptions));
+            return;
+        }
+
+        writer.WriteLine(artifact.SummaryLine);
+        writer.WriteLine();
+        writer.WriteLine($"Bundle path: {artifact.SourceBundlePath}");
+        writer.WriteLine($"Bundle sha256: {artifact.SourceBundleSha256}");
+        writer.WriteLine($"Body path: {artifact.SourceBodyPath}");
+        writer.WriteLine($"Body sha256: {artifact.SourceBodySha256}");
+        writer.WriteLine($"Domain: {artifact.Domain}");
+        writer.WriteLine("Status: ok");
+        writer.WriteLine($"Approval marker: {artifact.ApprovalMarker}");
+        writer.WriteLine($"Approval marker kind: {artifact.ApprovalMarkerKind}");
+        writer.WriteLine($"Reviewed bridge status: {artifact.ReviewedBridgeStatus}");
+        writer.WriteLine($"Is published: {artifact.IsPublished}");
+        writer.WriteLine($"Is automation visible: {artifact.IsAutomationVisible}");
+        writer.WriteLine($"Verify valid: {artifact.VerifySummary.Valid}");
+        writer.WriteLine($"Body valid: {artifact.BodyContractValidation.IsValid}");
+        writer.WriteLine($"Generated at (UTC): {artifact.GeneratedAtUtc}");
+        writer.WriteLine($"Artifact path: {artifact.ArtifactPath}");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string fromBundle,
+        out string fromBody,
+        out string approval,
+        out string outPath,
+        out string format,
+        out string error)
+    {
+        fromBundle = string.Empty;
+        fromBody = string.Empty;
+        approval = string.Empty;
+        outPath = string.Empty;
+        format = FormatText;
+        error = string.Empty;
+
+        var sawApproval = false;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-bundle":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-bundle requires a non-empty value.";
+                        return false;
+                    }
+
+                    fromBundle = args[index + 1];
+                    index++;
+                    break;
+
+                case "--from-body":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-body requires a non-empty value.";
+                        return false;
+                    }
+
+                    fromBody = args[index + 1];
+                    index++;
+                    break;
+
+                case "--approval":
+                    // Approval is allowed to be an empty string here so the
+                    // command can flow through to the marker validator and
+                    // emit status=approval_marker_invalid. We still require
+                    // the flag itself to be present and to consume one value
+                    // slot.
+                    if (index + 1 >= args.Length)
+                    {
+                        error = "--approval requires a value.";
+                        return false;
+                    }
+
+                    approval = args[index + 1];
+                    sawApproval = true;
+                    index++;
+                    break;
+
+                case "--out":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--out requires a non-empty value.";
+                        return false;
+                    }
+
+                    outPath = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error =
+                        $"Unknown argument '{argument}'. Supported: --from-bundle, --from-body, --approval, --out, --format.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromBundle))
+        {
+            error = "--from-bundle is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(fromBody))
+        {
+            error = "--from-body is required.";
+            return false;
+        }
+
+        if (!sawApproval)
+        {
+            error = "--approval is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(outPath))
+        {
+            error = "--out is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private sealed record FailureProjection
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("source_bundle_path")]
+        public required string SourceBundlePath { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("source_bundle_sha256")]
+        public required string? SourceBundleSha256 { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("source_body_path")]
+        public required string SourceBodyPath { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("source_body_sha256")]
+        public required string? SourceBodySha256 { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("domain")]
+        public required string? Domain { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("status")]
+        public required string Status { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("approval_marker")]
+        public required string ApprovalMarker { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("approval_marker_kind")]
+        public required string? ApprovalMarkerKind { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("errors")]
+        public required IReadOnlyList<string> Errors { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("verify_summary")]
+        public required TaskingPublishReviewedBridgeVerifySummary VerifySummary { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("body_contract_validation")]
+        public required TaskingPublishReviewedBridgeBodyValidation BodyContractValidation { get; init; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("summary_line")]
+        public required string SummaryLine { get; init; }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/TaskingPublishReviewedBridgeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskingPublishReviewedBridgeCommandTests.cs
@@ -1,0 +1,893 @@
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G199 — coverage for <c>intent-cli tasking publish-reviewed-bridge</c>.
+/// Class name contains <c>Tasking</c>, <c>PublishReviewed</c>, and
+/// <c>Bridge</c> so reviewers can match the issue's recommended
+/// <c>~Tasking</c> filter.
+/// </summary>
+public sealed class TaskingPublishReviewedBridgeCommandTests : IDisposable
+{
+    private readonly Func<bool>? originalLauncher;
+    private readonly Func<DateTimeOffset> originalTimestampFactory;
+
+    public TaskingPublishReviewedBridgeCommandTests()
+    {
+        originalLauncher = TaskingPublishReviewedBridgeCommand.NestedProviderLauncher;
+        originalTimestampFactory = TaskingPublishReviewedBridgeCommand.TimestampFactory;
+        TaskingPublishReviewedBridgeCommand.TimestampFactory =
+            () => new DateTimeOffset(2026, 4, 29, 12, 34, 56, TimeSpan.Zero);
+    }
+
+    public void Dispose()
+    {
+        TaskingPublishReviewedBridgeCommand.NestedProviderLauncher = originalLauncher;
+        TaskingPublishReviewedBridgeCommand.TimestampFactory = originalTimestampFactory;
+    }
+
+    [Fact]
+    public void Execute_GivenValidBundleBodyAndApproval_WritesReviewedReadyArtifact()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bundlePath = workspace.GenerateBundle("happy");
+        var bodyPath = workspace.WriteValidBody("body-happy.md");
+        var outPath = workspace.GetPath("reviewed-happy.json");
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", bodyPath,
+                "--approval", "approved",
+                "--out", outPath
+            },
+            writer);
+
+        Assert.Equal(0, exit);
+        var output = writer.ToString();
+        Assert.Contains(
+            "UNPUBLISHED, local-only, not automation-visible",
+            output,
+            StringComparison.Ordinal);
+        Assert.Contains("Status: ok", output, StringComparison.Ordinal);
+
+        Assert.True(File.Exists(outPath), $"Artifact not written at {outPath}");
+        var artifact = ReadArtifact(outPath);
+        Assert.False(artifact.IsPublished);
+        Assert.False(artifact.IsAutomationVisible);
+        Assert.Equal(
+            TaskingPublishReviewedBridgeConstants.LocalOnlyStatus,
+            artifact.ReviewedBridgeStatus);
+        Assert.Contains(
+            "UNPUBLISHED, local-only, not automation-visible",
+            artifact.SummaryLine,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenValidInputs_ReviewedArtifactJsonRoundTripsStably()
+    {
+        using var workspace = new BridgeWorkspace();
+        var (artifact, _) = RunSuccessful(workspace, "rt", "approved");
+
+        var serialized = JsonSerializer.Serialize(artifact);
+        var reparsed = JsonSerializer.Deserialize<TaskingPublishReviewedBridgeArtifact>(serialized);
+        Assert.NotNull(reparsed);
+        Assert.Equal(artifact.SourceBundlePath, reparsed!.SourceBundlePath);
+        Assert.Equal(artifact.SourceBundleSha256, reparsed.SourceBundleSha256);
+        Assert.Equal(artifact.SourceBodyPath, reparsed.SourceBodyPath);
+        Assert.Equal(artifact.SourceBodySha256, reparsed.SourceBodySha256);
+        Assert.Equal(artifact.Domain, reparsed.Domain);
+        Assert.Equal(artifact.IsPublished, reparsed.IsPublished);
+        Assert.Equal(artifact.IsAutomationVisible, reparsed.IsAutomationVisible);
+        Assert.Equal(artifact.ReviewedBridgeStatus, reparsed.ReviewedBridgeStatus);
+        Assert.Equal(artifact.ApprovalMarker, reparsed.ApprovalMarker);
+        Assert.Equal(artifact.ApprovalMarkerKind, reparsed.ApprovalMarkerKind);
+        Assert.Equal(artifact.GeneratedAtUtc, reparsed.GeneratedAtUtc);
+        Assert.Equal(artifact.SummaryLine, reparsed.SummaryLine);
+        Assert.Equal(artifact.VerifySummary.Valid, reparsed.VerifySummary.Valid);
+        Assert.Equal(artifact.BodyContractValidation.IsValid, reparsed.BodyContractValidation.IsValid);
+    }
+
+    [Fact]
+    public void Execute_GivenValidInputs_RecordsBundleSha256AndBodySha256()
+    {
+        using var workspace = new BridgeWorkspace();
+        var (artifact, paths) = RunSuccessful(workspace, "shas", "approved");
+
+        var bundleBytes = File.ReadAllBytes(paths.BundlePath);
+        var bodyBytes = File.ReadAllBytes(paths.BodyPath);
+        var expectedBundleSha = IssuePrepareCommand.ComputeSha256Hex(bundleBytes);
+        var expectedBodySha = IssuePrepareCommand.ComputeSha256Hex(bodyBytes);
+
+        Assert.Equal(expectedBundleSha, artifact.SourceBundleSha256);
+        Assert.Equal(expectedBodySha, artifact.SourceBodySha256);
+        Assert.Matches("^[0-9a-f]+$", artifact.SourceBundleSha256);
+        Assert.Matches("^[0-9a-f]+$", artifact.SourceBodySha256);
+    }
+
+    [Fact]
+    public void Execute_GivenApprovalLiteralApproved_RecordsApprovalKindApproved()
+    {
+        using var workspace = new BridgeWorkspace();
+        var (artifact, _) = RunSuccessful(workspace, "appr", "approved");
+        Assert.Equal(
+            TaskingPublishReviewedBridgeConstants.ApprovalMarkerKinds.Approved,
+            artifact.ApprovalMarkerKind);
+        Assert.Equal("approved", artifact.ApprovalMarker);
+    }
+
+    [Fact]
+    public void Execute_GivenApprovalLiteralReviewedByOperator_RecordsApprovalKindReviewedByOperator()
+    {
+        using var workspace = new BridgeWorkspace();
+        var (artifact, _) = RunSuccessful(workspace, "rbo", "reviewed-by-operator");
+        Assert.Equal(
+            TaskingPublishReviewedBridgeConstants.ApprovalMarkerKinds.ReviewedByOperator,
+            artifact.ApprovalMarkerKind);
+        Assert.Equal("reviewed-by-operator", artifact.ApprovalMarker);
+    }
+
+    [Fact]
+    public void Execute_GivenApprovalWithTagPrefix_RecordsApprovalKindApprovedWithTag()
+    {
+        using var workspace = new BridgeWorkspace();
+        var marker = "approved:tomohisa-2026-04-29";
+        var (artifact, _) = RunSuccessful(workspace, "tag", marker);
+        Assert.Equal(
+            TaskingPublishReviewedBridgeConstants.ApprovalMarkerKinds.ApprovedWithTag,
+            artifact.ApprovalMarkerKind);
+        Assert.Equal(marker, artifact.ApprovalMarker);
+    }
+
+    [Fact]
+    public void Execute_GivenInvalidApprovalMarker_ReturnsNonZero_NoArtifactWritten()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bundlePath = workspace.GenerateBundle("inv");
+        var bodyPath = workspace.WriteValidBody("body-inv.md");
+        var outPath = workspace.GetPath("reviewed-inv.json");
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", bodyPath,
+                "--approval", "yes",
+                "--out", outPath,
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.False(File.Exists(outPath), "Artifact must not be written on approval failure");
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(
+            TaskingPublishReviewedBridgeConstants.Statuses.ApprovalMarkerInvalid,
+            doc.RootElement.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenBlankApprovalMarker_ReturnsNonZero_NoArtifactWritten()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bundlePath = workspace.GenerateBundle("blank");
+        var bodyPath = workspace.WriteValidBody("body-blank.md");
+        var outPath = workspace.GetPath("reviewed-blank.json");
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", bodyPath,
+                "--approval", "",
+                "--out", outPath,
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.False(File.Exists(outPath), "Artifact must not be written on blank approval");
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(
+            TaskingPublishReviewedBridgeConstants.Statuses.ApprovalMarkerInvalid,
+            doc.RootElement.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenBundleWithFailedVerify_ReturnsNonZero_StatusVerifyFailed()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bundlePath = workspace.GenerateBundle("vf");
+        var bundle = JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(
+            File.ReadAllText(bundlePath))!;
+        // Tamper the task packet so its sha no longer matches the bundle's
+        // recorded source_task_packet_sha256.
+        using (var stream = new FileStream(bundle.SourceTaskPacketPath, FileMode.Append, FileAccess.Write))
+        {
+            stream.WriteByte((byte)' ');
+        }
+
+        var bodyPath = workspace.WriteValidBody("body-vf.md");
+        var outPath = workspace.GetPath("reviewed-vf.json");
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", bodyPath,
+                "--approval", "approved",
+                "--out", outPath,
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.False(File.Exists(outPath), "Artifact must not be written on verify_failed");
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(
+            TaskingPublishReviewedBridgeConstants.Statuses.VerifyFailed,
+            doc.RootElement.GetProperty("status").GetString());
+
+        var failedCheckIds = doc.RootElement
+            .GetProperty("verify_summary")
+            .GetProperty("failed_check_ids");
+        var ids = new List<string>();
+        foreach (var element in failedCheckIds.EnumerateArray())
+        {
+            ids.Add(element.GetString() ?? string.Empty);
+        }
+
+        Assert.Contains(
+            TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches,
+            ids);
+
+        var errors = doc.RootElement.GetProperty("errors");
+        var anyMatch = false;
+        foreach (var element in errors.EnumerateArray())
+        {
+            var s = element.GetString() ?? string.Empty;
+            if (s.Contains(TaskingHandoffBundleVerifyConstants.CheckIds.TaskPacketHashMatches, StringComparison.Ordinal))
+            {
+                anyMatch = true;
+                break;
+            }
+        }
+
+        Assert.True(anyMatch, "Expected errors to mention task_packet hash check id");
+    }
+
+    [Fact]
+    public void Execute_GivenMissingBundleFile_ReturnsNonZero()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bodyPath = workspace.WriteValidBody("body-missing-bundle.md");
+        var outPath = workspace.GetPath("reviewed-missing-bundle.json");
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", "/tmp/does-not-exist-g199.json",
+                "--from-body", bodyPath,
+                "--approval", "approved",
+                "--out", outPath,
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.False(File.Exists(outPath), "Artifact must not be written when bundle missing");
+    }
+
+    [Fact]
+    public void Execute_GivenMissingBodyFile_ReturnsNonZero_StatusMissingBody()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bundlePath = workspace.GenerateBundle("mb");
+        var outPath = workspace.GetPath("reviewed-missing-body.json");
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", "/tmp/does-not-exist-g199-body.md",
+                "--approval", "approved",
+                "--out", outPath,
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.False(File.Exists(outPath), "Artifact must not be written on missing_body");
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(
+            TaskingPublishReviewedBridgeConstants.Statuses.MissingBody,
+            doc.RootElement.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenContractInvalidBody_ReturnsNonZero_StatusBodyContractInvalid()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bundlePath = workspace.GenerateBundle("ci");
+        var bodyPath = workspace.GetPath("body-ci.md");
+        // Drop "## Acceptance Criteria" section.
+        var content = CompleteValidBody.Replace(
+            "## Acceptance Criteria\n\n- Deterministic behaviour described here.\n\n",
+            string.Empty,
+            StringComparison.Ordinal);
+        File.WriteAllText(bodyPath, content);
+        var outPath = workspace.GetPath("reviewed-ci.json");
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", bodyPath,
+                "--approval", "approved",
+                "--out", outPath,
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.False(File.Exists(outPath));
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(
+            TaskingPublishReviewedBridgeConstants.Statuses.BodyContractInvalid,
+            doc.RootElement.GetProperty("status").GetString());
+
+        var errors = doc.RootElement.GetProperty("errors");
+        var anyMissing = false;
+        foreach (var element in errors.EnumerateArray())
+        {
+            var s = element.GetString() ?? string.Empty;
+            if (s.Contains("Acceptance Criteria", StringComparison.Ordinal))
+            {
+                anyMissing = true;
+                break;
+            }
+        }
+
+        Assert.True(anyMissing, "Expected errors to mention 'Acceptance Criteria' missing heading");
+    }
+
+    [Fact]
+    public void Execute_GivenBodyWithPlaceholderRelatedLinks_ReturnsNonZero_StatusBodyContractInvalid()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bundlePath = workspace.GenerateBundle("rl");
+        var bodyPath = workspace.GetPath("body-rl.md");
+        var content = CompleteValidBody.Replace(
+            "- Host runbook: intents/rules/automations/runbook.md",
+            "- TODO",
+            StringComparison.Ordinal);
+        File.WriteAllText(bodyPath, content);
+        var outPath = workspace.GetPath("reviewed-rl.json");
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", bodyPath,
+                "--approval", "approved",
+                "--out", outPath,
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.False(File.Exists(outPath));
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(
+            TaskingPublishReviewedBridgeConstants.Statuses.BodyContractInvalid,
+            doc.RootElement.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedBundleJson_ReturnsNonZero_NoArtifactWritten()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bundlePath = workspace.GetPath("bundle-garbage.json");
+        File.WriteAllText(bundlePath, "{ this is not : valid json,");
+        var bodyPath = workspace.WriteValidBody("body-garbage.md");
+        var outPath = workspace.GetPath("reviewed-garbage.json");
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", bodyPath,
+                "--approval", "approved",
+                "--out", outPath,
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.False(File.Exists(outPath), "Artifact must not be written on malformed bundle");
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFlag_ReturnsNonZero()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bundlePath = workspace.GenerateBundle("mf");
+        var bodyPath = workspace.WriteValidBody("body-mf.md");
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", bodyPath,
+                "--approval", "approved"
+                // no --out
+            },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--out", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsNonZero()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bundlePath = workspace.GenerateBundle("ua");
+        var bodyPath = workspace.WriteValidBody("body-ua.md");
+        var outPath = workspace.GetPath("reviewed-ua.json");
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", bodyPath,
+                "--approval", "approved",
+                "--out", outPath,
+                "--bogus", "value"
+            },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesToQueueStateOrRunsLog()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bundlePath = workspace.GenerateBundle("noq");
+        var bodyPath = workspace.WriteValidBody("body-noq.md");
+        var outPath = workspace.GetPath("reviewed-noq.json");
+
+        var queueStatePath = workspace.Context.GetQueueStatePath();
+        var runsLogPath = workspace.Context.GetRunLogPath();
+
+        var queueBytes = Encoding.UTF8.GetBytes("{\"schema_version\":\"1\",\"items\":[]}\n");
+        var runsBytes = Encoding.UTF8.GetBytes("{\"event\":\"sentinel\",\"ts\":\"2026-04-29T00:00:00Z\"}\n");
+        Directory.CreateDirectory(Path.GetDirectoryName(queueStatePath)!);
+        File.WriteAllBytes(queueStatePath, queueBytes);
+        File.WriteAllBytes(runsLogPath, runsBytes);
+
+        var queueBefore = File.ReadAllBytes(queueStatePath);
+        var runsBefore = File.ReadAllBytes(runsLogPath);
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", bodyPath,
+                "--approval", "approved",
+                "--out", outPath
+            },
+            writer);
+
+        Assert.Equal(0, exit);
+
+        Assert.Equal(queueBefore, File.ReadAllBytes(queueStatePath));
+        Assert.Equal(runsBefore, File.ReadAllBytes(runsLogPath));
+    }
+
+    [Fact]
+    public void Execute_NeverOverwritesUnrelatedArtifacts_OnlyWritesToOutFlag()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bundlePath = workspace.GenerateBundle("only");
+        var bodyPath = workspace.WriteValidBody("body-only.md");
+        var outPath = workspace.GetPath("reviewed-only.json");
+
+        var sentinelPath = workspace.GetPath("sentinel.txt");
+        var sentinelContent = Encoding.UTF8.GetBytes("DO NOT TOUCH\n");
+        File.WriteAllBytes(sentinelPath, sentinelContent);
+
+        var snapshotBefore = workspace.SnapshotAllFiles();
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", bodyPath,
+                "--approval", "approved",
+                "--out", outPath
+            },
+            writer);
+
+        Assert.Equal(0, exit);
+
+        // Sentinel must be byte-identical.
+        Assert.Equal(sentinelContent, File.ReadAllBytes(sentinelPath));
+
+        var snapshotAfter = workspace.SnapshotAllFiles();
+        // Only the new file must be the --out path.
+        var newPaths = snapshotAfter.Keys.Where(p => !snapshotBefore.ContainsKey(p)).ToList();
+        Assert.Single(newPaths);
+        Assert.Equal(Path.GetFullPath(outPath), Path.GetFullPath(newPaths[0]));
+
+        // Any pre-existing file (excluding the sentinel and any unrelated)
+        // must not have been mutated.
+        foreach (var (path, contentBefore) in snapshotBefore)
+        {
+            Assert.True(snapshotAfter.ContainsKey(path), $"Pre-existing file disappeared: {path}");
+            Assert.Equal(contentBefore, snapshotAfter[path]);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesProvider_NoProcessStartInNewSurface()
+    {
+        using var workspace = new BridgeWorkspace();
+        var bundlePath = workspace.GenerateBundle("npr");
+        var bodyPath = workspace.WriteValidBody("body-npr.md");
+        var outPath = workspace.GetPath("reviewed-npr.json");
+
+        var launcherInvoked = false;
+        TaskingPublishReviewedBridgeCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", bodyPath,
+                "--approval", "approved",
+                "--out", outPath
+            },
+            writer);
+
+        Assert.Equal(0, exit);
+        Assert.False(launcherInvoked, "NestedProviderLauncher must never be invoked by G199");
+
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        foreach (var name in NewSurfaceFileNames)
+        {
+            var p = Path.Combine(commandsDir, name);
+            if (!File.Exists(p))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(p);
+            Assert.DoesNotContain("Process.Start(", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverCreatesBranchOrWorktree_NoGitInvocationInNewSurface()
+    {
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        foreach (var name in NewSurfaceFileNames)
+        {
+            var p = Path.Combine(commandsDir, name);
+            Assert.True(File.Exists(p), $"Missing new-surface file at {p}");
+            var text = File.ReadAllText(p);
+            Assert.DoesNotContain("git checkout", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("git worktree", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverPublishesGitHubIssue_NoGhInvocationInNewSurface()
+    {
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        foreach (var name in NewSurfaceFileNames)
+        {
+            var p = Path.Combine(commandsDir, name);
+            Assert.True(File.Exists(p), $"Missing new-surface file at {p}");
+            var text = File.ReadAllText(p);
+            Assert.DoesNotContain("gh issue create", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("gh issue edit", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("gh pr", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_AlwaysMarksContractFieldsLiteralFalseAndLocalOnly()
+    {
+        using var workspace = new BridgeWorkspace();
+        var (artifact, _) = RunSuccessful(workspace, "lock", "approved:tomohisa-2026-04-29");
+        Assert.False(artifact.IsPublished);
+        Assert.False(artifact.IsAutomationVisible);
+        Assert.Equal("local_only", artifact.ReviewedBridgeStatus);
+
+        // Verify accepted shapes constant is locked too.
+        Assert.Contains("approved", TaskingPublishReviewedBridgeConstants.AcceptedApprovalShapes);
+        Assert.Contains("reviewed-by-operator", TaskingPublishReviewedBridgeConstants.AcceptedApprovalShapes);
+        Assert.Contains(
+            TaskingPublishReviewedBridgeConstants.AcceptedApprovalShapes,
+            s => s.StartsWith("approved:", StringComparison.Ordinal));
+    }
+
+    // ----- helpers -----
+
+    private static readonly string[] NewSurfaceFileNames = new[]
+    {
+        "TaskingPublishReviewedBridgeCommand.cs",
+        "TaskingPublishReviewedBridgeAnalyzer.cs",
+        "TaskingPublishReviewedBridgeArtifact.cs"
+    };
+
+    private static TaskingPublishReviewedBridgeArtifact ReadArtifact(string path)
+    {
+        var json = File.ReadAllText(path);
+        var artifact = JsonSerializer.Deserialize<TaskingPublishReviewedBridgeArtifact>(json);
+        Assert.NotNull(artifact);
+        return artifact!;
+    }
+
+    private static (TaskingPublishReviewedBridgeArtifact artifact, BridgePaths paths) RunSuccessful(
+        BridgeWorkspace workspace,
+        string tag,
+        string approval)
+    {
+        var bundlePath = workspace.GenerateBundle(tag);
+        var bodyPath = workspace.WriteValidBody($"body-{tag}.md");
+        var outPath = workspace.GetPath($"reviewed-{tag}.json");
+
+        using var writer = new StringWriter();
+        var exit = TaskingPublishReviewedBridgeCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-bundle", bundlePath,
+                "--from-body", bodyPath,
+                "--approval", approval,
+                "--out", outPath
+            },
+            writer);
+
+        Assert.Equal(0, exit);
+        Assert.True(File.Exists(outPath), $"Artifact not written at {outPath}");
+
+        return (ReadArtifact(outPath), new BridgePaths(bundlePath, bodyPath, outPath));
+    }
+
+    private sealed record BridgePaths(string BundlePath, string BodyPath, string OutPath);
+
+    private static bool TryResolveCommandsSourceDirectory(out string commandsDirectory)
+    {
+        commandsDirectory = string.Empty;
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, "src", "IntentSystem.Cli", "Commands");
+            if (Directory.Exists(candidate))
+            {
+                commandsDirectory = candidate;
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private const string CompleteValidBody =
+        "# G999 Example child issue body for validator tests\n\n"
+        + "## Goal\n\nStand-alone description of what this slice changes.\n\n"
+        + "## Why This Slice Exists Now\n\nSurrounding rationale for cutting the slice now.\n\n"
+        + "## Current Observed State\n\nObserved state described in actionable terms.\n\n"
+        + "## Accepted Baseline You May Assume\n\nBaseline assumptions stated explicitly.\n\n"
+        + "## Target Repo / Path / Part\n\n- Repository: J-Tech-Japan/intent-system\n- Likely areas: src/, tests/\n\n"
+        + "## In Scope\n\n- The slice change itself.\n\n"
+        + "## Out Of Scope\n\n- Adjacent refactors.\n\n"
+        + "## Acceptance Criteria\n\n- Deterministic behaviour described here.\n\n"
+        + "## Verification\n\nRun the focused suite.\n\n"
+        + "## Related Links\n\n- Host runbook: intents/rules/automations/runbook.md\n";
+
+    private sealed class BridgeWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("tasking-publish-reviewed-bridge-tests-")
+            .FullName;
+
+        public BridgeWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string GetPath(string relative) => Path.Combine(rootPath, relative);
+
+        public string WriteValidBody(string relative)
+        {
+            var path = GetPath(relative);
+            File.WriteAllText(path, CompleteValidBody);
+            return path;
+        }
+
+        public IReadOnlyDictionary<string, byte[]> SnapshotAllFiles()
+        {
+            var map = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories))
+            {
+                map[path] = File.ReadAllBytes(path);
+            }
+
+            return map;
+        }
+
+        public string GenerateBundle(string tag)
+        {
+            var (previewPath, checklistPath) = GeneratePreviewAndChecklist(tag);
+            var bundlePath = GetPath($"bundle-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingHandoffBundleCommand.Execute(
+                Context,
+                new[]
+                {
+                    "--from-preview", previewPath,
+                    "--from-checklist", checklistPath,
+                    "--out", bundlePath
+                },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G194 bundle for tests: exit={exit}, stderr={sink}");
+            }
+
+            return bundlePath;
+        }
+
+        private (string previewPath, string checklistPath) GeneratePreviewAndChecklist(string tag)
+        {
+            var previewPath = GeneratePreview(tag);
+            var checklistPath = GetPath($"checklist-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingTaskPacketChecklistCommand.Execute(
+                Context,
+                new[] { "--from-preview", previewPath, "--out", checklistPath },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G193 checklist: exit={exit}, stderr={sink}");
+            }
+
+            return (previewPath, checklistPath);
+        }
+
+        private string GeneratePreview(string tag)
+        {
+            var handoffPath = GetPath($"__handoff_{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingHandoffCommand.Execute(
+                    Context,
+                    new[] { "--out", handoffPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G190 handoff: exit={exit}, stderr={sink}");
+                }
+            }
+
+            var taskPacketPath = GetPath($"__task_packet_{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingTaskPacketCommand.Execute(
+                    Context,
+                    new[] { "--from-handoff", handoffPath, "--out", taskPacketPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G191 task packet: exit={exit}, stderr={sink}");
+                }
+            }
+
+            var previewPath = GetPath($"preview-{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingTaskPacketPreviewCommand.Execute(
+                    Context,
+                    new[] { "--from-task-packet", taskPacketPath, "--out", previewPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G192 preview: exit={exit}, stderr={sink}");
+                }
+            }
+
+            return previewPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new subcommand `intent-cli tasking publish-reviewed-bridge --from-bundle <bundle> --from-body <body.md> --approval <marker> --out <reviewed-artifact-path> [--format text|json]` under the existing `tasking` group. Ninth in the chain G190 → G191 → G192 → G193 → G194 → G195 → G196 → G197 → G198 → **G199 reviewed publish bridge**. The bridge consumes a verified G194 handoff bundle through the G196/G197 verify analyzer + an operator-supplied G183-contract-valid Markdown body file + an explicit approval marker, and writes a deterministic local-only \"reviewed-ready\" artifact. **It does NOT publish a GitHub issue** (G184 `issue publish-reviewed` remains the actual GitHub publish step). No GitHub network. No provider/worker launch. No queue/runs mutation. No `intent-target` exposure. No branch/worktree creation. No overwrite of unrelated artifacts.
- Naming: avoided collision with the existing `issue publish-reviewed` (G184, the real publish step). Sits under the `tasking` group as `publish-reviewed-bridge` to make the role obvious.
- Strict precedence (each check before the next; first failure exits 1, NO output artifact written):
  - missing/blank required flag → exit 1.
  - `--from-bundle` file not found → exit 1.
  - bundle JSON parse failure → exit 1.
  - G196/G197 verify reports `valid == false` → exit 1, JSON `status: \"verify_failed\"`, errors lists failed check ids.
  - `--from-body` file not found → exit 1, JSON `status: \"missing_body\"`.
  - body fails G183 `IssueValidateBodyValidator` (any missing required heading or invalid Related Links) → exit 1, JSON `status: \"body_contract_invalid\"`, errors lists missing headings or related-links problem.
  - `--approval` not in the documented stable set → exit 1, JSON `status: \"approval_marker_invalid\"`.
  - Otherwise: write the reviewed-ready artifact, exit 0, JSON `status: \"ok\"`.
- **Approval marker contract** (locked in `TaskingPublishReviewedBridgeConstants.AcceptedApprovalShapes`): exactly one of `\"approved\"`, `\"reviewed-by-operator\"`, or any string starting with `\"approved:\"` (e.g. `\"approved:tomohisa-2026-04-29\"`). Anything else is rejected. The `approval_marker_kind` is recorded in the artifact as `\"approved\"` / `\"reviewed_by_operator\"` / `\"approved_with_tag\"` for stable downstream parsing.
- Output reviewed-ready artifact JSON shape (snake_case, stable, round-trippable through `JsonSerializer.Deserialize<TaskingPublishReviewedBridgeArtifact>`):
  ```
  { \"source_bundle_path\": \"...\", \"source_bundle_sha256\": \"<lowercase hex>\",
    \"source_body_path\":   \"...\", \"source_body_sha256\":   \"<lowercase hex>\",
    \"domain\": \"...\",
    \"is_published\": false,
    \"is_automation_visible\": false,
    \"reviewed_bridge_status\": \"local_only\",
    \"approval_marker\": \"<as-passed>\",
    \"approval_marker_kind\": \"approved\" | \"reviewed_by_operator\" | \"approved_with_tag\",
    \"verify_summary\": { \"valid\": true, \"failed_check_ids\": [] },
    \"body_contract_validation\": { \"is_valid\": true, \"missing_headings\": [], \"related_links_invalid\": false, \"related_links_reason\": null },
    \"generated_at_utc\": \"<ISO8601 UTC>\",
    \"artifact_path\": \"<absolute>\",
    \"summary_line\": \"Reviewed task packet publish bridge for <domain> — UNPUBLISHED, local-only, not automation-visible. status=ok.\" }
  ```
  Contract fields `is_published` / `is_automation_visible` are ALWAYS literal `false`; `reviewed_bridge_status` is ALWAYS literal `\"local_only\"`. Locked in by an explicit regression so future drift cannot accidentally flip these.
- The reviewed-ready artifact contains EVERYTHING needed for a future operator to consume / hand to G184 `issue publish-reviewed` for the real GitHub publish — it's a stable handoff packet, not a publish.
- No-mutation invariants:
  - Sentinel `TaskingPublishReviewedBridgeCommand.NestedProviderLauncher` (mirrors G187/G190/.../G198) — never invoked.
  - Source-scan asserts the new command + analyzer files contain no `Process.Start(`, no `git checkout`/`git worktree`, and no `gh issue create`/`gh issue edit`/`gh pr` literals.
  - Byte-equivalence test on `.intent-cli/queue-state.json` and `.intent-cli/runs.jsonl` before/after.
  - Sentinel-file test (`Execute_NeverOverwritesUnrelatedArtifacts_OnlyWritesToOutFlag`) writes a file at `<workspace>/sentinel.txt` BEFORE the bridge runs, then asserts (a) sentinel.txt is byte-identical after, AND (b) only the `--out` path was created.
- Reuse, not duplication:
  - `TaskingHandoffBundleArtifact` (G194) — deserialize the bundle.
  - `TaskingHandoffBundleVerifyAnalyzer.BuildChecks` (G196/G197) — reuse for verify.
  - `TaskingHandoffBundleVerifyCommand.ObserveReferencedSourceArtifacts` (G197 → G198 already promoted to `internal`) — reuse.
  - `IssueValidateBodyValidator.Validate` (G183) — reuse for body contract validation.
  - `IssuePrepareCommand.ComputeSha256Hex(byte[])` — for both source sha256 fields.
  - `IssuePrepareCommand.FormatUtcTimestamp(DateTimeOffset)` — for `generated_at_utc`.
  - **No `private→internal` promotions needed this slice** — all helpers were already accessible.

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter \"FullyQualifiedName~TaskingPublishReviewedBridge\"` — **22/22 passing**. Issue-required scenarios covered:
  - **valid reviewed body**: `Execute_GivenValidBundleBodyAndApproval_WritesReviewedReadyArtifact`, `Execute_GivenValidInputs_ReviewedArtifactJsonRoundTripsStably`, `Execute_GivenValidInputs_RecordsBundleSha256AndBodySha256`, plus 3 approval-kind regressions (`...ApprovalLiteralApproved...`, `...LiteralReviewedByOperator...`, `...WithTagPrefix...`).
  - **missing approval refusal**: `Execute_GivenInvalidApprovalMarker_ReturnsNonZero_NoArtifactWritten`, `Execute_GivenBlankApprovalMarker_ReturnsNonZero_NoArtifactWritten`.
  - **failed verification refusal**: `Execute_GivenBundleWithFailedVerify_ReturnsNonZero_StatusVerifyFailed` (edits the task packet file → G197 hash check fails → bridge refuses; explicit no-artifact-written assertion).
  - **invalid body refusal**: `Execute_GivenContractInvalidBody_ReturnsNonZero_StatusBodyContractInvalid` (missing required heading), `Execute_GivenBodyWithPlaceholderRelatedLinks_ReturnsNonZero_StatusBodyContractInvalid` (G183's TODO/placeholder Related Links rule).
  - **malformed input refusal**: `Execute_GivenMissingBundleFile_ReturnsNonZero`, `Execute_GivenMissingBodyFile_ReturnsNonZero_StatusMissingBody`, `Execute_GivenMalformedBundleJson_ReturnsNonZero_NoArtifactWritten`.
  - **CLI plumbing**: `Execute_GivenMissingFlag_ReturnsNonZero`, `Execute_GivenUnknownArgument_ReturnsNonZero`.
  - **no-mutation behavior**: `Execute_NeverWritesToQueueStateOrRunsLog` (queue/runs byte-equivalence), `Execute_NeverOverwritesUnrelatedArtifacts_OnlyWritesToOutFlag` (sentinel-file test — issue's explicit no-overwrite criterion), `Execute_NeverInvokesProvider_NoProcessStartInNewSurface` (sentinel + source-scan), `Execute_NeverCreatesBranchOrWorktree_NoGitInvocationInNewSurface` (source-scan), `Execute_NeverPublishesGitHubIssue_NoGhInvocationInNewSurface` (source-scan asserts no `gh issue create`/`gh issue edit`/`gh pr` literals — issue's no-publish criterion).
  - **contract-locking regression**: `Execute_AlwaysMarksContractFieldsLiteralFalseAndLocalOnly` (`is_published`/`is_automation_visible`/`reviewed_bridge_status`).
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **1165/1165 passing + 1 skip** (the 1 skip is the pre-existing G190 `TolerantToSubAnalyzerFailure` `[Fact(Skip)]` not introduced by this slice; CLI: 1143 → 1165 = +22 new G199 tests; no regressions).
- Confirmation that no provider launch or GitHub mutation behavior was added: verified by sentinel + source-scan (Process.Start + git invocation patterns + gh issue/pr patterns) + queue/runs byte-equivalence + sentinel-file no-overwrite test.
- [ ] Manual smoke (recommended after merge):
  - `dotnet run ... -- tasking handoff --domain intent-cli --out /tmp/g199-handoff.json && ... task-packet ... && ... task-packet-preview ... && ... task-packet-checklist ... && ... handoff-bundle ... --out /tmp/g199-bundle.json`
  - prepare a G183-contract-valid `/tmp/g199-body.md`
  - `dotnet run ... -- tasking publish-reviewed-bridge --from-bundle /tmp/g199-bundle.json --from-body /tmp/g199-body.md --approval approved --out /tmp/g199-reviewed.json --format json` (assert `status: \"ok\"`, `reviewed_bridge_status: \"local_only\"`, `approval_marker_kind: \"approved\"`)
  - `dotnet run ... -- tasking publish-reviewed-bridge --from-bundle /tmp/g199-bundle.json --from-body /tmp/g199-body.md --approval yes --out /tmp/g199-reviewed.json` (assert `status: \"approval_marker_invalid\"`, NO output file written)

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)