### PR TITLE
G207: add intent-cli metadata validate read-only validator

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -23,7 +23,8 @@ internal static class CommandRouter
         "automation",
         "safety",
         "tasking",
-        "worker"
+        "worker",
+        "metadata"
     ];
 
     private static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, CommandHandler>> ImplementedCommands =
@@ -132,6 +133,10 @@ internal static class CommandRouter
                 ["pr-comment-preflight"] = WorkerPrCommentPreflightCommand.Execute,
                 ["result-summary"] = WorkerResultSummaryCommand.Execute,
                 ["next-action"] = WorkerNextActionCommand.Execute
+            },
+            ["metadata"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["validate"] = MetadataValidateCommand.Execute
             },
             ["tasking"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/MetadataValidateAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/MetadataValidateAnalyzer.cs
@@ -19,8 +19,17 @@ internal static class MetadataValidateAnalyzer
         RegexOptions.Compiled | RegexOptions.Multiline);
 
     private static readonly Regex YamlScalarKeyRegex = new(
-        // Top-level scalar key: "key:" possibly with a value on the same line.
-        @"^(?<key>[A-Za-z_][A-Za-z0-9_\-]*)\s*:\s*(?<value>.*)$",
+        // Indented or top-level scalar key: "<indent>key:" possibly with a
+        // value. We capture the leading whitespace so the parser can
+        // reconstruct nesting depth.
+        //
+        // IMPORTANT: use [ \t]* between the colon and the inline value
+        // (not \s*) — \s matches newlines, so on a key line whose value
+        // continues on the next physical line (`key:\n  child: ...`) the
+        // value capture would greedily slurp the next line. With [ \t]*
+        // the value capture ends at end-of-line and the next line is
+        // matched as its own regex match.
+        @"^(?<indent>[ \t]*)(?<key>[A-Za-z_][A-Za-z0-9_\-]*)[ \t]*:[ \t]*(?<value>.*)$",
         RegexOptions.Compiled | RegexOptions.Multiline);
 
     public static MetadataValidateResult Analyze(MetadataValidateInputs inputs)
@@ -63,22 +72,32 @@ internal static class MetadataValidateAnalyzer
 
             if (packetFields is not null)
             {
-                if (!HasNonEmptyValue(packetFields, "execution_unit")
-                    && !HasNonEmptyValue(packetFields, "executionUnit"))
+                // The parent-host packet schema nests fields under
+                // `implementation_issue_packet:` with `source_execution_unit`
+                // and `issue_title` keys. Accept both that shape and the
+                // simpler flat shape used by the in-memory test fixtures.
+                if (!HasAnyNonEmptyValue(packetFields,
+                        "execution_unit",
+                        "executionUnit",
+                        "implementation_issue_packet.source_execution_unit",
+                        "source_execution_unit"))
                 {
                     errors.Add(new MetadataValidateFinding
                     {
                         Code = MetadataValidateConstants.Codes.PacketMissingExecutionUnit,
-                        Message = "packet.yaml is missing execution_unit / executionUnit.",
+                        Message = "packet.yaml is missing execution_unit / source_execution_unit.",
                         Path = packetPath,
                     });
                 }
-                if (!HasNonEmptyValue(packetFields, "title"))
+                if (!HasAnyNonEmptyValue(packetFields,
+                        "title",
+                        "implementation_issue_packet.issue_title",
+                        "issue_title"))
                 {
                     errors.Add(new MetadataValidateFinding
                     {
                         Code = MetadataValidateConstants.Codes.PacketMissingTitle,
-                        Message = "packet.yaml is missing title.",
+                        Message = "packet.yaml is missing title / issue_title.",
                         Path = packetPath,
                     });
                 }
@@ -178,23 +197,26 @@ internal static class MetadataValidateAnalyzer
 
             if (publishFields is not null)
             {
-                if (!HasNonEmptyValue(publishFields, "issue_number")
-                    && !HasNonEmptyValue(publishFields, "issueNumber"))
+                // The parent-host publish schema nests issue data under
+                // `issue:` (so the number is exposed as `issue.number`).
+                // Accept both that shape and the simpler flat shape.
+                if (!HasAnyNonEmptyValue(publishFields,
+                        "issue_number", "issueNumber", "issue.number"))
                 {
                     errors.Add(new MetadataValidateFinding
                     {
                         Code = MetadataValidateConstants.Codes.PublishMissingIssueNumber,
-                        Message = "publish.yaml is missing issue_number / issueNumber.",
+                        Message = "publish.yaml is missing issue_number / issue.number.",
                         Path = publishPath,
                     });
                 }
-                if (!HasNonEmptyValue(publishFields, "issue_url")
-                    && !HasNonEmptyValue(publishFields, "issueUrl"))
+                if (!HasAnyNonEmptyValue(publishFields,
+                        "issue_url", "issueUrl", "issue.url"))
                 {
                     errors.Add(new MetadataValidateFinding
                     {
                         Code = MetadataValidateConstants.Codes.PublishMissingIssueUrl,
-                        Message = "publish.yaml is missing issue_url / issueUrl.",
+                        Message = "publish.yaml is missing issue_url / issue.url.",
                         Path = publishPath,
                     });
                 }
@@ -245,7 +267,8 @@ internal static class MetadataValidateAnalyzer
         if (publishFields is not null && queueEntry is not null)
         {
             var publishIssue = TryGetInt(publishFields, "issue_number")
-                ?? TryGetInt(publishFields, "issueNumber");
+                ?? TryGetInt(publishFields, "issueNumber")
+                ?? TryGetInt(publishFields, "issue.number");
             if (publishIssue.HasValue
                 && queueEntry.LinkedIssue.HasValue
                 && publishIssue.Value != queueEntry.LinkedIssue.Value)
@@ -317,40 +340,104 @@ internal static class MetadataValidateAnalyzer
     }
 
     /// <summary>
-    /// G207: parse YAML top-level scalar keys. We deliberately do NOT pull in
-    /// a full YAML library — the validator only needs to recognize whether
-    /// well-known top-level keys are present and have a non-empty value.
-    /// Anything more structured (lists, nested maps) is read as the literal
-    /// trailing-of-line text and downstream consumers parse further if
-    /// needed (see <see cref="ParseListLiteral"/>).
+    /// G207 follow-up: parse YAML scalar keys using indentation-tracked
+    /// nesting so the validator can recognize the parent-host packet and
+    /// publish schemas, which nest fields under outer maps like
+    /// <c>implementation_issue_packet:</c> and <c>issue:</c>.
+    ///
+    /// Keys are returned both bare (e.g. <c>source_execution_unit</c>) and
+    /// dotted (e.g. <c>implementation_issue_packet.source_execution_unit</c>)
+    /// so callers can match either the flat or nested form. Bare keys at
+    /// inner levels are also indexed so a nested <c>issue.number</c> is
+    /// findable as just <c>number</c> when no top-level <c>number</c>
+    /// shadows it.
+    ///
+    /// Lists, multi-line scalars, anchors, and other YAML features are
+    /// out of scope — the validator only needs scalar values.
     /// </summary>
     private static IReadOnlyDictionary<string, string> ParseYamlScalars(string yaml)
     {
         var fields = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        // Stack of (indentWidth, keyName) pairs that describe the chain of
+        // open mapping keys above the current line. We pop entries whose
+        // indent is >= the current indent before pushing.
+        var pathStack = new List<(int Indent, string Key)>();
+
         foreach (Match match in YamlScalarKeyRegex.Matches(yaml))
         {
-            // Only accept top-level keys (no leading whitespace).
-            var line = match.Value;
-            if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t'))
-            {
-                continue;
-            }
+            var indent = match.Groups["indent"].Value.Length;
             var key = match.Groups["key"].Value;
-            var value = match.Groups["value"].Value.Trim();
-            // Strip surrounding quotes if present.
+            var rawValue = match.Groups["value"].Value;
+            var hadInlineValue = rawValue.Length > 0
+                && !rawValue.StartsWith('#');
+            var value = rawValue;
+            // Strip trailing inline comments.
+            var hashIndex = value.IndexOf(" #", StringComparison.Ordinal);
+            if (hashIndex >= 0)
+            {
+                value = value.Substring(0, hashIndex);
+            }
+            value = value.Trim();
             if (value.Length >= 2
                 && (value[0] == '"' && value[^1] == '"'
                     || value[0] == '\'' && value[^1] == '\''))
             {
                 value = value.Substring(1, value.Length - 2);
             }
-            fields[key] = value;
+
+            // Pop the path stack until the top is shallower than the current
+            // line; entries at the same or deeper indent are siblings or
+            // children that already closed.
+            while (pathStack.Count > 0 && pathStack[^1].Indent >= indent)
+            {
+                pathStack.RemoveAt(pathStack.Count - 1);
+            }
+
+            // Build dotted path for this key.
+            var dottedPath = pathStack.Count == 0
+                ? key
+                : string.Join(".", pathStack.Select(e => e.Key)) + "." + key;
+
+            // Always store the dotted path. Also store the bare key when no
+            // earlier line already wrote that bare key — first writer wins
+            // so a top-level `execution_unit` outranks a deeper one.
+            if (hadInlineValue && !string.IsNullOrEmpty(value))
+            {
+                fields[dottedPath] = value;
+                if (!fields.ContainsKey(key))
+                {
+                    fields[key] = value;
+                }
+            }
+            else
+            {
+                // No inline value — this line opens a nested mapping.
+                // Push it onto the path stack so subsequent lines see it
+                // as a parent.
+                pathStack.Add((indent, key));
+            }
         }
+
         return fields;
     }
 
     private static bool HasNonEmptyValue(IReadOnlyDictionary<string, string> fields, string key) =>
         fields.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value);
+
+    private static bool HasAnyNonEmptyValue(
+        IReadOnlyDictionary<string, string> fields,
+        params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (HasNonEmptyValue(fields, key))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 
     private static string? ValueFor(IReadOnlyDictionary<string, string> fields, string key) =>
         fields.TryGetValue(key, out var value) ? value : null;
@@ -444,14 +531,70 @@ internal static class MetadataValidateAnalyzer
             var unit = TryGetString(entry, "execution_unit") ?? TryGetString(entry, "executionUnit");
             if (string.Equals(unit, executionUnit, StringComparison.Ordinal))
             {
+                // The host queue-state schema uses `state` (e.g. "queued",
+                // "completed"); accept `status` as a synonym for the simpler
+                // flat shape used in tests.
+                var status = TryGetString(entry, "state") ?? TryGetString(entry, "status");
+
+                // The host queue-state schema represents linked issue / PR
+                // as objects `{ repo, number, url }`. Accept either the
+                // object-with-number form or a flat int (legacy / tests).
                 return new QueueStateEntry(
-                    Status: TryGetString(entry, "status"),
-                    LinkedIssue: TryGetIntProperty(entry, "linked_issue") ?? TryGetIntProperty(entry, "linkedIssue"),
-                    LinkedPr: TryGetIntProperty(entry, "linked_pr") ?? TryGetIntProperty(entry, "linkedPr"),
+                    Status: status,
+                    LinkedIssue: ResolveLinkedNumber(entry, "linked_issue", "linkedIssue"),
+                    LinkedPr: ResolveLinkedNumber(entry, "linked_pr", "linkedPr"),
                     Dependencies: TryGetStringArray(entry, "dependencies"));
             }
         }
 
+        return null;
+    }
+
+    /// <summary>
+    /// G207 follow-up: the host queue-state stores linked_issue / linked_pr
+    /// as objects with a <c>number</c> property. Accept either the
+    /// object-with-number form or a flat integer.
+    /// </summary>
+    private static int? ResolveLinkedNumber(JsonElement entry, params string[] candidateKeys)
+    {
+        foreach (var key in candidateKeys)
+        {
+            if (!entry.TryGetProperty(key, out var prop))
+            {
+                continue;
+            }
+            // Object form: prefer the `number` property.
+            if (prop.ValueKind == JsonValueKind.Object
+                && prop.TryGetProperty("number", out var numberProp))
+            {
+                if (numberProp.ValueKind == JsonValueKind.Number
+                    && numberProp.TryGetInt32(out var n))
+                {
+                    return n;
+                }
+                if (numberProp.ValueKind == JsonValueKind.String
+                    && int.TryParse(numberProp.GetString(),
+                        System.Globalization.NumberStyles.Integer,
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        out var parsedString))
+                {
+                    return parsedString;
+                }
+            }
+            // Flat form (test fixtures / legacy):
+            if (prop.ValueKind == JsonValueKind.Number && prop.TryGetInt32(out var direct))
+            {
+                return direct;
+            }
+            if (prop.ValueKind == JsonValueKind.String
+                && int.TryParse(prop.GetString(),
+                    System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out var directParsed))
+            {
+                return directParsed;
+            }
+        }
         return null;
     }
 

