### PR TITLE
G205: add intent-cli worker result-summary deterministic post-run summary

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -129,7 +129,8 @@ internal static class CommandRouter
             {
                 ["issue-preflight"] = WorkerIssuePreflightCommand.Execute,
                 ["pr-review-preflight"] = WorkerPrReviewPreflightCommand.Execute,
-                ["pr-comment-preflight"] = WorkerPrCommentPreflightCommand.Execute
+                ["pr-comment-preflight"] = WorkerPrCommentPreflightCommand.Execute,
+                ["result-summary"] = WorkerResultSummaryCommand.Execute
             },
             ["tasking"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/WorkerResultSummaryAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerResultSummaryAnalyzer.cs
@@ -1,0 +1,277 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G205: Pure deterministic mapper for <c>intent-cli worker result-summary</c>.
+/// Given a (kind, outcome, repo, issue, pr) tuple, returns the canonical
+/// <see cref="WorkerResultSummaryResult"/> with derived status, advisory
+/// label-cleanup actions, and any policy warnings. No I/O, no Process.Start,
+/// no GitHub network, no provider launch — pure data in, pure data out.
+/// </summary>
+internal static class WorkerResultSummaryAnalyzer
+{
+    /// <summary>
+    /// Build the canonical result for a recognized (kind, outcome) pair.
+    /// Caller is expected to have already validated <paramref name="kind"/>
+    /// and <paramref name="outcome"/> against the allowlists in
+    /// <see cref="WorkerResultSummaryConstants"/>; passing an unrecognized
+    /// pair throws <see cref="ArgumentException"/>.
+    /// </summary>
+    public static WorkerResultSummaryResult Analyze(
+        string kind,
+        string outcome,
+        string repo,
+        int? issue,
+        int? pr)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outcome);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        if (!WorkerResultSummaryConstants.AllKinds.Contains(kind, StringComparer.Ordinal))
+        {
+            throw new ArgumentException(
+                $"unrecognized kind '{kind}'. Supported: {string.Join(", ", WorkerResultSummaryConstants.AllKinds)}.",
+                nameof(kind));
+        }
+
+        if (!WorkerResultSummaryConstants.AllOutcomes.Contains(outcome, StringComparer.Ordinal))
+        {
+            throw new ArgumentException(
+                $"unrecognized outcome '{outcome}'. Supported: {string.Join(", ", WorkerResultSummaryConstants.AllOutcomes)}.",
+                nameof(outcome));
+        }
+
+        if (!IsSupportedKindOutcome(kind, outcome))
+        {
+            throw new ArgumentException(
+                $"outcome '{outcome}' is not supported for kind '{kind}'.",
+                nameof(outcome));
+        }
+
+        var status = DeriveStatus(outcome);
+        var labelActions = DeriveLabelActions(kind, outcome);
+        var warnings = DeriveWarnings(kind, outcome, issue, pr);
+        var summary = DeriveSummaryText(kind, outcome, repo, issue, pr);
+
+        return new WorkerResultSummaryResult
+        {
+            Kind = kind,
+            Repo = repo,
+            Issue = issue,
+            Pr = pr,
+            Outcome = outcome,
+            Status = status,
+            RecommendedLabelActions = labelActions,
+            Warnings = warnings,
+            Summary = summary,
+        };
+    }
+
+    /// <summary>
+    /// G205: which (kind, outcome) combinations are accepted as well-formed.
+    /// Public for the focused test that asserts every documented pair is
+    /// supported and only those — locks the matrix against accidental
+    /// regression. Some outcomes only make sense for one kind (e.g.
+    /// <c>repair-pushed</c> belongs to <c>pr-comment-fix</c>; <c>pr-created</c>
+    /// belongs to <c>issue-to-pr</c>). Outcomes that can occur in either
+    /// context (clarification, failed, label-cleanup-required, already-resolved)
+    /// are accepted for both.
+    /// </summary>
+    internal static bool IsSupportedKindOutcome(string kind, string outcome)
+    {
+        return (kind, outcome) switch
+        {
+            // issue-to-pr kind
+            (WorkerResultSummaryConstants.Kinds.IssueToPr,
+                WorkerResultSummaryConstants.Outcomes.PrCreated) => true,
+            (WorkerResultSummaryConstants.Kinds.IssueToPr,
+                WorkerResultSummaryConstants.Outcomes.DeclinedContractIncomplete) => true,
+            (WorkerResultSummaryConstants.Kinds.IssueToPr,
+                WorkerResultSummaryConstants.Outcomes.AlreadyResolved) => true,
+
+            // pr-comment-fix kind
+            (WorkerResultSummaryConstants.Kinds.PrCommentFix,
+                WorkerResultSummaryConstants.Outcomes.RepairPushed) => true,
+            (WorkerResultSummaryConstants.Kinds.PrCommentFix,
+                WorkerResultSummaryConstants.Outcomes.NoActionableComments) => true,
+            (WorkerResultSummaryConstants.Kinds.PrCommentFix,
+                WorkerResultSummaryConstants.Outcomes.AlreadyResolved) => true,
+
+            // shared
+            (_, WorkerResultSummaryConstants.Outcomes.ClarificationRequired) => true,
+            (_, WorkerResultSummaryConstants.Outcomes.Failed) => true,
+            (_, WorkerResultSummaryConstants.Outcomes.LabelCleanupRequired) => true,
+
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    /// G205: outcome → status. Used both as an internal mapping and exposed
+    /// for the focused test that asserts every outcome maps to a known
+    /// status.
+    /// </summary>
+    internal static string DeriveStatus(string outcome) => outcome switch
+    {
+        WorkerResultSummaryConstants.Outcomes.PrCreated => WorkerResultSummaryConstants.Statuses.Completed,
+        WorkerResultSummaryConstants.Outcomes.RepairPushed => WorkerResultSummaryConstants.Statuses.Completed,
+        WorkerResultSummaryConstants.Outcomes.AlreadyResolved => WorkerResultSummaryConstants.Statuses.Completed,
+        WorkerResultSummaryConstants.Outcomes.NoActionableComments => WorkerResultSummaryConstants.Statuses.Completed,
+        WorkerResultSummaryConstants.Outcomes.DeclinedContractIncomplete => WorkerResultSummaryConstants.Statuses.Declined,
+        WorkerResultSummaryConstants.Outcomes.ClarificationRequired => WorkerResultSummaryConstants.Statuses.ClarificationRequired,
+        WorkerResultSummaryConstants.Outcomes.Failed => WorkerResultSummaryConstants.Statuses.Failed,
+        WorkerResultSummaryConstants.Outcomes.LabelCleanupRequired => WorkerResultSummaryConstants.Statuses.LabelCleanupRequired,
+        _ => throw new ArgumentException($"unrecognized outcome '{outcome}'", nameof(outcome)),
+    };
+
+    private static IReadOnlyList<WorkerResultSummaryLabelAction> DeriveLabelActions(
+        string kind,
+        string outcome)
+    {
+        var actions = new List<WorkerResultSummaryLabelAction>();
+
+        // Common cleanup: when issue work ended (any terminal outcome on the
+        // issue-to-pr kind), recommend removing intent-issue-in-progress.
+        if (kind == WorkerResultSummaryConstants.Kinds.IssueToPr)
+        {
+            actions.Add(MakeAction(
+                WorkerResultSummaryConstants.LabelActionVerbs.Remove,
+                WorkerResultSummaryConstants.LabelActionTargets.Issue,
+                WorkerResultSummaryConstants.Labels.IntentIssueInProgress));
+        }
+
+        // Common cleanup: when PR-comment-fix work ended on a non-cleanup
+        // terminal outcome, the worker's claim label on the PR
+        // (intent-pr-update-in-progress) should be released.
+        if (kind == WorkerResultSummaryConstants.Kinds.PrCommentFix
+            && outcome != WorkerResultSummaryConstants.Outcomes.RepairPushed)
+        {
+            actions.Add(MakeAction(
+                WorkerResultSummaryConstants.LabelActionVerbs.Remove,
+                WorkerResultSummaryConstants.LabelActionTargets.Pr,
+                WorkerResultSummaryConstants.Labels.IntentPrUpdateInProgress));
+        }
+
+        // Outcome-specific advisory actions.
+        switch (outcome)
+        {
+            case WorkerResultSummaryConstants.Outcomes.PrCreated:
+                // intent-pr-created belongs on the source ISSUE per existing
+                // policy (see AcceptedBaseline in the issue body).
+                actions.Add(MakeAction(
+                    WorkerResultSummaryConstants.LabelActionVerbs.Add,
+                    WorkerResultSummaryConstants.LabelActionTargets.Issue,
+                    WorkerResultSummaryConstants.Labels.IntentPrCreated));
+                break;
+
+            case WorkerResultSummaryConstants.Outcomes.RepairPushed:
+                // The PR claim label flips from update-in-progress to
+                // rereview-ready. Modeled as a single swap action so the
+                // caller can apply both edits atomically.
+                actions.Add(new WorkerResultSummaryLabelAction
+                {
+                    Action = WorkerResultSummaryConstants.LabelActionVerbs.Swap,
+                    Target = WorkerResultSummaryConstants.LabelActionTargets.Pr,
+                    Label = $"{WorkerResultSummaryConstants.Labels.IntentPrUpdateInProgress}->" +
+                            WorkerResultSummaryConstants.Labels.IntentPrRereviewReady,
+                });
+                break;
+
+            case WorkerResultSummaryConstants.Outcomes.LabelCleanupRequired:
+                // No specific label is recommended here — the action is
+                // "operator must inspect and clean up". The status itself
+                // signals this; the warnings list will spell it out.
+                break;
+        }
+
+        return actions;
+    }
+
+    private static IReadOnlyList<string> DeriveWarnings(
+        string kind,
+        string outcome,
+        int? issue,
+        int? pr)
+    {
+        var warnings = new List<string>();
+
+        // Policy invariant: intent-pr-created belongs on the source ISSUE,
+        // never on the PR. Surface that as a warning whenever the outcome
+        // could conceivably be misapplied to a PR position.
+        if (outcome == WorkerResultSummaryConstants.Outcomes.PrCreated)
+        {
+            warnings.Add(
+                $"label policy: '{WorkerResultSummaryConstants.Labels.IntentPrCreated}' must be added to the source issue, not the PR.");
+        }
+
+        if (outcome == WorkerResultSummaryConstants.Outcomes.LabelCleanupRequired)
+        {
+            warnings.Add(
+                "label-cleanup-required: an in-progress label or a stale review-state label was left behind; operator inspection required.");
+        }
+
+        // Coherence warnings: an issue-to-pr outcome should usually have an
+        // issue number; a pr-comment-fix outcome should have a pr number.
+        if (kind == WorkerResultSummaryConstants.Kinds.IssueToPr && issue is null)
+        {
+            warnings.Add("kind 'issue-to-pr' typically requires --issue; none was provided.");
+        }
+
+        if (kind == WorkerResultSummaryConstants.Kinds.PrCommentFix && pr is null)
+        {
+            warnings.Add("kind 'pr-comment-fix' typically requires --pr; none was provided.");
+        }
+
+        return warnings;
+    }
+
+    private static string DeriveSummaryText(
+        string kind,
+        string outcome,
+        string repo,
+        int? issue,
+        int? pr)
+    {
+        return outcome switch
+        {
+            WorkerResultSummaryConstants.Outcomes.PrCreated =>
+                pr is { } prNum
+                    ? $"PR #{prNum} created for {Identifier(repo, issue, "#")}."
+                    : $"PR created for {Identifier(repo, issue, "#")}.",
+
+            WorkerResultSummaryConstants.Outcomes.RepairPushed =>
+                $"Repair commit pushed to {Identifier(repo, pr, "#")}.",
+
+            WorkerResultSummaryConstants.Outcomes.DeclinedContractIncomplete =>
+                $"Declined before implementation — issue body was not a sufficient standalone contract ({Identifier(repo, issue, "#")}).",
+
+            WorkerResultSummaryConstants.Outcomes.ClarificationRequired =>
+                $"Clarification required — worker stopped without changing scope ({Identifier(repo, issue ?? pr, "#")}).",
+
+            WorkerResultSummaryConstants.Outcomes.AlreadyResolved =>
+                $"Already resolved on origin/main — no further action needed ({Identifier(repo, issue ?? pr, "#")}).",
+
+            WorkerResultSummaryConstants.Outcomes.NoActionableComments =>
+                $"No actionable review comments remain on PR ({Identifier(repo, pr, "#")}).",
+
+            WorkerResultSummaryConstants.Outcomes.Failed =>
+                $"Worker failed — recommended labels may need cleanup ({Identifier(repo, issue ?? pr, "#")}).",
+
+            WorkerResultSummaryConstants.Outcomes.LabelCleanupRequired =>
+                $"Label cleanup required ({Identifier(repo, issue ?? pr, "#")}).",
+
+            _ => $"{kind} run completed: {outcome}.",
+        };
+    }
+
+    private static string Identifier(string repo, int? number, string sep) =>
+        number is { } n ? $"{repo}{sep}{n}" : repo;
+
+    private static WorkerResultSummaryLabelAction MakeAction(string action, string target, string label) =>
+        new()
+        {
+            Action = action,
+            Target = target,
+            Label = label,
+        };
+}

--- a/src/IntentSystem.Cli/Commands/WorkerResultSummaryCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerResultSummaryCommand.cs
@@ -1,0 +1,269 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G205: Read-only <c>intent-cli worker result-summary</c> command. Normalizes
+/// the outcome of an external Claude/Codex worker run (issue-to-PR, PR comment
+/// fix) into a small machine-readable summary that automation loops can use
+/// for logging, label cleanup decisions, and next-action selection.
+///
+/// No-mutation invariants (verified by tests):
+/// - never invokes <c>NestedProviderLauncher</c>;
+/// - never calls <c>Process.Start</c>, <c>gh</c>, or any GitHub network path;
+/// - never creates branches/PRs/comments;
+/// - never resolves review threads / merges / closes;
+/// - never edits <c>.intent-cli</c> queue or runs state.
+///
+/// The command is a pure function of its CLI flags into the result emitted by
+/// <see cref="WorkerResultSummaryAnalyzer"/>.
+/// </summary>
+internal static class WorkerResultSummaryCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    /// <summary>
+    /// Test sentinel: must NEVER be invoked by this command. Tests assert
+    /// it remains uninvoked across all command paths to lock in the
+    /// "no nested provider launch" guarantee.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args,
+                out var kind,
+                out var repo,
+                out var issue,
+                out var pr,
+                out var outcome,
+                out var format,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        WorkerResultSummaryResult result;
+        try
+        {
+            result = WorkerResultSummaryAnalyzer.Analyze(
+                kind!,
+                outcome!,
+                repo!,
+                issue,
+                pr);
+        }
+        catch (ArgumentException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static void WriteText(TextWriter writer, WorkerResultSummaryResult result)
+    {
+        writer.WriteLine($"# Worker result-summary for {result.Repo} ({result.Kind})");
+        writer.WriteLine();
+        writer.WriteLine($"- kind: {result.Kind}");
+        writer.WriteLine($"- repo: {result.Repo}");
+        if (result.Issue is { } issueNum)
+        {
+            writer.WriteLine($"- issue: {issueNum}");
+        }
+        if (result.Pr is { } prNum)
+        {
+            writer.WriteLine($"- pr: {prNum}");
+        }
+        writer.WriteLine($"- outcome: {result.Outcome}");
+        writer.WriteLine($"- status: {result.Status}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Recommended label actions (advisory only)");
+        if (result.RecommendedLabelActions.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var action in result.RecommendedLabelActions)
+            {
+                writer.WriteLine($"- {action.Action} {action.Label} on {action.Target}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Warnings");
+        if (result.Warnings.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var warning in result.Warnings)
+            {
+                writer.WriteLine($"- {warning}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine(result.Summary);
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? kind,
+        out string? repo,
+        out int? issue,
+        out int? pr,
+        out string? outcome,
+        out string format,
+        out string error)
+    {
+        kind = null;
+        repo = null;
+        issue = null;
+        pr = null;
+        outcome = null;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--kind":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--kind requires a value (issue-to-pr or pr-comment-fix).";
+                        return false;
+                    }
+                    kind = args[index + 1];
+                    index++;
+                    break;
+
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--issue":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--issue requires a value (issue number).";
+                        return false;
+                    }
+                    if (!int.TryParse(args[index + 1],
+                            System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            out var issueNumber)
+                        || issueNumber <= 0)
+                    {
+                        error = $"--issue must be a positive integer (got '{args[index + 1]}').";
+                        return false;
+                    }
+                    issue = issueNumber;
+                    index++;
+                    break;
+
+                case "--pr":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--pr requires a value (PR number).";
+                        return false;
+                    }
+                    if (!int.TryParse(args[index + 1],
+                            System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            out var prNumber)
+                        || prNumber <= 0)
+                    {
+                        error = $"--pr must be a positive integer (got '{args[index + 1]}').";
+                        return false;
+                    }
+                    pr = prNumber;
+                    index++;
+                    break;
+
+                case "--outcome":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--outcome requires a value.";
+                        return false;
+                    }
+                    outcome = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --kind <kind> --repo <owner/repo> --outcome <outcome> [--issue <n>] [--pr <n>] [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(kind))
+        {
+            error = "--kind is required (e.g. --kind issue-to-pr).";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "--repo is required (e.g. --repo owner/repo).";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(outcome))
+        {
+            error = "--outcome is required (e.g. --outcome pr-created).";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerResultSummaryResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerResultSummaryResult.cs
@@ -1,0 +1,153 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G205: Read-only result emitted by <c>intent-cli worker result-summary</c>.
+/// Normalizes a worker run's outcome (issue-to-PR, PR comment fix) into a
+/// machine-readable summary that automation loops can log and act on.
+///
+/// Field names are stable snake_case for AI-thread JSON ingestion. The
+/// camelCase aliases (<c>recommendedLabelActions</c>) hold the issue
+/// contract's exact key alongside the snake_case primary, mirroring the
+/// G202 / G203 / G204 alias pattern.
+///
+/// This record is pure data: producing it never mutates GitHub, never
+/// applies labels, never creates branches/PRs/comments, never touches the
+/// queue/runs logs, and never launches any AI provider.
+/// </summary>
+internal sealed record WorkerResultSummaryResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("issue")]
+    public int? Issue { get; init; }
+
+    [JsonPropertyName("pr")]
+    public int? Pr { get; init; }
+
+    [JsonPropertyName("outcome")]
+    public required string Outcome { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("recommended_label_actions")]
+    public required IReadOnlyList<WorkerResultSummaryLabelAction> RecommendedLabelActions { get; init; }
+
+    /// <summary>
+    /// G205 issue contract alias. Issue #515's JSON shape names this field
+    /// <c>recommendedLabelActions</c> (camelCase). The snake_case primary
+    /// stays the canonical source; this read-only alias emits the camelCase
+    /// key alongside it so the contract holds verbatim and round-trip stays
+    /// stable (alias is ignored on deserialize).
+    /// </summary>
+    [JsonPropertyName("recommendedLabelActions")]
+    public IReadOnlyList<WorkerResultSummaryLabelAction> RecommendedLabelActionsCamelCase
+        => RecommendedLabelActions;
+
+    [JsonPropertyName("warnings")]
+    public required IReadOnlyList<string> Warnings { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}
+
+/// <summary>
+/// G205: Single advisory label action emitted in
+/// <see cref="WorkerResultSummaryResult.RecommendedLabelActions"/>. Advisory
+/// only — this slice does NOT mutate any GitHub label. The action shape
+/// stays narrow on purpose: a verb (<c>add</c> / <c>remove</c>), a target
+/// (<c>issue</c> / <c>pr</c>), and the label name. Automation that wants to
+/// apply the action does so via its own gh CLI / label policy layer.
+/// </summary>
+internal sealed record WorkerResultSummaryLabelAction
+{
+    [JsonPropertyName("action")]
+    public required string Action { get; init; }
+
+    [JsonPropertyName("target")]
+    public required string Target { get; init; }
+
+    [JsonPropertyName("label")]
+    public required string Label { get; init; }
+}
+
+/// <summary>
+/// G205: Stable string constants for the eight outcomes, two kinds, and
+/// derived statuses emitted by <c>intent-cli worker result-summary</c>.
+/// </summary>
+internal static class WorkerResultSummaryConstants
+{
+    public static class Kinds
+    {
+        public const string IssueToPr = "issue-to-pr";
+        public const string PrCommentFix = "pr-comment-fix";
+    }
+
+    public static class Outcomes
+    {
+        public const string PrCreated = "pr-created";
+        public const string RepairPushed = "repair-pushed";
+        public const string DeclinedContractIncomplete = "declined-contract-incomplete";
+        public const string ClarificationRequired = "clarification-required";
+        public const string AlreadyResolved = "already-resolved";
+        public const string NoActionableComments = "no-actionable-comments";
+        public const string Failed = "failed";
+        public const string LabelCleanupRequired = "label-cleanup-required";
+    }
+
+    public static class Statuses
+    {
+        public const string Completed = "completed";
+        public const string Declined = "declined";
+        public const string ClarificationRequired = "clarification-required";
+        public const string Failed = "failed";
+        public const string LabelCleanupRequired = "label-cleanup-required";
+    }
+
+    public static class LabelActionVerbs
+    {
+        public const string Add = "add";
+        public const string Remove = "remove";
+        public const string Swap = "swap";
+    }
+
+    public static class LabelActionTargets
+    {
+        public const string Issue = "issue";
+        public const string Pr = "pr";
+    }
+
+    public static class Labels
+    {
+        public const string IntentTarget = "intent-target";
+        public const string IntentIssueInProgress = "intent-issue-in-progress";
+        public const string IntentPrCreated = "intent-pr-created";
+        public const string IntentPrUpdateInProgress = "intent-pr-update-in-progress";
+        public const string IntentPrRereviewReady = "intent-pr-rereview-ready";
+        public const string IntentPrRequestUpdate = "intent-pr-request-update";
+    }
+
+    public static IReadOnlyList<string> AllKinds { get; } = new[]
+    {
+        Kinds.IssueToPr,
+        Kinds.PrCommentFix,
+    };
+
+    public static IReadOnlyList<string> AllOutcomes { get; } = new[]
+    {
+        Outcomes.PrCreated,
+        Outcomes.RepairPushed,
+        Outcomes.DeclinedContractIncomplete,
+        Outcomes.ClarificationRequired,
+        Outcomes.AlreadyResolved,
+        Outcomes.NoActionableComments,
+        Outcomes.Failed,
+        Outcomes.LabelCleanupRequired,
+    };
+}

--- a/tests/IntentSystem.Cli.Tests/WorkerResultSummaryCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerResultSummaryCommandTests.cs
@@ -1,0 +1,631 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G205: Tests for <c>intent-cli worker result-summary</c>. Cover every
+/// outcome named in the issue Acceptance Criteria, the status mapping, the
+/// advisory label-cleanup actions, the warnings, the JSON shape, the
+/// camelCase alias, and the no-mutation invariants.
+/// </summary>
+public sealed class WorkerResultSummaryCommandTests : IDisposable
+{
+    public WorkerResultSummaryCommandTests()
+    {
+        WorkerResultSummaryCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        WorkerResultSummaryCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void Execute_GivenIssueToPrPrCreated_EmitsCompletedStatusAndIssueLabelActions()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "515",
+                "--pr", "999",
+                "--outcome", "pr-created",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerResultSummaryResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.Equal(WorkerResultSummaryConstants.Kinds.IssueToPr, result!.Kind);
+        Assert.Equal("J-Tech-Japan/intent-system", result.Repo);
+        Assert.Equal(515, result.Issue);
+        Assert.Equal(999, result.Pr);
+        Assert.Equal(WorkerResultSummaryConstants.Outcomes.PrCreated, result.Outcome);
+        Assert.Equal(WorkerResultSummaryConstants.Statuses.Completed, result.Status);
+
+        // Recommended actions: remove in-progress on the issue, add intent-pr-created on the issue.
+        Assert.Contains(result.RecommendedLabelActions, a =>
+            a.Action == "remove" && a.Target == "issue"
+            && a.Label == WorkerResultSummaryConstants.Labels.IntentIssueInProgress);
+        Assert.Contains(result.RecommendedLabelActions, a =>
+            a.Action == "add" && a.Target == "issue"
+            && a.Label == WorkerResultSummaryConstants.Labels.IntentPrCreated);
+
+        // Policy warning: intent-pr-created belongs on the issue, not the PR.
+        Assert.Contains(result.Warnings, w =>
+            w.Contains(WorkerResultSummaryConstants.Labels.IntentPrCreated, StringComparison.Ordinal)
+            && w.Contains("source issue", StringComparison.Ordinal));
+
+        Assert.Contains("PR #999", result.Summary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenPrCommentFixRepairPushed_EmitsSwapActionToRereviewReady()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "pr-comment-fix",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "514",
+                "--outcome", "repair-pushed",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerResultSummaryResult>(writer.ToString())!;
+        Assert.Equal(WorkerResultSummaryConstants.Statuses.Completed, result.Status);
+
+        // Single swap action: update-in-progress -> rereview-ready on the PR.
+        Assert.Contains(result.RecommendedLabelActions, a =>
+            a.Action == "swap"
+            && a.Target == "pr"
+            && a.Label.Contains(WorkerResultSummaryConstants.Labels.IntentPrUpdateInProgress, StringComparison.Ordinal)
+            && a.Label.Contains(WorkerResultSummaryConstants.Labels.IntentPrRereviewReady, StringComparison.Ordinal));
+
+        // No spurious "remove in-progress" action — the swap covers it.
+        Assert.DoesNotContain(result.RecommendedLabelActions, a =>
+            a.Action == "remove"
+            && a.Label == WorkerResultSummaryConstants.Labels.IntentPrUpdateInProgress);
+    }
+
+    [Fact]
+    public void Execute_GivenIssueToPrDeclinedContractIncomplete_EmitsDeclinedStatus()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "999",
+                "--outcome", "declined-contract-incomplete",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerResultSummaryResult>(writer.ToString())!;
+        Assert.Equal(WorkerResultSummaryConstants.Statuses.Declined, result.Status);
+
+        // Declined runs still recommend removing the worker's claim label.
+        Assert.Contains(result.RecommendedLabelActions, a =>
+            a.Action == "remove" && a.Target == "issue"
+            && a.Label == WorkerResultSummaryConstants.Labels.IntentIssueInProgress);
+    }
+
+    [Fact]
+    public void Execute_GivenClarificationRequiredForIssueKind_EmitsClarificationStatus()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "999",
+                "--outcome", "clarification-required",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerResultSummaryResult>(writer.ToString())!;
+        Assert.Equal(WorkerResultSummaryConstants.Statuses.ClarificationRequired, result.Status);
+        Assert.Contains("Clarification required", result.Summary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenAlreadyResolvedForIssueKind_EmitsCompletedStatus()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "999",
+                "--outcome", "already-resolved",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerResultSummaryResult>(writer.ToString())!;
+        Assert.Equal(WorkerResultSummaryConstants.Statuses.Completed, result.Status);
+        Assert.Contains("Already resolved", result.Summary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNoActionableCommentsForPrFix_EmitsCompletedStatus()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "pr-comment-fix",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "514",
+                "--outcome", "no-actionable-comments",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerResultSummaryResult>(writer.ToString())!;
+        Assert.Equal(WorkerResultSummaryConstants.Statuses.Completed, result.Status);
+
+        // PR claim label release recommendation is present for non-repair-pushed terminal outcomes.
+        Assert.Contains(result.RecommendedLabelActions, a =>
+            a.Action == "remove" && a.Target == "pr"
+            && a.Label == WorkerResultSummaryConstants.Labels.IntentPrUpdateInProgress);
+    }
+
+    [Fact]
+    public void Execute_GivenFailedOutcome_EmitsFailedStatus()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "999",
+                "--outcome", "failed",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerResultSummaryResult>(writer.ToString())!;
+        Assert.Equal(WorkerResultSummaryConstants.Statuses.Failed, result.Status);
+    }
+
+    [Fact]
+    public void Execute_GivenLabelCleanupRequired_EmitsCleanupStatusAndWarning()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "pr-comment-fix",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "514",
+                "--outcome", "label-cleanup-required",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerResultSummaryResult>(writer.ToString())!;
+        Assert.Equal(WorkerResultSummaryConstants.Statuses.LabelCleanupRequired, result.Status);
+        Assert.Contains(result.Warnings, w =>
+            w.Contains("label-cleanup-required", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenUnsupportedKindOutcomeCombo_ReturnsNonZero()
+    {
+        // pr-created is only valid for kind=issue-to-pr.
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "pr-comment-fix",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "514",
+                "--outcome", "pr-created",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("not supported for kind", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownOutcome_ReturnsNonZero()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "999",
+                "--outcome", "made-up-outcome",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("unrecognized outcome", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownKind_ReturnsNonZero()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "made-up-kind",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--outcome", "pr-created",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("unrecognized kind", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MissingKind_ReturnsNonZero()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--outcome", "pr-created"
+            },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("--kind is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NonNumericIssue_ReturnsNonZero()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "abc",
+                "--outcome", "pr-created"
+            },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("--issue must be a positive integer", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsonOutput_IncludesCamelCaseAliasForRecommendedLabelActions()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "515",
+                "--outcome", "pr-created",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var raw = writer.ToString();
+        // Both keys present, identical payloads.
+        Assert.Contains("\"recommended_label_actions\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"recommendedLabelActions\"", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TextOutput_RendersStableSectionsAndSummary()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "515",
+                "--pr", "999",
+                "--outcome", "pr-created"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var raw = writer.ToString();
+        Assert.Contains("# Worker result-summary for J-Tech-Japan/intent-system (issue-to-pr)", raw, StringComparison.Ordinal);
+        Assert.Contains("## Recommended label actions (advisory only)", raw, StringComparison.Ordinal);
+        Assert.Contains("## Warnings", raw, StringComparison.Ordinal);
+        Assert.Contains("PR #999", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Analyzer_DeriveStatus_CoversEveryDocumentedOutcome()
+    {
+        // Lock the outcome→status map at the helper layer so a future
+        // outcome cannot be added without a status mapping.
+        foreach (var outcome in WorkerResultSummaryConstants.AllOutcomes)
+        {
+            var status = WorkerResultSummaryAnalyzer.DeriveStatus(outcome);
+            Assert.False(string.IsNullOrWhiteSpace(status),
+                $"DeriveStatus produced no status for outcome '{outcome}'");
+        }
+    }
+
+    [Fact]
+    public void Analyzer_IsSupportedKindOutcome_AcceptsDocumentedPairsAndRejectsOthers()
+    {
+        // Sample of supported pairs.
+        Assert.True(WorkerResultSummaryAnalyzer.IsSupportedKindOutcome(
+            WorkerResultSummaryConstants.Kinds.IssueToPr,
+            WorkerResultSummaryConstants.Outcomes.PrCreated));
+        Assert.True(WorkerResultSummaryAnalyzer.IsSupportedKindOutcome(
+            WorkerResultSummaryConstants.Kinds.PrCommentFix,
+            WorkerResultSummaryConstants.Outcomes.RepairPushed));
+        Assert.True(WorkerResultSummaryAnalyzer.IsSupportedKindOutcome(
+            WorkerResultSummaryConstants.Kinds.IssueToPr,
+            WorkerResultSummaryConstants.Outcomes.ClarificationRequired));
+
+        // Cross-kind invalids.
+        Assert.False(WorkerResultSummaryAnalyzer.IsSupportedKindOutcome(
+            WorkerResultSummaryConstants.Kinds.PrCommentFix,
+            WorkerResultSummaryConstants.Outcomes.PrCreated));
+        Assert.False(WorkerResultSummaryAnalyzer.IsSupportedKindOutcome(
+            WorkerResultSummaryConstants.Kinds.IssueToPr,
+            WorkerResultSummaryConstants.Outcomes.RepairPushed));
+        Assert.False(WorkerResultSummaryAnalyzer.IsSupportedKindOutcome(
+            WorkerResultSummaryConstants.Kinds.IssueToPr,
+            WorkerResultSummaryConstants.Outcomes.NoActionableComments));
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesNestedProviderLauncher()
+    {
+        using var workspace = new WorkerResultSummaryWorkspace();
+        var launcherInvoked = false;
+        WorkerResultSummaryCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+
+        using var writer = new StringWriter();
+        // Walk every supported kind/outcome combination just once each, plus
+        // a few invalid inputs, to lock the no-launch invariant across all
+        // execution paths.
+        ExecuteAndAssertExit(workspace, writer, "issue-to-pr", "515", null, "pr-created", expected: 0);
+        ExecuteAndAssertExit(workspace, writer, "issue-to-pr", "999", null, "declined-contract-incomplete", expected: 0);
+        ExecuteAndAssertExit(workspace, writer, "issue-to-pr", "999", null, "clarification-required", expected: 0);
+        ExecuteAndAssertExit(workspace, writer, "issue-to-pr", "999", null, "already-resolved", expected: 0);
+        ExecuteAndAssertExit(workspace, writer, "issue-to-pr", "999", null, "failed", expected: 0);
+        ExecuteAndAssertExit(workspace, writer, "issue-to-pr", "999", null, "label-cleanup-required", expected: 0);
+        ExecuteAndAssertExit(workspace, writer, "pr-comment-fix", null, "514", "repair-pushed", expected: 0);
+        ExecuteAndAssertExit(workspace, writer, "pr-comment-fix", null, "514", "no-actionable-comments", expected: 0);
+        ExecuteAndAssertExit(workspace, writer, "pr-comment-fix", null, "514", "already-resolved", expected: 0);
+        ExecuteAndAssertExit(workspace, writer, "pr-comment-fix", null, "514", "clarification-required", expected: 0);
+        ExecuteAndAssertExit(workspace, writer, "pr-comment-fix", null, "514", "failed", expected: 0);
+        ExecuteAndAssertExit(workspace, writer, "pr-comment-fix", null, "514", "label-cleanup-required", expected: 0);
+        ExecuteAndAssertExit(workspace, writer, "made-up", null, null, "pr-created", expected: 1);
+        ExecuteAndAssertExit(workspace, writer, "issue-to-pr", "999", null, "made-up", expected: 1);
+
+        Assert.False(launcherInvoked,
+            "WorkerResultSummaryCommand must never invoke NestedProviderLauncher.");
+    }
+
+    [Fact]
+    public void Execute_LeavesIntentCliWorkspaceByteEquivalent()
+    {
+        // Whole-workspace byte-snapshot — the command must not create any
+        // file or modify any file on disk. Walks every supported (kind,
+        // outcome) pair once.
+        using var workspace = new WorkerResultSummaryWorkspace();
+        var before = workspace.SnapshotWorkspace();
+
+        using (var writer = new StringWriter())
+        {
+            ExecuteAndAssertExit(workspace, writer, "issue-to-pr", "515", "999", "pr-created", expected: 0);
+            ExecuteAndAssertExit(workspace, writer, "pr-comment-fix", null, "514", "repair-pushed", expected: 0);
+            ExecuteAndAssertExit(workspace, writer, "issue-to-pr", "999", null, "label-cleanup-required", expected: 0);
+        }
+
+        var after = workspace.SnapshotWorkspace();
+        Assert.Equal(before.Count, after.Count);
+        foreach (var (path, hash) in before)
+        {
+            Assert.True(after.TryGetValue(path, out var afterHash),
+                $"file disappeared after run: {path}");
+            Assert.Equal(hash, afterHash);
+        }
+    }
+
+    [Fact]
+    public void SourceScan_AnalyzerAndCommand_ContainNoProcessStartOrGitHubMutationLiterals()
+    {
+        // Locks the no-mutation guarantee at the source level: neither the
+        // analyzer nor the command file may contain Process.Start, gh CLI
+        // mutation verbs, or GraphQL review-thread mutations. Mirrors the
+        // G204 source-scan pattern.
+        var analyzer = File.ReadAllText(LocateSourceFile("WorkerResultSummaryAnalyzer.cs"));
+        var command = File.ReadAllText(LocateSourceFile("WorkerResultSummaryCommand.cs"));
+
+        var combined = analyzer + "\n" + command;
+
+        Assert.DoesNotContain("Process.Start(", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh issue edit", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr edit", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr merge", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr close", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr reopen", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr comment", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr review", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("resolveReviewThread", combined, StringComparison.Ordinal);
+    }
+
+    private static void ExecuteAndAssertExit(
+        WorkerResultSummaryWorkspace workspace,
+        StringWriter writer,
+        string kind,
+        string? issue,
+        string? pr,
+        string outcome,
+        int expected)
+    {
+        writer.GetStringBuilder().Clear();
+        var args = new List<string> { "--kind", kind, "--repo", "J-Tech-Japan/intent-system" };
+        if (issue is not null)
+        {
+            args.Add("--issue");
+            args.Add(issue);
+        }
+        if (pr is not null)
+        {
+            args.Add("--pr");
+            args.Add(pr);
+        }
+        args.Add("--outcome");
+        args.Add(outcome);
+        args.Add("--format");
+        args.Add("json");
+
+        var exitCode = WorkerResultSummaryCommand.Execute(workspace.Context, args.ToArray(), writer);
+        Assert.Equal(expected, exitCode);
+    }
+
+    private static string LocateSourceFile(string fileName)
+    {
+        var directory = AppContext.BaseDirectory;
+        var dir = new DirectoryInfo(directory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(
+                dir.FullName, "src", "IntentSystem.Cli", "Commands", fileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = dir.Parent;
+        }
+
+        throw new FileNotFoundException(
+            $"Could not locate source file {fileName} from {directory}");
+    }
+
+    private sealed class WorkerResultSummaryWorkspace : IDisposable
+    {
+        public WorkerResultSummaryWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("worker-result-summary-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public IReadOnlyDictionary<string, string> SnapshotWorkspace()
+        {
+            var snapshot = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(RootPath, "*", SearchOption.AllDirectories))
+            {
+                var bytes = File.ReadAllBytes(path);
+                var hash = Convert.ToHexString(SHA256.HashData(bytes));
+                snapshot[path] = hash;
+            }
+            return snapshot;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `intent-cli worker result-summary --kind <kind> --repo <owner/repo> [--issue <n>] [--pr <n>] --outcome <outcome> [--format text|json]` under the existing `worker` group. Fourth in the worker chain (G202 issue-preflight → G203 pr-review-preflight → G204 pr-comment-preflight → **G205 result-summary**) and the missing paired post-run boundary for coding automation loops.
- Two recognized kinds: `issue-to-pr`, `pr-comment-fix`. Eight outcomes: `pr-created`, `repair-pushed`, `declined-contract-incomplete`, `clarification-required`, `already-resolved`, `no-actionable-comments`, `failed`, `label-cleanup-required`. (kind, outcome) pairs are validated against an explicit allowlist in `WorkerResultSummaryAnalyzer.IsSupportedKindOutcome` — unsupported combos exit non-zero.
- Status mapping (locked in `WorkerResultSummaryConstants.Statuses`): `completed` for `pr-created` / `repair-pushed` / `already-resolved` / `no-actionable-comments`; `declined` / `clarification-required` / `failed` / `label-cleanup-required` for the others.
- JSON output snake_case primary + camelCase alias `recommendedLabelActions` for issue-contract parity (mirrors G202/G203/G204).
- Recommended label actions are advisory only — the command does NOT mutate any GitHub label. Policy invariants surface as warnings (e.g. `pr-created` warns that `intent-pr-created` belongs on the source issue, never on the PR).

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release --filter \"FullyQualifiedName~WorkerResultSummary\"` — **20/20 passing**. Outcomes covered: PR-created, repair-pushed, declined-contract-incomplete, clarification-required, already-resolved, no-actionable-comments, failed, label-cleanup-required. Plus argument validation (unsupported (kind, outcome) combo, unknown outcome, unknown kind, missing kind, non-numeric issue), camelCase alias parity, text output stable shape, analyzer status-map coverage, kind/outcome support-matrix lock, nested-provider-launcher sentinel never invoked, whole-workspace byte-equivalence, source-scan against `Process.Start` / gh mutation verbs / GraphQL review-thread mutation.
- [x] Full CLI suite: 1331 passed + 1 pre-existing skip. One environment-sensitive `DirectRunLauncherTests.Launch_GivenRealProcessRunnerAndAbsoluteCodexCommand_AppendsBackendExitProviderEvent` test was flaky in the full-suite run; passes when re-run in isolation. Unrelated to G205.

### Sample JSON output

**issue-to-pr / pr-created:**

```json
{
  \"kind\": \"issue-to-pr\",
  \"repo\": \"J-Tech-Japan/intent-system\",
  \"issue\": 515,
  \"pr\": 999,
  \"outcome\": \"pr-created\",
  \"status\": \"completed\",
  \"recommended_label_actions\": [
    { \"action\": \"remove\", \"target\": \"issue\", \"label\": \"intent-issue-in-progress\" },
    { \"action\": \"add\",    \"target\": \"issue\", \"label\": \"intent-pr-created\" }
  ],
  \"recommendedLabelActions\": [ ... same ... ],
  \"warnings\": [ \"label policy: 'intent-pr-created' must be added to the source issue, not the PR.\" ],
  \"summary\": \"PR #999 created for J-Tech-Japan/intent-system#515.\"
}
```

**pr-comment-fix / repair-pushed:**

```json
{
  \"kind\": \"pr-comment-fix\",
  \"repo\": \"J-Tech-Japan/intent-system\",
  \"pr\": 514,
  \"outcome\": \"repair-pushed\",
  \"status\": \"completed\",
  \"recommended_label_actions\": [
    { \"action\": \"swap\", \"target\": \"pr\", \"label\": \"intent-pr-update-in-progress->intent-pr-rereview-ready\" }
  ],
  \"warnings\": [],
  \"summary\": \"Repair commit pushed to J-Tech-Japan/intent-system#514.\"
}
```

### Confirmation (no-mutation invariants verified by tests)

- The command does NOT mutate labels — verified by source-scan rejecting all 7 distinct `gh issue edit`/`gh pr edit`/`gh pr merge`/`gh pr close`/`gh pr reopen`/`gh pr comment`/`gh pr review` literal patterns in the analyzer + command files.
- The command does NOT create/merge/close PRs or branches — verified by source-scan + whole-workspace byte-equivalence test.
- The command does NOT post PR comments — `gh pr comment` literal explicitly rejected.
- The command does NOT resolve GitHub review threads — `resolveReviewThread` GraphQL mutation literal explicitly rejected.
- The command does NOT launch AI providers — sentinel `NestedProviderLauncher` (never invoked across every supported (kind, outcome) plus invalid paths) + source-scan rejecting `Process.Start(` in command/analyzer/result.
- The command does NOT touch `.intent-cli` queue/runs state — whole-workspace byte-snapshot before/after walks every supported (kind, outcome) and asserts no file is created or modified.

Closes #515