### PR TITLE
G201: add intent-cli tasking ai-thread-summary-attach for operator-authored summaries

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -135,7 +135,8 @@ internal static class CommandRouter
                 ["handoff-bundle-verify"] = TaskingHandoffBundleVerifyCommand.Execute,
                 ["handoff-bundle-import-dry-run"] = TaskingHandoffBundleImportDryRunCommand.Execute,
                 ["publish-reviewed-bridge"] = TaskingPublishReviewedBridgeCommand.Execute,
-                ["handoff-bundle-history"] = TaskingHandoffBundleHistoryCommand.Execute
+                ["handoff-bundle-history"] = TaskingHandoffBundleHistoryCommand.Execute,
+                ["ai-thread-summary-attach"] = TaskingAiThreadSummaryAttachCommand.Execute
             },
             ["intake"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/TaskingAiThreadSummaryAttachAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingAiThreadSummaryAttachAnalyzer.cs
@@ -1,0 +1,55 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G201 — pure builder for <see cref="TaskingAiThreadSummaryAttachArtifact"/>.
+/// Takes already-validated provenance values (paths, digests, kind, domain,
+/// timestamp) and assembles the deterministic attachment record.
+///
+/// The analyzer never reads the filesystem, never launches providers, and never
+/// looks at the actual summary text — only the digest and byte count are
+/// passed in. This keeps the artifact purely provenance-only.
+/// </summary>
+internal static class TaskingAiThreadSummaryAttachAnalyzer
+{
+    public static TaskingAiThreadSummaryAttachArtifact Build(
+        string sourceArtifactPath,
+        string sourceArtifactSha256,
+        string sourceArtifactKind,
+        string sourceSummaryPath,
+        string sourceSummarySha256,
+        int sourceSummaryByteCount,
+        string domain,
+        string generatedAtUtc,
+        string artifactPath)
+    {
+        ArgumentNullException.ThrowIfNull(sourceArtifactPath);
+        ArgumentNullException.ThrowIfNull(sourceArtifactSha256);
+        ArgumentNullException.ThrowIfNull(sourceArtifactKind);
+        ArgumentNullException.ThrowIfNull(sourceSummaryPath);
+        ArgumentNullException.ThrowIfNull(sourceSummarySha256);
+        ArgumentNullException.ThrowIfNull(domain);
+        ArgumentNullException.ThrowIfNull(generatedAtUtc);
+        ArgumentNullException.ThrowIfNull(artifactPath);
+
+        var summaryLine =
+            $"AI-thread session summary attachment for {domain} — UNPUBLISHED, local-only, "
+            + "not automation-visible. status=ok.";
+
+        return new TaskingAiThreadSummaryAttachArtifact
+        {
+            SourceArtifactPath = sourceArtifactPath,
+            SourceArtifactSha256 = sourceArtifactSha256,
+            SourceArtifactKind = sourceArtifactKind,
+            SourceSummaryPath = sourceSummaryPath,
+            SourceSummarySha256 = sourceSummarySha256,
+            SourceSummaryByteCount = sourceSummaryByteCount,
+            Domain = domain,
+            IsPublished = false,
+            IsAutomationVisible = false,
+            AttachmentStatus = TaskingAiThreadSummaryAttachConstants.LocalOnlyStatus,
+            GeneratedAtUtc = generatedAtUtc,
+            ArtifactPath = artifactPath,
+            SummaryLine = summaryLine
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingAiThreadSummaryAttachArtifact.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingAiThreadSummaryAttachArtifact.cs
@@ -1,0 +1,79 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G201 AI-thread session summary attachment artifact. Snake_case JSON shape
+/// that <c>intent-cli tasking ai-thread-summary-attach</c> writes when an
+/// operator binds a manually-authored AI-thread session summary file to one of
+/// the existing local tasking chain artifacts (G190 handoff packet, G191 task
+/// packet, G192 preview, G193 checklist, or G194 handoff bundle).
+///
+/// The attachment is explicitly local-only and provenance-only: it never
+/// publishes a GitHub issue, applies labels, mutates queue/runs state, launches
+/// provider processes, or copies the actual summary text into the artifact.
+///
+/// <see cref="IsPublished"/> and <see cref="IsAutomationVisible"/> are ALWAYS
+/// literal <c>false</c>; <see cref="AttachmentStatus"/> is ALWAYS the literal
+/// value <see cref="TaskingAiThreadSummaryAttachConstants.LocalOnlyStatus"/>.
+/// </summary>
+internal sealed record TaskingAiThreadSummaryAttachArtifact
+{
+    [JsonPropertyName("source_artifact_path")]
+    public required string SourceArtifactPath { get; init; }
+
+    [JsonPropertyName("source_artifact_sha256")]
+    public required string SourceArtifactSha256 { get; init; }
+
+    [JsonPropertyName("source_artifact_kind")]
+    public required string SourceArtifactKind { get; init; }
+
+    [JsonPropertyName("source_summary_path")]
+    public required string SourceSummaryPath { get; init; }
+
+    [JsonPropertyName("source_summary_sha256")]
+    public required string SourceSummarySha256 { get; init; }
+
+    [JsonPropertyName("source_summary_byte_count")]
+    public required int SourceSummaryByteCount { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("is_published")]
+    public required bool IsPublished { get; init; }
+
+    [JsonPropertyName("is_automation_visible")]
+    public required bool IsAutomationVisible { get; init; }
+
+    [JsonPropertyName("attachment_status")]
+    public required string AttachmentStatus { get; init; }
+
+    [JsonPropertyName("generated_at_utc")]
+    public required string GeneratedAtUtc { get; init; }
+
+    [JsonPropertyName("artifact_path")]
+    public required string ArtifactPath { get; init; }
+
+    [JsonPropertyName("summary_line")]
+    public required string SummaryLine { get; init; }
+}
+
+internal static class TaskingAiThreadSummaryAttachConstants
+{
+    public const string LocalOnlyStatus = "local_only";
+
+    /// <summary>
+    /// Stable kind tags that record which chain artifact deserialized
+    /// successfully when the source artifact was inspected. Locked here so
+    /// downstream consumers and tests can match exact strings.
+    /// </summary>
+    public static class SourceArtifactKinds
+    {
+        public const string HandoffBundle = "handoff_bundle";
+        public const string HandoffPacket = "handoff_packet";
+        public const string TaskPacket = "task_packet";
+        public const string TaskPacketPreview = "task_packet_preview";
+        public const string TaskPacketChecklist = "task_packet_checklist";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/TaskingAiThreadSummaryAttachCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingAiThreadSummaryAttachCommand.cs
@@ -1,0 +1,437 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G201: <c>intent-cli tasking ai-thread-summary-attach</c>. A LOCAL operator
+/// command that binds an operator-authored AI-thread session summary text file
+/// to one of the existing local tasking chain artifacts (G190 handoff packet,
+/// G191 task packet, G192 preview, G193 checklist, or G194 handoff bundle) by
+/// writing a deterministic provenance-only attachment artifact.
+///
+/// The command is artifact-only and operator-input driven:
+/// <list type="bullet">
+/// <item><description>It NEVER launches Codex, Claude, workers, or any
+/// provider — the summary text is operator-authored input, not generated.</description></item>
+/// <item><description>It NEVER mutates GitHub (no labels, no issues, no PRs).</description></item>
+/// <item><description>It NEVER touches <c>.intent-cli/queue-state.json</c> or
+/// <c>.intent-cli/runs.jsonl</c>.</description></item>
+/// <item><description>It NEVER creates branches or worktrees.</description></item>
+/// <item><description>It NEVER overwrites paths other than <c>--out</c>.</description></item>
+/// <item><description>It records PROVENANCE — paths and digests — never the
+/// actual summary text in the attachment artifact.</description></item>
+/// </list>
+/// </summary>
+internal static class TaskingAiThreadSummaryAttachCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private const string StatusOk = "ok";
+    private const string StatusMissingArtifact = "missing_artifact";
+    private const string StatusMalformedSourceArtifact = "malformed_source_artifact";
+    private const string StatusMissingSummary = "missing_summary";
+    private const string StatusBlankSummary = "blank_summary";
+
+    private static readonly JsonSerializerOptions ArtifactSerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    private static readonly JsonSerializerOptions PermissiveDeserializeOptions = new()
+    {
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        PropertyNameCaseInsensitive = false
+    };
+
+    /// <summary>
+    /// Test seam mirroring sibling tasking command timestamp factories.
+    /// </summary>
+    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Test seam mirroring sibling tasking command no-provider sentinels.
+    /// G201 must NEVER invoke this delegate. Tests register a sentinel that
+    /// flips a flag if invoked; the attach path leaves it untouched.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(
+                args,
+                out var fromArtifact,
+                out var fromSummary,
+                out var outPath,
+                out var format,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedFromArtifact = Path.GetFullPath(fromArtifact);
+        if (!File.Exists(resolvedFromArtifact))
+        {
+            EmitErrorStatus(
+                writer,
+                StatusMissingArtifact,
+                $"--from-artifact path does not exist: {fromArtifact}");
+            return 1;
+        }
+
+        byte[] artifactBytes;
+        try
+        {
+            artifactBytes = File.ReadAllBytes(resolvedFromArtifact);
+        }
+        catch (Exception exception)
+        {
+            EmitErrorStatus(
+                writer,
+                StatusMissingArtifact,
+                $"Failed to read --from-artifact: {exception.Message}");
+            return 1;
+        }
+
+        if (!TryDeserializeAnyKnownKind(
+                artifactBytes,
+                out var sourceKind,
+                out var sourceDomain,
+                out var parseFailureSummary))
+        {
+            EmitErrorStatus(
+                writer,
+                StatusMalformedSourceArtifact,
+                $"Failed to parse --from-artifact as any known tasking chain artifact "
+                + $"(handoff bundle / handoff packet / task packet / preview / checklist) — "
+                + $"parse failure: {parseFailureSummary}");
+            return 1;
+        }
+
+        var resolvedFromSummary = Path.GetFullPath(fromSummary);
+        if (!File.Exists(resolvedFromSummary))
+        {
+            EmitErrorStatus(
+                writer,
+                StatusMissingSummary,
+                $"--from-summary path does not exist: {fromSummary}");
+            return 1;
+        }
+
+        byte[] summaryBytes;
+        try
+        {
+            summaryBytes = File.ReadAllBytes(resolvedFromSummary);
+        }
+        catch (Exception exception)
+        {
+            EmitErrorStatus(
+                writer,
+                StatusMissingSummary,
+                $"Failed to read --from-summary: {exception.Message}");
+            return 1;
+        }
+
+        var summaryText = System.Text.Encoding.UTF8.GetString(summaryBytes);
+        if (string.IsNullOrWhiteSpace(summaryText))
+        {
+            EmitErrorStatus(
+                writer,
+                StatusBlankSummary,
+                $"--from-summary file contains empty content (blank or whitespace-only): {fromSummary}");
+            return 1;
+        }
+
+        // Reuse IssuePrepareCommand.ComputeSha256Hex for both digest fields.
+        var sourceArtifactSha256 = IssuePrepareCommand.ComputeSha256Hex(artifactBytes);
+        var sourceSummarySha256 = IssuePrepareCommand.ComputeSha256Hex(summaryBytes);
+
+        // Reuse IssuePrepareCommand.FormatUtcTimestamp for ISO8601 UTC formatting.
+        var generatedAt = IssuePrepareCommand.FormatUtcTimestamp(TimestampFactory());
+
+        var resolvedOutPath = Path.GetFullPath(outPath);
+        var artifactDirectory = Path.GetDirectoryName(resolvedOutPath);
+        if (!string.IsNullOrEmpty(artifactDirectory))
+        {
+            Directory.CreateDirectory(artifactDirectory);
+        }
+
+        var attachment = TaskingAiThreadSummaryAttachAnalyzer.Build(
+            fromArtifact,
+            sourceArtifactSha256,
+            sourceKind,
+            fromSummary,
+            sourceSummarySha256,
+            summaryBytes.Length,
+            sourceDomain,
+            generatedAt,
+            resolvedOutPath);
+
+        var serialized = JsonSerializer.Serialize(attachment, ArtifactSerializerOptions);
+        File.WriteAllText(resolvedOutPath, serialized);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(serialized);
+        }
+        else
+        {
+            WriteTextSummary(writer, attachment);
+        }
+
+        return 0;
+    }
+
+    private static void EmitErrorStatus(TextWriter writer, string status, string errorMessage)
+    {
+        var payload = new
+        {
+            status,
+            errors = new[] { errorMessage }
+        };
+
+        writer.WriteLine(JsonSerializer.Serialize(payload, ArtifactSerializerOptions));
+    }
+
+    private static bool TryDeserializeAnyKnownKind(
+        byte[] bytes,
+        out string kind,
+        out string domain,
+        out string parseFailureSummary)
+    {
+        kind = string.Empty;
+        domain = string.Empty;
+        var failures = new List<string>();
+
+        if (TryDeserialize<TaskingHandoffBundleArtifact>(bytes, out var bundle, out var bundleError)
+            && bundle is not null
+            && !string.IsNullOrWhiteSpace(bundle.Domain))
+        {
+            kind = TaskingAiThreadSummaryAttachConstants.SourceArtifactKinds.HandoffBundle;
+            domain = bundle.Domain;
+            parseFailureSummary = string.Empty;
+            return true;
+        }
+        if (bundleError is not null)
+        {
+            failures.Add($"handoff_bundle: {bundleError}");
+        }
+
+        if (TryDeserialize<TaskingHandoffPacket>(bytes, out var handoff, out var handoffError)
+            && handoff is not null
+            && !string.IsNullOrWhiteSpace(handoff.Domain))
+        {
+            kind = TaskingAiThreadSummaryAttachConstants.SourceArtifactKinds.HandoffPacket;
+            domain = handoff.Domain;
+            parseFailureSummary = string.Empty;
+            return true;
+        }
+        if (handoffError is not null)
+        {
+            failures.Add($"handoff_packet: {handoffError}");
+        }
+
+        if (TryDeserialize<TaskingTaskPacketArtifact>(bytes, out var taskPacket, out var taskError)
+            && taskPacket is not null
+            && !string.IsNullOrWhiteSpace(taskPacket.Domain))
+        {
+            kind = TaskingAiThreadSummaryAttachConstants.SourceArtifactKinds.TaskPacket;
+            domain = taskPacket.Domain;
+            parseFailureSummary = string.Empty;
+            return true;
+        }
+        if (taskError is not null)
+        {
+            failures.Add($"task_packet: {taskError}");
+        }
+
+        if (TryDeserialize<TaskingTaskPacketPreviewArtifact>(bytes, out var preview, out var previewError)
+            && preview is not null
+            && !string.IsNullOrWhiteSpace(preview.Domain))
+        {
+            kind = TaskingAiThreadSummaryAttachConstants.SourceArtifactKinds.TaskPacketPreview;
+            domain = preview.Domain;
+            parseFailureSummary = string.Empty;
+            return true;
+        }
+        if (previewError is not null)
+        {
+            failures.Add($"task_packet_preview: {previewError}");
+        }
+
+        if (TryDeserialize<TaskingTaskPacketChecklistArtifact>(bytes, out var checklist, out var checklistError)
+            && checklist is not null
+            && !string.IsNullOrWhiteSpace(checklist.Domain))
+        {
+            kind = TaskingAiThreadSummaryAttachConstants.SourceArtifactKinds.TaskPacketChecklist;
+            domain = checklist.Domain;
+            parseFailureSummary = string.Empty;
+            return true;
+        }
+        if (checklistError is not null)
+        {
+            failures.Add($"task_packet_checklist: {checklistError}");
+        }
+
+        parseFailureSummary = failures.Count == 0
+            ? "no candidate kind matched"
+            : string.Join("; ", failures);
+        return false;
+    }
+
+    private static bool TryDeserialize<T>(byte[] bytes, out T? value, out string? errorMessage)
+        where T : class
+    {
+        try
+        {
+            value = JsonSerializer.Deserialize<T>(bytes, PermissiveDeserializeOptions);
+            errorMessage = value is null ? "deserialized to null" : null;
+            return value is not null;
+        }
+        catch (JsonException exception)
+        {
+            value = null;
+            errorMessage = exception.Message;
+            return false;
+        }
+        catch (NotSupportedException exception)
+        {
+            // Triggered when System.Text.Json sees a missing required property.
+            value = null;
+            errorMessage = exception.Message;
+            return false;
+        }
+        catch (InvalidOperationException exception)
+        {
+            // Triggered when a required init-only property is missing from the source JSON.
+            value = null;
+            errorMessage = exception.Message;
+            return false;
+        }
+    }
+
+    private static void WriteTextSummary(TextWriter writer, TaskingAiThreadSummaryAttachArtifact attachment)
+    {
+        writer.WriteLine(attachment.SummaryLine);
+        writer.WriteLine($"artifact_path: {attachment.ArtifactPath}");
+        writer.WriteLine($"source_artifact_path: {attachment.SourceArtifactPath}");
+        writer.WriteLine($"source_artifact_sha256: {attachment.SourceArtifactSha256}");
+        writer.WriteLine($"source_artifact_kind: {attachment.SourceArtifactKind}");
+        writer.WriteLine($"source_summary_path: {attachment.SourceSummaryPath}");
+        writer.WriteLine($"source_summary_sha256: {attachment.SourceSummarySha256}");
+        writer.WriteLine($"source_summary_byte_count: {attachment.SourceSummaryByteCount}");
+        writer.WriteLine($"domain: {attachment.Domain}");
+        writer.WriteLine($"is_published: {attachment.IsPublished.ToString().ToLowerInvariant()}");
+        writer.WriteLine(
+            $"is_automation_visible: {attachment.IsAutomationVisible.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"attachment_status: {attachment.AttachmentStatus}");
+        writer.WriteLine($"generated_at_utc: {attachment.GeneratedAtUtc}");
+        writer.WriteLine($"status: {StatusOk}");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string fromArtifact,
+        out string fromSummary,
+        out string outPath,
+        out string format,
+        out string error)
+    {
+        fromArtifact = string.Empty;
+        fromSummary = string.Empty;
+        outPath = string.Empty;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-artifact":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-artifact requires a non-empty value.";
+                        return false;
+                    }
+
+                    fromArtifact = args[index + 1];
+                    index++;
+                    break;
+
+                case "--from-summary":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-summary requires a non-empty value.";
+                        return false;
+                    }
+
+                    fromSummary = args[index + 1];
+                    index++;
+                    break;
+
+                case "--out":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--out requires a non-empty value.";
+                        return false;
+                    }
+
+                    outPath = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error =
+                        $"Unknown argument '{argument}'. Supported: --from-artifact, --from-summary, --out, --format.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(fromArtifact))
+        {
+            error = "--from-artifact is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(fromSummary))
+        {
+            error = "--from-summary is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(outPath))
+        {
+            error = "--out is required.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/TaskingAiThreadSummaryAttachCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskingAiThreadSummaryAttachCommandTests.cs
@@ -1,0 +1,774 @@
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G201 — coverage for <c>intent-cli tasking ai-thread-summary-attach</c>.
+/// Class name contains <c>Tasking</c>, <c>AiThreadSummary</c>, and
+/// <c>Attach</c> so reviewers can match the issue's recommended
+/// <c>~TaskingAiThreadSummary</c> filter.
+/// </summary>
+public sealed class TaskingAiThreadSummaryAttachCommandTests : IDisposable
+{
+    private readonly Func<bool>? originalLauncher;
+    private readonly Func<DateTimeOffset> originalTimestamp;
+
+    public TaskingAiThreadSummaryAttachCommandTests()
+    {
+        originalLauncher = TaskingAiThreadSummaryAttachCommand.NestedProviderLauncher;
+        originalTimestamp = TaskingAiThreadSummaryAttachCommand.TimestampFactory;
+    }
+
+    public void Dispose()
+    {
+        TaskingAiThreadSummaryAttachCommand.NestedProviderLauncher = originalLauncher;
+        TaskingAiThreadSummaryAttachCommand.TimestampFactory = originalTimestamp;
+    }
+
+    [Fact]
+    public void Execute_GivenValidBundleAndSummary_WritesAttachmentArtifact()
+    {
+        using var workspace = new AttachWorkspace();
+        var bundlePath = workspace.GenerateBundle("v1");
+        var summaryPath = workspace.WriteSummary("summary-v1.txt", "Operator-authored AI thread summary content.\n");
+        var outPath = workspace.GetPath("attachment-v1.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", bundlePath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(outPath));
+
+        var attachment = JsonSerializer.Deserialize<TaskingAiThreadSummaryAttachArtifact>(
+            File.ReadAllBytes(outPath));
+        Assert.NotNull(attachment);
+        Assert.Equal(TaskingAiThreadSummaryAttachConstants.LocalOnlyStatus, attachment!.AttachmentStatus);
+        Assert.False(attachment.IsPublished);
+        Assert.False(attachment.IsAutomationVisible);
+        Assert.Equal(
+            TaskingAiThreadSummaryAttachConstants.SourceArtifactKinds.HandoffBundle,
+            attachment.SourceArtifactKind);
+        Assert.Contains(
+            "UNPUBLISHED, local-only, not automation-visible",
+            attachment.SummaryLine,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenValidTaskPacketAndSummary_RecordsKindTaskPacket()
+    {
+        using var workspace = new AttachWorkspace();
+        var taskPacketPath = workspace.GenerateTaskPacket("tp1");
+        var summaryPath = workspace.WriteSummary("summary-tp1.txt", "task-packet summary.\n");
+        var outPath = workspace.GetPath("attachment-tp1.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", taskPacketPath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var attachment = JsonSerializer.Deserialize<TaskingAiThreadSummaryAttachArtifact>(
+            File.ReadAllBytes(outPath));
+        Assert.NotNull(attachment);
+        Assert.Equal(
+            TaskingAiThreadSummaryAttachConstants.SourceArtifactKinds.TaskPacket,
+            attachment!.SourceArtifactKind);
+    }
+
+    [Fact]
+    public void Execute_GivenValidPreviewAndSummary_RecordsKindTaskPacketPreview()
+    {
+        using var workspace = new AttachWorkspace();
+        var previewPath = workspace.GeneratePreview("pv1");
+        var summaryPath = workspace.WriteSummary("summary-pv1.txt", "preview summary.\n");
+        var outPath = workspace.GetPath("attachment-pv1.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", previewPath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var attachment = JsonSerializer.Deserialize<TaskingAiThreadSummaryAttachArtifact>(
+            File.ReadAllBytes(outPath));
+        Assert.NotNull(attachment);
+        Assert.Equal(
+            TaskingAiThreadSummaryAttachConstants.SourceArtifactKinds.TaskPacketPreview,
+            attachment!.SourceArtifactKind);
+    }
+
+    [Fact]
+    public void Execute_GivenValidChecklistAndSummary_RecordsKindTaskPacketChecklist()
+    {
+        using var workspace = new AttachWorkspace();
+        var checklistPath = workspace.GenerateChecklist("ck1");
+        var summaryPath = workspace.WriteSummary("summary-ck1.txt", "checklist summary.\n");
+        var outPath = workspace.GetPath("attachment-ck1.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", checklistPath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var attachment = JsonSerializer.Deserialize<TaskingAiThreadSummaryAttachArtifact>(
+            File.ReadAllBytes(outPath));
+        Assert.NotNull(attachment);
+        Assert.Equal(
+            TaskingAiThreadSummaryAttachConstants.SourceArtifactKinds.TaskPacketChecklist,
+            attachment!.SourceArtifactKind);
+    }
+
+    [Fact]
+    public void Execute_GivenValidHandoffPacketAndSummary_RecordsKindHandoffPacket()
+    {
+        using var workspace = new AttachWorkspace();
+        var handoffPath = workspace.GenerateHandoff("hp1");
+        var summaryPath = workspace.WriteSummary("summary-hp1.txt", "handoff summary.\n");
+        var outPath = workspace.GetPath("attachment-hp1.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", handoffPath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var attachment = JsonSerializer.Deserialize<TaskingAiThreadSummaryAttachArtifact>(
+            File.ReadAllBytes(outPath));
+        Assert.NotNull(attachment);
+        Assert.Equal(
+            TaskingAiThreadSummaryAttachConstants.SourceArtifactKinds.HandoffPacket,
+            attachment!.SourceArtifactKind);
+    }
+
+    [Fact]
+    public void Execute_GivenValidInputs_AttachmentJsonRoundTripsStably()
+    {
+        using var workspace = new AttachWorkspace();
+        var bundlePath = workspace.GenerateBundle("rt");
+        var summaryPath = workspace.WriteSummary("summary-rt.txt", "round-trip summary.\n");
+        var outPath = workspace.GetPath("attachment-rt.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", bundlePath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+        Assert.Equal(0, exitCode);
+
+        var first = JsonSerializer.Deserialize<TaskingAiThreadSummaryAttachArtifact>(
+            File.ReadAllBytes(outPath));
+        Assert.NotNull(first);
+        var reserialized = JsonSerializer.Serialize(first);
+        var second = JsonSerializer.Deserialize<TaskingAiThreadSummaryAttachArtifact>(reserialized);
+        Assert.NotNull(second);
+
+        Assert.Equal(first!.SourceArtifactPath, second!.SourceArtifactPath);
+        Assert.Equal(first.SourceArtifactSha256, second.SourceArtifactSha256);
+        Assert.Equal(first.SourceArtifactKind, second.SourceArtifactKind);
+        Assert.Equal(first.SourceSummaryPath, second.SourceSummaryPath);
+        Assert.Equal(first.SourceSummarySha256, second.SourceSummarySha256);
+        Assert.Equal(first.SourceSummaryByteCount, second.SourceSummaryByteCount);
+        Assert.Equal(first.Domain, second.Domain);
+        Assert.Equal(first.IsPublished, second.IsPublished);
+        Assert.Equal(first.IsAutomationVisible, second.IsAutomationVisible);
+        Assert.Equal(first.AttachmentStatus, second.AttachmentStatus);
+        Assert.Equal(first.GeneratedAtUtc, second.GeneratedAtUtc);
+        Assert.Equal(first.ArtifactPath, second.ArtifactPath);
+        Assert.Equal(first.SummaryLine, second.SummaryLine);
+    }
+
+    [Fact]
+    public void Execute_GivenValidInputs_RecordsBothSha256s()
+    {
+        using var workspace = new AttachWorkspace();
+        var bundlePath = workspace.GenerateBundle("sha");
+        var summaryContent = "deterministic summary content for sha test\n";
+        var summaryPath = workspace.WriteSummary("summary-sha.txt", summaryContent);
+        var outPath = workspace.GetPath("attachment-sha.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", bundlePath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+        Assert.Equal(0, exitCode);
+
+        var attachment = JsonSerializer.Deserialize<TaskingAiThreadSummaryAttachArtifact>(
+            File.ReadAllBytes(outPath));
+        Assert.NotNull(attachment);
+
+        var artifactBytes = File.ReadAllBytes(bundlePath);
+        var summaryBytes = File.ReadAllBytes(summaryPath);
+        var expectedArtifactSha = IssuePrepareCommand.ComputeSha256Hex(artifactBytes);
+        var expectedSummarySha = IssuePrepareCommand.ComputeSha256Hex(summaryBytes);
+
+        Assert.Equal(expectedArtifactSha, attachment!.SourceArtifactSha256);
+        Assert.Equal(expectedSummarySha, attachment.SourceSummarySha256);
+        Assert.Equal(summaryBytes.Length, attachment.SourceSummaryByteCount);
+        Assert.Matches("^[0-9a-f]+$", attachment.SourceArtifactSha256);
+        Assert.Matches("^[0-9a-f]+$", attachment.SourceSummarySha256);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingArtifactFile_ReturnsNonZero_StatusMissingArtifact()
+    {
+        using var workspace = new AttachWorkspace();
+        var missingPath = workspace.GetPath("never-existed.json");
+        var summaryPath = workspace.WriteSummary("summary-missing.txt", "any summary\n");
+        var outPath = workspace.GetPath("attachment-missing-artifact.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", missingPath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("\"status\": \"missing_artifact\"", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedArtifact_ReturnsNonZero_StatusMalformedSourceArtifact()
+    {
+        using var workspace = new AttachWorkspace();
+        var malformedPath = workspace.GetPath("malformed.json");
+        File.WriteAllText(malformedPath, "{ this is :: not valid json,,,");
+        var summaryPath = workspace.WriteSummary("summary-malformed.txt", "summary text\n");
+        var outPath = workspace.GetPath("attachment-malformed.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", malformedPath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("\"status\": \"malformed_source_artifact\"", output, StringComparison.Ordinal);
+        Assert.Contains("parse failure", output, StringComparison.Ordinal);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingSummaryFile_ReturnsNonZero_StatusMissingSummary()
+    {
+        using var workspace = new AttachWorkspace();
+        var bundlePath = workspace.GenerateBundle("ms");
+        var missingSummary = workspace.GetPath("no-summary-here.txt");
+        var outPath = workspace.GetPath("attachment-missing-summary.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", bundlePath, "--from-summary", missingSummary, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("\"status\": \"missing_summary\"", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenBlankSummary_ReturnsNonZero_StatusBlankSummary()
+    {
+        using var workspace = new AttachWorkspace();
+        var bundlePath = workspace.GenerateBundle("blank");
+        var summaryPath = workspace.WriteSummary("summary-blank.txt", "");
+        var outPath = workspace.GetPath("attachment-blank.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", bundlePath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("\"status\": \"blank_summary\"", output, StringComparison.Ordinal);
+        Assert.Contains("empty content", output, StringComparison.Ordinal);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenWhitespaceOnlySummary_ReturnsNonZero_StatusBlankSummary()
+    {
+        using var workspace = new AttachWorkspace();
+        var bundlePath = workspace.GenerateBundle("ws");
+        var summaryPath = workspace.WriteSummary("summary-ws.txt", "   \t \n\t  \r\n   ");
+        var outPath = workspace.GetPath("attachment-ws.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", bundlePath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("\"status\": \"blank_summary\"", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(File.Exists(outPath));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingFlag_ReturnsNonZero()
+    {
+        using var workspace = new AttachWorkspace();
+        var bundlePath = workspace.GenerateBundle("mf");
+        var summaryPath = workspace.WriteSummary("summary-mf.txt", "x\n");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", bundlePath, "--from-summary", summaryPath },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--out", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsNonZero()
+    {
+        using var workspace = new AttachWorkspace();
+        var bundlePath = workspace.GenerateBundle("uk");
+        var summaryPath = workspace.WriteSummary("summary-uk.txt", "x\n");
+        var outPath = workspace.GetPath("attachment-uk.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--from-artifact", bundlePath,
+                "--from-summary", summaryPath,
+                "--out", outPath,
+                "--bogus", "value"
+            },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("--bogus", output, StringComparison.Ordinal);
+        Assert.Contains("Unknown argument", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesToQueueStateOrRunsLog()
+    {
+        using var workspace = new AttachWorkspace();
+        var bundlePath = workspace.GenerateBundle("queue");
+        var summaryPath = workspace.WriteSummary("summary-queue.txt", "queue test\n");
+        var outPath = workspace.GetPath("attachment-queue.json");
+
+        var queueStatePath = workspace.Context.GetQueueStatePath();
+        var runsLogPath = workspace.Context.GetRunLogPath();
+
+        var queueBytes = Encoding.UTF8.GetBytes("{\"schema_version\":\"1\",\"items\":[]}\n");
+        var runsBytes = Encoding.UTF8.GetBytes("{\"event\":\"sentinel\",\"ts\":\"2026-04-29T00:00:00Z\"}\n");
+        Directory.CreateDirectory(Path.GetDirectoryName(queueStatePath)!);
+        File.WriteAllBytes(queueStatePath, queueBytes);
+        File.WriteAllBytes(runsLogPath, runsBytes);
+
+        var queueBefore = File.ReadAllBytes(queueStatePath);
+        var runsBefore = File.ReadAllBytes(runsLogPath);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", bundlePath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(queueBefore, File.ReadAllBytes(queueStatePath));
+        Assert.Equal(runsBefore, File.ReadAllBytes(runsLogPath));
+    }
+
+    [Fact]
+    public void Execute_NeverOverwritesUnrelatedArtifacts_OnlyWritesToOutFlag()
+    {
+        using var workspace = new AttachWorkspace();
+        var bundlePath = workspace.GenerateBundle("only-out");
+        var summaryPath = workspace.WriteSummary("summary-only-out.txt", "only-out test\n");
+        var outPath = workspace.GetPath("attachment-only-out.json");
+
+        var sentinelPath = workspace.GetPath("sentinel.txt");
+        var sentinelBytes = Encoding.UTF8.GetBytes("untouched\n");
+        File.WriteAllBytes(sentinelPath, sentinelBytes);
+
+        var bundleBefore = File.ReadAllBytes(bundlePath);
+        var summaryBefore = File.ReadAllBytes(summaryPath);
+        var sentinelBefore = File.ReadAllBytes(sentinelPath);
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", bundlePath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(File.Exists(outPath));
+        Assert.Equal(bundleBefore, File.ReadAllBytes(bundlePath));
+        Assert.Equal(summaryBefore, File.ReadAllBytes(summaryPath));
+        Assert.Equal(sentinelBefore, File.ReadAllBytes(sentinelPath));
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesProvider_NoProcessStartInNewSurface()
+    {
+        using var workspace = new AttachWorkspace();
+        var bundlePath = workspace.GenerateBundle("np");
+        var summaryPath = workspace.WriteSummary("summary-np.txt", "no provider\n");
+        var outPath = workspace.GetPath("attachment-np.json");
+
+        var launcherInvoked = false;
+        TaskingAiThreadSummaryAttachCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", bundlePath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(launcherInvoked);
+
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        foreach (var name in new[]
+                 {
+                     "TaskingAiThreadSummaryAttachCommand.cs",
+                     "TaskingAiThreadSummaryAttachAnalyzer.cs",
+                     "TaskingAiThreadSummaryAttachArtifact.cs"
+                 })
+        {
+            var path = Path.Combine(commandsDir, name);
+            if (!File.Exists(path))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("Process.Start(", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverGeneratesSummaryText_NoLlmOrAiCall()
+    {
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        foreach (var name in new[]
+                 {
+                     "TaskingAiThreadSummaryAttachCommand.cs",
+                     "TaskingAiThreadSummaryAttachAnalyzer.cs",
+                     "TaskingAiThreadSummaryAttachArtifact.cs"
+                 })
+        {
+            var path = Path.Combine(commandsDir, name);
+            if (!File.Exists(path))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("HttpClient", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("OpenAI", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("Anthropic", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("AzureAI", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverCreatesBranchOrWorktree_NoGitInvocationInNewSurface()
+    {
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        foreach (var name in new[]
+                 {
+                     "TaskingAiThreadSummaryAttachCommand.cs",
+                     "TaskingAiThreadSummaryAttachAnalyzer.cs",
+                     "TaskingAiThreadSummaryAttachArtifact.cs"
+                 })
+        {
+            var path = Path.Combine(commandsDir, name);
+            if (!File.Exists(path))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("git checkout", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("git worktree", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverPublishesGitHubIssue_NoGhInvocationInNewSurface()
+    {
+        if (!TryResolveCommandsSourceDirectory(out var commandsDir))
+        {
+            return;
+        }
+
+        foreach (var name in new[]
+                 {
+                     "TaskingAiThreadSummaryAttachCommand.cs",
+                     "TaskingAiThreadSummaryAttachAnalyzer.cs",
+                     "TaskingAiThreadSummaryAttachArtifact.cs"
+                 })
+        {
+            var path = Path.Combine(commandsDir, name);
+            if (!File.Exists(path))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("gh issue create", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("gh issue edit", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("gh pr", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_AlwaysMarksContractFieldsLiteralFalseAndLocalOnly()
+    {
+        using var workspace = new AttachWorkspace();
+        var bundlePath = workspace.GenerateBundle("contract");
+        var summaryPath = workspace.WriteSummary("summary-contract.txt", "contract test\n");
+        var outPath = workspace.GetPath("attachment-contract.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", bundlePath, "--from-summary", summaryPath, "--out", outPath },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var attachment = JsonSerializer.Deserialize<TaskingAiThreadSummaryAttachArtifact>(
+            File.ReadAllBytes(outPath));
+        Assert.NotNull(attachment);
+        Assert.False(attachment!.IsPublished);
+        Assert.False(attachment.IsAutomationVisible);
+        Assert.Equal("local_only", attachment.AttachmentStatus);
+        Assert.Equal(TaskingAiThreadSummaryAttachConstants.LocalOnlyStatus, attachment.AttachmentStatus);
+    }
+
+    [Fact]
+    public void Execute_GivenValidInputs_TextOutputContainsLiteralStatusPhrase()
+    {
+        using var workspace = new AttachWorkspace();
+        var bundlePath = workspace.GenerateBundle("text");
+        var summaryPath = workspace.WriteSummary("summary-text.txt", "text output test\n");
+        var outPath = workspace.GetPath("attachment-text.json");
+
+        using var writer = new StringWriter();
+        var exitCode = TaskingAiThreadSummaryAttachCommand.Execute(
+            workspace.Context,
+            new[] { "--from-artifact", bundlePath, "--from-summary", summaryPath, "--out", outPath, "--format", "text" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("UNPUBLISHED, local-only, not automation-visible", output, StringComparison.Ordinal);
+    }
+
+    private static bool TryResolveCommandsSourceDirectory(out string commandsDirectory)
+    {
+        commandsDirectory = string.Empty;
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, "src", "IntentSystem.Cli", "Commands");
+            if (Directory.Exists(candidate))
+            {
+                commandsDirectory = candidate;
+                return true;
+            }
+
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private sealed class AttachWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("tasking-ai-thread-summary-attach-tests-")
+            .FullName;
+
+        public AttachWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string GetPath(string relative) => Path.Combine(rootPath, relative);
+
+        public string WriteSummary(string fileName, string content)
+        {
+            var path = GetPath(fileName);
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        public string GenerateHandoff(string tag)
+        {
+            var handoffPath = GetPath($"handoff-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingHandoffCommand.Execute(
+                Context,
+                new[] { "--out", handoffPath },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G190 handoff for tests: exit={exit}, stderr={sink}");
+            }
+
+            return handoffPath;
+        }
+
+        public string GenerateTaskPacket(string tag)
+        {
+            var handoffPath = GenerateHandoff($"for-tp-{tag}");
+            var taskPacketPath = GetPath($"task-packet-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingTaskPacketCommand.Execute(
+                Context,
+                new[] { "--from-handoff", handoffPath, "--out", taskPacketPath },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G191 task packet for tests: exit={exit}, stderr={sink}");
+            }
+
+            return taskPacketPath;
+        }
+
+        public string GeneratePreview(string tag)
+        {
+            var taskPacketPath = GenerateTaskPacket($"for-pv-{tag}");
+            var previewPath = GetPath($"preview-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingTaskPacketPreviewCommand.Execute(
+                Context,
+                new[] { "--from-task-packet", taskPacketPath, "--out", previewPath },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G192 preview for tests: exit={exit}, stderr={sink}");
+            }
+
+            return previewPath;
+        }
+
+        public string GenerateChecklist(string tag)
+        {
+            var previewPath = GeneratePreview($"for-ck-{tag}");
+            var checklistPath = GetPath($"checklist-{tag}.json");
+            using var sink = new StringWriter();
+            var exit = TaskingTaskPacketChecklistCommand.Execute(
+                Context,
+                new[] { "--from-preview", previewPath, "--out", checklistPath },
+                sink);
+            if (exit != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to generate G193 checklist for tests: exit={exit}, stderr={sink}");
+            }
+
+            return checklistPath;
+        }
+
+        public string GenerateBundle(string tag)
+        {
+            var previewPath = GeneratePreview($"for-bundle-{tag}");
+            var checklistPath = GetPath($"checklist-bundle-{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingTaskPacketChecklistCommand.Execute(
+                    Context,
+                    new[] { "--from-preview", previewPath, "--out", checklistPath },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G193 checklist for bundle tests: exit={exit}, stderr={sink}");
+                }
+            }
+
+            var bundlePath = GetPath($"bundle-{tag}.json");
+            using (var sink = new StringWriter())
+            {
+                var exit = TaskingHandoffBundleCommand.Execute(
+                    Context,
+                    new[]
+                    {
+                        "--from-preview", previewPath,
+                        "--from-checklist", checklistPath,
+                        "--out", bundlePath
+                    },
+                    sink);
+                if (exit != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Failed to generate G194 bundle for tests: exit={exit}, stderr={sink}");
+                }
+            }
+
+            return bundlePath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new subcommand `intent-cli tasking ai-thread-summary-attach --from-artifact <local-tasking-artifact-or-bundle-path> --from-summary <summary-text-path> --out <attachment-artifact-path> [--format text|json]` under the existing `tasking` group. Eleventh in the chain G190 → G191 → G192 → G193 → G194 → G195 → G196 → G197 → G198 → G199 → G200 → **G201 AI-thread session summary attach**. The command takes an operator-authored AI-thread session summary text file and binds it to ANY of the chain artifacts (handoff bundle / handoff packet / task packet / preview / checklist), writing a deterministic local-only attachment artifact that records provenance only (paths + digests, never the summary text itself). **The summary is operator-authored input; this command never generates summary text and never invokes any AI provider.**
- Multi-kind source-artifact tolerance: tries to deserialize the source as `TaskingHandoffBundleArtifact` (G194) → `TaskingHandoffPacket` (G190) → `TaskingTaskPacketArtifact` (G191) → `TaskingTaskPacketPreviewArtifact` (G192) → `TaskingTaskPacketChecklistArtifact` (G193) in that order; the first deserialize that succeeds determines the recorded `source_artifact_kind`. Each chain record's required-property set is unique, so disambiguation is clean. If NONE deserialize → exit 1, JSON `status: "malformed_source_artifact"`. The 5 stable kinds are locked in `TaskingAiThreadSummaryAttachConstants.SourceArtifactKinds`.
- Strict precedence (each before the next; first failure exits 1, NO output artifact written):
  - missing/blank required flag → exit 1.
  - `--from-artifact` file not found → exit 1, JSON `status: "missing_artifact"`.
  - source artifact does not deserialize as ANY of the 5 chain shapes → exit 1, JSON `status: "malformed_source_artifact"`.
  - `--from-summary` file not found → exit 1, JSON `status: "missing_summary"`.
  - summary content is blank or whitespace-only → exit 1, JSON `status: "blank_summary"`.
  - Otherwise: write the attachment artifact, exit 0.
- Output attachment artifact JSON shape (snake_case, stable, round-trippable through `JsonSerializer.Deserialize<TaskingAiThreadSummaryAttachArtifact>`):
  ```
  { \"source_artifact_path\": \"...\", \"source_artifact_sha256\": \"<lowercase hex>\",
    \"source_artifact_kind\": \"handoff_bundle\" | \"handoff_packet\" | \"task_packet\" | \"task_packet_preview\" | \"task_packet_checklist\",
    \"source_summary_path\":   \"...\", \"source_summary_sha256\":   \"<lowercase hex>\", \"source_summary_byte_count\": <int>,
    \"domain\": \"...\",
    \"is_published\": false,
    \"is_automation_visible\": false,
    \"attachment_status\": \"local_only\",
    \"generated_at_utc\": \"<ISO8601 UTC>\",
    \"artifact_path\": \"<absolute>\",
    \"summary_line\": \"AI-thread session summary attachment for <domain> — UNPUBLISHED, local-only, not automation-visible. status=ok.\" }
  ```
  Contract fields `is_published` / `is_automation_visible` are ALWAYS literal `false`; `attachment_status` is ALWAYS literal `\"local_only\"`. The artifact records PROVENANCE only — paths and digests — never the actual summary text. Locked in by an explicit regression so future drift cannot accidentally include text or flip the publication status.
- No-mutation invariants:
  - Sentinel `TaskingAiThreadSummaryAttachCommand.NestedProviderLauncher` (mirrors G187/G190/.../G200) — never invoked.
  - Source-scan asserts the new command + analyzer files contain no `Process.Start(`, no `git checkout`/`git worktree`, and no `gh issue create`/`gh issue edit`/`gh pr` literals.
  - Source-scan asserts no provider/HTTP literals (`HttpClient`, `OpenAI`, `Anthropic`, `AzureAI`) — the summary is operator-authored, never generated.
  - Byte-equivalence test on `.intent-cli/queue-state.json` and `.intent-cli/runs.jsonl` before/after.
  - Sentinel-file test (`Execute_NeverOverwritesUnrelatedArtifacts_OnlyWritesToOutFlag`) writes `<workspace>/sentinel.txt` AND the source artifact + summary file BEFORE the command, runs, asserts ALL three are byte-identical AND only `--out` was created.
- Reuse, not duplication:
  - All 5 chain record types (G190, G191, G192, G193, G194) — used for source-artifact deserialize.
  - `IssuePrepareCommand.ComputeSha256Hex(byte[])` — for both `source_artifact_sha256` and `source_summary_sha256`.
  - `IssuePrepareCommand.FormatUtcTimestamp(DateTimeOffset)` — for `generated_at_utc`.
  - **No `private→internal` promotions needed this slice** — all reused helpers were already accessible.

## Test plan

- [x] Focused (issue's recommended filter): `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter \"FullyQualifiedName~TaskingAiThreadSummary\"` — **22/22 passing**. Issue-required scenarios covered:
  - **valid attachment**: `Execute_GivenValidBundleAndSummary_WritesAttachmentArtifact`, `Execute_GivenValidTaskPacketAndSummary_RecordsKindTaskPacket`, `Execute_GivenValidPreviewAndSummary_RecordsKindTaskPacketPreview`, `Execute_GivenValidChecklistAndSummary_RecordsKindTaskPacketChecklist`, `Execute_GivenValidHandoffPacketAndSummary_RecordsKindHandoffPacket` (each of the 5 supported source kinds), plus `Execute_GivenValidInputs_AttachmentJsonRoundTripsStably`, `Execute_GivenValidInputs_RecordsBothSha256s`, `Execute_GivenValidInputs_TextOutputContainsLiteralStatusPhrase`.
  - **missing/blank input refusal**: `Execute_GivenMissingArtifactFile_ReturnsNonZero_StatusMissingArtifact`, `Execute_GivenMissingSummaryFile_ReturnsNonZero_StatusMissingSummary`, `Execute_GivenBlankSummary_ReturnsNonZero_StatusBlankSummary`, `Execute_GivenWhitespaceOnlySummary_ReturnsNonZero_StatusBlankSummary`, `Execute_GivenMissingFlag_ReturnsNonZero`, `Execute_GivenUnknownArgument_ReturnsNonZero`.
  - **malformed source artifact**: `Execute_GivenMalformedArtifact_ReturnsNonZero_StatusMalformedSourceArtifact` (write garbage to `--from-artifact`).
  - **JSON shape coverage**: round-trip + `RecordsBothSha256s` + per-kind regressions.
  - **no-mutation behavior**: `Execute_NeverWritesToQueueStateOrRunsLog`, `Execute_NeverOverwritesUnrelatedArtifacts_OnlyWritesToOutFlag` (sentinel-file test — issue's explicit no-overwrite criterion: source artifact, summary file, queue-state, runs log all unchanged), `Execute_NeverInvokesProvider_NoProcessStartInNewSurface` (sentinel + source-scan), `Execute_NeverGeneratesSummaryText_NoLlmOrAiCall` (source-scan rejects HttpClient/OpenAI/Anthropic/AzureAI literals — the issue's explicit no-provider-launch + operator-authors-summary criterion), `Execute_NeverCreatesBranchOrWorktree_NoGitInvocationInNewSurface`, `Execute_NeverPublishesGitHubIssue_NoGhInvocationInNewSurface`.
  - **contract-locking regression**: `Execute_AlwaysMarksContractFieldsLiteralFalseAndLocalOnly` (`is_published` / `is_automation_visible` / `attachment_status`).
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **1207/1207 passing + 1 skip** (the 1 skip is the pre-existing G190 `TolerantToSubAnalyzerFailure` `[Fact(Skip)]` not introduced by this slice; CLI: 1185 → 1207 = +22 new G201 tests; no regressions).
- Confirmation that no provider launch or GitHub mutation behavior was added: verified by sentinel + multi-pattern source-scan (Process.Start + git checkout/worktree + gh issue/pr + provider/HTTP literals) + queue/runs byte-equivalence + sentinel-file no-overwrite test that asserts the source artifact AND summary file are also byte-identical (since the issue explicitly says \"leaves the source artifact, summary file, queue-state, and runs log unchanged\").
- [ ] Manual smoke (recommended after merge):
  - generate a bundle via `tasking handoff-bundle ...` to `/tmp/g201-bundle.json`
  - operator authors `/tmp/g201-summary.md` with their AI-thread session notes
  - `dotnet run ... -- tasking ai-thread-summary-attach --from-artifact /tmp/g201-bundle.json --from-summary /tmp/g201-summary.md --out /tmp/g201-attachment.json --format json` (assert `attachment_status: \"local_only\"`, `source_artifact_kind: \"handoff_bundle\"`, both sha256s present)
  - test against a task packet too: same flags but `--from-artifact /tmp/g201-task-packet.json` → `source_artifact_kind: \"task_packet\"`

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)