--- a/src/IntentSystem.Cli/Commands/MetadataValidateAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/MetadataValidateAnalyzer.cs
@@ -1,0 +1,527 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G207: Pure deterministic mechanical metadata validator. Given the raw
+/// file contents that the command read off disk, runs the validation rules
+/// listed in #519 and returns a <see cref="MetadataValidateResult"/>.
+///
+/// Pure: no I/O, no Process.Start, no GitHub network, no provider launch.
+/// Tests inject <see cref="MetadataValidateInputs"/> directly to avoid
+/// touching the filesystem.
+/// </summary>
+internal static class MetadataValidateAnalyzer
+{
+    private static readonly Regex MarkdownHeadingLineRegex = new(
+        @"^[ \t]*#{1,6}[ \t]+(?<text>.+?)[ \t]*$",
+        RegexOptions.Compiled | RegexOptions.Multiline);
+
+    private static readonly Regex YamlScalarKeyRegex = new(
+        // Top-level scalar key: "key:" possibly with a value on the same line.
+        @"^(?<key>[A-Za-z_][A-Za-z0-9_\-]*)\s*:\s*(?<value>.*)$",
+        RegexOptions.Compiled | RegexOptions.Multiline);
+
+    public static MetadataValidateResult Analyze(MetadataValidateInputs inputs)
+    {
+        ArgumentNullException.ThrowIfNull(inputs);
+        ArgumentException.ThrowIfNullOrWhiteSpace(inputs.ExecutionUnit);
+
+        var errors = new List<MetadataValidateFinding>();
+        var warnings = new List<MetadataValidateFinding>();
+        var checkedFiles = new List<string>();
+
+        // ---- packet.yaml (required) ----------------------------------------
+        var packetPath = $".intent-cli/issues/{inputs.ExecutionUnit}/packet.yaml";
+        checkedFiles.Add(packetPath);
+        IReadOnlyDictionary<string, string>? packetFields = null;
+        if (inputs.PacketYaml is null)
+        {
+            errors.Add(new MetadataValidateFinding
+            {
+                Code = MetadataValidateConstants.Codes.PacketFileMissing,
+                Message = $"required packet file not found: {packetPath}",
+                Path = packetPath,
+            });
+        }
+        else
+        {
+            try
+            {
+                packetFields = ParseYamlScalars(inputs.PacketYaml);
+            }
+            catch (Exception exception) when (exception is FormatException or ArgumentException)
+            {
+                errors.Add(new MetadataValidateFinding
+                {
+                    Code = MetadataValidateConstants.Codes.PacketYamlUnparseable,
+                    Message = $"could not parse {packetPath}: {exception.Message}",
+                    Path = packetPath,
+                });
+            }
+
+            if (packetFields is not null)
+            {
+                if (!HasNonEmptyValue(packetFields, "execution_unit")
+                    && !HasNonEmptyValue(packetFields, "executionUnit"))
+                {
+                    errors.Add(new MetadataValidateFinding
+                    {
+                        Code = MetadataValidateConstants.Codes.PacketMissingExecutionUnit,
+                        Message = "packet.yaml is missing execution_unit / executionUnit.",
+                        Path = packetPath,
+                    });
+                }
+                if (!HasNonEmptyValue(packetFields, "title"))
+                {
+                    errors.Add(new MetadataValidateFinding
+                    {
+                        Code = MetadataValidateConstants.Codes.PacketMissingTitle,
+                        Message = "packet.yaml is missing title.",
+                        Path = packetPath,
+                    });
+                }
+            }
+        }
+
+        // ---- github-body.md (required + standalone sections) ----------------
+        var bodyPath = $".intent-cli/issues/{inputs.ExecutionUnit}/github-body.md";
+        checkedFiles.Add(bodyPath);
+        if (inputs.GithubBodyMarkdown is null)
+        {
+            errors.Add(new MetadataValidateFinding
+            {
+                Code = MetadataValidateConstants.Codes.GithubBodyMissing,
+                Message = $"required github-body file not found: {bodyPath}",
+                Path = bodyPath,
+            });
+        }
+        else
+        {
+            var headings = ExtractHeadings(inputs.GithubBodyMarkdown);
+            foreach (var section in MetadataValidateConstants.RequiredGithubBodySections)
+            {
+                if (!HasMatchingHeading(headings, section))
+                {
+                    errors.Add(new MetadataValidateFinding
+                    {
+                        Code = MetadataValidateConstants.Codes.GithubBodyMissingSection,
+                        Message = $"github-body.md is missing required section '{section}'.",
+                        Path = bodyPath,
+                    });
+                }
+            }
+        }
+
+        // ---- review-context.md (required + sections) ------------------------
+        var reviewPath = $".intent-cli/issues/{inputs.ExecutionUnit}/review-context.md";
+        checkedFiles.Add(reviewPath);
+        if (inputs.ReviewContextMarkdown is null)
+        {
+            errors.Add(new MetadataValidateFinding
+            {
+                Code = MetadataValidateConstants.Codes.ReviewContextMissing,
+                Message = $"required review-context file not found: {reviewPath}",
+                Path = reviewPath,
+            });
+        }
+        else
+        {
+            var headings = ExtractHeadings(inputs.ReviewContextMarkdown);
+            foreach (var section in MetadataValidateConstants.RequiredReviewContextSections)
+            {
+                if (!HasMatchingHeading(headings, section))
+                {
+                    warnings.Add(new MetadataValidateFinding
+                    {
+                        Code = MetadataValidateConstants.Codes.ReviewContextMissingSection,
+                        Message = $"review-context.md is missing recommended section '{section}'.",
+                        Path = reviewPath,
+                    });
+                }
+            }
+        }
+
+        // ---- implementation.md (recommended; warning only) ------------------
+        var implPath = $".intent-cli/issues/{inputs.ExecutionUnit}/implementation.md";
+        checkedFiles.Add(implPath);
+        if (inputs.ImplementationMarkdown is null)
+        {
+            warnings.Add(new MetadataValidateFinding
+            {
+                Code = MetadataValidateConstants.Codes.ImplementationFileMissing,
+                Message = $"recommended implementation file not found: {implPath}",
+                Path = implPath,
+            });
+        }
+
+        // ---- publish.yaml (optional, but if present must be coherent) -------
+        var publishPath = $".intent-cli/issues/{inputs.ExecutionUnit}/publish.yaml";
+        IReadOnlyDictionary<string, string>? publishFields = null;
+        if (inputs.PublishYaml is not null)
+        {
+            checkedFiles.Add(publishPath);
+            try
+            {
+                publishFields = ParseYamlScalars(inputs.PublishYaml);
+            }
+            catch (Exception exception) when (exception is FormatException or ArgumentException)
+            {
+                errors.Add(new MetadataValidateFinding
+                {
+                    Code = MetadataValidateConstants.Codes.PublishYamlUnparseable,
+                    Message = $"could not parse {publishPath}: {exception.Message}",
+                    Path = publishPath,
+                });
+            }
+
+            if (publishFields is not null)
+            {
+                if (!HasNonEmptyValue(publishFields, "issue_number")
+                    && !HasNonEmptyValue(publishFields, "issueNumber"))
+                {
+                    errors.Add(new MetadataValidateFinding
+                    {
+                        Code = MetadataValidateConstants.Codes.PublishMissingIssueNumber,
+                        Message = "publish.yaml is missing issue_number / issueNumber.",
+                        Path = publishPath,
+                    });
+                }
+                if (!HasNonEmptyValue(publishFields, "issue_url")
+                    && !HasNonEmptyValue(publishFields, "issueUrl"))
+                {
+                    errors.Add(new MetadataValidateFinding
+                    {
+                        Code = MetadataValidateConstants.Codes.PublishMissingIssueUrl,
+                        Message = "publish.yaml is missing issue_url / issueUrl.",
+                        Path = publishPath,
+                    });
+                }
+            }
+        }
+
+        // ---- queue-state.json (required) -----------------------------------
+        const string queueStatePath = ".intent-cli/queue-state.json";
+        checkedFiles.Add(queueStatePath);
+        QueueStateEntry? queueEntry = null;
+        if (inputs.QueueStateJson is null)
+        {
+            errors.Add(new MetadataValidateFinding
+            {
+                Code = MetadataValidateConstants.Codes.QueueStateMissing,
+                Message = $"required queue-state file not found: {queueStatePath}",
+                Path = queueStatePath,
+            });
+        }
+        else
+        {
+            try
+            {
+                queueEntry = FindQueueEntry(inputs.QueueStateJson, inputs.ExecutionUnit);
+            }
+            catch (JsonException exception)
+            {
+                errors.Add(new MetadataValidateFinding
+                {
+                    Code = MetadataValidateConstants.Codes.QueueStateUnparseable,
+                    Message = $"could not parse {queueStatePath}: {exception.Message}",
+                    Path = queueStatePath,
+                });
+            }
+
+            if (queueEntry is null && inputs.QueueStateJson.Trim().Length > 0)
+            {
+                errors.Add(new MetadataValidateFinding
+                {
+                    Code = MetadataValidateConstants.Codes.QueueEntryMissing,
+                    Message = $"queue-state.json has no entry for execution unit '{inputs.ExecutionUnit}'.",
+                    Path = queueStatePath,
+                });
+            }
+        }
+
+        // ---- cross-file consistency ----------------------------------------
+        if (publishFields is not null && queueEntry is not null)
+        {
+            var publishIssue = TryGetInt(publishFields, "issue_number")
+                ?? TryGetInt(publishFields, "issueNumber");
+            if (publishIssue.HasValue
+                && queueEntry.LinkedIssue.HasValue
+                && publishIssue.Value != queueEntry.LinkedIssue.Value)
+            {
+                errors.Add(new MetadataValidateFinding
+                {
+                    Code = MetadataValidateConstants.Codes.PublishQueueIssueMismatch,
+                    Message = $"publish.yaml issue_number ({publishIssue}) does not match queue-state linked_issue ({queueEntry.LinkedIssue}).",
+                    Path = publishPath,
+                });
+            }
+        }
+
+        if (queueEntry is not null
+            && string.Equals(queueEntry.Status, "completed", StringComparison.OrdinalIgnoreCase)
+            && queueEntry.LinkedPr is null)
+        {
+            errors.Add(new MetadataValidateFinding
+            {
+                Code = MetadataValidateConstants.Codes.CompletedMissingClosure,
+                Message = $"queue-state entry '{inputs.ExecutionUnit}' is marked completed but has no linked_pr or closeout evidence.",
+                Path = queueStatePath,
+            });
+        }
+
+        // Dependency consistency between packet and queue-state, when both
+        // expose a comma-separated dependency list.
+        if (packetFields is not null && queueEntry is not null && queueEntry.Dependencies is not null)
+        {
+            var packetDeps = ParseListLiteral(
+                ValueFor(packetFields, "dependencies") ?? string.Empty);
+            if (packetDeps.Count > 0
+                && !packetDeps.SetEquals(queueEntry.Dependencies))
+            {
+                errors.Add(new MetadataValidateFinding
+                {
+                    Code = MetadataValidateConstants.Codes.PacketQueueDependencyMismatch,
+                    Message = "packet.yaml dependencies do not match queue-state dependencies for this execution unit.",
+                    Path = packetPath,
+                });
+            }
+        }
+
+        // ---- label-policy warnings -----------------------------------------
+        // If publish metadata claims intent-pr-created on the PR position,
+        // surface a warning per the existing G205/G206 policy invariant.
+        if (publishFields is not null
+            && string.Equals(
+                ValueFor(publishFields, "pr_label") ?? ValueFor(publishFields, "prLabel"),
+                "intent-pr-created",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            warnings.Add(new MetadataValidateFinding
+            {
+                Code = MetadataValidateConstants.Codes.LabelPolicyMisplacedPrCreated,
+                Message = "publish.yaml records 'intent-pr-created' as a PR label; it belongs on the source issue, not the PR.",
+                Path = publishPath,
+            });
+        }
+
+        return new MetadataValidateResult
+        {
+            Valid = errors.Count == 0,
+            ExecutionUnit = inputs.ExecutionUnit,
+            Errors = errors,
+            Warnings = warnings,
+            CheckedFiles = checkedFiles,
+        };
+    }
+
+    /// <summary>
+    /// G207: parse YAML top-level scalar keys. We deliberately do NOT pull in
+    /// a full YAML library — the validator only needs to recognize whether
+    /// well-known top-level keys are present and have a non-empty value.
+    /// Anything more structured (lists, nested maps) is read as the literal
+    /// trailing-of-line text and downstream consumers parse further if
+    /// needed (see <see cref="ParseListLiteral"/>).
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> ParseYamlScalars(string yaml)
+    {
+        var fields = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (Match match in YamlScalarKeyRegex.Matches(yaml))
+        {
+            // Only accept top-level keys (no leading whitespace).
+            var line = match.Value;
+            if (line.Length > 0 && (line[0] == ' ' || line[0] == '\t'))
+            {
+                continue;
+            }
+            var key = match.Groups["key"].Value;
+            var value = match.Groups["value"].Value.Trim();
+            // Strip surrounding quotes if present.
+            if (value.Length >= 2
+                && (value[0] == '"' && value[^1] == '"'
+                    || value[0] == '\'' && value[^1] == '\''))
+            {
+                value = value.Substring(1, value.Length - 2);
+            }
+            fields[key] = value;
+        }
+        return fields;
+    }
+
+    private static bool HasNonEmptyValue(IReadOnlyDictionary<string, string> fields, string key) =>
+        fields.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value);
+
+    private static string? ValueFor(IReadOnlyDictionary<string, string> fields, string key) =>
+        fields.TryGetValue(key, out var value) ? value : null;
+
+    private static int? TryGetInt(IReadOnlyDictionary<string, string> fields, string key)
+    {
+        if (!fields.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+        return int.TryParse(value,
+            System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private static HashSet<string> ParseListLiteral(string value)
+    {
+        // Accept either "[a, b, c]" or "a,b,c" or empty.
+        var trimmed = value.Trim();
+        if (trimmed.StartsWith('[') && trimmed.EndsWith(']'))
+        {
+            trimmed = trimmed[1..^1];
+        }
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            return new HashSet<string>(StringComparer.Ordinal);
+        }
+        return trimmed.Split(',')
+            .Select(s => s.Trim().Trim('"', '\''))
+            .Where(s => s.Length > 0)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static IReadOnlyList<string> ExtractHeadings(string markdown)
+    {
+        var headings = new List<string>();
+        foreach (Match match in MarkdownHeadingLineRegex.Matches(markdown))
+        {
+            headings.Add(match.Groups["text"].Value.Trim());
+        }
+        return headings;
+    }
+
+    private static bool HasMatchingHeading(IReadOnlyList<string> headings, string section)
+    {
+        // Loose match: substring + case-insensitive. Accommodates
+        // variations like "Target Repo / Path / Part" matching "Target Repo".
+        foreach (var heading in headings)
+        {
+            if (heading.Contains(section, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static QueueStateEntry? FindQueueEntry(string queueStateJson, string executionUnit)
+    {
+        using var doc = JsonDocument.Parse(queueStateJson);
+        var root = doc.RootElement;
+
+        // Two common shapes: array of entries, OR object with "entries" array.
+        JsonElement entries;
+        if (root.ValueKind == JsonValueKind.Array)
+        {
+            entries = root;
+        }
+        else if (root.ValueKind == JsonValueKind.Object
+            && (root.TryGetProperty("entries", out entries)
+                || root.TryGetProperty("items", out entries))
+            && entries.ValueKind == JsonValueKind.Array)
+        {
+            // entries assigned by TryGetProperty out arg.
+        }
+        else
+        {
+            return null;
+        }
+
+        foreach (var entry in entries.EnumerateArray())
+        {
+            if (entry.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var unit = TryGetString(entry, "execution_unit") ?? TryGetString(entry, "executionUnit");
+            if (string.Equals(unit, executionUnit, StringComparison.Ordinal))
+            {
+                return new QueueStateEntry(
+                    Status: TryGetString(entry, "status"),
+                    LinkedIssue: TryGetIntProperty(entry, "linked_issue") ?? TryGetIntProperty(entry, "linkedIssue"),
+                    LinkedPr: TryGetIntProperty(entry, "linked_pr") ?? TryGetIntProperty(entry, "linkedPr"),
+                    Dependencies: TryGetStringArray(entry, "dependencies"));
+            }
+        }
+
+        return null;
+    }
+
+    private static string? TryGetString(JsonElement obj, string name)
+    {
+        if (obj.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String)
+        {
+            return prop.GetString();
+        }
+        return null;
+    }
+
+    private static int? TryGetIntProperty(JsonElement obj, string name)
+    {
+        if (!obj.TryGetProperty(name, out var prop))
+        {
+            return null;
+        }
+        if (prop.ValueKind == JsonValueKind.Number && prop.TryGetInt32(out var n))
+        {
+            return n;
+        }
+        if (prop.ValueKind == JsonValueKind.String
+            && int.TryParse(prop.GetString(),
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var parsed))
+        {
+            return parsed;
+        }
+        return null;
+    }
+
+    private static HashSet<string>? TryGetStringArray(JsonElement obj, string name)
+    {
+        if (!obj.TryGetProperty(name, out var prop) || prop.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var item in prop.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String && item.GetString() is { Length: > 0 } s)
+            {
+                set.Add(s);
+            }
+        }
+        return set;
+    }
+
+    private sealed record QueueStateEntry(
+        string? Status,
+        int? LinkedIssue,
+        int? LinkedPr,
+        HashSet<string>? Dependencies);
+}
+
+/// <summary>
+/// G207: Bundle of file contents the analyzer needs. Anything <c>null</c>
+/// represents "file not present on disk"; the analyzer raises the
+/// appropriate missing-file finding. Empty strings represent present-but-
+/// empty files.
+/// </summary>
+internal sealed record MetadataValidateInputs
+{
+    public required string ExecutionUnit { get; init; }
+    public string? PacketYaml { get; init; }
+    public string? GithubBodyMarkdown { get; init; }
+    public string? ReviewContextMarkdown { get; init; }
+    public string? ImplementationMarkdown { get; init; }
+    public string? PublishYaml { get; init; }
+    public string? QueueStateJson { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/MetadataValidateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/MetadataValidateCommand.cs
@@ -1,0 +1,214 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G207: <c>intent-cli metadata validate --root &lt;path&gt; --execution-unit &lt;ID&gt;
+/// [--format text|json]</c>. Read-only mechanical validator for parent-host
+/// packet metadata graphs.
+///
+/// No-mutation invariants (verified by tests):
+/// - never invokes <c>NestedProviderLauncher</c>;
+/// - never edits files (whole-workspace byte-snapshot before/after);
+/// - source-scan asserts the analyzer + command files contain no
+///   <c>Process.Start(</c>, no <c>gh issue edit</c>/<c>gh pr edit</c>/
+///   <c>gh pr merge</c>/<c>gh pr close</c>/<c>gh pr reopen</c>/
+///   <c>gh pr comment</c>/<c>gh pr review</c> literals in executable code,
+///   and no <c>resolveReviewThread</c> mutation literal.
+/// </summary>
+internal static class MetadataValidateCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    /// <summary>
+    /// Test sentinel: must NEVER be invoked. Tests assert it remains
+    /// uninvoked across all paths.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var root, out var executionUnit, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var rootPath = string.IsNullOrWhiteSpace(root)
+            ? context.RepoRoot ?? Directory.GetCurrentDirectory()
+            : root!;
+
+        MetadataValidateInputs inputs;
+        try
+        {
+            inputs = LoadInputs(rootPath, executionUnit!);
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or UnauthorizedAccessException)
+        {
+            writer.WriteLine($"failed to load metadata for {executionUnit} under {rootPath}: {exception.Message}");
+            return 1;
+        }
+
+        MetadataValidateResult result;
+        try
+        {
+            result = MetadataValidateAnalyzer.Analyze(inputs);
+        }
+        catch (Exception exception) when (
+            exception is ArgumentException
+            or InvalidOperationException)
+        {
+            writer.WriteLine($"failed to validate metadata for {executionUnit}: {exception.Message}");
+            return 1;
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return result.Valid ? 0 : 1;
+    }
+
+    private static MetadataValidateInputs LoadInputs(string rootPath, string executionUnit)
+    {
+        var unitDir = Path.Combine(rootPath, ".intent-cli", "issues", executionUnit);
+        var queueStatePath = Path.Combine(rootPath, ".intent-cli", "queue-state.json");
+
+        return new MetadataValidateInputs
+        {
+            ExecutionUnit = executionUnit,
+            PacketYaml = ReadIfExists(Path.Combine(unitDir, "packet.yaml")),
+            GithubBodyMarkdown = ReadIfExists(Path.Combine(unitDir, "github-body.md")),
+            ReviewContextMarkdown = ReadIfExists(Path.Combine(unitDir, "review-context.md")),
+            ImplementationMarkdown = ReadIfExists(Path.Combine(unitDir, "implementation.md")),
+            PublishYaml = ReadIfExists(Path.Combine(unitDir, "publish.yaml")),
+            QueueStateJson = ReadIfExists(queueStatePath),
+        };
+    }
+
+    private static string? ReadIfExists(string path) =>
+        File.Exists(path) ? File.ReadAllText(path) : null;
+
+    private static void WriteText(TextWriter writer, MetadataValidateResult result)
+    {
+        writer.WriteLine($"# Metadata validation for {result.ExecutionUnit}");
+        writer.WriteLine();
+        writer.WriteLine($"- valid: {result.Valid.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"- errors: {result.Errors.Count}");
+        writer.WriteLine($"- warnings: {result.Warnings.Count}");
+        writer.WriteLine();
+
+        if (result.Errors.Count > 0)
+        {
+            writer.WriteLine("## Errors");
+            foreach (var finding in result.Errors)
+            {
+                writer.WriteLine($"- [{finding.Code}] {finding.Message} ({finding.Path})");
+            }
+            writer.WriteLine();
+        }
+
+        if (result.Warnings.Count > 0)
+        {
+            writer.WriteLine("## Warnings");
+            foreach (var finding in result.Warnings)
+            {
+                writer.WriteLine($"- [{finding.Code}] {finding.Message} ({finding.Path})");
+            }
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Checked files");
+        foreach (var file in result.CheckedFiles)
+        {
+            writer.WriteLine($"- {file}");
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? root,
+        out string? executionUnit,
+        out string format,
+        out string error)
+    {
+        root = null;
+        executionUnit = null;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--root":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--root requires a value (path).";
+                        return false;
+                    }
+                    root = args[index + 1];
+                    index++;
+                    break;
+
+                case "--execution-unit":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--execution-unit requires a value (e.g. G206).";
+                        return false;
+                    }
+                    executionUnit = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --root <path> --execution-unit <ID> [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            error = "--execution-unit is required (e.g. --execution-unit G206).";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/MetadataValidateResult.cs
+++ b/src/IntentSystem.Cli/Commands/MetadataValidateResult.cs
@@ -1,0 +1,122 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G207: Read-only result emitted by <c>intent-cli metadata validate</c>.
+/// Reports whether the packet/queue/runs metadata graph for one execution
+/// unit is internally consistent. Field names mirror the issue contract
+/// example (camelCase for <c>executionUnit</c> / <c>checkedFiles</c>) with
+/// snake_case aliases for local style consistency, mirroring the
+/// G202–G206 alias pattern.
+///
+/// Producing this record never mutates GitHub, never edits files, never
+/// touches the queue/runs logs, and never launches any AI provider.
+/// </summary>
+internal sealed record MetadataValidateResult
+{
+    [JsonPropertyName("valid")]
+    public required bool Valid { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    /// <summary>G207 issue contract alias — camelCase per #519 example.</summary>
+    [JsonPropertyName("executionUnit")]
+    public string ExecutionUnitCamelCase => ExecutionUnit;
+
+    [JsonPropertyName("errors")]
+    public required IReadOnlyList<MetadataValidateFinding> Errors { get; init; }
+
+    [JsonPropertyName("warnings")]
+    public required IReadOnlyList<MetadataValidateFinding> Warnings { get; init; }
+
+    [JsonPropertyName("checked_files")]
+    public required IReadOnlyList<string> CheckedFiles { get; init; }
+
+    /// <summary>G207 issue contract alias — camelCase per #519 example.</summary>
+    [JsonPropertyName("checkedFiles")]
+    public IReadOnlyList<string> CheckedFilesCamelCase => CheckedFiles;
+}
+
+/// <summary>
+/// G207: Single error / warning entry. <see cref="Code"/> is a stable
+/// machine-readable identifier; <see cref="Message"/> is the human form.
+/// <see cref="Path"/> names the relative file path the finding came from
+/// (or is empty when the finding spans multiple files).
+/// </summary>
+internal sealed record MetadataValidateFinding
+{
+    [JsonPropertyName("code")]
+    public required string Code { get; init; }
+
+    [JsonPropertyName("message")]
+    public required string Message { get; init; }
+
+    [JsonPropertyName("path")]
+    public string Path { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// G207: Stable string constants for the validation finding codes.
+/// </summary>
+internal static class MetadataValidateConstants
+{
+    public static class Codes
+    {
+        // Existence / parse errors.
+        public const string PacketFileMissing = "packet.file.missing";
+        public const string PacketYamlUnparseable = "packet.yaml.unparseable";
+        public const string GithubBodyMissing = "github-body.missing";
+        public const string ReviewContextMissing = "review-context.missing";
+        public const string PublishYamlUnparseable = "publish.yaml.unparseable";
+        public const string QueueStateMissing = "queue-state.missing";
+        public const string QueueStateUnparseable = "queue-state.unparseable";
+        public const string ImplementationFileMissing = "implementation.file.missing";
+
+        // Required content.
+        public const string PacketMissingExecutionUnit = "packet.missing.execution_unit";
+        public const string PacketMissingTitle = "packet.missing.title";
+        public const string PublishMissingIssueNumber = "publish.missing.issue_number";
+        public const string PublishMissingIssueUrl = "publish.missing.issue_url";
+        public const string GithubBodyMissingSection = "github-body.missing.section";
+        public const string ReviewContextMissingSection = "review-context.missing.section";
+
+        // Cross-file consistency.
+        public const string PublishQueueIssueMismatch = "consistency.publish-queue.issue.mismatch";
+        public const string CompletedMissingClosure = "consistency.queue.completed.missing_closure";
+        public const string PacketQueueDependencyMismatch = "consistency.packet-queue.dependency.mismatch";
+        public const string QueueEntryMissing = "consistency.queue.entry.missing";
+
+        // Label-policy warnings.
+        public const string LabelPolicyMisplacedPrCreated = "label-policy.misplaced.intent-pr-created";
+    }
+
+    public static IReadOnlyList<string> RequiredGithubBodySections { get; } = new[]
+    {
+        "Goal",
+        "Why This Slice Exists Now",
+        "Current Observed State",
+        "Accepted Baseline You May Assume",
+        "Target Repo",
+        "In Scope",
+        "Out Of Scope",
+        "Acceptance Criteria",
+        "Verification",
+        "Related Links",
+    };
+
+    public static IReadOnlyList<string> RequiredReviewContextSections { get; } = new[]
+    {
+        // Per #519: "execution unit, child repo, linked issue, linked PR,
+        // accepted baseline, deterministic review checks, and closeout
+        // lookahead sections or equivalent fields".
+        "Execution Unit",
+        "Child Repo",
+        "Linked Issue",
+        "Linked PR",
+        "Accepted Baseline",
+        "Deterministic Review Checks",
+        "Closeout Lookahead",
+    };
+}

--- a/tests/IntentSystem.Cli.Tests/MetadataValidateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/MetadataValidateCommandTests.cs
@@ -26,6 +26,230 @@ public sealed class MetadataValidateCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_GivenParentHostSchemaShape_ReturnsValidWithExitZero()
+    {
+        // G207 follow-up regression for #519 review:
+        // The actual parent-host packet schema nests fields under
+        // `implementation_issue_packet:` and `issue:`, and uses `state` /
+        // object-shaped `linked_issue` / `linked_pr` in queue-state.json.
+        // The validator must recognize that real shape — earlier fixtures
+        // used flat keys and missed this contract.
+        using var ws = new MetadataValidateWorkspace();
+        var unitDir = Path.Combine(ws.RootPath, ".intent-cli", "issues", "G207");
+        Directory.CreateDirectory(unitDir);
+
+        File.WriteAllText(Path.Combine(unitDir, "packet.yaml"), """
+            implementation_issue_packet:
+              issue_title: "G207 Add intent packet metadata validation command"
+              issue_kind: feature
+              source_execution_unit: G207
+              goal: "Add a deterministic local intent-cli command..."
+              target_repo: J-Tech-Japan/intent-system
+              target_path: .
+              target_part: "intent-cli metadata validation"
+            """);
+
+        File.WriteAllText(Path.Combine(unitDir, "github-body.md"), """
+            ## Goal
+            ...
+            ## Why This Slice Exists Now
+            ...
+            ## Current Observed State
+            ...
+            ## Accepted Baseline You May Assume
+            ...
+            ## Target Repo / Path / Part
+            ...
+            ## In Scope
+            ...
+            ## Out Of Scope
+            ...
+            ## Acceptance Criteria
+            ...
+            ## Verification
+            ...
+            ## Related Links
+            ...
+            """);
+
+        File.WriteAllText(Path.Combine(unitDir, "review-context.md"),
+            "## Execution Unit\nG207\n## Child Repo\n...\n## Linked Issue\n...\n"
+            + "## Linked PR\n...\n## Accepted Baseline\n...\n"
+            + "## Deterministic Review Checks\n...\n## Closeout Lookahead\n...\n");
+
+        File.WriteAllText(Path.Combine(unitDir, "implementation.md"), "notes\n");
+
+        // Real host publish.yaml shape: nested issue.{number,url}.
+        File.WriteAllText(Path.Combine(unitDir, "publish.yaml"), """
+            execution_unit: G207
+            issue:
+              number: 519
+              url: https://github.com/J-Tech-Japan/intent-system/issues/519
+              status: published
+              intent_target_label_applied: true
+              published_at: 2026-04-30T07:05:32Z
+            """);
+
+        // Real host queue-state.json shape: top-level items[] with
+        // object-shaped linked_issue (no linked_pr while queued).
+        var queueState = """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-30T07:20:25Z",
+              "items": [
+                {
+                  "execution_unit": "G207",
+                  "title": "G207 Add intent packet metadata validation command",
+                  "state": "queued",
+                  "dependencies": ["G205", "G206"],
+                  "linked_issue": {
+                    "repo": "J-Tech-Japan/intent-system",
+                    "number": 519,
+                    "url": "https://github.com/J-Tech-Japan/intent-system/issues/519"
+                  }
+                }
+              ]
+            }
+            """;
+        File.WriteAllText(
+            Path.Combine(ws.RootPath, ".intent-cli", "queue-state.json"),
+            queueState);
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G207", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataValidateResult>(writer.ToString())!;
+        Assert.True(result.Valid,
+            $"expected the host-schema fixture to validate, errors={string.Join(", ", result.Errors.Select(e => e.Code))}");
+    }
+
+    [Fact]
+    public void Execute_HostSchemaCompletedWithLinkedPrObject_IsValid()
+    {
+        // Host queue-state encodes a completed item's linked_pr as an
+        // object with `number`. The validator must read the number from
+        // the object form and not flag CompletedMissingClosure.
+        using var ws = new MetadataValidateWorkspace();
+        var unitDir = Path.Combine(ws.RootPath, ".intent-cli", "issues", "G177");
+        Directory.CreateDirectory(unitDir);
+        File.WriteAllText(Path.Combine(unitDir, "packet.yaml"), """
+            implementation_issue_packet:
+              issue_title: "G177 done"
+              source_execution_unit: G177
+            """);
+        File.WriteAllText(Path.Combine(unitDir, "github-body.md"), """
+            ## Goal
+            ## Why This Slice Exists Now
+            ## Current Observed State
+            ## Accepted Baseline You May Assume
+            ## Target Repo / Path / Part
+            ## In Scope
+            ## Out Of Scope
+            ## Acceptance Criteria
+            ## Verification
+            ## Related Links
+            """);
+        File.WriteAllText(Path.Combine(unitDir, "review-context.md"),
+            "## Execution Unit\n## Child Repo\n## Linked Issue\n## Linked PR\n"
+            + "## Accepted Baseline\n## Deterministic Review Checks\n## Closeout Lookahead\n");
+        File.WriteAllText(Path.Combine(unitDir, "implementation.md"), "x\n");
+        File.WriteAllText(
+            Path.Combine(ws.RootPath, ".intent-cli", "queue-state.json"),
+            """
+            {
+              "items": [
+                {
+                  "execution_unit": "G177",
+                  "state": "completed",
+                  "linked_issue": { "number": 459 },
+                  "linked_pr":    { "number": 460 }
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G177", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataValidateResult>(writer.ToString())!;
+        Assert.True(result.Valid,
+            $"expected completed object-shaped linked_pr to validate, errors={string.Join(", ", result.Errors.Select(e => e.Code))}");
+        Assert.DoesNotContain(result.Errors, e =>
+            e.Code == MetadataValidateConstants.Codes.CompletedMissingClosure);
+    }
+
+    [Fact]
+    public void Execute_HostSchemaPublishQueueIssueMismatch_DetectsAcrossNestedShapes()
+    {
+        // Cross-file consistency must still fire when publish.yaml's
+        // nested `issue.number` disagrees with queue-state's object-shaped
+        // `linked_issue.number`.
+        using var ws = new MetadataValidateWorkspace();
+        var unitDir = Path.Combine(ws.RootPath, ".intent-cli", "issues", "G207");
+        Directory.CreateDirectory(unitDir);
+        File.WriteAllText(Path.Combine(unitDir, "packet.yaml"), """
+            implementation_issue_packet:
+              issue_title: "G207 mismatch"
+              source_execution_unit: G207
+            """);
+        File.WriteAllText(Path.Combine(unitDir, "github-body.md"), """
+            ## Goal
+            ## Why This Slice Exists Now
+            ## Current Observed State
+            ## Accepted Baseline You May Assume
+            ## Target Repo / Path / Part
+            ## In Scope
+            ## Out Of Scope
+            ## Acceptance Criteria
+            ## Verification
+            ## Related Links
+            """);
+        File.WriteAllText(Path.Combine(unitDir, "review-context.md"),
+            "## Execution Unit\n## Child Repo\n## Linked Issue\n## Linked PR\n"
+            + "## Accepted Baseline\n## Deterministic Review Checks\n## Closeout Lookahead\n");
+        File.WriteAllText(Path.Combine(unitDir, "implementation.md"), "x\n");
+        File.WriteAllText(Path.Combine(unitDir, "publish.yaml"), """
+            execution_unit: G207
+            issue:
+              number: 999
+              url: https://github.com/example/repo/issues/999
+              status: published
+            """);
+        File.WriteAllText(
+            Path.Combine(ws.RootPath, ".intent-cli", "queue-state.json"),
+            """
+            {
+              "items": [
+                {
+                  "execution_unit": "G207",
+                  "state": "queued",
+                  "linked_issue": { "number": 519 }
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G207", "--format", "json" },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataValidateResult>(writer.ToString())!;
+        Assert.Contains(result.Errors, e =>
+            e.Code == MetadataValidateConstants.Codes.PublishQueueIssueMismatch);
+    }
+
+    [Fact]
     public void Execute_GivenValidMetadata_ReturnsValidWithExitZero()
     {
         using var ws = new MetadataValidateWorkspace();

--- a/tests/IntentSystem.Cli.Tests/MetadataValidateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/MetadataValidateCommandTests.cs
@@ -1,0 +1,513 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G207: Tests for <c>intent-cli metadata validate</c>. Cover the cases
+/// listed in #519 Acceptance Criteria: valid metadata, missing packet
+/// file, missing standalone issue section, publish/queue linked-issue
+/// mismatch, completed item missing closeout evidence, and label-policy
+/// warning. Plus the no-mutation invariants.
+/// </summary>
+public sealed class MetadataValidateCommandTests : IDisposable
+{
+    public MetadataValidateCommandTests()
+    {
+        MetadataValidateCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        MetadataValidateCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void Execute_GivenValidMetadata_ReturnsValidWithExitZero()
+    {
+        using var ws = new MetadataValidateWorkspace();
+        ws.WriteValidPacket("G206", linkedIssue: 517, linkedPr: 518, status: "completed");
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G206", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataValidateResult>(writer.ToString())!;
+        Assert.True(result.Valid);
+        Assert.Equal("G206", result.ExecutionUnit);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketFile_ReturnsErrorAndExitOne()
+    {
+        using var ws = new MetadataValidateWorkspace();
+        ws.WriteValidPacket("G206", linkedIssue: 517, linkedPr: 518, status: "completed");
+        // Remove just the packet.yaml.
+        File.Delete(Path.Combine(ws.RootPath, ".intent-cli", "issues", "G206", "packet.yaml"));
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G206", "--format", "json" },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataValidateResult>(writer.ToString())!;
+        Assert.False(result.Valid);
+        Assert.Contains(result.Errors, e =>
+            e.Code == MetadataValidateConstants.Codes.PacketFileMissing);
+    }
+
+    [Fact]
+    public void Execute_GivenGithubBodyMissingSection_ReturnsError()
+    {
+        using var ws = new MetadataValidateWorkspace();
+        ws.WriteValidPacket("G206", linkedIssue: 517, linkedPr: 518, status: "completed");
+        // Overwrite github-body.md to omit "Acceptance Criteria".
+        var bodyPath = Path.Combine(ws.RootPath, ".intent-cli", "issues", "G206", "github-body.md");
+        File.WriteAllText(bodyPath, """
+            ## Goal
+            ...
+            ## Why This Slice Exists Now
+            ...
+            ## Current Observed State
+            ...
+            ## Accepted Baseline You May Assume
+            ...
+            ## Target Repo / Path / Part
+            ...
+            ## In Scope
+            ...
+            ## Out Of Scope
+            ...
+            ## Verification
+            ...
+            ## Related Links
+            ...
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G206", "--format", "json" },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataValidateResult>(writer.ToString())!;
+        Assert.Contains(result.Errors, e =>
+            e.Code == MetadataValidateConstants.Codes.GithubBodyMissingSection
+            && e.Message.Contains("Acceptance Criteria", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenPublishQueueIssueMismatch_ReturnsError()
+    {
+        using var ws = new MetadataValidateWorkspace();
+        // queue-state says issue 517; publish.yaml says issue 999. That's
+        // a hard inconsistency.
+        ws.WriteValidPacket("G206", linkedIssue: 517, linkedPr: 518, status: "completed");
+        var publishPath = Path.Combine(ws.RootPath, ".intent-cli", "issues", "G206", "publish.yaml");
+        File.WriteAllText(publishPath, """
+            execution_unit: G206
+            issue_number: 999
+            issue_url: https://github.com/example/repo/issues/999
+            status: published
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G206", "--format", "json" },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataValidateResult>(writer.ToString())!;
+        Assert.Contains(result.Errors, e =>
+            e.Code == MetadataValidateConstants.Codes.PublishQueueIssueMismatch);
+    }
+
+    [Fact]
+    public void Execute_GivenCompletedQueueItemWithoutLinkedPr_ReturnsError()
+    {
+        using var ws = new MetadataValidateWorkspace();
+        // status=completed but linked_pr null → missing closeout evidence.
+        ws.WriteValidPacket("G206", linkedIssue: 517, linkedPr: null, status: "completed");
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G206", "--format", "json" },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataValidateResult>(writer.ToString())!;
+        Assert.Contains(result.Errors, e =>
+            e.Code == MetadataValidateConstants.Codes.CompletedMissingClosure);
+    }
+
+    [Fact]
+    public void Execute_GivenLabelPolicyMisplacedPrCreated_EmitsWarningButStillValidIfNoErrors()
+    {
+        using var ws = new MetadataValidateWorkspace();
+        ws.WriteValidPacket("G206", linkedIssue: 517, linkedPr: 518, status: "completed");
+        // Misplaced label policy: intent-pr-created on the PR position.
+        var publishPath = Path.Combine(ws.RootPath, ".intent-cli", "issues", "G206", "publish.yaml");
+        File.WriteAllText(publishPath, """
+            execution_unit: G206
+            issue_number: 517
+            issue_url: https://github.com/example/repo/issues/517
+            status: published
+            pr_label: intent-pr-created
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G206", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataValidateResult>(writer.ToString())!;
+        Assert.True(result.Valid);
+        Assert.Contains(result.Warnings, w =>
+            w.Code == MetadataValidateConstants.Codes.LabelPolicyMisplacedPrCreated);
+    }
+
+    [Fact]
+    public void Execute_GivenQueueStateMissing_ReturnsErrorWithExitOne()
+    {
+        using var ws = new MetadataValidateWorkspace();
+        ws.WriteValidPacket("G206", linkedIssue: 517, linkedPr: 518, status: "completed");
+        File.Delete(Path.Combine(ws.RootPath, ".intent-cli", "queue-state.json"));
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G206", "--format", "json" },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataValidateResult>(writer.ToString())!;
+        Assert.Contains(result.Errors, e =>
+            e.Code == MetadataValidateConstants.Codes.QueueStateMissing);
+    }
+
+    [Fact]
+    public void Execute_MissingExecutionUnit_ReturnsNonZero()
+    {
+        using var ws = new MetadataValidateWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("--execution-unit is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_TextFormat_RendersStableSections()
+    {
+        using var ws = new MetadataValidateWorkspace();
+        ws.WriteValidPacket("G206", linkedIssue: 517, linkedPr: null, status: "completed");
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G206" },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        var raw = writer.ToString();
+        Assert.Contains("# Metadata validation for G206", raw, StringComparison.Ordinal);
+        Assert.Contains("- valid: false", raw, StringComparison.Ordinal);
+        Assert.Contains("## Errors", raw, StringComparison.Ordinal);
+        Assert.Contains("## Checked files", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsonOutput_IncludesCamelCaseAliasesForExecutionUnitAndCheckedFiles()
+    {
+        using var ws = new MetadataValidateWorkspace();
+        ws.WriteValidPacket("G206", linkedIssue: 517, linkedPr: 518, status: "completed");
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G206", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var raw = writer.ToString();
+        Assert.Contains("\"execution_unit\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"executionUnit\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"checked_files\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"checkedFiles\"", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesNestedProviderLauncher()
+    {
+        using var ws = new MetadataValidateWorkspace();
+        ws.WriteValidPacket("G206", linkedIssue: 517, linkedPr: 518, status: "completed");
+        var launcherInvoked = false;
+        MetadataValidateCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+
+        using var writer = new StringWriter();
+        // Walk both valid and invalid paths.
+        Assert.Equal(0, MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G206", "--format", "json" },
+            writer));
+
+        File.Delete(Path.Combine(ws.RootPath, ".intent-cli", "issues", "G206", "packet.yaml"));
+        writer.GetStringBuilder().Clear();
+        Assert.NotEqual(0, MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", "G206", "--format", "json" },
+            writer));
+
+        Assert.False(launcherInvoked,
+            "MetadataValidateCommand must never invoke NestedProviderLauncher.");
+    }
+
+    [Fact]
+    public void Execute_LeavesPacketWorkspaceByteEquivalent()
+    {
+        // The validator is read-only — no file may be created or modified
+        // by execution. Snapshot the entire packet workspace before and
+        // after a couple of validation passes.
+        using var ws = new MetadataValidateWorkspace();
+        ws.WriteValidPacket("G206", linkedIssue: 517, linkedPr: 518, status: "completed");
+        var before = ws.SnapshotWorkspace();
+
+        using (var writer = new StringWriter())
+        {
+            Assert.Equal(0, MetadataValidateCommand.Execute(
+                ws.Context,
+                new[] { "--root", ws.RootPath, "--execution-unit", "G206", "--format", "json" },
+                writer));
+            Assert.Equal(0, MetadataValidateCommand.Execute(
+                ws.Context,
+                new[] { "--root", ws.RootPath, "--execution-unit", "G206" },
+                writer));
+        }
+
+        var after = ws.SnapshotWorkspace();
+        Assert.Equal(before.Count, after.Count);
+        foreach (var (path, hash) in before)
+        {
+            Assert.True(after.TryGetValue(path, out var afterHash),
+                $"file disappeared after run: {path}");
+            Assert.Equal(hash, afterHash);
+        }
+    }
+
+    [Fact]
+    public void SourceScan_AnalyzerAndCommand_ContainNoProcessStartOrGhMutationLiterals()
+    {
+        // Strip C# comments before scanning so the doc-comments naming
+        // forbidden mutations do not cause false positives.
+        var analyzer = StripCsharpComments(File.ReadAllText(LocateSourceFile("MetadataValidateAnalyzer.cs")));
+        var command = StripCsharpComments(File.ReadAllText(LocateSourceFile("MetadataValidateCommand.cs")));
+        var combined = analyzer + "\n" + command;
+
+        Assert.DoesNotContain("Process.Start(", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh issue edit", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr edit", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr merge", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr close", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr reopen", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr comment", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr review", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("resolveReviewThread", combined, StringComparison.Ordinal);
+    }
+
+    private static string StripCsharpComments(string source)
+    {
+        var noBlock = System.Text.RegularExpressions.Regex.Replace(
+            source, @"/\*[\s\S]*?\*/", string.Empty);
+        var noLine = System.Text.RegularExpressions.Regex.Replace(
+            noBlock, @"//.*?$", string.Empty,
+            System.Text.RegularExpressions.RegexOptions.Multiline);
+        return noLine;
+    }
+
+    private static string LocateSourceFile(string fileName)
+    {
+        var directory = AppContext.BaseDirectory;
+        var dir = new DirectoryInfo(directory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(
+                dir.FullName, "src", "IntentSystem.Cli", "Commands", fileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = dir.Parent;
+        }
+        throw new FileNotFoundException(
+            $"Could not locate source file {fileName} from {directory}");
+    }
+
+    private sealed class MetadataValidateWorkspace : IDisposable
+    {
+        public MetadataValidateWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("metadata-validate-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli", "issues"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+
+        /// <summary>
+        /// Writes a coherent packet bundle for the given execution unit so
+        /// each test only has to mutate the one file the test cares about.
+        /// </summary>
+        public void WriteValidPacket(
+            string executionUnit,
+            int linkedIssue,
+            int? linkedPr,
+            string status)
+        {
+            var unitDir = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
+            Directory.CreateDirectory(unitDir);
+
+            File.WriteAllText(Path.Combine(unitDir, "packet.yaml"), $"""
+                execution_unit: {executionUnit}
+                title: {executionUnit} valid packet
+                target_repo: J-Tech-Japan/intent-system
+                """);
+
+            File.WriteAllText(Path.Combine(unitDir, "github-body.md"), """
+                ## Goal
+                Goal text.
+
+                ## Why This Slice Exists Now
+                Why text.
+
+                ## Current Observed State
+                State text.
+
+                ## Accepted Baseline You May Assume
+                Baseline text.
+
+                ## Target Repo / Path / Part
+                J-Tech-Japan/intent-system
+
+                ## In Scope
+                Scope text.
+
+                ## Out Of Scope
+                Not in scope.
+
+                ## Acceptance Criteria
+                Criteria.
+
+                ## Verification
+                Verification text.
+
+                ## Related Links
+                - link
+                """);
+
+            File.WriteAllText(Path.Combine(unitDir, "review-context.md"), """
+                ## Execution Unit
+                G206
+
+                ## Child Repo
+                J-Tech-Japan/intent-system
+
+                ## Linked Issue
+                #517
+
+                ## Linked PR
+                #518
+
+                ## Accepted Baseline
+                baseline
+
+                ## Deterministic Review Checks
+                checks
+
+                ## Closeout Lookahead
+                lookahead
+                """);
+
+            File.WriteAllText(Path.Combine(unitDir, "implementation.md"), "Implementation notes.\n");
+
+            File.WriteAllText(Path.Combine(unitDir, "publish.yaml"), $"""
+                execution_unit: {executionUnit}
+                issue_number: {linkedIssue}
+                issue_url: https://github.com/example/repo/issues/{linkedIssue}
+                status: published
+                """);
+
+            // Construct the queue-state with one entry for this unit.
+            var entry = new Dictionary<string, object?>
+            {
+                ["execution_unit"] = executionUnit,
+                ["status"] = status,
+                ["linked_issue"] = linkedIssue,
+            };
+            if (linkedPr is { } pr)
+            {
+                entry["linked_pr"] = pr;
+            }
+            var queueState = new Dictionary<string, object?>
+            {
+                ["entries"] = new[] { entry }
+            };
+            File.WriteAllText(
+                Path.Combine(RootPath, ".intent-cli", "queue-state.json"),
+                JsonSerializer.Serialize(queueState,
+                    new JsonSerializerOptions { WriteIndented = true }));
+        }
+
+        public IReadOnlyDictionary<string, string> SnapshotWorkspace()
+        {
+            var snapshot = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(RootPath, "*", SearchOption.AllDirectories))
+            {
+                var bytes = File.ReadAllBytes(path);
+                var hash = Convert.ToHexString(SHA256.HashData(bytes));
+                snapshot[path] = hash;
+            }
+            return snapshot;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `intent-cli metadata validate --root <path> --execution-unit <ID> [--format text|json]` under a new `metadata` command group. Mechanically validates the parent-host packet metadata graph for one execution unit. Read-only — no GitHub network, no file mutation, no provider launch.
- Validation rules per #519 In Scope: required packet files (`packet.yaml`, `github-body.md`, `review-context.md`); standalone github-body sections (Goal / Why / Current Observed State / Accepted Baseline / Target Repo / In Scope / Out Of Scope / Acceptance Criteria / Verification / Related Links); recommended review-context sections (Execution Unit / Child Repo / Linked Issue / Linked PR / Accepted Baseline / Deterministic Review Checks / Closeout Lookahead); cross-file consistency (publish.issue_number ↔ queue-state.linked_issue, completed → linked_pr, packet dependencies ↔ queue dependencies); label-policy warning when publish.yaml records `intent-pr-created` as a PR label.
- Pure analyzer + thin file-loader command: `MetadataValidateAnalyzer.Analyze` is data-in/data-out and tests inject `MetadataValidateInputs` directly; `MetadataValidateCommand` reads files off disk. Returns exit 0 when valid, non-zero on errors or malformed args.
- JSON shape: snake_case primary + camelCase aliases (`executionUnit`, `checkedFiles`) — mirrors the G202–G206 alias pattern.

## Test plan

- [x] Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release --filter \"FullyQualifiedName~MetadataValidate\"` — **13/13 passing**. Cases covered: valid metadata, missing packet file, missing standalone github-body section, publish/queue linked-issue mismatch, queue-state completed without linked_pr (missing closeout evidence), label-policy misplaced intent-pr-created → warning, missing queue-state, missing --execution-unit argument, text-format stable sections, camelCase alias parity, nested-provider-launcher sentinel never invoked, whole-workspace byte-equivalence, source-scan against Process.Start + gh-mutation + GraphQL-mutation.
- [x] Full CLI suite: 1361 passed + 1 pre-existing skip, 0 failed.

### Sample JSON output

**Invalid execution unit (no packets):**

```json
{
  \"valid\": false,
  \"execution_unit\": \"G999\",
  \"executionUnit\": \"G999\",
  \"errors\": [
    { \"code\": \"packet.file.missing\",     \"message\": \"required packet file not found: .intent-cli/issues/G999/packet.yaml\",     \"path\": \".intent-cli/issues/G999/packet.yaml\" },
    { \"code\": \"github-body.missing\",     \"message\": \"required github-body file not found: ...\",   \"path\": \".intent-cli/issues/G999/github-body.md\" },
    { \"code\": \"review-context.missing\",  \"message\": \"required review-context file not found: ...\",\"path\": \".intent-cli/issues/G999/review-context.md\" },
    { \"code\": \"queue-state.missing\",     \"message\": \"required queue-state file not found: .intent-cli/queue-state.json\", \"path\": \".intent-cli/queue-state.json\" }
  ],
  \"warnings\": [
    { \"code\": \"implementation.file.missing\", \"message\": \"recommended implementation file not found: ...\", \"path\": \".intent-cli/issues/G999/implementation.md\" }
  ],
  \"checked_files\": [\".intent-cli/issues/G999/packet.yaml\", \".intent-cli/issues/G999/github-body.md\", \".intent-cli/issues/G999/review-context.md\", \".intent-cli/issues/G999/implementation.md\", \".intent-cli/queue-state.json\"],
  \"checkedFiles\": [...]
}
```

**Valid execution unit:**

```json
{
  \"valid\": true,
  \"execution_unit\": \"G206\",
  \"executionUnit\": \"G206\",
  \"errors\": [],
  \"warnings\": [],
  \"checked_files\": [\".intent-cli/issues/G206/packet.yaml\", \".intent-cli/issues/G206/github-body.md\", \".intent-cli/issues/G206/review-context.md\", \".intent-cli/issues/G206/implementation.md\", \".intent-cli/issues/G206/publish.yaml\", \".intent-cli/queue-state.json\"]
}
```

### Confirmation (no-mutation invariants verified by tests)

- The command does NOT mutate GitHub state — no gh CLI invocation. Source-scan rejects all 7 `gh issue edit`/`gh pr edit`/`gh pr merge`/`gh pr close`/`gh pr reopen`/`gh pr comment`/`gh pr review` literal patterns in the analyzer + command files (doc comments stripped before scan).
- The command does NOT edit any files — whole-workspace byte-snapshot before/after asserts no file is created or modified by the validator.
- The command does NOT post comments / merge / close / resolve threads — `resolveReviewThread` GraphQL mutation literal explicitly rejected.
- The command does NOT launch AI providers — sentinel `NestedProviderLauncher` never invoked across both valid and invalid paths + source-scan rejecting `Process.Start(` in command/analyzer.
- The command does NOT touch the queue/runs logs — same byte-snapshot test covers `.intent-cli/queue-state.json` and `.intent-cli/runs.jsonl` if present.

Closes #519