### PR TITLE
G200: add intent-cli tasking handoff-bundle-history operator list

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -134,7 +134,8 @@ internal static class CommandRouter
                 ["handoff-bundle-inspect"] = TaskingHandoffBundleInspectCommand.Execute,
                 ["handoff-bundle-verify"] = TaskingHandoffBundleVerifyCommand.Execute,
                 ["handoff-bundle-import-dry-run"] = TaskingHandoffBundleImportDryRunCommand.Execute,
-                ["publish-reviewed-bridge"] = TaskingPublishReviewedBridgeCommand.Execute
+                ["publish-reviewed-bridge"] = TaskingPublishReviewedBridgeCommand.Execute,
+                ["handoff-bundle-history"] = TaskingHandoffBundleHistoryCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleHistoryAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleHistoryAnalyzer.cs
@@ -1,0 +1,233 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G200 — pure logic that takes a directory enumeration result (a list of
+/// candidate <c>*.json</c> file paths) and builds a deterministic
+/// <see cref="TaskingHandoffBundleHistoryResult"/>. No directory enumeration
+/// happens here; that concern is owned by
+/// <see cref="TaskingHandoffBundleHistoryCommand"/>. No file write of any kind
+/// happens here; the history command/analyzer pair is strictly read-only.
+///
+/// Classification rules:
+/// <list type="bullet">
+/// <item><description><c>valid_bundle</c>: deserializes as
+/// <see cref="TaskingHandoffBundleArtifact"/> AND
+/// <c>bundle_status == "local_only"</c> AND <c>is_published == false</c>
+/// AND <c>is_automation_visible == false</c>.</description></item>
+/// <item><description><c>invalid_bundle</c>: deserializes but one of those
+/// three contract checks fails.</description></item>
+/// <item><description><c>malformed</c>: not parseable as
+/// <see cref="TaskingHandoffBundleArtifact"/>.</description></item>
+/// <item><description><c>unreadable</c>: read I/O failure (caller passes the
+/// pre-collected exception via <see cref="EntryInput"/>).</description></item>
+/// </list>
+/// </summary>
+internal static class TaskingHandoffBundleHistoryAnalyzer
+{
+    /// <summary>
+    /// Stable header phrase emitted at the top of both text and JSON
+    /// outputs. Locked by tests so the wording cannot drift silently.
+    /// </summary>
+    public const string HeaderPhrase = "Tasking handoff bundle history";
+
+    public static TaskingHandoffBundleHistoryResult Build(
+        string fromDirectory,
+        IReadOnlyList<EntryInput> inputs)
+    {
+        ArgumentNullException.ThrowIfNull(fromDirectory);
+        ArgumentNullException.ThrowIfNull(inputs);
+
+        var sorted = inputs
+            .OrderBy(input => input.FileName, StringComparer.Ordinal)
+            .ToList();
+
+        var entries = new List<HistoryEntry>(sorted.Count);
+        var validCount = 0;
+        var invalidCount = 0;
+        var malformedCount = 0;
+        var unreadableCount = 0;
+
+        foreach (var input in sorted)
+        {
+            var entry = ClassifyEntry(input);
+            entries.Add(entry);
+
+            switch (entry.Classification)
+            {
+                case TaskingHandoffBundleHistoryConstants.Classifications.ValidBundle:
+                    validCount++;
+                    break;
+                case TaskingHandoffBundleHistoryConstants.Classifications.InvalidBundle:
+                    invalidCount++;
+                    break;
+                case TaskingHandoffBundleHistoryConstants.Classifications.Malformed:
+                    malformedCount++;
+                    break;
+                case TaskingHandoffBundleHistoryConstants.Classifications.Unreadable:
+                    unreadableCount++;
+                    break;
+            }
+        }
+
+        var entryCount = entries.Count;
+        var summaryLine =
+            $"{HeaderPhrase} for {fromDirectory} — "
+            + $"{entryCount} {(entryCount == 1 ? "entry" : "entries")}, "
+            + $"{validCount} valid, "
+            + $"{invalidCount} invalid, "
+            + $"{malformedCount} malformed, "
+            + $"{unreadableCount} unreadable.";
+
+        return new TaskingHandoffBundleHistoryResult
+        {
+            FromDirectory = fromDirectory,
+            EntryCount = entryCount,
+            ValidCount = validCount,
+            InvalidCount = invalidCount,
+            MalformedCount = malformedCount,
+            UnreadableCount = unreadableCount,
+            Entries = entries,
+            SummaryLine = summaryLine
+        };
+    }
+
+    private static HistoryEntry ClassifyEntry(EntryInput input)
+    {
+        if (input.ReadError is not null)
+        {
+            return new HistoryEntry
+            {
+                FileName = input.FileName,
+                AbsolutePath = input.AbsolutePath,
+                Classification = TaskingHandoffBundleHistoryConstants.Classifications.Unreadable,
+                Domain = null,
+                BundleStatus = null,
+                IsPublished = null,
+                IsAutomationVisible = null,
+                SourceTaskPacketPath = null,
+                SourcePreviewPath = null,
+                SourceChecklistPath = null,
+                SourceHandoffPath = null,
+                ChecklistReadyForHandoff = null,
+                Errors = new[] { $"unreadable: {input.ReadError}" }
+            };
+        }
+
+        TaskingHandoffBundleArtifact? bundle;
+        try
+        {
+            bundle = JsonSerializer.Deserialize<TaskingHandoffBundleArtifact>(input.RawBytes!);
+        }
+        catch (JsonException exception)
+        {
+            return new HistoryEntry
+            {
+                FileName = input.FileName,
+                AbsolutePath = input.AbsolutePath,
+                Classification = TaskingHandoffBundleHistoryConstants.Classifications.Malformed,
+                Domain = null,
+                BundleStatus = null,
+                IsPublished = null,
+                IsAutomationVisible = null,
+                SourceTaskPacketPath = null,
+                SourcePreviewPath = null,
+                SourceChecklistPath = null,
+                SourceHandoffPath = null,
+                ChecklistReadyForHandoff = null,
+                Errors = new[] { $"parse failure: {exception.Message}" }
+            };
+        }
+
+        if (bundle is null)
+        {
+            return new HistoryEntry
+            {
+                FileName = input.FileName,
+                AbsolutePath = input.AbsolutePath,
+                Classification = TaskingHandoffBundleHistoryConstants.Classifications.Malformed,
+                Domain = null,
+                BundleStatus = null,
+                IsPublished = null,
+                IsAutomationVisible = null,
+                SourceTaskPacketPath = null,
+                SourcePreviewPath = null,
+                SourceChecklistPath = null,
+                SourceHandoffPath = null,
+                ChecklistReadyForHandoff = null,
+                Errors = new[] { "parse failure: deserialized to null bundle." }
+            };
+        }
+
+        var contractErrors = new List<string>();
+        if (!string.Equals(
+                bundle.BundleStatus,
+                TaskingHandoffBundleConstants.LocalOnlyStatus,
+                StringComparison.Ordinal))
+        {
+            contractErrors.Add(
+                $"bundle_status must be '{TaskingHandoffBundleConstants.LocalOnlyStatus}' "
+                + $"(got '{bundle.BundleStatus}').");
+        }
+
+        if (bundle.IsPublished)
+        {
+            contractErrors.Add("is_published must be false (got true).");
+        }
+
+        if (bundle.IsAutomationVisible)
+        {
+            contractErrors.Add("is_automation_visible must be false (got true).");
+        }
+
+        if (contractErrors.Count > 0)
+        {
+            return new HistoryEntry
+            {
+                FileName = input.FileName,
+                AbsolutePath = input.AbsolutePath,
+                Classification = TaskingHandoffBundleHistoryConstants.Classifications.InvalidBundle,
+                Domain = null,
+                BundleStatus = null,
+                IsPublished = null,
+                IsAutomationVisible = null,
+                SourceTaskPacketPath = null,
+                SourcePreviewPath = null,
+                SourceChecklistPath = null,
+                SourceHandoffPath = null,
+                ChecklistReadyForHandoff = null,
+                Errors = contractErrors
+            };
+        }
+
+        return new HistoryEntry
+        {
+            FileName = input.FileName,
+            AbsolutePath = input.AbsolutePath,
+            Classification = TaskingHandoffBundleHistoryConstants.Classifications.ValidBundle,
+            Domain = bundle.Domain,
+            BundleStatus = bundle.BundleStatus,
+            IsPublished = bundle.IsPublished,
+            IsAutomationVisible = bundle.IsAutomationVisible,
+            SourceTaskPacketPath = bundle.SourceTaskPacketPath,
+            SourcePreviewPath = bundle.SourcePreviewPath,
+            SourceChecklistPath = bundle.SourceChecklistPath,
+            SourceHandoffPath = bundle.SourceHandoffPath,
+            ChecklistReadyForHandoff = bundle.ChecklistReadyForHandoff,
+            Errors = Array.Empty<string>()
+        };
+    }
+
+    /// <summary>
+    /// Per-file pre-read input passed from the command layer. The command does
+    /// the read so the analyzer stays pure (no I/O).
+    /// </summary>
+    internal sealed record EntryInput
+    {
+        public required string FileName { get; init; }
+        public required string AbsolutePath { get; init; }
+        public byte[]? RawBytes { get; init; }
+        public string? ReadError { get; init; }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleHistoryCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleHistoryCommand.cs
@@ -1,0 +1,211 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G200: <c>intent-cli tasking handoff-bundle-history</c>. A LOCAL operator
+/// list/scan command that enumerates top-level <c>*.json</c> files in a
+/// directory and classifies each as a G194
+/// <see cref="TaskingHandoffBundleArtifact"/> handoff bundle, an invalid
+/// bundle, malformed JSON, or unreadable. The command performs no GitHub
+/// network calls, applies no labels, launches no provider processes, and does
+/// NOT touch <c>.intent-cli/queue-state.json</c> or
+/// <c>.intent-cli/runs.jsonl</c>. It emits to STDOUT only — no artifact file
+/// is written, ever.
+///
+/// Sits beside G190..G199 under the same <c>tasking</c> group. It does NOT
+/// replace any of those commands, nor does it touch
+/// <c>issue plan-candidate</c>, <c>issue prepare</c>, or
+/// <c>issue publish-reviewed</c>.
+///
+/// Network-mutation invariance: this command's hot path contains no
+/// <c>Process.Start</c>, no shell-out to <c>gh</c>, and no provider launcher.
+/// The associated tests validate the no-provider-launch invariant via the
+/// <see cref="NestedProviderLauncher"/> sentinel and a source-scan assertion.
+///
+/// Non-recursive: only top-level <c>*.json</c> files in the supplied directory
+/// are scanned. Subdirectory contents are ignored. Sorted by file name
+/// (ordinal) for deterministic output.
+///
+/// Exit conventions:
+/// <list type="bullet">
+/// <item><description>Missing/blank <c>--from-directory</c> → exit 1.</description></item>
+/// <item><description>Path missing on disk → exit 1.</description></item>
+/// <item><description>Path exists but is not a directory → exit 1.</description></item>
+/// <item><description>Empty directory → exit 0 with empty entries.</description></item>
+/// <item><description>Any successful scan (including malformed/invalid entries
+/// reported in the result) → exit 0.</description></item>
+/// </list>
+/// </summary>
+internal static class TaskingHandoffBundleHistoryCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private static readonly JsonSerializerOptions JsonOutputOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    /// <summary>
+    /// Test seam mirroring G190..G199 <c>NestedProviderLauncher</c>.
+    /// G200 must NEVER invoke this delegate. Tests register a sentinel that
+    /// flips a flag if invoked; the history path leaves it untouched.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var fromDirectory, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedFromDirectory = Path.GetFullPath(fromDirectory);
+
+        if (File.Exists(resolvedFromDirectory) && !Directory.Exists(resolvedFromDirectory))
+        {
+            writer.WriteLine(
+                $"--from-directory path is not a directory: {fromDirectory}");
+            return 1;
+        }
+
+        if (!Directory.Exists(resolvedFromDirectory))
+        {
+            writer.WriteLine(
+                $"--from-directory path does not exist (not found): {fromDirectory}");
+            return 1;
+        }
+
+        var jsonFiles = Directory
+            .EnumerateFiles(resolvedFromDirectory, "*.json", SearchOption.TopDirectoryOnly)
+            .ToList();
+
+        var inputs = new List<TaskingHandoffBundleHistoryAnalyzer.EntryInput>(jsonFiles.Count);
+        foreach (var path in jsonFiles)
+        {
+            var fileName = Path.GetFileName(path);
+            byte[]? bytes = null;
+            string? readError = null;
+            try
+            {
+                bytes = File.ReadAllBytes(path);
+            }
+            catch (Exception exception)
+            {
+                readError = exception.Message;
+            }
+
+            inputs.Add(new TaskingHandoffBundleHistoryAnalyzer.EntryInput
+            {
+                FileName = fileName,
+                AbsolutePath = path,
+                RawBytes = bytes,
+                ReadError = readError
+            });
+        }
+
+        var result = TaskingHandoffBundleHistoryAnalyzer.Build(fromDirectory, inputs);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOutputOptions));
+        }
+        else
+        {
+            WriteTextSummary(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static void WriteTextSummary(TextWriter writer, TaskingHandoffBundleHistoryResult result)
+    {
+        writer.WriteLine(result.SummaryLine);
+
+        if (result.EntryCount == 0)
+        {
+            writer.WriteLine($"no bundle entries found in {result.FromDirectory}");
+            return;
+        }
+
+        foreach (var entry in result.Entries)
+        {
+            var domain = entry.Domain ?? "?";
+            var status = entry.BundleStatus ?? "?";
+            var ready = entry.ChecklistReadyForHandoff is null
+                ? "?"
+                : entry.ChecklistReadyForHandoff.Value.ToString();
+            var errors = entry.Errors.Count;
+            writer.WriteLine(
+                $"[{entry.Classification}] {entry.FileName} — domain: {domain}, status: {status}, ready: {ready}, errors: {errors}");
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string fromDirectory,
+        out string format,
+        out string error)
+    {
+        fromDirectory = string.Empty;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-directory":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-directory requires a non-empty value.";
+                        return false;
+                    }
+
+                    fromDirectory = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error =
+                        $"Unknown argument '{argument}'. Supported: --from-directory, --format.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromDirectory))
+        {
+            error = "--from-directory is required.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingHandoffBundleHistoryResult.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingHandoffBundleHistoryResult.cs
@@ -1,0 +1,109 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G200 history result record. Snake_case JSON shape that
+/// <c>intent-cli tasking handoff-bundle-history</c> emits to STDOUT when
+/// <c>--format json</c> is requested. The result is a deterministic, read-only
+/// directory scan of zero or more local G194
+/// <see cref="TaskingHandoffBundleArtifact"/> bundle JSON files: the history
+/// command does NOT write any artifact file, never mutates inputs, and never
+/// recurses into subdirectories.
+///
+/// <para>
+/// <see cref="Entries"/> is sorted by <see cref="HistoryEntry.FileName"/>
+/// (ordinal) so reviewers can rely on stable diff-friendly output. Each entry
+/// has a <see cref="HistoryEntry.Classification"/> drawn from
+/// <see cref="TaskingHandoffBundleHistoryConstants.Classifications"/>; for
+/// non-<c>valid_bundle</c> entries the bundle-identity fields are <c>null</c>.
+/// </para>
+/// </summary>
+internal sealed record TaskingHandoffBundleHistoryResult
+{
+    [JsonPropertyName("from_directory")]
+    public required string FromDirectory { get; init; }
+
+    [JsonPropertyName("entry_count")]
+    public required int EntryCount { get; init; }
+
+    [JsonPropertyName("valid_count")]
+    public required int ValidCount { get; init; }
+
+    [JsonPropertyName("invalid_count")]
+    public required int InvalidCount { get; init; }
+
+    [JsonPropertyName("malformed_count")]
+    public required int MalformedCount { get; init; }
+
+    [JsonPropertyName("unreadable_count")]
+    public required int UnreadableCount { get; init; }
+
+    [JsonPropertyName("entries")]
+    public required IReadOnlyList<HistoryEntry> Entries { get; init; }
+
+    [JsonPropertyName("summary_line")]
+    public required string SummaryLine { get; init; }
+}
+
+/// <summary>
+/// G200 single-entry record. One per top-level <c>*.json</c> file in the
+/// scanned directory.
+/// </summary>
+internal sealed record HistoryEntry
+{
+    [JsonPropertyName("file_name")]
+    public required string FileName { get; init; }
+
+    [JsonPropertyName("absolute_path")]
+    public required string AbsolutePath { get; init; }
+
+    [JsonPropertyName("classification")]
+    public required string Classification { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string? Domain { get; init; }
+
+    [JsonPropertyName("bundle_status")]
+    public required string? BundleStatus { get; init; }
+
+    [JsonPropertyName("is_published")]
+    public required bool? IsPublished { get; init; }
+
+    [JsonPropertyName("is_automation_visible")]
+    public required bool? IsAutomationVisible { get; init; }
+
+    [JsonPropertyName("source_task_packet_path")]
+    public required string? SourceTaskPacketPath { get; init; }
+
+    [JsonPropertyName("source_preview_path")]
+    public required string? SourcePreviewPath { get; init; }
+
+    [JsonPropertyName("source_checklist_path")]
+    public required string? SourceChecklistPath { get; init; }
+
+    [JsonPropertyName("source_handoff_path")]
+    public required string? SourceHandoffPath { get; init; }
+
+    [JsonPropertyName("checklist_ready_for_handoff")]
+    public required bool? ChecklistReadyForHandoff { get; init; }
+
+    [JsonPropertyName("errors")]
+    public required IReadOnlyList<string> Errors { get; init; }
+}
+
+/// <summary>
+/// G200 stable classification constants. The history analyzer assigns exactly
+/// one of these strings to every entry; tests assert against the literal
+/// values so the contract cannot drift silently.
+/// </summary>
+internal static class TaskingHandoffBundleHistoryConstants
+{
+    public static class Classifications
+    {
+        public const string ValidBundle = "valid_bundle";
+        public const string InvalidBundle = "invalid_bundle";
+        public const string Malformed = "malformed";
+        public const string Unreadable = "unreadable";
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/TaskingHandoffBundleHistoryCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskingHandoffBundleHistoryCommandTests.cs
@@ -1,0 +1,762 @@
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G200 — coverage for <c>intent-cli tasking handoff-bundle-history</c>. Class
+/// name contains <c>Tasking</c>, <c>Handoff</c>, <c>Bundle</c>, and
+/// <c>History</c> so reviewers can match the issue's recommended
+/// <c>~TaskingHandoffBundle</c> filter.
+/// </summary>
+public sealed class TaskingHandoffBundleHistoryCommandTests : IDisposable
+{
+    private readonly Func<bool>? originalLauncher;
+
+    public TaskingHandoffBundleHistoryCommandTests()
+    {
+        originalLauncher = TaskingHandoffBundleHistoryCommand.NestedProviderLauncher;
+    }
+
+    public void Dispose()
+    {
+        TaskingHandoffBundleHistoryCommand.NestedProviderLauncher = originalLauncher;
+    }
+
+    [Fact]
+    public void Execute_GivenDirectoryWithThreeValidBundles_ListsAllThreeAsValid()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("three-valid");
+        workspace.GenerateBundleInto(scanDir, "alpha-bundle");
+        workspace.GenerateBundleInto(scanDir, "beta-bundle");
+        workspace.GenerateBundleInto(scanDir, "gamma-bundle");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleHistoryResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(3, result!.EntryCount);
+        Assert.Equal(3, result.ValidCount);
+        Assert.Equal(0, result.InvalidCount);
+        Assert.Equal(0, result.MalformedCount);
+        Assert.Equal(0, result.UnreadableCount);
+        Assert.Equal(3, result.Entries.Count);
+
+        // Sorted ordinal: alpha-bundle.json, beta-bundle.json, gamma-bundle.json
+        Assert.Equal("alpha-bundle.json", result.Entries[0].FileName);
+        Assert.Equal("beta-bundle.json", result.Entries[1].FileName);
+        Assert.Equal("gamma-bundle.json", result.Entries[2].FileName);
+
+        foreach (var entry in result.Entries)
+        {
+            Assert.Equal(
+                TaskingHandoffBundleHistoryConstants.Classifications.ValidBundle,
+                entry.Classification);
+            Assert.Equal("intent-cli", entry.Domain);
+            Assert.Equal("local_only", entry.BundleStatus);
+            Assert.False(entry.IsPublished);
+            Assert.False(entry.IsAutomationVisible);
+            Assert.NotNull(entry.SourceTaskPacketPath);
+            Assert.NotNull(entry.SourcePreviewPath);
+            Assert.NotNull(entry.SourceChecklistPath);
+            Assert.NotNull(entry.SourceHandoffPath);
+            Assert.NotNull(entry.ChecklistReadyForHandoff);
+            Assert.Empty(entry.Errors);
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenEmptyDirectory_ReturnsZeroAndEmptyEntries()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("empty");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("no bundle entries found", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenEmptyDirectory_JsonHasZeroCounts()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("empty-json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleHistoryResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(0, result!.EntryCount);
+        Assert.Empty(result.Entries);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDirectoryPath_ReturnsNonZero_DeterministicError()
+    {
+        using var workspace = new HistoryWorkspace();
+        var missing = workspace.GetPath("does-not-exist-dir");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", missing },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains(missing, output, StringComparison.Ordinal);
+        Assert.True(
+            output.Contains("not found", StringComparison.Ordinal)
+            || output.Contains("does not exist", StringComparison.Ordinal),
+            $"Expected 'not found' or 'does not exist' in error output but got: {output}");
+    }
+
+    [Fact]
+    public void Execute_GivenPathIsFileNotDirectory_ReturnsNonZero()
+    {
+        using var workspace = new HistoryWorkspace();
+        var filePath = workspace.GetPath("a-regular-file.json");
+        File.WriteAllText(filePath, "{}");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", filePath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("not a directory", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenDirectoryWithMalformedJson_ReportsAsMalformed()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("malformed-mix");
+        workspace.GenerateBundleInto(scanDir, "real-bundle");
+        File.WriteAllText(Path.Combine(scanDir, "garbage.json"), "{ not : valid json,,,");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleHistoryResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(2, result!.EntryCount);
+        Assert.Equal(1, result.ValidCount);
+        Assert.Equal(1, result.MalformedCount);
+
+        var malformed = result.Entries.Single(e =>
+            e.Classification == TaskingHandoffBundleHistoryConstants.Classifications.Malformed);
+        Assert.Equal("garbage.json", malformed.FileName);
+        Assert.NotEmpty(malformed.Errors);
+        Assert.Contains(
+            malformed.Errors,
+            err => err.Contains("parse failure", StringComparison.Ordinal));
+        Assert.Null(malformed.Domain);
+        Assert.Null(malformed.BundleStatus);
+    }
+
+    [Fact]
+    public void Execute_GivenDirectoryWithInvalidBundle_ReportsAsInvalidBundle()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("invalid-bundle");
+
+        // Build a valid bundle, then tamper status to violate the local_only contract.
+        var bundlePath = workspace.GenerateBundleInto(scanDir, "tampered");
+        var json = File.ReadAllText(bundlePath);
+        var tampered = json.Replace(
+            "\"bundle_status\": \"local_only\"",
+            "\"bundle_status\": \"published\"",
+            StringComparison.Ordinal);
+        Assert.NotEqual(json, tampered);
+        File.WriteAllText(bundlePath, tampered);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleHistoryResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.EntryCount);
+        Assert.Equal(0, result.ValidCount);
+        Assert.Equal(1, result.InvalidCount);
+
+        var invalid = result.Entries.Single();
+        Assert.Equal(
+            TaskingHandoffBundleHistoryConstants.Classifications.InvalidBundle,
+            invalid.Classification);
+        Assert.NotEmpty(invalid.Errors);
+        Assert.Contains(
+            invalid.Errors,
+            err => err.Contains("bundle_status", StringComparison.Ordinal)
+                && err.Contains("local_only", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenDirectoryWithMixedClassifications_AllCountsCorrect()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("mixed");
+
+        // 1 valid bundle (a-good.json — sorted first)
+        workspace.GenerateBundleInto(scanDir, "a-good");
+
+        // 1 invalid bundle (b-invalid.json — flipped is_published)
+        var invalidPath = workspace.GenerateBundleInto(scanDir, "b-invalid");
+        var invalidJson = File.ReadAllText(invalidPath);
+        var invalidTampered = invalidJson.Replace(
+            "\"is_published\": false",
+            "\"is_published\": true",
+            StringComparison.Ordinal);
+        Assert.NotEqual(invalidJson, invalidTampered);
+        File.WriteAllText(invalidPath, invalidTampered);
+
+        // 1 malformed (c-malformed.json — invalid JSON)
+        File.WriteAllText(Path.Combine(scanDir, "c-malformed.json"), "garbage{");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleHistoryResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(3, result!.EntryCount);
+        Assert.Equal(1, result.ValidCount);
+        Assert.Equal(1, result.InvalidCount);
+        Assert.Equal(1, result.MalformedCount);
+        Assert.Equal(0, result.UnreadableCount);
+
+        Assert.Equal(
+            result.ValidCount + result.InvalidCount + result.MalformedCount + result.UnreadableCount,
+            result.EntryCount);
+
+        Assert.Equal("a-good.json", result.Entries[0].FileName);
+        Assert.Equal("b-invalid.json", result.Entries[1].FileName);
+        Assert.Equal("c-malformed.json", result.Entries[2].FileName);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_ResultRoundTripsStably()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("round-trip");
+        workspace.GenerateBundleInto(scanDir, "rt-bundle");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir, "--format", "json" },
+            writer);
+        Assert.Equal(0, exitCode);
+
+        var first = JsonSerializer.Deserialize<TaskingHandoffBundleHistoryResult>(writer.ToString());
+        Assert.NotNull(first);
+
+        var reserialized = JsonSerializer.Serialize(first);
+        var second = JsonSerializer.Deserialize<TaskingHandoffBundleHistoryResult>(reserialized);
+        Assert.NotNull(second);
+
+        Assert.Equal(first!.FromDirectory, second!.FromDirectory);
+        Assert.Equal(first.EntryCount, second.EntryCount);
+        Assert.Equal(first.ValidCount, second.ValidCount);
+        Assert.Equal(first.InvalidCount, second.InvalidCount);
+        Assert.Equal(first.MalformedCount, second.MalformedCount);
+        Assert.Equal(first.UnreadableCount, second.UnreadableCount);
+        Assert.Equal(first.SummaryLine, second.SummaryLine);
+        Assert.Equal(first.Entries.Count, second.Entries.Count);
+
+        for (var i = 0; i < first.Entries.Count; i++)
+        {
+            var a = first.Entries[i];
+            var b = second.Entries[i];
+            Assert.Equal(a.FileName, b.FileName);
+            Assert.Equal(a.AbsolutePath, b.AbsolutePath);
+            Assert.Equal(a.Classification, b.Classification);
+            Assert.Equal(a.Domain, b.Domain);
+            Assert.Equal(a.BundleStatus, b.BundleStatus);
+            Assert.Equal(a.IsPublished, b.IsPublished);
+            Assert.Equal(a.IsAutomationVisible, b.IsAutomationVisible);
+            Assert.Equal(a.SourceTaskPacketPath, b.SourceTaskPacketPath);
+            Assert.Equal(a.SourcePreviewPath, b.SourcePreviewPath);
+            Assert.Equal(a.SourceChecklistPath, b.SourceChecklistPath);
+            Assert.Equal(a.SourceHandoffPath, b.SourceHandoffPath);
+            Assert.Equal(a.ChecklistReadyForHandoff, b.ChecklistReadyForHandoff);
+            Assert.Equal(a.Errors, b.Errors);
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_PerEntryStatusErrorsArePresent()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("per-entry-errors");
+        workspace.GenerateBundleInto(scanDir, "valid-one");
+        File.WriteAllText(Path.Combine(scanDir, "broken.json"), "{ : ");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir, "--format", "json" },
+            writer);
+        Assert.Equal(0, exitCode);
+
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleHistoryResult>(writer.ToString());
+        Assert.NotNull(result);
+
+        var valid = result!.Entries.Single(e =>
+            e.Classification == TaskingHandoffBundleHistoryConstants.Classifications.ValidBundle);
+        Assert.Empty(valid.Errors);
+
+        var malformed = result.Entries.Single(e =>
+            e.Classification == TaskingHandoffBundleHistoryConstants.Classifications.Malformed);
+        Assert.NotEmpty(malformed.Errors);
+    }
+
+    [Fact]
+    public void Execute_GivenTextFormat_StableOutputContainsKeyHeadingsAndCounts()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("text-fmt");
+        workspace.GenerateBundleInto(scanDir, "valid-text");
+
+        // invalid (flipped is_automation_visible)
+        var invalidPath = workspace.GenerateBundleInto(scanDir, "invalid-text");
+        var invalidJson = File.ReadAllText(invalidPath);
+        var invalidTampered = invalidJson.Replace(
+            "\"is_automation_visible\": false",
+            "\"is_automation_visible\": true",
+            StringComparison.Ordinal);
+        File.WriteAllText(invalidPath, invalidTampered);
+
+        // malformed
+        File.WriteAllText(Path.Combine(scanDir, "zzz-malformed.json"), "garbage");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+
+        Assert.Contains(TaskingHandoffBundleHistoryAnalyzer.HeaderPhrase, output, StringComparison.Ordinal);
+        Assert.Contains("3 entries", output, StringComparison.Ordinal);
+        Assert.Contains("[valid_bundle]", output, StringComparison.Ordinal);
+        Assert.Contains("[invalid_bundle]", output, StringComparison.Ordinal);
+        Assert.Contains("[malformed]", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverMutatesAnyFileInScannedDirectory()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("no-mutate");
+        var bundlePath = workspace.GenerateBundleInto(scanDir, "stable-bundle");
+        var sentinelPath = Path.Combine(scanDir, "sentinel.txt");
+        var sentinelContent = Encoding.UTF8.GetBytes("do-not-touch-me");
+        File.WriteAllBytes(sentinelPath, sentinelContent);
+
+        var bundleBytesBefore = File.ReadAllBytes(bundlePath);
+        var sentinelBytesBefore = File.ReadAllBytes(sentinelPath);
+        var filesBefore = Directory.GetFiles(scanDir).OrderBy(s => s, StringComparer.Ordinal).ToArray();
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var bundleBytesAfter = File.ReadAllBytes(bundlePath);
+        var sentinelBytesAfter = File.ReadAllBytes(sentinelPath);
+        var filesAfter = Directory.GetFiles(scanDir).OrderBy(s => s, StringComparer.Ordinal).ToArray();
+
+        Assert.Equal(bundleBytesBefore, bundleBytesAfter);
+        Assert.Equal(sentinelBytesBefore, sentinelBytesAfter);
+        Assert.Equal(filesBefore, filesAfter);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesToQueueStateOrRunsLog()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("no-queue");
+        workspace.GenerateBundleInto(scanDir, "queue-test");
+
+        var queueStatePath = workspace.Context.GetQueueStatePath();
+        var runsLogPath = workspace.Context.GetRunLogPath();
+
+        var queueBytes = Encoding.UTF8.GetBytes("{\"schema_version\":\"1\",\"items\":[]}\n");
+        var runsBytes = Encoding.UTF8.GetBytes("{\"event\":\"sentinel\",\"ts\":\"2026-04-29T00:00:00Z\"}\n");
+        Directory.CreateDirectory(Path.GetDirectoryName(queueStatePath)!);
+        File.WriteAllBytes(queueStatePath, queueBytes);
+        File.WriteAllBytes(runsLogPath, runsBytes);
+
+        var queueBefore = File.ReadAllBytes(queueStatePath);
+        var runsBefore = File.ReadAllBytes(runsLogPath);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var queueAfter = File.ReadAllBytes(queueStatePath);
+        var runsAfter = File.ReadAllBytes(runsLogPath);
+        Assert.Equal(queueBefore, queueAfter);
+        Assert.Equal(runsBefore, runsAfter);
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesProvider_NoProcessStartInNewSurface()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("no-provider");
+        workspace.GenerateBundleInto(scanDir, "no-provider-bundle");
+
+        var launcherInvoked = false;
+        TaskingHandoffBundleHistoryCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(launcherInvoked);
+
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        var commandFile = Path.Combine(commandsDir, "TaskingHandoffBundleHistoryCommand.cs");
+        var analyzerFile = Path.Combine(commandsDir, "TaskingHandoffBundleHistoryAnalyzer.cs");
+        var resultFile = Path.Combine(commandsDir, "TaskingHandoffBundleHistoryResult.cs");
+        if (!File.Exists(commandFile) || !File.Exists(analyzerFile) || !File.Exists(resultFile))
+        {
+            return;
+        }
+
+        foreach (var path in new[] { commandFile, analyzerFile, resultFile })
+        {
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("Process.Start(", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverCreatesBundle_NoBundleArtifactWriteAttempt()
+    {
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        var commandFile = Path.Combine(commandsDir, "TaskingHandoffBundleHistoryCommand.cs");
+        var analyzerFile = Path.Combine(commandsDir, "TaskingHandoffBundleHistoryAnalyzer.cs");
+        var resultFile = Path.Combine(commandsDir, "TaskingHandoffBundleHistoryResult.cs");
+        if (!File.Exists(commandFile) || !File.Exists(analyzerFile) || !File.Exists(resultFile))
+        {
+            return;
+        }
+
+        foreach (var path in new[] { commandFile, analyzerFile, resultFile })
+        {
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("File.WriteAllText", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("File.WriteAllBytes", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFlag_ReturnsNonZero()
+    {
+        using var workspace = new HistoryWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-directory", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsNonZero()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("unknown-arg");
+
+        var args = new[] { "--from-directory", scanDir, "--bogus", "value" };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(workspace.Context, args, writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNonRecursiveScan_DoesNotPickUpJsonInSubdirectories()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("non-recursive");
+        workspace.GenerateBundleInto(scanDir, "top");
+
+        var subDir = Path.Combine(scanDir, "sub");
+        Directory.CreateDirectory(subDir);
+        workspace.GenerateBundleInto(subDir, "inner");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleHistoryResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(1, result!.EntryCount);
+        Assert.Equal(1, result.ValidCount);
+        Assert.Equal("top.json", result.Entries.Single().FileName);
+    }
+
+    [Fact]
+    public void Execute_GivenSortedEntriesByFileName_ListReturnsOrdinalSortedOrder()
+    {
+        using var workspace = new HistoryWorkspace();
+        var scanDir = workspace.CreateScanDirectory("sort-order");
+        workspace.GenerateBundleInto(scanDir, "c");
+        workspace.GenerateBundleInto(scanDir, "a");
+        workspace.GenerateBundleInto(scanDir, "b");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", scanDir, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<TaskingHandoffBundleHistoryResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(3, result!.EntryCount);
+        Assert.Equal("a.json", result.Entries[0].FileName);
+        Assert.Equal("b.json", result.Entries[1].FileName);
+        Assert.Equal("c.json", result.Entries[2].FileName);
+    }
+
+    [Fact]
+    public void Execute_GivenBlankFromDirectoryValue_ReturnsNonZero()
+    {
+        using var workspace = new HistoryWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingHandoffBundleHistoryCommand.Execute(
+            workspace.Context,
+            new[] { "--from-directory", "   " },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-directory", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static bool TryResolveCommandsSourceDirectory(out string commandsDirectory)
+    {
+        commandsDirectory = string.Empty;
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, "src", "IntentSystem.Cli", "Commands");
+            if (Directory.Exists(candidate))
+            {
+                commandsDirectory = candidate;
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private sealed class HistoryWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("tasking-handoff-bundle-history-tests-")
+            .FullName;
+
+        public HistoryWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string GetPath(string relative) => Path.Combine(rootPath, relative);
+
+        public string CreateScanDirectory(string tag)
+        {
+            var path = Path.Combine(rootPath, $"scan-{tag}");
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        /// <summary>
+        /// Generate a fresh G190 → G191 → G192 → G193 → G194 chain and place
+        /// the resulting bundle JSON in the supplied scan directory under
+        /// <c>{tag}.json</c>.
+        /// </summary>
+        public string GenerateBundleInto(string scanDir, string tag)
+        {
+            var (previewPath, checklistPath) = GeneratePreviewAndChecklist(tag);
+            var bundlePath = Path.Combine(scanDir, $"{tag}.json");
+
+            using var sink = new StringWriter();
+            var exit = TaskingHandoffBundleCommand.Execute(
+                Context,
+                new[]
+                {
+                    "--from-preview", previewPath,
+                    "--from-checklist", checklistPath,
+                    "--out", bundlePath
+                },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G194 bundle for tests: exit={exit}, stderr={sink}");
+            }
+
+            return bundlePath;
+        }
+
+        private (string previewPath, string checklistPath) GeneratePreviewAndChecklist(string tag)
+        {
+            var previewPath = GeneratePreview(tag);
+            var checklistPath = GetPath($"checklist-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingTaskPacketChecklistCommand.Execute(
+                Context,
+                new[] { "--from-preview", previewPath, "--out", checklistPath },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G193 checklist: exit={exit}, stderr={sink}");
+            }
+
+            return (previewPath, checklistPath);
+        }
+
+        private string GeneratePreview(string tag)
+        {
+            var handoffPath = GetPath($"__handoff_{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingHandoffCommand.Execute(
+                    Context,
+                    new[] { "--out", handoffPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G190 handoff: exit={exit}, stderr={sink}");
+                }
+            }
+
+            var taskPacketPath = GetPath($"__task_packet_{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingTaskPacketCommand.Execute(
+                    Context,
+                    new[] { "--from-handoff", handoffPath, "--out", taskPacketPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G191 task packet: exit={exit}, stderr={sink}");
+                }
+            }
+
+            var previewPath = GetPath($"preview-{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingTaskPacketPreviewCommand.Execute(
+                    Context,
+                    new[] { "--from-task-packet", taskPacketPath, "--out", previewPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G192 preview: exit={exit}, stderr={sink}");
+                }
+            }
+
+            return previewPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new subcommand `intent-cli tasking handoff-bundle-history --from-directory <dir-path> [--format text|json]` under the existing `tasking` group. Tenth in the chain G190 → G191 → G192 → G193 → G194 → G195 → G196 → G197 → G198 → G199 → **G200 history list**. Read-only operator visibility command that scans a directory of bundle JSON artifacts non-recursively and classifies each entry into one of four stable classifications: `valid_bundle` / `invalid_bundle` / `malformed` / `unreadable`. Entries are deterministically sorted by file_name (ordinal). **No `--out` flag**: the command emits the list to STDOUT only and writes nothing.
- Per-entry classification rules:
  - **valid_bundle**: deserializes as G194 `TaskingHandoffBundleArtifact` AND `bundle_status == "local_only"` AND `is_published == false` AND `is_automation_visible == false`. Bundle-identity fields populated; `errors: []`.
  - **invalid_bundle**: deserializes successfully but fails one of the contract checks above. The specific violation is named in `errors`.
  - **malformed**: file is not parseable as `TaskingHandoffBundleArtifact` (parse exception or required-field deserialize failure). Parse error captured in `errors`.
  - **unreadable**: file exists but read throws (locked / permission denied). IO error captured in `errors`.
  - Non-`valid_bundle` entries have all bundle-identity fields set to `null`; only `file_name`, `absolute_path`, `classification`, `errors` are populated.
- Exit/output behavior:
  - missing/blank `--from-directory` flag → exit 1, deterministic error.
  - `--from-directory` path does not exist → exit 1, deterministic error mentioning the path.
  - path exists but is NOT a directory → exit 1, deterministic error mentioning "not a directory".
  - directory exists but is empty → exit 0, JSON `entries: []`, text says "no bundle entries found in <path>".
  - directory has files: enumerate top-level `*.json` files only (non-recursive — locked by `SearchOption.TopDirectoryOnly` and an explicit regression test). Classify each, sort by file_name ordinal, exit 0. **Malformed/invalid entries do NOT cause non-zero exit** — the listing command itself succeeded; the entries are simply reported with their specific classification.
- Output JSON shape (snake_case, stable, round-trippable through `JsonSerializer.Deserialize<TaskingHandoffBundleHistoryResult>`):
  ```
  { "from_directory": "...",
    "entry_count": <int>, "valid_count": <int>, "invalid_count": <int>, "malformed_count": <int>, "unreadable_count": <int>,
    "entries": [
      { "file_name": "g194-bundle.json", "absolute_path": "...",
        "classification": "valid_bundle" | "invalid_bundle" | "malformed" | "unreadable",
        "domain": "..." | null, "bundle_status": "..." | null,
        "is_published": <bool> | null, "is_automation_visible": <bool> | null,
        "source_task_packet_path": "..." | null, "source_preview_path": "..." | null,
        "source_checklist_path": "..." | null, "source_handoff_path": "..." | null,
        "checklist_ready_for_handoff": <bool> | null,
        "errors": ["..."] },
      ...
    ],
    "summary_line": "Tasking handoff bundle history for <from_directory> — <entry_count> entr(y|ies), ..." }
  ```
  Stable classification constants are defined in `TaskingHandoffBundleHistoryConstants.Classifications` for downstream automation parsing.
- Text output: stable header line + one line per entry like `[<classification>] <file_name> — domain: <domain or '?'>, status: <bundle_status or '?'>, ready: <True/False/?>, errors: <count>`. Format locked by a regression test.
- No-mutation invariants:
  - Sentinel `TaskingHandoffBundleHistoryCommand.NestedProviderLauncher` (mirrors G187/G190/.../G199) — never invoked.
  - Source-scan asserts the new command + analyzer files contain no `Process.Start(`.
  - Source-scan asserts the new files contain no `File.WriteAllText`/`File.WriteAllBytes` literals (the analyzer/command must be fully read-only).
  - Byte-equivalence test on `.intent-cli/queue-state.json` and `.intent-cli/runs.jsonl` before/after.
  - Sentinel-file test (`Execute_NeverMutatesAnyFileInScannedDirectory`): writes a `sentinel.txt` + a real bundle to the scanned directory, runs history, asserts both files are byte-identical AND no new file was created in the scanned directory.
- Reuse, not duplication:
  - `TaskingHandoffBundleArtifact` (G194) — deserialize each scanned JSON file.
  - `TaskingHandoffBundleConstants.LocalOnlyStatus` (G194) — for the `bundle_status` validity check.
  - **No `private→internal` promotions needed this slice** — both reused helpers are already accessible.
  - History deliberately does NOT compute hashes or call any G196/G197 analyzer; it's a lightweight directory listing, not a full verify pass. Operators can run `tasking handoff-bundle-verify` on individual paths from the listing if they want hash pinning.

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter \"FullyQualifiedName~TaskingHandoffBundleHistory\"` — **20/20 passing**. Issue-required scenarios covered:
  - **valid listing**: `Execute_GivenDirectoryWithThreeValidBundles_ListsAllThreeAsValid` (3 different bundles via the full chain, all listed as valid_bundle, sorted by file_name).
  - **empty/missing input**: `Execute_GivenEmptyDirectory_ReturnsZeroAndEmptyEntries`, `Execute_GivenEmptyDirectory_JsonHasZeroCounts`, `Execute_GivenMissingDirectoryPath_ReturnsNonZero_DeterministicError`, `Execute_GivenPathIsFileNotDirectory_ReturnsNonZero`, `Execute_GivenBlankFromDirectoryValue_ReturnsNonZero`.
  - **malformed entries**: `Execute_GivenDirectoryWithMalformedJson_ReportsAsMalformed`, `Execute_GivenDirectoryWithInvalidBundle_ReportsAsInvalidBundle`, `Execute_GivenDirectoryWithMixedClassifications_AllCountsCorrect` (1 valid + 1 invalid + 1 malformed → counts add up).
  - **JSON output**: `Execute_GivenJsonFormat_ResultRoundTripsStably`, `Execute_GivenJsonFormat_PerEntryStatusErrorsArePresent`.
  - **text output stability**: `Execute_GivenTextFormat_StableOutputContainsKeyHeadingsAndCounts`.
  - **no-mutation behavior**: `Execute_NeverMutatesAnyFileInScannedDirectory` (sentinel + bundle byte-equivalence in scanned dir), `Execute_NeverWritesToQueueStateOrRunsLog`, `Execute_NeverInvokesProvider_NoProcessStartInNewSurface`, `Execute_NeverCreatesBundle_NoBundleArtifactWriteAttempt` (source-scan for write APIs).
  - **CLI plumbing**: `Execute_GivenMissingFlag_ReturnsNonZero`, `Execute_GivenUnknownArgument_ReturnsNonZero`.
  - **contract-locking regressions**: `Execute_GivenNonRecursiveScan_DoesNotPickUpJsonInSubdirectories` (locks the non-recursive scan), `Execute_GivenSortedEntriesByFileName_ListReturnsOrdinalSortedOrder` (locks the sort order).
- [x] Issue's recommended broader filter `~TaskingHandoffBundle` — passes (20 new G200 tests + every existing TaskingHandoffBundle* surface stays green).
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **1185/1185 passing + 1 skip** (the 1 skip is the pre-existing G190 `TolerantToSubAnalyzerFailure` `[Fact(Skip)]` not introduced by this slice; CLI: 1165 → 1185 = +20 new G200 tests; no regressions).
- Confirmation that no provider launch or GitHub mutation behavior was added: verified by sentinel + source-scan (Process.Start + File.WriteAllText/Bytes patterns) + queue/runs byte-equivalence + sentinel-file no-mutation test on the scanned directory itself.
- [ ] Manual smoke (recommended after merge):
  - generate 2-3 bundles via `tasking handoff-bundle ...` into `/tmp/g200-bundles/`
  - `dotnet run ... -- tasking handoff-bundle-history --from-directory /tmp/g200-bundles/ --format json` (assert each entry has `classification: "valid_bundle"`)
  - touch `/tmp/g200-bundles/garbage.json` (write garbage); re-run; assert one entry now has `classification: "malformed"` with parse error in `errors[]`

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)