### PR TITLE
G206: add intent-cli worker next-action deterministic target selector

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -130,7 +130,8 @@ internal static class CommandRouter
                 ["issue-preflight"] = WorkerIssuePreflightCommand.Execute,
                 ["pr-review-preflight"] = WorkerPrReviewPreflightCommand.Execute,
                 ["pr-comment-preflight"] = WorkerPrCommentPreflightCommand.Execute,
-                ["result-summary"] = WorkerResultSummaryCommand.Execute
+                ["result-summary"] = WorkerResultSummaryCommand.Execute,
+                ["next-action"] = WorkerNextActionCommand.Execute
             },
             ["tasking"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
@@ -1,0 +1,227 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G206: Testability seam for <c>intent-cli worker next-action</c>. The
+/// production implementation shells out to <c>gh pr list</c> and
+/// <c>gh issue list</c> with label filters; tests inject a fake to avoid
+/// any GitHub network access.
+/// </summary>
+internal interface IGitHubAutomationCandidateLister
+{
+    IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+        string repo,
+        IReadOnlyCollection<string> requiredLabels);
+
+    IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+        string repo,
+        IReadOnlyCollection<string> requiredLabels);
+}
+
+/// <summary>
+/// G206: Single PR candidate row returned by
+/// <see cref="IGitHubAutomationCandidateLister.ListPullRequests"/>.
+/// </summary>
+internal sealed record GitHubAutomationPrCandidate
+{
+    [JsonPropertyName("number")]
+    public int Number { get; init; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("url")]
+    public string Url { get; init; } = string.Empty;
+
+    [JsonPropertyName("createdAt")]
+    public string CreatedAt { get; init; } = string.Empty;
+
+    [JsonPropertyName("labels")]
+    public IReadOnlyList<GitHubAutomationLabel> Labels { get; init; }
+        = Array.Empty<GitHubAutomationLabel>();
+}
+
+/// <summary>
+/// G206: Single issue candidate row returned by
+/// <see cref="IGitHubAutomationCandidateLister.ListIssues"/>.
+/// </summary>
+internal sealed record GitHubAutomationIssueCandidate
+{
+    [JsonPropertyName("number")]
+    public int Number { get; init; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("url")]
+    public string Url { get; init; } = string.Empty;
+
+    [JsonPropertyName("createdAt")]
+    public string CreatedAt { get; init; } = string.Empty;
+
+    [JsonPropertyName("labels")]
+    public IReadOnlyList<GitHubAutomationLabel> Labels { get; init; }
+        = Array.Empty<GitHubAutomationLabel>();
+}
+
+internal sealed record GitHubAutomationLabel
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// G206: Default lister that shells out to <c>gh pr list</c> and
+/// <c>gh issue list</c>. The only file in the worker next-action surface
+/// permitted to call <c>Process.Start</c> — the analyzer and command layers
+/// must remain pure. Both calls request a stable supported field subset
+/// (<c>number,title,url,createdAt,labels</c>).
+/// </summary>
+internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCandidateLister
+{
+    /// <summary>
+    /// G206: comma-separated <c>gh pr list --json</c> field list. Exposed
+    /// internally so adapter-shape regression tests can lock the supported
+    /// subset.
+    /// </summary>
+    internal const string ListJsonFields = "number,title,url,createdAt,labels";
+
+    /// <summary>
+    /// G206: builds the <c>gh pr list</c> argument list shared by the live
+    /// adapter and adapter-shape tests.
+    /// </summary>
+    internal static IReadOnlyList<string> BuildPrListArguments(
+        string repo,
+        IReadOnlyCollection<string> requiredLabels)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentNullException.ThrowIfNull(requiredLabels);
+
+        var args = new List<string>
+        {
+            "pr",
+            "list",
+            "--repo", repo,
+            "--state", "open",
+            "--json", ListJsonFields,
+            "--limit", "200"
+        };
+        foreach (var label in requiredLabels)
+        {
+            args.Add("--label");
+            args.Add(label);
+        }
+        return args;
+    }
+
+    /// <summary>
+    /// G206: builds the <c>gh issue list</c> argument list.
+    /// </summary>
+    internal static IReadOnlyList<string> BuildIssueListArguments(
+        string repo,
+        IReadOnlyCollection<string> requiredLabels)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentNullException.ThrowIfNull(requiredLabels);
+
+        var args = new List<string>
+        {
+            "issue",
+            "list",
+            "--repo", repo,
+            "--state", "open",
+            "--json", ListJsonFields,
+            "--limit", "200"
+        };
+        foreach (var label in requiredLabels)
+        {
+            args.Add("--label");
+            args.Add(label);
+        }
+        return args;
+    }
+
+    public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+        string repo,
+        IReadOnlyCollection<string> requiredLabels)
+    {
+        var args = BuildPrListArguments(repo, requiredLabels);
+        var stdout = RunGh(args, $"list PRs in {repo}");
+        return DeserializeList<GitHubAutomationPrCandidate>(stdout, $"`gh pr list` for {repo}");
+    }
+
+    public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+        string repo,
+        IReadOnlyCollection<string> requiredLabels)
+    {
+        var args = BuildIssueListArguments(repo, requiredLabels);
+        var stdout = RunGh(args, $"list issues in {repo}");
+        return DeserializeList<GitHubAutomationIssueCandidate>(stdout, $"`gh issue list` for {repo}");
+    }
+
+    private static string RunGh(IReadOnlyList<string> arguments, string description)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        string stdout;
+        string stderr;
+        int exitCode;
+        try
+        {
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException(
+                    $"failed to start `gh` process to {description}");
+            stdout = process.StandardOutput.ReadToEnd();
+            stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            exitCode = process.ExitCode;
+        }
+        catch (Exception exception) when (
+            exception is System.ComponentModel.Win32Exception
+            or InvalidOperationException
+            or IOException)
+        {
+            throw new InvalidOperationException(
+                $"could not invoke `gh` to {description}: {exception.Message}",
+                exception);
+        }
+
+        if (exitCode != 0)
+        {
+            var errorBody = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+            throw new InvalidOperationException(
+                $"`gh` failed to {description} with exit {exitCode}: {errorBody.Trim()}");
+        }
+
+        return stdout;
+    }
+
+    private static IReadOnlyList<T> DeserializeList<T>(string stdout, string callDescription)
+    {
+        try
+        {
+            var result = JsonSerializer.Deserialize<List<T>>(stdout);
+            return (IReadOnlyList<T>?)result ?? Array.Empty<T>();
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException(
+                $"could not parse {callDescription} JSON: {exception.Message}",
+                exception);
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerNextActionAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerNextActionAnalyzer.cs
@@ -1,0 +1,133 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G206: Pure deterministic selector for <c>intent-cli worker next-action</c>.
+/// Given the open PR and issue candidate lists (already filtered to
+/// <c>intent-target</c>) for a repo, returns at most one
+/// <see cref="WorkerNextActionResult"/> following the priority order
+/// documented in #517.
+///
+/// Pure: no I/O, no Process.Start, no GitHub network, no provider launch.
+/// </summary>
+internal static class WorkerNextActionAnalyzer
+{
+    /// <summary>
+    /// Apply the selection rules and produce the canonical result.
+    /// </summary>
+    public static WorkerNextActionResult Analyze(
+        string repo,
+        IReadOnlyList<GitHubAutomationPrCandidate> intentTargetPrs,
+        IReadOnlyList<GitHubAutomationIssueCandidate> intentTargetIssues)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentNullException.ThrowIfNull(intentTargetPrs);
+        ArgumentNullException.ThrowIfNull(intentTargetIssues);
+
+        var warnings = new List<string>();
+
+        // Policy invariant warnings: any PR carrying intent-pr-created is a
+        // misplaced label (intent-pr-created belongs on the source ISSUE).
+        foreach (var pr in intentTargetPrs)
+        {
+            var labels = LabelNames(pr.Labels);
+            if (labels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal))
+            {
+                warnings.Add(
+                    $"label policy: PR #{pr.Number} carries '{WorkerNextActionConstants.Labels.IntentPrCreated}' which belongs on the source issue, not the PR. Excluded from selection.");
+            }
+        }
+
+        // Priority 1: PR comment/update repair target.
+        // Eligible: open PR with intent-target + intent-pr-request-update,
+        // and NOT intent-pr-update-in-progress (already claimed) and NOT
+        // intent-pr-created (misplaced — already warned above).
+        var prRepair = intentTargetPrs
+            .Where(pr =>
+            {
+                var labels = LabelNames(pr.Labels);
+                return labels.Contains(WorkerNextActionConstants.Labels.IntentPrRequestUpdate, StringComparer.Ordinal)
+                    && !labels.Contains(WorkerNextActionConstants.Labels.IntentPrUpdateInProgress, StringComparer.Ordinal)
+                    && !labels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal);
+            })
+            .OrderBy(pr => pr.CreatedAt, StringComparer.Ordinal)
+            .FirstOrDefault();
+
+        if (prRepair is not null)
+        {
+            return new WorkerNextActionResult
+            {
+                Action = WorkerNextActionConstants.Actions.PrCommentFix,
+                Repo = repo,
+                Number = prRepair.Number,
+                Url = prRepair.Url,
+                Reason = "open PR has actionable repair feedback (intent-pr-request-update without intent-pr-update-in-progress)",
+                RecommendedWorkflow = WorkerNextActionConstants.RecommendedWorkflows.PrCommentFix,
+                Warnings = warnings,
+                SourceClassification = WorkerNextActionConstants.SourceClassifications.RepairRequired,
+            };
+        }
+
+        // Priority 2: PR review target — intentionally not implemented for
+        // child-side automation. Host-side review/next-slice loop owns
+        // review selection per the parent-host contract; an implementation
+        // worker calling `worker next-action` should not pick up review
+        // work itself. This priority slot is documented for completeness;
+        // when host-side ever delegates review here we add a third action
+        // value, but for now the loop falls through to priority 3.
+
+        // Priority 3: Issue-to-PR target.
+        // Eligible: open issue with intent-target, NOT intent-issue-in-progress,
+        // NOT intent-pr-created.
+        var issueToPr = intentTargetIssues
+            .Where(issue =>
+            {
+                var labels = LabelNames(issue.Labels);
+                return !labels.Contains(WorkerNextActionConstants.Labels.IntentIssueInProgress, StringComparer.Ordinal)
+                    && !labels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal);
+            })
+            .OrderBy(issue => issue.CreatedAt, StringComparer.Ordinal)
+            .FirstOrDefault();
+
+        if (issueToPr is not null)
+        {
+            return new WorkerNextActionResult
+            {
+                Action = WorkerNextActionConstants.Actions.IssueToPr,
+                Repo = repo,
+                Number = issueToPr.Number,
+                Url = issueToPr.Url,
+                Reason = "oldest open intent-target issue without in-progress or pr-created state",
+                RecommendedWorkflow = WorkerNextActionConstants.RecommendedWorkflows.GhIssueToPr,
+                Warnings = warnings,
+                SourceClassification = WorkerNextActionConstants.SourceClassifications.ReadyToImplement,
+            };
+        }
+
+        // Priority 4: no actionable target.
+        return new WorkerNextActionResult
+        {
+            Action = WorkerNextActionConstants.Actions.None,
+            Repo = repo,
+            Reason = "no actionable coding automation target",
+            Warnings = warnings,
+        };
+    }
+
+    private static IReadOnlyCollection<string> LabelNames(IReadOnlyList<GitHubAutomationLabel>? labels)
+    {
+        if (labels is null || labels.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var names = new List<string>(labels.Count);
+        foreach (var label in labels)
+        {
+            if (!string.IsNullOrEmpty(label.Name))
+            {
+                names.Add(label.Name);
+            }
+        }
+        return names;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerNextActionCommand.cs
@@ -1,0 +1,228 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G206: <c>intent-cli worker next-action</c> command. Selects at most one
+/// coding-automation target (PR repair / issue-to-PR / none) deterministically
+/// per the priority order in #517.
+///
+/// No-mutation invariants (verified by tests):
+/// - never invokes <c>NestedProviderLauncher</c>;
+/// - command + analyzer files contain no <c>Process.Start</c>, no
+///   <c>gh issue edit</c>/<c>gh pr edit</c>/<c>gh pr merge</c>/
+///   <c>gh pr close</c>/<c>gh pr reopen</c>/<c>gh pr comment</c>/
+///   <c>gh pr review</c>, no <c>resolveReviewThread</c> mutation;
+/// - whole-workspace byte-snapshot before/after asserts no file is created
+///   or modified;
+/// - the only file in the worker next-action surface that calls
+///   <c>Process.Start</c> is the lister adapter
+///   <see cref="GhCliGitHubAutomationCandidateLister"/>, by design.
+/// </summary>
+internal static class WorkerNextActionCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    /// <summary>
+    /// Test seam: tests inject a fake <see cref="IGitHubAutomationCandidateLister"/>
+    /// here so no real GitHub network call is made. Production callers leave
+    /// this null and the default <see cref="GhCliGitHubAutomationCandidateLister"/>
+    /// is used.
+    /// </summary>
+    public static Func<IGitHubAutomationCandidateLister>? CandidateListerFactory { get; set; }
+
+    /// <summary>
+    /// Test sentinel: must NEVER be invoked. Tests assert it remains
+    /// uninvoked across all command paths to lock the "no nested provider
+    /// launch" guarantee.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var repo, out var workdir, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        IGitHubAutomationCandidateLister lister;
+        try
+        {
+            lister = CandidateListerFactory?.Invoke()
+                ?? new GhCliGitHubAutomationCandidateLister();
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub lister: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<GitHubAutomationPrCandidate> prs;
+        IReadOnlyList<GitHubAutomationIssueCandidate> issues;
+        try
+        {
+            prs = lister.ListPullRequests(
+                repo!,
+                new[] { WorkerNextActionConstants.Labels.IntentTarget });
+            issues = lister.ListIssues(
+                repo!,
+                new[] { WorkerNextActionConstants.Labels.IntentTarget });
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine(
+                $"failed to list automation candidates for {repo}: {exception.Message}");
+            return 1;
+        }
+
+        WorkerNextActionResult result;
+        try
+        {
+            result = WorkerNextActionAnalyzer.Analyze(repo!, prs, issues);
+        }
+        catch (Exception exception) when (
+            exception is ArgumentException
+            or InvalidOperationException)
+        {
+            writer.WriteLine($"failed to classify next-action for {repo}: {exception.Message}");
+            return 1;
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        // Suppress unused-warning for workdir — accepted for forward-compat
+        // with other worker commands that consume it.
+        _ = workdir;
+        return 0;
+    }
+
+    private static void WriteText(TextWriter writer, WorkerNextActionResult result)
+    {
+        writer.WriteLine($"# Worker next-action for {result.Repo}");
+        writer.WriteLine();
+        writer.WriteLine($"- action: {result.Action}");
+        if (result.Number is { } number)
+        {
+            writer.WriteLine($"- number: {number}");
+        }
+        if (!string.IsNullOrEmpty(result.Url))
+        {
+            writer.WriteLine($"- url: {result.Url}");
+        }
+        writer.WriteLine($"- reason: {result.Reason}");
+        if (!string.IsNullOrEmpty(result.RecommendedWorkflow))
+        {
+            writer.WriteLine($"- recommended_workflow: {result.RecommendedWorkflow}");
+        }
+        if (!string.IsNullOrEmpty(result.SourceClassification))
+        {
+            writer.WriteLine($"- source_classification: {result.SourceClassification}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Warnings");
+        if (result.Warnings.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var warning in result.Warnings)
+            {
+                writer.WriteLine($"- {warning}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string? workdir,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        workdir = null;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--workdir":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--workdir requires a value.";
+                        return false;
+                    }
+                    workdir = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --repo <owner/repo> [--workdir <path>] [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "--repo is required (e.g. --repo owner/repo).";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerNextActionResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerNextActionResult.cs
@@ -1,0 +1,91 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G206: Read-only result emitted by <c>intent-cli worker next-action</c>.
+/// Names a single coding-automation target (or <c>none</c>) for a coding
+/// loop to act on next, plus a recommended workflow hint and any policy
+/// warnings.
+///
+/// Field names mirror the issue contract exactly (camelCase for
+/// <c>recommendedWorkflow</c> / <c>sourceClassification</c>) and add
+/// snake_case aliases for local style consistency, mirroring the
+/// G202/G203/G204/G205 alias pattern. The snake_case form is the canonical
+/// source; the camelCase form is the contract surface.
+///
+/// Producing this record never mutates GitHub, never applies labels, never
+/// creates branches/PRs/comments, never touches the queue/runs logs, and
+/// never launches any AI provider.
+/// </summary>
+internal sealed record WorkerNextActionResult
+{
+    [JsonPropertyName("action")]
+    public required string Action { get; init; }
+
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("number")]
+    public int? Number { get; init; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
+
+    [JsonPropertyName("recommended_workflow")]
+    public string? RecommendedWorkflow { get; init; }
+
+    /// <summary>G206 issue contract alias — camelCase per #517.</summary>
+    [JsonPropertyName("recommendedWorkflow")]
+    public string? RecommendedWorkflowCamelCase => RecommendedWorkflow;
+
+    [JsonPropertyName("warnings")]
+    public required IReadOnlyList<string> Warnings { get; init; }
+
+    [JsonPropertyName("source_classification")]
+    public string? SourceClassification { get; init; }
+
+    /// <summary>G206 issue contract alias — camelCase per #517.</summary>
+    [JsonPropertyName("sourceClassification")]
+    public string? SourceClassificationCamelCase => SourceClassification;
+}
+
+/// <summary>
+/// G206: Stable string constants for the actions, workflows, and source
+/// classifications emitted by <c>intent-cli worker next-action</c>.
+/// </summary>
+internal static class WorkerNextActionConstants
+{
+    public static class Actions
+    {
+        public const string PrCommentFix = "pr-comment-fix";
+        public const string IssueToPr = "issue-to-pr";
+        public const string None = "none";
+    }
+
+    public static class RecommendedWorkflows
+    {
+        public const string PrCommentFix = "pr-comment-fix";
+        public const string GhIssueToPr = "gh-issue-to-pr";
+    }
+
+    public static class SourceClassifications
+    {
+        public const string RepairRequired = "repair-required";
+        public const string ReadyToImplement = "ready-to-implement";
+    }
+
+    public static class Labels
+    {
+        public const string IntentTarget = "intent-target";
+        public const string IntentPrRequestUpdate = "intent-pr-request-update";
+        public const string IntentPrUpdateInProgress = "intent-pr-update-in-progress";
+        public const string IntentPrRereviewReady = "intent-pr-rereview-ready";
+        public const string IntentPrApproved = "intent-pr-approved";
+        public const string IntentIssueInProgress = "intent-issue-in-progress";
+        public const string IntentPrCreated = "intent-pr-created";
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkerNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerNextActionCommandTests.cs
@@ -1,0 +1,609 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G206: Tests for <c>intent-cli worker next-action</c>. Cover the four
+/// priority cases (PR repair > issue-to-PR > none), the in-progress and
+/// pr-created exclusions, the misplaced-PR-label warning, and the
+/// no-mutation invariants.
+/// </summary>
+public sealed class WorkerNextActionCommandTests : IDisposable
+{
+    public WorkerNextActionCommandTests()
+    {
+        WorkerNextActionCommand.CandidateListerFactory = null;
+        WorkerNextActionCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        WorkerNextActionCommand.CandidateListerFactory = null;
+        WorkerNextActionCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void Execute_GivenPrWithRequestUpdate_SelectsPrCommentFix()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        var lister = new FakeLister
+        {
+            Prs = new[]
+            {
+                BuildPr(514, "G204 PR", "https://github.com/J-Tech-Japan/intent-system/pull/514",
+                    createdAt: "2026-04-30T00:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-request-update" }),
+            },
+            Issues = new[]
+            {
+                BuildIssue(515, "G205 Issue", "https://github.com/J-Tech-Japan/intent-system/issues/515",
+                    createdAt: "2026-04-30T01:00:00Z",
+                    labels: new[] { "intent-target" }),
+            },
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal(WorkerNextActionConstants.Actions.PrCommentFix, result.Action);
+        Assert.Equal(514, result.Number);
+        Assert.Equal(WorkerNextActionConstants.RecommendedWorkflows.PrCommentFix, result.RecommendedWorkflow);
+        Assert.Equal(WorkerNextActionConstants.SourceClassifications.RepairRequired, result.SourceClassification);
+        Assert.StartsWith("https://github.com/", result.Url, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenPrInUpdateInProgress_FallsThroughToIssueToPr()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        var lister = new FakeLister
+        {
+            Prs = new[]
+            {
+                // PR already claimed by a worker — must be excluded.
+                BuildPr(514, "Already-claimed PR", "https://github.com/J-Tech-Japan/intent-system/pull/514",
+                    createdAt: "2026-04-30T00:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-request-update", "intent-pr-update-in-progress" }),
+            },
+            Issues = new[]
+            {
+                BuildIssue(515, "G205", "https://github.com/J-Tech-Japan/intent-system/issues/515",
+                    createdAt: "2026-04-30T01:00:00Z",
+                    labels: new[] { "intent-target" }),
+            },
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal(WorkerNextActionConstants.Actions.IssueToPr, result.Action);
+        Assert.Equal(515, result.Number);
+        Assert.Equal(WorkerNextActionConstants.RecommendedWorkflows.GhIssueToPr, result.RecommendedWorkflow);
+    }
+
+    [Fact]
+    public void Execute_GivenIssueWithIntentPrCreated_ExcludesItFromIssueToPrSelection()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        var lister = new FakeLister
+        {
+            Prs = Array.Empty<GitHubAutomationPrCandidate>(),
+            Issues = new[]
+            {
+                // First (older) issue carries intent-pr-created — excluded.
+                BuildIssue(513, "Already PR'd", "https://github.com/J-Tech-Japan/intent-system/issues/513",
+                    createdAt: "2026-04-29T00:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-created" }),
+                // Eligible newer issue.
+                BuildIssue(517, "Eligible", "https://github.com/J-Tech-Japan/intent-system/issues/517",
+                    createdAt: "2026-04-30T00:00:00Z",
+                    labels: new[] { "intent-target" }),
+            },
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal(WorkerNextActionConstants.Actions.IssueToPr, result.Action);
+        Assert.Equal(517, result.Number);
+    }
+
+    [Fact]
+    public void Execute_GivenIssueInProgress_ExcludesItFromIssueToPrSelection()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        var lister = new FakeLister
+        {
+            Prs = Array.Empty<GitHubAutomationPrCandidate>(),
+            Issues = new[]
+            {
+                BuildIssue(517, "In progress", "https://github.com/J-Tech-Japan/intent-system/issues/517",
+                    createdAt: "2026-04-30T00:00:00Z",
+                    labels: new[] { "intent-target", "intent-issue-in-progress" }),
+            },
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal(WorkerNextActionConstants.Actions.None, result.Action);
+        Assert.Null(result.Number);
+    }
+
+    [Fact]
+    public void Execute_GivenNoCandidates_ReturnsNoneActionWithDeterministicReason()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        var lister = new FakeLister();
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal(WorkerNextActionConstants.Actions.None, result.Action);
+        Assert.Equal("no actionable coding automation target", result.Reason);
+        Assert.Null(result.RecommendedWorkflow);
+        Assert.Null(result.Number);
+    }
+
+    [Fact]
+    public void Execute_GivenPrWithMisplacedIntentPrCreated_EmitsWarningAndExcludesIt()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        var lister = new FakeLister
+        {
+            Prs = new[]
+            {
+                // Misplaced label: intent-pr-created on the PR itself.
+                BuildPr(600, "Misplaced", "https://github.com/J-Tech-Japan/intent-system/pull/600",
+                    createdAt: "2026-04-30T00:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-request-update", "intent-pr-created" }),
+            },
+            Issues = Array.Empty<GitHubAutomationIssueCandidate>(),
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        // Misplaced PR is excluded → no eligible target → none.
+        Assert.Equal(WorkerNextActionConstants.Actions.None, result.Action);
+        Assert.Contains(result.Warnings, w =>
+            w.Contains("PR #600", StringComparison.Ordinal)
+            && w.Contains("intent-pr-created", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_PrRepairBeatsIssueToPrEvenWhenIssueIsOlder()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        var lister = new FakeLister
+        {
+            // Issue was created first (older) but priority is still PR repair.
+            Issues = new[]
+            {
+                BuildIssue(100, "Old issue", "https://github.com/J-Tech-Japan/intent-system/issues/100",
+                    createdAt: "2026-01-01T00:00:00Z",
+                    labels: new[] { "intent-target" }),
+            },
+            Prs = new[]
+            {
+                BuildPr(900, "New PR repair", "https://github.com/J-Tech-Japan/intent-system/pull/900",
+                    createdAt: "2026-04-30T00:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-request-update" }),
+            },
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal(WorkerNextActionConstants.Actions.PrCommentFix, result.Action);
+        Assert.Equal(900, result.Number);
+    }
+
+    [Fact]
+    public void Execute_PicksOldestPrWhenMultipleAreEligible()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        var lister = new FakeLister
+        {
+            Prs = new[]
+            {
+                BuildPr(901, "newer", "https://github.com/J-Tech-Japan/intent-system/pull/901",
+                    createdAt: "2026-04-30T05:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-request-update" }),
+                BuildPr(900, "older", "https://github.com/J-Tech-Japan/intent-system/pull/900",
+                    createdAt: "2026-04-29T05:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-request-update" }),
+            },
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal(900, result.Number);
+    }
+
+    [Fact]
+    public void Execute_MissingRepo_ReturnsNonZero()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            Array.Empty<string>(),
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("--repo is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_TransportFailure_ReturnsNonZero()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        WorkerNextActionCommand.CandidateListerFactory =
+            () => new ThrowingLister("simulated gh failure");
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("simulated gh failure", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsonOutput_IncludesCamelCaseAliasesForRecommendedWorkflowAndSourceClassification()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        var lister = new FakeLister
+        {
+            Prs = new[]
+            {
+                BuildPr(514, "PR repair", "https://github.com/J-Tech-Japan/intent-system/pull/514",
+                    createdAt: "2026-04-30T00:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-request-update" }),
+            },
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var raw = writer.ToString();
+        Assert.Contains("\"recommended_workflow\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"recommendedWorkflow\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"source_classification\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"sourceClassification\"", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Adapter_PrListArguments_RequestSupportedSubsetWithLabelFilter()
+    {
+        var args = GhCliGitHubAutomationCandidateLister.BuildPrListArguments(
+            "J-Tech-Japan/intent-system",
+            new[] { "intent-target" });
+
+        Assert.Contains("pr", args);
+        Assert.Contains("list", args);
+        Assert.Contains("--repo", args);
+        Assert.Contains("J-Tech-Japan/intent-system", args);
+        Assert.Contains("--state", args);
+        Assert.Contains("open", args);
+        Assert.Contains("--json", args);
+        Assert.Contains(GhCliGitHubAutomationCandidateLister.ListJsonFields, args);
+        Assert.Contains("--label", args);
+        Assert.Contains("intent-target", args);
+    }
+
+    [Fact]
+    public void Adapter_IssueListArguments_RequestSupportedSubsetWithLabelFilter()
+    {
+        var args = GhCliGitHubAutomationCandidateLister.BuildIssueListArguments(
+            "J-Tech-Japan/intent-system",
+            new[] { "intent-target" });
+
+        Assert.Contains("issue", args);
+        Assert.Contains("list", args);
+        Assert.Contains("--repo", args);
+        Assert.Contains("J-Tech-Japan/intent-system", args);
+        Assert.Contains(GhCliGitHubAutomationCandidateLister.ListJsonFields, args);
+        Assert.Contains("--label", args);
+        Assert.Contains("intent-target", args);
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesNestedProviderLauncher()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        var launcherInvoked = false;
+        WorkerNextActionCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => new FakeLister
+        {
+            Prs = new[]
+            {
+                BuildPr(514, "PR", "https://example.com/pr/514",
+                    createdAt: "2026-04-30T00:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-request-update" }),
+            },
+            Issues = new[]
+            {
+                BuildIssue(517, "Issue", "https://example.com/issue/517",
+                    createdAt: "2026-04-30T01:00:00Z",
+                    labels: new[] { "intent-target" }),
+            },
+        };
+
+        using var writer = new StringWriter();
+        // Walk both selection paths and the no-action path.
+        Assert.Equal(0, WorkerNextActionCommand.Execute(workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer));
+
+        WorkerNextActionCommand.CandidateListerFactory = () => new FakeLister();
+        writer.GetStringBuilder().Clear();
+        Assert.Equal(0, WorkerNextActionCommand.Execute(workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer));
+
+        Assert.False(launcherInvoked,
+            "WorkerNextActionCommand must never invoke NestedProviderLauncher.");
+    }
+
+    [Fact]
+    public void Execute_LeavesIntentCliWorkspaceByteEquivalent()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        var before = workspace.SnapshotWorkspace();
+
+        WorkerNextActionCommand.CandidateListerFactory = () => new FakeLister
+        {
+            Prs = new[]
+            {
+                BuildPr(514, "PR", "https://example.com/pr/514",
+                    createdAt: "2026-04-30T00:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-request-update" }),
+            },
+        };
+
+        using (var writer = new StringWriter())
+        {
+            Assert.Equal(0, WorkerNextActionCommand.Execute(workspace.Context,
+                new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+                writer));
+        }
+
+        var after = workspace.SnapshotWorkspace();
+        Assert.Equal(before.Count, after.Count);
+        foreach (var (path, hash) in before)
+        {
+            Assert.True(after.TryGetValue(path, out var afterHash),
+                $"file disappeared after run: {path}");
+            Assert.Equal(hash, afterHash);
+        }
+    }
+
+    [Fact]
+    public void SourceScan_AnalyzerAndCommand_ContainNoProcessStartOrGhMutationLiterals()
+    {
+        // The analyzer and command files must remain pure: no Process.Start
+        // and no gh CLI mutation literals in EXECUTABLE code. The lister
+        // adapter is exempt (its job is to shell out to `gh pr list` /
+        // `gh issue list` for read-only metadata). Doc-comment listings of
+        // forbidden mutations are stripped before scanning so the
+        // documentation can name what it forbids.
+        var analyzer = StripCsharpComments(File.ReadAllText(LocateSourceFile("WorkerNextActionAnalyzer.cs")));
+        var command = StripCsharpComments(File.ReadAllText(LocateSourceFile("WorkerNextActionCommand.cs")));
+        var combined = analyzer + "\n" + command;
+
+        Assert.DoesNotContain("Process.Start(", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh issue edit", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr edit", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr merge", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr close", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr reopen", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr comment", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr review", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("resolveReviewThread", combined, StringComparison.Ordinal);
+    }
+
+    private static string StripCsharpComments(string source)
+    {
+        // Remove block comments (/* … */) including XML doc blocks like
+        // /** … */, and remove line comments (// … to end of line, plus
+        // /// … to end of line). Order matters — strip block comments
+        // first so a "//" inside a /* … */ block doesn't survive.
+        var noBlockComments = System.Text.RegularExpressions.Regex.Replace(
+            source, @"/\*[\s\S]*?\*/", string.Empty);
+        var noLineComments = System.Text.RegularExpressions.Regex.Replace(
+            noBlockComments, @"//.*?$", string.Empty,
+            System.Text.RegularExpressions.RegexOptions.Multiline);
+        return noLineComments;
+    }
+
+    private static GitHubAutomationPrCandidate BuildPr(
+        int number, string title, string url, string createdAt, string[] labels)
+    {
+        return new GitHubAutomationPrCandidate
+        {
+            Number = number,
+            Title = title,
+            Url = url,
+            CreatedAt = createdAt,
+            Labels = labels.Select(n => new GitHubAutomationLabel { Name = n }).ToArray(),
+        };
+    }
+
+    private static GitHubAutomationIssueCandidate BuildIssue(
+        int number, string title, string url, string createdAt, string[] labels)
+    {
+        return new GitHubAutomationIssueCandidate
+        {
+            Number = number,
+            Title = title,
+            Url = url,
+            CreatedAt = createdAt,
+            Labels = labels.Select(n => new GitHubAutomationLabel { Name = n }).ToArray(),
+        };
+    }
+
+    private static string LocateSourceFile(string fileName)
+    {
+        var directory = AppContext.BaseDirectory;
+        var dir = new DirectoryInfo(directory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(
+                dir.FullName, "src", "IntentSystem.Cli", "Commands", fileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = dir.Parent;
+        }
+
+        throw new FileNotFoundException(
+            $"Could not locate source file {fileName} from {directory}");
+    }
+
+    private sealed class FakeLister : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationPrCandidate> Prs { get; init; }
+            = Array.Empty<GitHubAutomationPrCandidate>();
+        public IReadOnlyList<GitHubAutomationIssueCandidate> Issues { get; init; }
+            = Array.Empty<GitHubAutomationIssueCandidate>();
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) => Prs;
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) => Issues;
+    }
+
+    private sealed class ThrowingLister : IGitHubAutomationCandidateLister
+    {
+        private readonly string message;
+
+        public ThrowingLister(string message)
+        {
+            this.message = message;
+        }
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo, IReadOnlyCollection<string> requiredLabels) =>
+            throw new InvalidOperationException(message);
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo, IReadOnlyCollection<string> requiredLabels) =>
+            throw new InvalidOperationException(message);
+    }
+
+    private sealed class WorkerNextActionWorkspace : IDisposable
+    {
+        public WorkerNextActionWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("worker-next-action-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public IReadOnlyDictionary<string, string> SnapshotWorkspace()
+        {
+            var snapshot = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(RootPath, "*", SearchOption.AllDirectories))
+            {
+                var bytes = File.ReadAllBytes(path);
+                var hash = Convert.ToHexString(SHA256.HashData(bytes));
+                snapshot[path] = hash;
+            }
+            return snapshot;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `intent-cli worker next-action --repo <owner/repo> [--workdir <path>] [--format text|json]` under the existing `worker` group. Selects at most one coding-automation target per invocation following the priority order in #517: **PR comment/update repair → (PR review, child-side intentionally falls through) → issue-to-PR → none**.
- Eligibility rules (label-driven, deterministic):
  - PR repair: open PR with `intent-target` + `intent-pr-request-update`, NOT `intent-pr-update-in-progress`, NOT `intent-pr-created`. Oldest by `createdAt` wins.
  - Issue-to-PR: open issue with `intent-target`, NOT `intent-issue-in-progress`, NOT `intent-pr-created`. Oldest by `createdAt` wins.
- Misplaced-label policy: any PR carrying `intent-pr-created` is reported as a warning and excluded from selection (`intent-pr-created` belongs on the source issue, not the PR).
- New testability seam `IGitHubAutomationCandidateLister` (default impl shells out to `gh pr list` / `gh issue list` for read-only metadata; tests inject a fake to avoid GitHub network access). The analyzer + command files remain pure — no `Process.Start`, no GitHub mutation calls, no provider launches.
- JSON output snake_case primary + camelCase aliases (`recommendedWorkflow`, `sourceClassification`) — mirrors the G202/G203/G204/G205 alias pattern.

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release --filter \"FullyQualifiedName~WorkerNextAction\"` — **16/16 passing**. Classifications/actions covered: PR-repair priority over issue-to-PR (even with older issue), update-in-progress PR excluded (falls through to issue-to-PR), intent-pr-created issue excluded (newer eligible issue selected), in-progress issue excluded (returns none), no candidates → none with deterministic reason, misplaced intent-pr-created on PR → warning + exclusion, oldest-wins tie-break, camelCase alias parity, transport failure → non-zero, missing --repo → non-zero, adapter-shape locks for `gh pr list` / `gh issue list`, nested-provider-launcher sentinel never invoked, whole-workspace byte-equivalence, source-scan.
- [x] Full CLI suite: 1348 passed + 1 pre-existing skip, 0 failed.

### Sample JSON output

**PR repair (`pr-comment-fix`):**

```json
{
  \"action\": \"pr-comment-fix\",
  \"repo\": \"J-Tech-Japan/intent-system\",
  \"number\": 514,
  \"url\": \"https://github.com/J-Tech-Japan/intent-system/pull/514\",
  \"reason\": \"open PR has actionable repair feedback (intent-pr-request-update without intent-pr-update-in-progress)\",
  \"recommended_workflow\": \"pr-comment-fix\",
  \"recommendedWorkflow\": \"pr-comment-fix\",
  \"warnings\": [],
  \"source_classification\": \"repair-required\",
  \"sourceClassification\": \"repair-required\"
}
```

**Issue-to-PR (`issue-to-pr`):** verified end-to-end — running the new command against this repo selects #517 with `recommendedWorkflow: gh-issue-to-pr`, `sourceClassification: ready-to-implement`.

**None (`none`):**

```json
{
  \"action\": \"none\",
  \"repo\": \"J-Tech-Japan/intent-system\",
  \"reason\": \"no actionable coding automation target\",
  \"warnings\": []
}
```

### Confirmation (no-mutation invariants verified by tests)

- The command does NOT mutate labels — verified by source-scan rejecting all 7 distinct `gh issue edit`/`gh pr edit`/`gh pr merge`/`gh pr close`/`gh pr reopen`/`gh pr comment`/`gh pr review` literal patterns in the analyzer + command files (doc comments stripped before scan).
- The command does NOT create/merge/close PRs or branches — verified by source-scan + whole-workspace byte-equivalence.
- The command does NOT post PR comments — `gh pr comment` literal explicitly rejected.
- The command does NOT resolve GitHub review threads — `resolveReviewThread` GraphQL mutation literal explicitly rejected.
- The command does NOT launch AI providers — sentinel `NestedProviderLauncher` never invoked across PR-repair, issue-to-PR, and no-action paths + source-scan rejecting `Process.Start(` in command/analyzer/result. The lister adapter `GhCliGitHubAutomationCandidateLister` is the only file in this surface that calls `Process.Start`, by design (read-only `gh pr list` / `gh issue list`).
- The command does NOT touch `.intent-cli` queue/runs state — whole-workspace byte-snapshot before/after asserts no file is created or modified.

Closes #517