### PR TITLE
G203: add intent-cli worker pr-review-preflight deterministic classifier

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -127,7 +127,8 @@ internal static class CommandRouter
             },
             ["worker"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
-                ["issue-preflight"] = WorkerIssuePreflightCommand.Execute
+                ["issue-preflight"] = WorkerIssuePreflightCommand.Execute,
+                ["pr-review-preflight"] = WorkerPrReviewPreflightCommand.Execute
             },
             ["tasking"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/GitHubPrLookupResult.cs
+++ b/src/IntentSystem.Cli/Commands/GitHubPrLookupResult.cs
@@ -1,0 +1,89 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G203: Deserialized GitHub PR payload returned by
+/// <see cref="IGitHubPrLookup"/>. Field names match the JSON shape emitted by
+/// <c>gh pr view --json number,state,title,body,labels,isDraft,closed,merged,mergedAt,closedAt,closingIssuesReferences</c>
+/// so the default adapter can deserialize directly into this record.
+/// </summary>
+internal sealed record GitHubPrLookupResult
+{
+    [JsonPropertyName("number")]
+    public int Number { get; init; }
+
+    [JsonPropertyName("state")]
+    public string State { get; init; } = string.Empty;
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("body")]
+    public string Body { get; init; } = string.Empty;
+
+    [JsonPropertyName("isDraft")]
+    public bool IsDraft { get; init; }
+
+    [JsonPropertyName("closed")]
+    public bool Closed { get; init; }
+
+    [JsonPropertyName("merged")]
+    public bool Merged { get; init; }
+
+    [JsonPropertyName("mergedAt")]
+    public string? MergedAt { get; init; }
+
+    [JsonPropertyName("closedAt")]
+    public string? ClosedAt { get; init; }
+
+    [JsonPropertyName("labels")]
+    public IReadOnlyList<GitHubPrLabel> Labels { get; init; } = Array.Empty<GitHubPrLabel>();
+
+    [JsonPropertyName("closingIssuesReferences")]
+    public IReadOnlyList<GitHubPrClosingIssueReference> ClosingIssuesReferences { get; init; }
+        = Array.Empty<GitHubPrClosingIssueReference>();
+}
+
+/// <summary>
+/// G203: Single GitHub PR label as returned by <c>gh pr view --json labels</c>.
+/// Only <c>name</c> is consumed by the preflight classifier.
+/// </summary>
+internal sealed record GitHubPrLabel
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// G203: Single closing-issue reference entry as returned by
+/// <c>gh pr view --json closingIssuesReferences</c>. Captures the issue
+/// number plus an optional repo descriptor for cross-repo links.
+/// </summary>
+internal sealed record GitHubPrClosingIssueReference
+{
+    [JsonPropertyName("number")]
+    public int Number { get; init; }
+
+    [JsonPropertyName("repository")]
+    public GitHubPrClosingIssueRepository? Repository { get; init; }
+}
+
+/// <summary>
+/// G203: Repository descriptor for a closing-issue reference. Mirrors
+/// <c>{ "name": "&lt;repo&gt;", "owner": { "login": "&lt;owner&gt;" } }</c>.
+/// </summary>
+internal sealed record GitHubPrClosingIssueRepository
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("owner")]
+    public GitHubPrClosingIssueRepositoryOwner? Owner { get; init; }
+}
+
+internal sealed record GitHubPrClosingIssueRepositoryOwner
+{
+    [JsonPropertyName("login")]
+    public string Login { get; init; } = string.Empty;
+}

--- a/src/IntentSystem.Cli/Commands/IGitHubPrLookup.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubPrLookup.cs
@@ -1,0 +1,102 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G203: Testability seam for <c>intent-cli worker pr-review-preflight</c>. The
+/// production implementation shells out to <c>gh pr view</c>, but tests inject
+/// a fake to avoid GitHub network access.
+/// </summary>
+internal interface IGitHubPrLookup
+{
+    GitHubPrLookupResult Lookup(string repo, int prNumber);
+}
+
+/// <summary>
+/// G203: Default <see cref="IGitHubPrLookup"/> that shells out to
+/// <c>gh pr view &lt;num&gt; --repo &lt;repo&gt; --json number,state,title,body,labels,isDraft,closed,merged,mergedAt,closedAt,closingIssuesReferences</c>
+/// and deserializes the JSON payload. This is the only file in the worker
+/// pr-review-preflight surface that is permitted to call <c>Process.Start</c> —
+/// the command and analyzer layers must remain pure.
+/// </summary>
+internal sealed class GhCliGitHubPrLookup : IGitHubPrLookup
+{
+    public GitHubPrLookupResult Lookup(string repo, int prNumber)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var arguments = new List<string>
+        {
+            "pr",
+            "view",
+            prNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            "--repo",
+            repo,
+            "--json",
+            "number,state,title,body,labels,isDraft,closed,merged,mergedAt,closedAt,closingIssuesReferences"
+        };
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        string stdout;
+        string stderr;
+        int exitCode;
+
+        try
+        {
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("failed to start `gh` process for PR lookup");
+            stdout = process.StandardOutput.ReadToEnd();
+            stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            exitCode = process.ExitCode;
+        }
+        catch (Exception exception) when (
+            exception is System.ComponentModel.Win32Exception
+            or InvalidOperationException
+            or IOException)
+        {
+            throw new InvalidOperationException(
+                $"could not invoke `gh` to look up PR {prNumber} in {repo}: {exception.Message}",
+                exception);
+        }
+
+        if (exitCode != 0)
+        {
+            var errorBody = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+            throw new InvalidOperationException(
+                $"`gh pr view {prNumber} --repo {repo}` failed with exit {exitCode}: {errorBody.Trim()}");
+        }
+
+        try
+        {
+            var result = JsonSerializer.Deserialize<GitHubPrLookupResult>(stdout);
+            if (result is null)
+            {
+                throw new InvalidOperationException(
+                    $"`gh pr view` returned an empty payload for PR {prNumber} in {repo}");
+            }
+
+            return result;
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException(
+                $"could not parse `gh pr view` JSON for PR {prNumber} in {repo}: {exception.Message}",
+                exception);
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerPrReviewPreflightAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerPrReviewPreflightAnalyzer.cs
@@ -1,0 +1,488 @@
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G203: Pure deterministic classifier for <c>intent-cli worker pr-review-preflight</c>.
+/// Given a fetched <see cref="GitHubPrLookupResult"/>, the (optional) source
+/// issue lookup payload, target repo, and implementation workdir, runs the
+/// ten-step first-match-wins precedence and returns a stable
+/// <see cref="WorkerPrReviewPreflightResult"/>. Never mutates state, never
+/// invokes any external process, never touches GitHub.
+/// </summary>
+internal static class WorkerPrReviewPreflightAnalyzer
+{
+    private static readonly Regex RepositoryHeaderRegex = new(
+        @"Repository:\s*([A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex ClosesIssueRegex = new(
+        @"(?i)(?:closes|fixes|resolves)\s+#(\d+)",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Trace the source-issue candidate from the PR lookup payload using the
+    /// algorithm: prefer <c>closingIssuesReferences</c>, fall back to the
+    /// first <c>(?i)(closes|fixes|resolves)\s+#N</c> match in the body. Returns
+    /// the issue number and the cross-repo descriptor (if the closing-issues
+    /// metadata names a different repo). Returns null when neither produces a
+    /// candidate.
+    /// </summary>
+    public static SourceIssueCandidate? TraceSourceIssue(GitHubPrLookupResult pr, string defaultRepo)
+    {
+        ArgumentNullException.ThrowIfNull(pr);
+        ArgumentException.ThrowIfNullOrWhiteSpace(defaultRepo);
+
+        if (pr.ClosingIssuesReferences is { Count: > 0 } refs)
+        {
+            var first = refs[0];
+            if (first.Number > 0)
+            {
+                string repo = defaultRepo;
+                if (first.Repository is { } r
+                    && !string.IsNullOrWhiteSpace(r.Name)
+                    && r.Owner is { Login: { Length: > 0 } owner })
+                {
+                    repo = $"{owner}/{r.Name}";
+                }
+                return new SourceIssueCandidate(first.Number, repo, FromClosingIssuesMetadata: true);
+            }
+        }
+
+        var body = pr.Body ?? string.Empty;
+        var match = ClosesIssueRegex.Match(body);
+        if (match.Success
+            && int.TryParse(
+                match.Groups[1].Value,
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var number)
+            && number > 0)
+        {
+            return new SourceIssueCandidate(number, defaultRepo, FromClosingIssuesMetadata: false);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Run the ten-step classifier. <paramref name="sourceIssue"/> is the
+    /// already-fetched source issue payload (or <c>null</c> if no candidate
+    /// was traced or if the caller did not look it up). The analyzer does not
+    /// itself perform the lookup — that is the command layer's responsibility.
+    /// </summary>
+    public static WorkerPrReviewPreflightResult Analyze(
+        GitHubPrLookupResult pr,
+        string repo,
+        int prNumber,
+        string workdir,
+        SourceIssueCandidate? sourceIssueCandidate,
+        GitHubIssueLookupResult? sourceIssue)
+    {
+        ArgumentNullException.ThrowIfNull(pr);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workdir);
+
+        var labels = pr.Labels?
+            .Select(label => label.Name ?? string.Empty)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .ToArray()
+            ?? Array.Empty<string>();
+        var labelsSet = new HashSet<string>(labels, StringComparer.Ordinal);
+
+        var sourceIssueLabels = sourceIssue?.Labels?
+            .Select(label => label.Name ?? string.Empty)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .ToArray();
+        var sourceIssueLabelsSet = new HashSet<string>(
+            sourceIssueLabels ?? Array.Empty<string>(),
+            StringComparer.Ordinal);
+
+        var rawState = string.IsNullOrWhiteSpace(pr.State) ? "unknown" : pr.State;
+        var stateNormalized = rawState.ToLowerInvariant();
+
+        // Surface the merged signal in the displayed pr_state. gh emits
+        // state="MERGED" already when a PR is merged, but defensively also
+        // honor merged==true even if state somehow says "closed".
+        string displayState;
+        if (pr.Merged || string.Equals(stateNormalized, "merged", StringComparison.Ordinal))
+        {
+            displayState = "merged";
+        }
+        else if (string.Equals(stateNormalized, "open", StringComparison.Ordinal))
+        {
+            displayState = "open";
+        }
+        else if (string.Equals(stateNormalized, "closed", StringComparison.Ordinal) || pr.Closed)
+        {
+            displayState = "closed";
+        }
+        else
+        {
+            displayState = stateNormalized;
+        }
+
+        var title = pr.Title ?? string.Empty;
+        var body = pr.Body ?? string.Empty;
+
+        bool HasAnyReviewLabel()
+        {
+            return labelsSet.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrReviewing)
+                || labelsSet.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrRequestUpdate)
+                || labelsSet.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrUpdateInProgress)
+                || labelsSet.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrApproved);
+        }
+
+        // Step 1: non-actionable — closed AND not merged, OR fresh draft.
+        var isClosedNotMerged =
+            (pr.Closed || string.Equals(stateNormalized, "closed", StringComparison.Ordinal))
+            && !pr.Merged
+            && !string.Equals(stateNormalized, "merged", StringComparison.Ordinal);
+        if (isClosedNotMerged)
+        {
+            return Build(
+                pr,
+                repo,
+                prNumber,
+                title,
+                displayState,
+                labels,
+                sourceIssueCandidate?.Number,
+                sourceIssueLabels,
+                WorkerPrReviewPreflightConstants.Classifications.NonActionable,
+                [$"pr is {displayState}"],
+                actionable: false,
+                WorkerPrReviewPreflightConstants.RecommendedActions.DeclineWithSummary);
+        }
+
+        if (pr.IsDraft && !HasAnyReviewLabel())
+        {
+            return Build(
+                pr,
+                repo,
+                prNumber,
+                title,
+                displayState,
+                labels,
+                sourceIssueCandidate?.Number,
+                sourceIssueLabels,
+                WorkerPrReviewPreflightConstants.Classifications.NonActionable,
+                ["pr is draft and not yet promoted for review"],
+                actionable: false,
+                WorkerPrReviewPreflightConstants.RecommendedActions.DeclineWithSummary);
+        }
+
+        // Step 2: approved-or-merged.
+        var hasApprovedLabel = labelsSet.Contains(
+            WorkerPrReviewPreflightConstants.Labels.IntentPrApproved);
+        if (hasApprovedLabel || pr.Merged)
+        {
+            var reasons = new List<string>();
+            if (pr.Merged)
+            {
+                reasons.Add("pr is already merged");
+            }
+            if (hasApprovedLabel)
+            {
+                reasons.Add("pr carries intent-pr-approved label");
+            }
+            return Build(
+                pr,
+                repo,
+                prNumber,
+                title,
+                displayState,
+                labels,
+                sourceIssueCandidate?.Number,
+                sourceIssueLabels,
+                WorkerPrReviewPreflightConstants.Classifications.ApprovedOrMerged,
+                reasons,
+                actionable: false,
+                WorkerPrReviewPreflightConstants.RecommendedActions.NoAction);
+        }
+
+        // Step 3: update-in-progress.
+        if (labelsSet.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrUpdateInProgress))
+        {
+            return Build(
+                pr,
+                repo,
+                prNumber,
+                title,
+                displayState,
+                labels,
+                sourceIssueCandidate?.Number,
+                sourceIssueLabels,
+                WorkerPrReviewPreflightConstants.Classifications.UpdateInProgress,
+                ["pr carries intent-pr-update-in-progress label; a worker is iterating on this PR"],
+                actionable: false,
+                WorkerPrReviewPreflightConstants.RecommendedActions.WaitForWorkerUpdate);
+        }
+
+        // Step 4: request-update-pending.
+        if (labelsSet.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrRequestUpdate))
+        {
+            return Build(
+                pr,
+                repo,
+                prNumber,
+                title,
+                displayState,
+                labels,
+                sourceIssueCandidate?.Number,
+                sourceIssueLabels,
+                WorkerPrReviewPreflightConstants.Classifications.RequestUpdatePending,
+                ["pr carries intent-pr-request-update label; reviewer requested a worker update"],
+                actionable: false,
+                WorkerPrReviewPreflightConstants.RecommendedActions.WaitForWorkerUpdate);
+        }
+
+        // Step 5: already-reviewing.
+        if (labelsSet.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrReviewing))
+        {
+            return Build(
+                pr,
+                repo,
+                prNumber,
+                title,
+                displayState,
+                labels,
+                sourceIssueCandidate?.Number,
+                sourceIssueLabels,
+                WorkerPrReviewPreflightConstants.Classifications.AlreadyReviewing,
+                ["pr carries intent-pr-reviewing label; another reviewer is already on it"],
+                actionable: false,
+                WorkerPrReviewPreflightConstants.RecommendedActions.NoAction);
+        }
+
+        // Step 6: missing-target-label.
+        if (!labelsSet.Contains(WorkerPrReviewPreflightConstants.Labels.IntentTarget))
+        {
+            return Build(
+                pr,
+                repo,
+                prNumber,
+                title,
+                displayState,
+                labels,
+                sourceIssueCandidate?.Number,
+                sourceIssueLabels,
+                WorkerPrReviewPreflightConstants.Classifications.MissingTargetLabel,
+                ["pr is missing intent-target label; not marked as an automation target"],
+                actionable: false,
+                WorkerPrReviewPreflightConstants.RecommendedActions.DeclineWithSummary);
+        }
+
+        // Step 7: target-mismatch — derived from PR body and (if known) source-issue repo.
+        var mismatchReasons = DetectTargetMismatch(body, repo, workdir, sourceIssueCandidate);
+        if (mismatchReasons.Count > 0)
+        {
+            return Build(
+                pr,
+                repo,
+                prNumber,
+                title,
+                displayState,
+                labels,
+                sourceIssueCandidate?.Number,
+                sourceIssueLabels,
+                WorkerPrReviewPreflightConstants.Classifications.TargetMismatch,
+                mismatchReasons,
+                actionable: false,
+                WorkerPrReviewPreflightConstants.RecommendedActions.SwitchRepo);
+        }
+
+        // Step 8: source-issue-missing.
+        if (sourceIssueCandidate is null)
+        {
+            return Build(
+                pr,
+                repo,
+                prNumber,
+                title,
+                displayState,
+                labels,
+                null,
+                sourceIssueLabels,
+                WorkerPrReviewPreflightConstants.Classifications.SourceIssueMissing,
+                ["pr has no linked source issue (no closingIssuesReferences and no Closes/Fixes/Resolves #N reference in body)"],
+                actionable: false,
+                WorkerPrReviewPreflightConstants.RecommendedActions.DeclineWithSummary);
+        }
+
+        // Step 9: source-issue-not-target.
+        // Sub-case 9a: PR itself carries intent-pr-created (label-policy violation).
+        if (labelsSet.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrCreated))
+        {
+            return Build(
+                pr,
+                repo,
+                prNumber,
+                title,
+                displayState,
+                labels,
+                sourceIssueCandidate?.Number,
+                sourceIssueLabels,
+                WorkerPrReviewPreflightConstants.Classifications.SourceIssueNotTarget,
+                ["label-policy violation: intent-pr-created found on PR but should be on source issue only"],
+                actionable: false,
+                WorkerPrReviewPreflightConstants.RecommendedActions.LabelCleanupRequired);
+        }
+
+        // Sub-case 9b/9c: source issue exists but lacks required labels.
+        if (sourceIssue is not null)
+        {
+            var missingLabels = new List<string>();
+            if (!sourceIssueLabelsSet.Contains(WorkerPrReviewPreflightConstants.Labels.IntentTarget))
+            {
+                missingLabels.Add("intent-target");
+            }
+            if (!sourceIssueLabelsSet.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrCreated))
+            {
+                missingLabels.Add("intent-pr-created");
+            }
+            if (missingLabels.Count > 0)
+            {
+                var reasons = new List<string>();
+                foreach (var label in missingLabels)
+                {
+                    reasons.Add(
+                        $"source issue #{sourceIssueCandidate.Value.Number} is missing {label} label");
+                }
+                return Build(
+                    pr,
+                    repo,
+                    prNumber,
+                    title,
+                    displayState,
+                    labels,
+                    sourceIssueCandidate?.Number,
+                    sourceIssueLabels,
+                    WorkerPrReviewPreflightConstants.Classifications.SourceIssueNotTarget,
+                    reasons,
+                    actionable: false,
+                    WorkerPrReviewPreflightConstants.RecommendedActions.LabelCleanupRequired);
+            }
+        }
+
+        // Step 10: ready-to-review.
+        return Build(
+            pr,
+            repo,
+            prNumber,
+            title,
+            displayState,
+            labels,
+            sourceIssueCandidate?.Number,
+            sourceIssueLabels,
+            WorkerPrReviewPreflightConstants.Classifications.ReadyToReview,
+            Array.Empty<string>(),
+            actionable: true,
+            WorkerPrReviewPreflightConstants.RecommendedActions.Review);
+    }
+
+    private static IReadOnlyList<string> DetectTargetMismatch(
+        string body,
+        string repo,
+        string workdir,
+        SourceIssueCandidate? sourceIssueCandidate)
+    {
+        var reasons = new List<string>();
+
+        // Heuristic 0: closing-issues metadata names a different repo.
+        if (sourceIssueCandidate is { } candidate
+            && candidate.FromClosingIssuesMetadata
+            && !string.Equals(candidate.Repo, repo, StringComparison.OrdinalIgnoreCase))
+        {
+            reasons.Add(
+                $"closingIssuesReferences names {candidate.Repo} which does not match --repo {repo}");
+        }
+
+        if (string.IsNullOrEmpty(body))
+        {
+            return reasons;
+        }
+
+        // Heuristic 1: explicit "Repository: <owner/repo>" header in body.
+        var repoMatch = RepositoryHeaderRegex.Match(body);
+        if (repoMatch.Success)
+        {
+            var declared = repoMatch.Groups[1].Value;
+            if (!string.Equals(declared, repo, StringComparison.OrdinalIgnoreCase))
+            {
+                reasons.Add(
+                    $"pr body declares Repository: {declared} which does not match --repo {repo}");
+            }
+        }
+
+        // Heuristic 2: body mentions submodules/ while workdir does not.
+        if (body.Contains("submodules/", StringComparison.OrdinalIgnoreCase))
+        {
+            var workdirNormalized = workdir.Replace('\\', '/');
+            if (workdirNormalized.IndexOf("submodules/", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                reasons.Add(
+                    "pr body references a submodules/ path but --workdir does not point inside a submodules/ tree");
+            }
+        }
+
+        // Heuristic 3: body mentions parent-host / MyIntentHost.
+        var mentionsParentHost = body.Contains("parent-host", StringComparison.OrdinalIgnoreCase)
+            || body.Contains("MyIntentHost", StringComparison.Ordinal);
+        if (mentionsParentHost)
+        {
+            reasons.Add(
+                $"pr body references parent-host/MyIntentHost execution path which conflicts with child --repo {repo}");
+        }
+
+        return reasons;
+    }
+
+    private static WorkerPrReviewPreflightResult Build(
+        GitHubPrLookupResult pr,
+        string repo,
+        int prNumber,
+        string title,
+        string displayState,
+        IReadOnlyList<string> labels,
+        int? sourceIssueNumber,
+        IReadOnlyList<string>? sourceIssueLabels,
+        string classification,
+        IReadOnlyList<string> reasons,
+        bool actionable,
+        string recommendedAction)
+    {
+        var summaryLine =
+            $"Worker pr-review-preflight for {repo}#{prNumber} — classification={classification}, actionable={actionable.ToString().ToLowerInvariant()}.";
+
+        return new WorkerPrReviewPreflightResult
+        {
+            Actionable = actionable,
+            Classification = classification,
+            Pr = prNumber,
+            Repo = repo,
+            Title = title,
+            PrState = displayState,
+            IsDraft = pr.IsDraft,
+            Labels = labels,
+            SourceIssue = sourceIssueNumber,
+            SourceIssueLabels = sourceIssueLabels,
+            Reasons = reasons,
+            RecommendedAction = recommendedAction,
+            SummaryLine = summaryLine
+        };
+    }
+}
+
+/// <summary>
+/// G203: Source-issue trace candidate produced by
+/// <see cref="WorkerPrReviewPreflightAnalyzer.TraceSourceIssue"/>. The
+/// <see cref="FromClosingIssuesMetadata"/> flag distinguishes the metadata
+/// path from the regex fallback so the cross-repo heuristic in
+/// target-mismatch detection only triggers when the repo descriptor came
+/// from gh's structured payload.
+/// </summary>
+internal readonly record struct SourceIssueCandidate(
+    int Number,
+    string Repo,
+    bool FromClosingIssuesMetadata);

--- a/src/IntentSystem.Cli/Commands/WorkerPrReviewPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerPrReviewPreflightCommand.cs
@@ -1,0 +1,325 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G203: Read-only <c>intent-cli worker pr-review-preflight</c> command.
+/// Answers "is this GitHub PR actionable for deterministic review in the
+/// current implementation repository right now?" with a single deterministic
+/// classification. Never mutates queue state, runs, GitHub labels/PRs, source
+/// files, or any on-disk state. Exposes <see cref="PrLookupFactory"/>,
+/// <see cref="IssueLookupFactory"/>, and <see cref="NestedProviderLauncher"/>
+/// so tests can inject fakes and assert that no nested provider is launched.
+/// </summary>
+internal static class WorkerPrReviewPreflightCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    /// <summary>
+    /// Test seam: tests inject a fake <see cref="IGitHubPrLookup"/> here so no
+    /// real GitHub network call is made. Production callers leave this null
+    /// and the default <see cref="GhCliGitHubPrLookup"/> is used.
+    /// </summary>
+    public static Func<IGitHubPrLookup>? PrLookupFactory { get; set; }
+
+    /// <summary>
+    /// Test seam for the source-issue lookup. Reuses the G202
+    /// <see cref="IGitHubIssueLookup"/> seam so tests inject a fake to return
+    /// canned issue data. Production callers leave this null and the default
+    /// <see cref="GhCliGitHubIssueLookup"/> is used.
+    /// </summary>
+    public static Func<IGitHubIssueLookup>? IssueLookupFactory { get; set; }
+
+    /// <summary>
+    /// Test sentinel: must NEVER be invoked by this command. Tests assert that
+    /// it remains uninvoked across all preflight code paths to lock in the
+    /// "no nested provider launch" guarantee.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var repo, out var prNumber, out var workdir, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedWorkdir = string.IsNullOrWhiteSpace(workdir)
+            ? Directory.GetCurrentDirectory()
+            : workdir!;
+
+        IGitHubPrLookup prLookup;
+        try
+        {
+            prLookup = PrLookupFactory?.Invoke() ?? new GhCliGitHubPrLookup();
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub PR lookup: {exception.Message}");
+            return 1;
+        }
+
+        GitHubPrLookupResult prPayload;
+        try
+        {
+            prPayload = prLookup.Lookup(repo!, prNumber);
+        }
+        catch (Exception exception)
+        {
+            writer.WriteLine(
+                $"failed to look up GitHub PR {repo}#{prNumber}: {exception.Message}");
+            return 1;
+        }
+
+        if (prPayload is null)
+        {
+            writer.WriteLine(
+                $"GitHub PR lookup returned no payload for {repo}#{prNumber}.");
+            return 1;
+        }
+
+        SourceIssueCandidate? candidate;
+        try
+        {
+            candidate = WorkerPrReviewPreflightAnalyzer.TraceSourceIssue(prPayload, repo!);
+        }
+        catch (Exception exception) when (
+            exception is ArgumentException
+            or InvalidOperationException
+            or FormatException)
+        {
+            writer.WriteLine(
+                $"failed to trace source issue for PR {repo}#{prNumber}: {exception.Message}");
+            return 1;
+        }
+
+        GitHubIssueLookupResult? sourceIssuePayload = null;
+        if (candidate is { } traced)
+        {
+            IGitHubIssueLookup issueLookup;
+            try
+            {
+                issueLookup = IssueLookupFactory?.Invoke() ?? new GhCliGitHubIssueLookup();
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or IOException)
+            {
+                writer.WriteLine(
+                    $"failed to initialize GitHub issue lookup for source issue {traced.Repo}#{traced.Number}: {exception.Message}");
+                return 1;
+            }
+
+            try
+            {
+                sourceIssuePayload = issueLookup.Lookup(traced.Repo, traced.Number);
+            }
+            catch (Exception exception)
+            {
+                writer.WriteLine(
+                    $"failed to look up source issue {traced.Repo}#{traced.Number}: {exception.Message}");
+                return 1;
+            }
+        }
+
+        WorkerPrReviewPreflightResult result;
+        try
+        {
+            result = WorkerPrReviewPreflightAnalyzer.Analyze(
+                prPayload,
+                repo!,
+                prNumber,
+                resolvedWorkdir,
+                candidate,
+                sourceIssuePayload);
+        }
+        catch (Exception exception) when (
+            exception is ArgumentException
+            or InvalidOperationException
+            or FormatException)
+        {
+            writer.WriteLine(
+                $"failed to classify GitHub PR {repo}#{prNumber}: {exception.Message}");
+            return 1;
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static void WriteText(TextWriter writer, WorkerPrReviewPreflightResult result)
+    {
+        writer.WriteLine($"# Worker pr-review-preflight for {result.Repo}#{result.Pr}");
+        writer.WriteLine();
+        writer.WriteLine($"- title: {result.Title}");
+        writer.WriteLine($"- pr_state: {result.PrState}");
+        writer.WriteLine($"- is_draft: {result.IsDraft.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"- classification: {result.Classification}");
+        writer.WriteLine($"- actionable: {result.Actionable.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"- recommended_action: {result.RecommendedAction}");
+        writer.WriteLine(
+            $"- source_issue: {(result.SourceIssue.HasValue ? result.SourceIssue.Value.ToString(System.Globalization.CultureInfo.InvariantCulture) : "(none)")}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Labels");
+        if (result.Labels.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var label in result.Labels)
+            {
+                writer.WriteLine($"- {label}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Source issue labels");
+        if (result.SourceIssueLabels is null || result.SourceIssueLabels.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var label in result.SourceIssueLabels)
+            {
+                writer.WriteLine($"- {label}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Reasons");
+        if (result.Reasons.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var reason in result.Reasons)
+            {
+                writer.WriteLine($"- {reason}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine(result.SummaryLine);
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out int prNumber,
+        out string? workdir,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        prNumber = 0;
+        workdir = null;
+        format = FormatText;
+        error = string.Empty;
+        var sawPr = false;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--pr":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--pr requires a value (PR number).";
+                        return false;
+                    }
+                    if (!int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer,
+                        System.Globalization.CultureInfo.InvariantCulture, out prNumber)
+                        || prNumber <= 0)
+                    {
+                        error = $"--pr must be a positive integer (got '{args[index + 1]}').";
+                        return false;
+                    }
+                    sawPr = true;
+                    index++;
+                    break;
+
+                case "--workdir":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--workdir requires a value.";
+                        return false;
+                    }
+                    workdir = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --repo <owner/repo> --pr <number> [--workdir <path>] [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "--repo is required (e.g. --repo owner/repo).";
+            return false;
+        }
+
+        if (!sawPr)
+        {
+            error = "--pr is required (e.g. --pr 123).";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerPrReviewPreflightResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerPrReviewPreflightResult.cs
@@ -1,0 +1,112 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G203: Read-only result emitted by <c>intent-cli worker pr-review-preflight</c>.
+/// Field names are stable snake_case for AI-thread JSON ingestion. CamelCase
+/// alias properties echo the issue contract verbatim alongside the snake_case
+/// primaries. Round-trippable via <see cref="System.Text.Json.JsonSerializer"/>.
+/// </summary>
+internal sealed record WorkerPrReviewPreflightResult
+{
+    [JsonPropertyName("actionable")]
+    public required bool Actionable { get; init; }
+
+    [JsonPropertyName("classification")]
+    public required string Classification { get; init; }
+
+    [JsonPropertyName("pr")]
+    public required int Pr { get; init; }
+
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    [JsonPropertyName("pr_state")]
+    public required string PrState { get; init; }
+
+    [JsonPropertyName("is_draft")]
+    public required bool IsDraft { get; init; }
+
+    [JsonPropertyName("labels")]
+    public required IReadOnlyList<string> Labels { get; init; }
+
+    [JsonPropertyName("source_issue")]
+    public required int? SourceIssue { get; init; }
+
+    /// <summary>
+    /// G203 issue contract alias. Issue #511's minimum-JSON example names this
+    /// field <c>sourceIssue</c> (camelCase). The primary property keeps
+    /// snake_case for local style consistency; this read-only alias property
+    /// emits the camelCase key alongside it so the issue contract holds
+    /// verbatim. On deserialize the alias is ignored — the snake_case
+    /// property is the canonical source — keeping round-trip stable.
+    /// </summary>
+    [JsonPropertyName("sourceIssue")]
+    public int? SourceIssueCamelCase => SourceIssue;
+
+    [JsonPropertyName("source_issue_labels")]
+    public required IReadOnlyList<string>? SourceIssueLabels { get; init; }
+
+    [JsonPropertyName("reasons")]
+    public required IReadOnlyList<string> Reasons { get; init; }
+
+    [JsonPropertyName("recommended_action")]
+    public required string RecommendedAction { get; init; }
+
+    /// <summary>
+    /// G203 issue contract alias. Issue #511's minimum-JSON example names this
+    /// field <c>recommendedAction</c> (camelCase). The primary property keeps
+    /// snake_case; this read-only alias emits the camelCase key alongside.
+    /// </summary>
+    [JsonPropertyName("recommendedAction")]
+    public string RecommendedActionCamelCase => RecommendedAction;
+
+    [JsonPropertyName("summary_line")]
+    public required string SummaryLine { get; init; }
+}
+
+/// <summary>
+/// G203: Stable string constants for the ten classification states emitted by
+/// <c>intent-cli worker pr-review-preflight</c>. Order matches the
+/// first-match-wins precedence documented in the issue body.
+/// </summary>
+internal static class WorkerPrReviewPreflightConstants
+{
+    public static class Classifications
+    {
+        public const string ReadyToReview = "ready-to-review";
+        public const string AlreadyReviewing = "already-reviewing";
+        public const string RequestUpdatePending = "request-update-pending";
+        public const string UpdateInProgress = "update-in-progress";
+        public const string ApprovedOrMerged = "approved-or-merged";
+        public const string MissingTargetLabel = "missing-target-label";
+        public const string SourceIssueMissing = "source-issue-missing";
+        public const string SourceIssueNotTarget = "source-issue-not-target";
+        public const string TargetMismatch = "target-mismatch";
+        public const string NonActionable = "non-actionable";
+    }
+
+    public static class RecommendedActions
+    {
+        public const string Review = "review";
+        public const string NoAction = "no-action";
+        public const string WaitForWorkerUpdate = "wait-for-worker-update";
+        public const string DeclineWithSummary = "decline-with-summary";
+        public const string LabelCleanupRequired = "label-cleanup-required";
+        public const string SwitchRepo = "switch-repo";
+    }
+
+    public static class Labels
+    {
+        public const string IntentTarget = "intent-target";
+        public const string IntentPrCreated = "intent-pr-created";
+        public const string IntentPrReviewing = "intent-pr-reviewing";
+        public const string IntentPrRequestUpdate = "intent-pr-request-update";
+        public const string IntentPrUpdateInProgress = "intent-pr-update-in-progress";
+        public const string IntentPrApproved = "intent-pr-approved";
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkerPrReviewPreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerPrReviewPreflightCommandTests.cs
@@ -1,0 +1,1164 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class WorkerPrReviewPreflightCommandTests : IDisposable
+{
+    public WorkerPrReviewPreflightCommandTests()
+    {
+        WorkerPrReviewPreflightCommand.PrLookupFactory = null;
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = null;
+        WorkerPrReviewPreflightCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        WorkerPrReviewPreflightCommand.PrLookupFactory = null;
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = null;
+        WorkerPrReviewPreflightCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void Execute_GivenReadyPr_ClassifiesAsReadyToReview()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 600,
+            state: "OPEN",
+            title: "Ready PR",
+            body: "Implements feature.\n\nCloses #100",
+            labelNames: new[] { "intent-target" },
+            isDraft: false,
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "600", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.True(result!.Actionable);
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.ReadyToReview, result.Classification);
+        Assert.Equal(WorkerPrReviewPreflightConstants.RecommendedActions.Review, result.RecommendedAction);
+        Assert.Equal(600, result.Pr);
+        Assert.Equal("J-Tech-Japan/intent-system", result.Repo);
+        Assert.Equal(100, result.SourceIssue);
+        Assert.Empty(result.Reasons);
+    }
+
+    [Fact]
+    public void Execute_GivenPrWithIntentPrRequestUpdate_ClassifiesAsRequestUpdatePending()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 1,
+            state: "OPEN",
+            title: "Update requested",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target", "intent-pr-request-update" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "1", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.False(result.Actionable);
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.RequestUpdatePending, result.Classification);
+        Assert.Equal(WorkerPrReviewPreflightConstants.RecommendedActions.WaitForWorkerUpdate, result.RecommendedAction);
+    }
+
+    [Fact]
+    public void Execute_GivenPrWithIntentPrUpdateInProgress_ClassifiesAsUpdateInProgress()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 2,
+            state: "OPEN",
+            title: "Worker iterating",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target", "intent-pr-update-in-progress" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "2", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.UpdateInProgress, result.Classification);
+        Assert.Equal(WorkerPrReviewPreflightConstants.RecommendedActions.WaitForWorkerUpdate, result.RecommendedAction);
+    }
+
+    [Fact]
+    public void Execute_GivenPrWithIntentPrReviewing_ClassifiesAsAlreadyReviewing()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 3,
+            state: "OPEN",
+            title: "Being reviewed",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target", "intent-pr-reviewing" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "3", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.AlreadyReviewing, result.Classification);
+        Assert.Equal(WorkerPrReviewPreflightConstants.RecommendedActions.NoAction, result.RecommendedAction);
+    }
+
+    [Fact]
+    public void Execute_GivenPrWithIntentPrApproved_ClassifiesAsApprovedOrMerged()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 4,
+            state: "OPEN",
+            title: "Approved",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target", "intent-pr-approved" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "4", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.ApprovedOrMerged, result.Classification);
+        Assert.Equal(WorkerPrReviewPreflightConstants.RecommendedActions.NoAction, result.RecommendedAction);
+        Assert.Contains(result.Reasons, r => r.Contains("intent-pr-approved", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenMergedPr_ClassifiesAsApprovedOrMerged()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 5,
+            state: "MERGED",
+            title: "Merged",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            merged: true,
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "5", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.ApprovedOrMerged, result.Classification);
+        Assert.Equal("merged", result.PrState);
+        Assert.Contains(result.Reasons, r => r.Contains("merged", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenPrWithoutIntentTarget_ClassifiesAsMissingTargetLabel()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 6,
+            state: "OPEN",
+            title: "Untargeted",
+            body: "Closes #100",
+            labelNames: Array.Empty<string>(),
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "6", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.MissingTargetLabel, result.Classification);
+        Assert.Equal(WorkerPrReviewPreflightConstants.RecommendedActions.DeclineWithSummary, result.RecommendedAction);
+        Assert.Contains(result.Reasons, r => r.Contains("intent-target", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenPrWithNoLinkedIssue_ClassifiesAsSourceIssueMissing()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 7,
+            state: "OPEN",
+            title: "No link",
+            body: "No issue references at all here.",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: Array.Empty<int>()));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "7", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.SourceIssueMissing, result.Classification);
+        Assert.Equal(WorkerPrReviewPreflightConstants.RecommendedActions.DeclineWithSummary, result.RecommendedAction);
+        Assert.Null(result.SourceIssue);
+    }
+
+    [Fact]
+    public void Execute_GivenPrSourceIssueMissingIntentTarget_ClassifiesAsSourceIssueNotTarget()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 8,
+            state: "OPEN",
+            title: "Source missing intent-target",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "8", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.SourceIssueNotTarget, result.Classification);
+        Assert.Equal(WorkerPrReviewPreflightConstants.RecommendedActions.LabelCleanupRequired, result.RecommendedAction);
+        Assert.Contains(result.Reasons, r => r.Contains("intent-target", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenPrSourceIssueMissingIntentPrCreated_ClassifiesAsSourceIssueNotTarget()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 9,
+            state: "OPEN",
+            title: "Source missing pr-created",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "9", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.SourceIssueNotTarget, result.Classification);
+        Assert.Contains(result.Reasons, r => r.Contains("intent-pr-created", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenPrCarriesIntentPrCreatedItself_ClassifiesAsSourceIssueNotTarget_LabelPolicyViolation()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 10,
+            state: "OPEN",
+            title: "PR carries intent-pr-created",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target", "intent-pr-created" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "10", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.SourceIssueNotTarget, result.Classification);
+        Assert.Equal(WorkerPrReviewPreflightConstants.RecommendedActions.LabelCleanupRequired, result.RecommendedAction);
+        Assert.Contains(result.Reasons, r =>
+            r.Contains("label-policy violation", StringComparison.Ordinal)
+            && r.Contains("intent-pr-created", StringComparison.Ordinal)
+            && r.Contains("PR", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenPrBodyReferencingDifferentRepo_ClassifiesAsTargetMismatch()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 11,
+            state: "OPEN",
+            title: "Cross-repo",
+            body: "Repository: SomeOther/Repo\n\nCloses #100",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "11", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.TargetMismatch, result.Classification);
+        Assert.Equal(WorkerPrReviewPreflightConstants.RecommendedActions.SwitchRepo, result.RecommendedAction);
+        Assert.Contains(result.Reasons, r =>
+            r.Contains("SomeOther/Repo", StringComparison.Ordinal)
+            && r.Contains("J-Tech-Japan/intent-system", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenClosedNotMergedPr_ClassifiesAsNonActionable()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 12,
+            state: "CLOSED",
+            title: "Closed",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            closed: true,
+            closingIssueNumbers: new[] { 100 }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "12", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.NonActionable, result.Classification);
+        Assert.Contains(result.Reasons, r => r.Contains("closed", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenFreshDraftPrNoReviewLabel_ClassifiesAsNonActionable()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 13,
+            state: "OPEN",
+            title: "Fresh draft",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            isDraft: true,
+            closingIssueNumbers: new[] { 100 }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "13", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.NonActionable, result.Classification);
+        Assert.Contains(result.Reasons, r => r.Contains("draft", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_RoundTripsStably()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 14,
+            state: "OPEN",
+            title: "Round trip",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "14", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var first = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        var serialized = JsonSerializer.Serialize(first);
+        var second = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(serialized)!;
+
+        Assert.Equal(first.Actionable, second.Actionable);
+        Assert.Equal(first.Classification, second.Classification);
+        Assert.Equal(first.Pr, second.Pr);
+        Assert.Equal(first.Repo, second.Repo);
+        Assert.Equal(first.Title, second.Title);
+        Assert.Equal(first.PrState, second.PrState);
+        Assert.Equal(first.IsDraft, second.IsDraft);
+        Assert.Equal(first.Labels, second.Labels);
+        Assert.Equal(first.SourceIssue, second.SourceIssue);
+        Assert.Equal(first.SourceIssueLabels, second.SourceIssueLabels);
+        Assert.Equal(first.Reasons, second.Reasons);
+        Assert.Equal(first.RecommendedAction, second.RecommendedAction);
+        Assert.Equal(first.SummaryLine, second.SummaryLine);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_FieldsMatchIssueAcceptanceCriteria()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 15,
+            state: "OPEN",
+            title: "Field check",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "15", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        // Required fields named in the issue's minimum example.
+        Assert.True(root.TryGetProperty("actionable", out _));
+        Assert.True(root.TryGetProperty("classification", out _));
+        Assert.True(root.TryGetProperty("pr", out _));
+        Assert.True(root.TryGetProperty("repo", out _));
+        Assert.True(root.TryGetProperty("sourceIssue", out var camelSource));
+        Assert.True(root.TryGetProperty("reasons", out _));
+        Assert.True(root.TryGetProperty("recommendedAction", out var camelAction));
+
+        // Both camelCase and snake_case keys must be present.
+        Assert.True(root.TryGetProperty("source_issue", out var snakeSource));
+        Assert.True(root.TryGetProperty("recommended_action", out var snakeAction));
+        Assert.Equal(snakeAction.GetString(), camelAction.GetString());
+        if (snakeSource.ValueKind == JsonValueKind.Number)
+        {
+            Assert.Equal(snakeSource.GetInt32(), camelSource.GetInt32());
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_CamelCaseAliasesMatchIssueContract()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 16,
+            state: "OPEN",
+            title: "Camel alias",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "16", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var stdout = writer.ToString();
+        Assert.Contains("\"sourceIssue\"", stdout, StringComparison.Ordinal);
+        Assert.Contains("\"recommendedAction\"", stdout, StringComparison.Ordinal);
+
+        using var document = JsonDocument.Parse(stdout);
+        var root = document.RootElement;
+        Assert.True(root.TryGetProperty("recommendedAction", out var camelAction));
+        Assert.True(root.TryGetProperty("recommended_action", out var snakeAction));
+        Assert.Equal(snakeAction.GetString(), camelAction.GetString());
+        Assert.Equal(WorkerPrReviewPreflightConstants.RecommendedActions.Review, camelAction.GetString());
+
+        Assert.True(root.TryGetProperty("sourceIssue", out var camelSource));
+        Assert.True(root.TryGetProperty("source_issue", out var snakeSource));
+        Assert.Equal(snakeSource.GetInt32(), camelSource.GetInt32());
+        Assert.Equal(100, camelSource.GetInt32());
+    }
+
+    [Fact]
+    public void Execute_GivenSourceIssueViaClosingIssuesMetadata_TracesCorrectly()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 17,
+            state: "OPEN",
+            title: "Closing-issues metadata",
+            body: "No body issue references at all.",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "17", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(100, result.SourceIssue);
+    }
+
+    [Fact]
+    public void Execute_GivenSourceIssueViaPrBodyClosesReference_TracesCorrectly()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 18,
+            state: "OPEN",
+            title: "Body Closes ref",
+            body: "Some text. Closes #100. More text.",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: Array.Empty<int>()));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "18", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(100, result.SourceIssue);
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.ReadyToReview, result.Classification);
+    }
+
+    [Fact]
+    public void Execute_PrecedenceClosedBeatsLabels()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 19,
+            state: "CLOSED",
+            title: "Closed with reviewing label",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target", "intent-pr-reviewing" },
+            closed: true,
+            closingIssueNumbers: new[] { 100 }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "19", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.NonActionable, result.Classification);
+    }
+
+    [Fact]
+    public void Execute_PrecedenceApprovedBeatsRequestUpdate()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 20,
+            state: "OPEN",
+            title: "Approved + request",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target", "intent-pr-approved", "intent-pr-request-update" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "20", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.ApprovedOrMerged, result.Classification);
+    }
+
+    [Fact]
+    public void Execute_PrecedenceUpdateInProgressBeatsRequestUpdate()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 21,
+            state: "OPEN",
+            title: "Update + request",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target", "intent-pr-update-in-progress", "intent-pr-request-update" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "21", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrReviewPreflightConstants.Classifications.UpdateInProgress, result.Classification);
+    }
+
+    [Fact]
+    public void Execute_GivenPrLookupTransportFailure_ReturnsNonZero_ActionableErrorMessage()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new ThrowingPrLookup(
+            "simulated network failure: gh pr view exited 1");
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "511", "--format", "json" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("simulated network failure", output, StringComparison.Ordinal);
+        Assert.Contains("511", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenIssueLookupTransportFailure_ReturnsNonZero_ActionableErrorMessage()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 22,
+            state: "OPEN",
+            title: "Issue lookup throws",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () =>
+            new ThrowingIssueLookup("simulated issue-lookup failure: gh issue view exited 1");
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "22", "--format", "json" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("simulated issue-lookup failure", output, StringComparison.Ordinal);
+        Assert.Contains("100", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingRepoFlag_ReturnsNonZero()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--pr", "1" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--repo", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPrFlag_ReturnsNonZero()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--pr", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNonNumericPr_ReturnsNonZero()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "abc" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--pr", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsNonZero()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "1", "--bogus" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--bogus", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesToQueueStateOrRunsLog()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 23,
+            state: "OPEN",
+            title: "Snapshot",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        var queueStatePath = Path.Combine(workspace.RootPath, ".intent-cli", "queue-state.json");
+        var runsLogPath = Path.Combine(workspace.RootPath, ".intent-cli", "runs.jsonl");
+        File.WriteAllText(queueStatePath, "{\"queue\":[]}");
+        File.WriteAllText(runsLogPath, "{\"event\":\"baseline\"}\n");
+
+        var queueBefore = File.ReadAllBytes(queueStatePath);
+        var runsBefore = File.ReadAllBytes(runsLogPath);
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "23", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var queueAfter = File.ReadAllBytes(queueStatePath);
+        var runsAfter = File.ReadAllBytes(runsLogPath);
+        Assert.Equal(queueBefore, queueAfter);
+        Assert.Equal(runsBefore, runsAfter);
+    }
+
+    [Fact]
+    public void Execute_NeverWritesAnyArtifactFile()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 24,
+            state: "OPEN",
+            title: "No writes",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        File.WriteAllText(Path.Combine(workspace.RootPath, "baseline.txt"), "baseline");
+        var before = workspace.SnapshotWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "24", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var after = workspace.SnapshotWorkspace();
+        Assert.Equal(before.Count, after.Count);
+        foreach (var (path, hash) in before)
+        {
+            Assert.True(after.TryGetValue(path, out var afterHash),
+                $"file disappeared during command execution: {path}");
+            Assert.Equal(hash, afterHash);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesProvider_NoProcessStartInNewSurface()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        var invoked = false;
+        WorkerPrReviewPreflightCommand.NestedProviderLauncher = () =>
+        {
+            invoked = true;
+            return false;
+        };
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 25,
+            state: "OPEN",
+            title: "No provider",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "25" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(invoked, "NestedProviderLauncher must never be invoked by the preflight command");
+
+        var commandSource = File.ReadAllText(LocateSourceFile("WorkerPrReviewPreflightCommand.cs"));
+        var analyzerSource = File.ReadAllText(LocateSourceFile("WorkerPrReviewPreflightAnalyzer.cs"));
+        var resultSource = File.ReadAllText(LocateSourceFile("WorkerPrReviewPreflightResult.cs"));
+
+        Assert.DoesNotContain("Process.Start(", commandSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("Process.Start(", analyzerSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("Process.Start(", resultSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverMutatesAnyLabelOrPr_NoGhEditOrMergeCallInAnalyzer()
+    {
+        var commandSource = File.ReadAllText(LocateSourceFile("WorkerPrReviewPreflightCommand.cs"));
+        var analyzerSource = File.ReadAllText(LocateSourceFile("WorkerPrReviewPreflightAnalyzer.cs"));
+
+        foreach (var literal in new[]
+        {
+            "gh issue edit",
+            "gh pr edit",
+            "gh pr merge",
+            "gh pr close",
+            "gh pr reopen",
+            "gh pr comment",
+            "gh pr review"
+        })
+        {
+            Assert.DoesNotContain(literal, commandSource, StringComparison.Ordinal);
+            Assert.DoesNotContain(literal, analyzerSource, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenTextFormat_PrintsStableSummaryLine()
+    {
+        using var workspace = new WorkerPrReviewPreflightWorkspace();
+        WorkerPrReviewPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 26,
+            state: "OPEN",
+            title: "Text format",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrReviewPreflightCommand.IssueLookupFactory = () => new FakeIssueLookup(BuildIssue(
+            number: 100,
+            state: "OPEN",
+            title: "Source",
+            body: string.Empty,
+            labelNames: new[] { "intent-target", "intent-pr-created" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrReviewPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "26" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Worker pr-review-preflight for J-Tech-Japan/intent-system#26", output, StringComparison.Ordinal);
+        Assert.Contains("classification=ready-to-review", output, StringComparison.Ordinal);
+        Assert.Contains("actionable=true", output, StringComparison.Ordinal);
+    }
+
+    private static string LocateSourceFile(string fileName)
+    {
+        var directory = AppContext.BaseDirectory;
+        var dir = new DirectoryInfo(directory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(
+                dir.FullName, "src", "IntentSystem.Cli", "Commands", fileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = dir.Parent;
+        }
+
+        throw new FileNotFoundException(
+            $"Could not locate source file {fileName} from {directory}");
+    }
+
+    private static GitHubPrLookupResult BuildPr(
+        int number,
+        string state,
+        string title,
+        string body,
+        string[] labelNames,
+        bool isDraft = false,
+        bool closed = false,
+        bool merged = false,
+        int[]? closingIssueNumbers = null)
+    {
+        var refs = (closingIssueNumbers ?? Array.Empty<int>())
+            .Select(n => new GitHubPrClosingIssueReference { Number = n })
+            .ToArray();
+
+        return new GitHubPrLookupResult
+        {
+            Number = number,
+            State = state,
+            Title = title,
+            Body = body,
+            IsDraft = isDraft,
+            Closed = closed,
+            Merged = merged,
+            MergedAt = merged ? "2025-01-01T00:00:00Z" : null,
+            ClosedAt = (closed || merged) ? "2025-01-01T00:00:00Z" : null,
+            Labels = labelNames.Select(n => new GitHubPrLabel { Name = n }).ToArray(),
+            ClosingIssuesReferences = refs
+        };
+    }
+
+    private static GitHubIssueLookupResult BuildIssue(
+        int number,
+        string state,
+        string title,
+        string body,
+        string[] labelNames,
+        bool closed = false)
+    {
+        return new GitHubIssueLookupResult
+        {
+            Number = number,
+            State = state,
+            Title = title,
+            Body = body,
+            Closed = closed,
+            ClosedAt = closed ? "2025-01-01T00:00:00Z" : null,
+            Labels = labelNames.Select(n => new GitHubIssueLabel { Name = n }).ToArray()
+        };
+    }
+
+    private sealed class FakePrLookup : IGitHubPrLookup
+    {
+        private readonly GitHubPrLookupResult payload;
+
+        public FakePrLookup(GitHubPrLookupResult payload)
+        {
+            this.payload = payload;
+        }
+
+        public GitHubPrLookupResult Lookup(string repo, int prNumber) => payload;
+    }
+
+    private sealed class ThrowingPrLookup : IGitHubPrLookup
+    {
+        private readonly string message;
+
+        public ThrowingPrLookup(string message)
+        {
+            this.message = message;
+        }
+
+        public GitHubPrLookupResult Lookup(string repo, int prNumber)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private sealed class FakeIssueLookup : IGitHubIssueLookup
+    {
+        private readonly GitHubIssueLookupResult payload;
+
+        public FakeIssueLookup(GitHubIssueLookupResult payload)
+        {
+            this.payload = payload;
+        }
+
+        public GitHubIssueLookupResult Lookup(string repo, int issueNumber) => payload;
+    }
+
+    private sealed class ThrowingIssueLookup : IGitHubIssueLookup
+    {
+        private readonly string message;
+
+        public ThrowingIssueLookup(string message)
+        {
+            this.message = message;
+        }
+
+        public GitHubIssueLookupResult Lookup(string repo, int issueNumber)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private sealed class WorkerPrReviewPreflightWorkspace : IDisposable
+    {
+        public WorkerPrReviewPreflightWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("worker-pr-review-preflight-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public IReadOnlyDictionary<string, string> SnapshotWorkspace()
+        {
+            var snapshot = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(RootPath, "*", SearchOption.AllDirectories))
+            {
+                var bytes = File.ReadAllBytes(path);
+                var hash = Convert.ToHexString(SHA256.HashData(bytes));
+                snapshot[path] = hash;
+            }
+            return snapshot;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `intent-cli worker pr-review-preflight --repo <owner/repo> --pr <number> [--workdir <path>] [--format text|json]` under the existing `worker` group introduced by G202. Mirrors G202's architecture (testability seam → analyzer → result + constants + camelCase aliases). Answers ONE deterministic question for review automation loops: \"Is this GitHub PR actionable for deterministic review in the current implementation repository right now?\" — without launching AI providers, mutating any label, posting comments, merging/closing PRs, or creating branches.
- 10 stable classifications locked in `WorkerPrReviewPreflightConstants.Classifications.*` (asserted by regression tests):
  - `ready-to-review` (only this one is `actionable: true`), `already-reviewing`, `request-update-pending`, `update-in-progress`, `approved-or-merged`, `missing-target-label`, `source-issue-missing`, `source-issue-not-target`, `target-mismatch`, `non-actionable`.
- First-match precedence (locked by precedence regression tests):
  1. closed-not-merged OR fresh-draft-no-review-label → `non-actionable`
  2. `intent-pr-approved` label OR `merged: true` → `approved-or-merged`
  3. `intent-pr-update-in-progress` label → `update-in-progress`
  4. `intent-pr-request-update` label → `request-update-pending`
  5. `intent-pr-reviewing` label → `already-reviewing`
  6. missing `intent-target` label → `missing-target-label`
  7. body/source-issue references different repo, `submodules/...` with non-submodules workdir, or `parent-host`/`MyIntentHost` literal → `target-mismatch`
  8. source-issue trace produces no candidate → `source-issue-missing`
  9. PR carries `intent-pr-created` itself (label-policy violation; that label is issue-only) OR source issue missing `intent-target` / `intent-pr-created` → `source-issue-not-target`
  10. otherwise → `ready-to-review`
- Source-issue trace (issue's explicit Acceptance Criterion): `pr.closingIssuesReferences[0].number` if non-empty; else regex on PR body for `(?i)(?:closes|fixes|resolves)\s+#(\d+)` (first match). Both paths covered by dedicated regression tests.
- Testability seams:
  - **`IGitHubPrLookup`** (new): default `GhCliGitHubPrLookup` shells out to `gh pr view <num> --repo <repo> --json number,state,title,body,labels,isDraft,closed,merged,mergedAt,closedAt,closingIssuesReferences`.
  - **`IGitHubIssueLookup`** (G202, reused unchanged): for source-issue label lookup. Tests inject fakes for both — **NO real GitHub network in tests**.
- `recommended_action` mapping (locked in `WorkerPrReviewPreflightConstants.RecommendedActions.*`): `ready-to-review` → `review`; `already-reviewing` / `approved-or-merged` → `no-action`; `request-update-pending` / `update-in-progress` → `wait-for-worker-update`; `missing-target-label` / `source-issue-missing` / `non-actionable` → `decline-with-summary`; `source-issue-not-target` → `label-cleanup-required`; `target-mismatch` → `switch-repo`.
- Output JSON shape (snake_case primary + camelCase aliases for issue contract parity, mirroring G202 fix #510):
  ```
  { \"actionable\": <bool>, \"classification\": \"...\", \"pr\": <int>, \"repo\": \"...\", \"title\": \"...\",
    \"pr_state\": \"open\" | \"closed\" | \"merged\",
    \"is_draft\": <bool>,
    \"labels\": [\"intent-target\", ...],
    \"source_issue\": <int> | null,                 \"sourceIssue\": <int> | null,        // camelCase alias
    \"source_issue_labels\": [\"...\"] | null,
    \"reasons\": [\"...\"],
    \"recommended_action\": \"...\",                 \"recommendedAction\": \"...\",        // camelCase alias
    \"summary_line\": \"Worker pr-review-preflight for <repo>#<pr> — classification=<...>, actionable=<...>.\" }
  ```
  Both `sourceIssue` and `recommendedAction` camelCase aliases are read-only properties that mirror their snake_case primaries; on deserialize the alias is ignored — round-trip stays stable. Locked by an explicit regression that asserts (a) the literal keys appear in stdout, (b) BOTH camelCase and snake_case versions carry identical values for both fields.
- No-mutation invariants (verified by tests):
  - Sentinel `WorkerPrReviewPreflightCommand.NestedProviderLauncher` (mirrors prior G-slice patterns) — never invoked.
  - Source-scan asserts the new analyzer + command + result files contain no `Process.Start(`. (The two lookup adapters `GhCliGitHubPrLookup` / `GhCliGitHubIssueLookup` are exempt — that's their job.)
  - Source-scan asserts the analyzer + command files contain no `gh issue edit`/`gh pr edit`/`gh pr merge`/`gh pr close`/`gh pr reopen`/`gh pr comment`/`gh pr review` literals — the issue's explicit \"do not mutate labels, do not create/update/merge/close/reopen PRs, do not post PR comments or resolve review threads\" criteria.
  - Byte-equivalence test on `.intent-cli/queue-state.json` and `.intent-cli/runs.jsonl` before/after.
  - Whole-workspace byte-snapshot test asserts NO new file created and NO existing file modified.
- Reuse, not duplication: G202's `IGitHubIssueLookup` + `GitHubIssueLookupResult` reused unchanged; G202's camelCase-alias pattern replicated for `sourceIssue` and `recommendedAction`; G202's target-mismatch heuristics mirrored inline (with one addition: closing-issues metadata pointing to a different repo). **No `private→internal` promotions needed**.

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter \"FullyQualifiedName~WorkerPrReviewPreflight\"` — **33/33 passing**. Issue's Acceptance Criteria explicitly requires tests covering `ready-to-review`, `request-update-pending`, `update-in-progress`, `missing-target-label`, `source-issue-missing`, `source-issue-not-target`, `non-actionable` — ALL seven covered. Plus the other 3 classifications (`already-reviewing`, `approved-or-merged` (×2: `intent-pr-approved` AND `merged: true`), `target-mismatch`). Plus precedence regressions: `Execute_PrecedenceClosedBeatsLabels`, `Execute_PrecedenceApprovedBeatsRequestUpdate`, `Execute_PrecedenceUpdateInProgressBeatsRequestUpdate`. Plus source-issue-trace regressions (closing-issues metadata path AND `Closes #N` body fallback path). Plus the explicit \"PR carries intent-pr-created itself (label-policy violation)\" regression. Plus JSON-shape coverage (round-trip + 7 fields + camelCase alias parity). Plus error paths: PR-lookup transport failure, issue-lookup transport failure, missing-flag, non-numeric-pr, unknown-argument. Plus no-mutation invariants: queue-state/runs byte-equivalence, whole-workspace byte snapshot, sentinel + source-scan rejecting `Process.Start(` and 7 distinct gh-edit/merge/close/reopen/comment/review literals (the issue's explicit \"do not mutate / do not post / do not merge\" criteria each enforced).
- [x] Full CLI suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — **1263/1263 passing + 1 skip** (the 1 skip is the pre-existing G190 `TolerantToSubAnalyzerFailure` `[Fact(Skip)]`; CLI: 1230 → 1263 = +33 new G203 tests; no regressions).

### Sample JSON output

**Actionable case** (`ready-to-review`):
```json
{
  \"actionable\": true,
  \"classification\": \"ready-to-review\",
  \"pr\": 511,
  \"repo\": \"J-Tech-Japan/intent-system\",
  \"title\": \"G203 Add PR review preflight command\",
  \"pr_state\": \"open\",
  \"is_draft\": false,
  \"labels\": [\"intent-target\"],
  \"source_issue\": 510,
  \"sourceIssue\": 510,
  \"source_issue_labels\": [\"intent-target\", \"intent-pr-created\"],
  \"reasons\": [],
  \"recommended_action\": \"review\",
  \"recommendedAction\": \"review\",
  \"summary_line\": \"Worker pr-review-preflight for J-Tech-Japan/intent-system#511 — classification=ready-to-review, actionable=true.\"
}
```

**Non-actionable case** (`source-issue-not-target`, label-policy violation):
```json
{
  \"actionable\": false,
  \"classification\": \"source-issue-not-target\",
  \"pr\": 9999,
  \"repo\": \"J-Tech-Japan/intent-system\",
  \"title\": \"Sample\",
  \"pr_state\": \"open\",
  \"is_draft\": false,
  \"labels\": [\"intent-target\", \"intent-pr-created\"],
  \"source_issue\": 9000,
  \"sourceIssue\": 9000,
  \"source_issue_labels\": [\"intent-target\", \"intent-pr-created\"],
  \"reasons\": [\"intent-pr-created found on PR but should be on source issue only (label policy violation)\"],
  \"recommended_action\": \"label-cleanup-required\",
  \"recommendedAction\": \"label-cleanup-required\",
  \"summary_line\": \"Worker pr-review-preflight for J-Tech-Japan/intent-system#9999 — classification=source-issue-not-target, actionable=false.\"
}
```

### Confirmation

- The command does NOT mutate labels — verified by source-scan rejecting all 7 distinct `gh issue edit`/`gh pr edit`/`gh pr merge`/`gh pr close`/`gh pr reopen`/`gh pr comment`/`gh pr review` literal patterns in the analyzer + command files.
- The command does NOT create/merge/close PRs or branches — verified by source-scan + the queue-state/runs/whole-workspace byte-equivalence tests.
- The command does NOT post PR comments or resolve review threads — verified by source-scan rejecting `gh pr comment` + `gh pr review`.
- The command does NOT launch AI providers — verified by sentinel `NestedProviderLauncher` (never invoked) + source-scan rejecting `Process.Start(` in the command/analyzer/result layer (the two lookup adapters are the ONLY exceptions, by design — they shell out to `gh pr view`/`gh issue view` for read-only metadata fetch).

### Manual smoke (recommended after merge)

  - `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- worker pr-review-preflight --repo J-Tech-Japan/intent-system --pr 511 --format json` (assert classification matches whatever state the host has set on this PR at the time)

Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)