### PR TITLE
G209: add local coding automation prompt templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,20 @@ review/next-slice loop and the provider-neutral label set described by
 `intent-cli automation summary`. For nested-provider handoff steps, use
 `intent-cli safety nested-provider-handoff` to emit a deterministic artifact
 instead of recursively launching providers from inside `run`.
+
+## Local coding automation prompt templates
+
+Operator-dogfooding prompt templates that drive a local Claude/Codex coding
+automation loop entirely through the deterministic `intent-cli` worker and
+metadata commands (G202–G208) live under
+[`docs/automation-templates/`](./docs/automation-templates/README.md). They
+make explicit that:
+
+- target selection runs through `intent-cli worker next-action`; prompts
+  never reimplement label-walking;
+- post-run outcomes go through `intent-cli worker result-summary`;
+- parent-host metadata is touched only via `metadata validate` and the
+  bounded `metadata update` transition modes;
+- `intent-cli` is deterministic support tooling — it MUST NOT launch
+  Claude, Codex, or any AI provider, and prompts must NOT call
+  `intent-cli run` from this local coding-automation path.

--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -1,0 +1,67 @@
+# Local Coding Automation Prompt Templates
+
+Operator-dogfooding-grade prompt templates that drive the local
+Claude/Codex coding automation loop entirely through the deterministic
+`intent-cli` worker and metadata commands. The templates are
+intentionally narrow in scope: they capture the prompt text an operator
+hands to the AI worker, not the AI worker behavior itself.
+
+These templates assume:
+
+- `intent-cli` is on the operator's `PATH`, or invoked through a pinned
+  wrapper exposed by the operator's `MyIntentHost` setup.
+- The local automation loop reads an `intent-cli worker next-action`
+  classification and runs at most ONE workflow per wake.
+- All target selection, label policy, and outcome normalization is done
+  by `intent-cli`; prompts must NOT reimplement label-selection logic in
+  natural language.
+
+## Layered intent-cli surface (consumed by these templates)
+
+| Slice | Command | Role |
+|-------|---------|------|
+| G202  | `intent-cli worker issue-preflight`     | "Is this issue actionable?" |
+| G203  | `intent-cli worker pr-review-preflight` | "Is this PR ready to review?" |
+| G204  | `intent-cli worker pr-comment-preflight`| "Does this PR need repair?" |
+| G205  | `intent-cli worker result-summary`      | Normalize a worker run's outcome |
+| G206  | `intent-cli worker next-action`         | Pick at most one target |
+| G207  | `intent-cli metadata validate`          | Mechanical packet validator |
+| G208  | `intent-cli metadata update`            | Bounded controlled writer |
+
+## Template index
+
+| File | Path | What it covers |
+|------|------|----------------|
+| [`coding-automation-loop.md`](./coding-automation-loop.md)         | combined loop | One wake: choose between PR repair / issue-to-PR / none |
+| [`issue-to-pr-execution.md`](./issue-to-pr-execution.md)           | issue handoff | Run `gh-issue-to-pr` workflow on the returned issue URL, summarize result |
+| [`pr-comment-fix-execution.md`](./pr-comment-fix-execution.md)     | PR repair handoff | Apply repair on the returned PR URL, summarize result |
+| [`metadata-safety.md`](./metadata-safety.md)                       | metadata boundaries | Validate before / after, controlled update only when explicit |
+
+## Hard rules these templates enforce
+
+- **Single source of truth for target selection**: prompts must call
+  `intent-cli worker next-action --format json` and act on its result.
+  No manual label-walking in the prompt body.
+- **No provider launch from `intent-cli`**: `intent-cli` is deterministic
+  support tooling; it must NEVER spawn Claude / Codex / any AI provider.
+  External AI workers run separately and consume `intent-cli` JSON.
+- **Do not call `intent-cli run`** from this local coding automation
+  path. `intent-cli run` is a separate command family with different
+  semantics and is out of scope here.
+- **Label policy invariant**: `intent-pr-created` belongs on the source
+  ISSUE, not on the PR. Prompts and post-run summaries that imply
+  otherwise are a bug — `worker result-summary` will surface this as a
+  warning automatically when it detects misuse.
+- **Single-target cap**: at most ONE branch/PR is touched per wake. If
+  `worker next-action` returns `none`, the wake is idle and ends without
+  pushing anything.
+
+## What is intentionally out of scope here
+
+- new worker commands;
+- changes to `intent-cli run`;
+- scheduler / cron registration;
+- mutating GitHub issues or PRs from prompts;
+- writing into the parent-host `MyIntentHost` repository from this
+  child repository's prompts;
+- distributing these templates as a public package.

--- a/docs/automation-templates/coding-automation-loop.md
+++ b/docs/automation-templates/coding-automation-loop.md
@@ -1,0 +1,89 @@
+# Combined Coding Automation Loop
+
+Use this prompt at the top of one wake of the local coding automation
+loop. It picks at most ONE target via `intent-cli worker next-action`
+and dispatches to the appropriate execution-handoff template.
+
+> **Hard rules** (do not paraphrase):
+> - Use `intent-cli worker next-action --format json` to choose work.
+>   Do NOT walk labels manually in this prompt.
+> - At most ONE branch/PR per wake.
+> - `intent-cli` MUST NOT launch any AI provider. The external AI
+>   worker runs separately on the URL this command returns.
+> - Do NOT call `intent-cli run` from this path.
+
+## Inputs
+
+- `--repo <owner/repo>` — child repo this loop targets.
+
+## Step 1: pick the next action
+
+```bash
+intent-cli worker next-action \
+  --repo "$REPO" \
+  --format json
+```
+
+The output has a stable shape (G206):
+
+```json
+{
+  "action": "pr-comment-fix" | "issue-to-pr" | "none",
+  "repo": "...",
+  "number": <int|null>,
+  "url": "<github URL|null>",
+  "reason": "...",
+  "recommended_workflow": "pr-comment-fix" | "gh-issue-to-pr" | null,
+  "recommendedWorkflow": "...",
+  "warnings": [...],
+  "source_classification": "...",
+  "sourceClassification": "..."
+}
+```
+
+## Step 2: dispatch on `action`
+
+| `action`           | Handoff template                                 |
+|--------------------|--------------------------------------------------|
+| `pr-comment-fix`   | [`pr-comment-fix-execution.md`](./pr-comment-fix-execution.md) — repair the returned PR URL |
+| `issue-to-pr`      | [`issue-to-pr-execution.md`](./issue-to-pr-execution.md) — implement the returned issue URL via the `gh-issue-to-pr` workflow |
+| `none`             | End the wake. NO push. NO label mutation. Emit a `status: idle` summary line. |
+
+If `warnings[]` is non-empty, surface each warning verbatim in the wake
+summary so the operator sees label-policy issues such as
+`intent-pr-created` being misplaced on a PR.
+
+## Step 3: post-run summary (after the AI worker returns)
+
+When the dispatched handoff has finished and produced an outcome string
+(e.g. `pr-created`, `repair-pushed`, `clarification-required`, `failed`),
+ask the operator (or the controlling automation) to run:
+
+```bash
+intent-cli worker result-summary \
+  --kind <issue-to-pr|pr-comment-fix> \
+  --repo "$REPO" \
+  [--issue <n>] [--pr <n>] \
+  --outcome <outcome> \
+  --format json
+```
+
+Use the JSON `recommended_label_actions[]` and `warnings[]` to render the
+wake summary. Do NOT mutate labels from this prompt — those actions are
+advisory; the controlling automation applies them via its own gh CLI
+layer.
+
+## Idempotency
+
+This template is fully idempotent: running it again on a state where
+`next-action` returns `none` is a no-op. Running it during a wake whose
+selected work is already in progress (in-progress label set) returns
+`none` and ends the wake.
+
+## What this template forbids
+
+- Manually selecting a target by reading labels in natural language.
+- Calling `intent-cli run` instead of an external AI worker.
+- Asking `intent-cli` to launch Claude or Codex.
+- Adding `intent-pr-created` to a PR (it belongs on the source issue).
+- Touching more than one branch/PR per wake.

--- a/docs/automation-templates/issue-to-pr-execution.md
+++ b/docs/automation-templates/issue-to-pr-execution.md
@@ -1,0 +1,85 @@
+# Issue-to-PR Execution Handoff
+
+Used when the combined loop's [`coding-automation-loop.md`](./coding-automation-loop.md)
+returned `action: "issue-to-pr"`. The AI worker (Claude / Codex) takes
+the returned issue URL and runs the `gh-issue-to-pr` workflow against
+it, then a post-run `result-summary` step is recorded.
+
+> **Hard rules** (do not paraphrase):
+> - The issue URL/number is taken from the upstream
+>   `worker next-action` result. Do NOT pick a different target.
+> - `intent-pr-created` belongs on the source ISSUE, not on the PR
+>   that gets created. The post-run `result-summary` will surface this
+>   as a warning if it appears on the PR.
+> - At most ONE PR is created per wake.
+
+## Inputs (from the upstream `next-action` result)
+
+- `repo`        — `<owner/repo>` of the child repo
+- `number`      — issue number
+- `url`         — issue URL
+- `recommended_workflow` — should be `gh-issue-to-pr`
+- `source_classification` — should be `ready-to-implement`
+
+## Step 1: hand off to the AI worker
+
+The external AI worker runs the `gh-issue-to-pr` workflow on the
+returned issue URL. The prompt to the AI worker should include:
+
+- the issue URL verbatim,
+- a reminder that this worker MUST NOT add `intent-target` to the
+  created PR,
+- a reminder that `intent-pr-created` (when applied) belongs on the
+  source issue, not on the PR.
+
+## Step 2: capture the outcome
+
+After the AI worker returns, classify the outcome as one of (G205
+schema):
+
+| Outcome                          | Means                                                  |
+|----------------------------------|--------------------------------------------------------|
+| `pr-created`                     | New draft PR opened against `origin/main`.             |
+| `declined-contract-incomplete`   | The issue body was insufficient; AI worker stopped.    |
+| `clarification-required`         | Contract was ambiguous; cooldown stop.                 |
+| `already-resolved`               | Already on `origin/main`; nothing to do.               |
+| `failed`                         | Worker stopped with an error mid-run.                  |
+| `label-cleanup-required`         | Stale labels left behind after a partial run.          |
+
+## Step 3: normalize via `result-summary`
+
+```bash
+intent-cli worker result-summary \
+  --kind issue-to-pr \
+  --repo "$REPO" \
+  --issue "$ISSUE_NUMBER" \
+  [--pr "$PR_NUMBER"] \
+  --outcome "$OUTCOME" \
+  --format json
+```
+
+This emits stable `recommended_label_actions[]` advice — for the
+happy `pr-created` path it will recommend:
+
+- remove `intent-issue-in-progress` from the source issue,
+- add `intent-pr-created` to the source issue.
+
+The controlling automation applies those edits via its own gh layer.
+The prompt here MUST NOT call `gh issue edit` or `gh pr edit` directly.
+
+## Verification (deterministic)
+
+- `intent-cli worker next-action --format json` → an issue URL.
+- AI worker runs `gh-issue-to-pr` against that URL.
+- `intent-cli worker result-summary` returns `valid: true` and an
+  outcome whose `status` is one of `completed` / `declined` /
+  `clarification-required` / `failed` / `label-cleanup-required`.
+- No additional GitHub mutations from this prompt.
+
+## What this template forbids
+
+- Selecting a different issue than the one returned by `next-action`.
+- Adding `intent-target` to the created PR.
+- Adding `intent-pr-created` to the PR (it belongs on the source issue).
+- Calling `intent-cli run`.
+- Asking `intent-cli` to launch the AI worker.

--- a/docs/automation-templates/metadata-safety.md
+++ b/docs/automation-templates/metadata-safety.md
@@ -1,0 +1,91 @@
+# Metadata Safety: Validate Before / Update With Intent
+
+These guidelines apply when a coding-automation prompt is about to
+operate against a parent-host packet root (e.g. `MyIntentHost`-style
+`.intent-cli/issues/<execution-unit>/`). They keep packet metadata
+consistent without giving the prompt free-form write authority.
+
+> **Hard rules** (do not paraphrase):
+> - Read-only validation FIRST. Always run `intent-cli metadata
+>   validate` against the selected execution unit before invoking any
+>   metadata writer.
+> - Use `intent-cli metadata update` only with an EXPLICIT supported
+>   transition mode. Do not use it to mass-edit packet content.
+> - `--root <path>` is REQUIRED for `metadata update`. There is NO
+>   silent fallback to the process working directory.
+
+## When to call validate
+
+| Situation                                              | Call                                              |
+|--------------------------------------------------------|---------------------------------------------------|
+| Before queueing or routing a packet                    | `metadata validate --root <host> --execution-unit <ID>` |
+| Before a closeout / merge step                         | `metadata validate --root <host> --execution-unit <ID>` |
+| After applying a `metadata update` transition          | `metadata validate --root <host> --execution-unit <ID>` (sanity check) |
+| When G207 surfaces warnings via `worker result-summary` | run `metadata validate` to capture full finding list |
+
+Sample call:
+
+```bash
+intent-cli metadata validate \
+  --root "$HOST_ROOT" \
+  --execution-unit "$EXEC_UNIT" \
+  --format json
+```
+
+Treat any `errors[]` item as a hard stop unless an explicit transition
+mode is intended to fix it (see G208's filter for
+`consistency.queue.completed.missing_closure`).
+
+## When to call update
+
+`metadata update` is a controlled writer. This slice (G208) supports
+exactly one transition mode:
+
+| Mode                  | What it does                                                                                       |
+|-----------------------|---------------------------------------------------------------------------------------------------|
+| `completed-closeout`  | On the selected queue item: set `state=completed`, attach object-shaped `linked_pr`, write `head_sha` + `merge_commit`; append a `pr:` block to `publish.yaml`; append one `metadata-update.completed-closeout` event to `runs.jsonl`. Refuse-to-clobber if the queue item is already completed or `publish.yaml` already has a `pr:` block. |
+
+Sample call:
+
+```bash
+intent-cli metadata update \
+  --root "$HOST_ROOT" \
+  --execution-unit "$EXEC_UNIT" \
+  --mode completed-closeout \
+  --linked-pr "$PR_NUMBER" \
+  --linked-pr-repo "$REPO" \
+  --linked-pr-url "$PR_URL" \
+  --head-sha "$HEAD_SHA" \
+  --merge-commit "$MERGE_COMMIT" \
+  --format json
+```
+
+Pre-validation runs automatically inside `metadata update`; it refuses
+on any hard error other than the one it exists to fix.
+
+## Bounded write surface
+
+`metadata update` modifies ONLY these files under `--root`:
+
+- `.intent-cli/queue-state.json` (matching item only)
+- `.intent-cli/issues/<execution-unit>/publish.yaml` (append `pr:` block)
+- `.intent-cli/runs.jsonl` (append one event line)
+
+A whole-workspace byte-snapshot test in the G208 implementation locks
+this invariant. Any other file is byte-identical before and after.
+
+## What this template forbids
+
+- Calling `metadata update` without `--root`. The flag is required;
+  there is no fallback to the process working directory.
+- Using `metadata update` for transitions other than the supported
+  modes. New transition needs go through a new G2xx slice that adds
+  the mode + tests.
+- Calling `metadata update` to "fix" arbitrary metadata drift. If a
+  packet is hard-invalid, treat it as a clarification stop and let the
+  parent-host owner repair the source.
+- Touching the parent host repository's git state from this child
+  repository's prompts. The metadata writer mutates the packet files
+  in place; the operator (or the host's own automation) commits them.
+- Asking `intent-cli` to launch any AI provider during validation or
+  update.

--- a/docs/automation-templates/pr-comment-fix-execution.md
+++ b/docs/automation-templates/pr-comment-fix-execution.md
@@ -1,0 +1,81 @@
+# PR Comment-Fix Execution Handoff
+
+Used when the combined loop's [`coding-automation-loop.md`](./coding-automation-loop.md)
+returned `action: "pr-comment-fix"`. The AI worker takes the returned
+PR URL, applies the narrow repair, pushes, and a post-run
+`result-summary` step is recorded.
+
+> **Hard rules** (do not paraphrase):
+> - The PR URL/number is taken from the upstream `worker next-action`
+>   result. Do NOT pick a different PR.
+> - The repair MUST be narrow: address only the host's most recent
+>   repair-request comment. Do NOT widen scope.
+> - At most ONE PR is touched per wake.
+
+## Inputs (from the upstream `next-action` result)
+
+- `repo`        — `<owner/repo>`
+- `number`      — PR number
+- `url`         — PR URL
+- `recommended_workflow` — should be `pr-comment-fix`
+- `source_classification` — should be `repair-required`
+
+## Step 1: hand off to the AI worker
+
+Provide the AI worker with the PR URL and the most recent host repair
+comment text. The worker:
+
+1. checks out the PR's head branch,
+2. applies the narrow fix the comment requested,
+3. runs the project's verification (e.g. `dotnet test ... --filter ...`),
+4. pushes the branch,
+5. posts a single "Update — fix applied" comment on the PR.
+
+## Step 2: capture the outcome
+
+Classify the outcome as one of (G205 schema):
+
+| Outcome                  | Means                                                          |
+|--------------------------|----------------------------------------------------------------|
+| `repair-pushed`          | A new commit was pushed; PR ready for re-review.               |
+| `no-actionable-comments` | No actionable repair feedback remains.                         |
+| `already-resolved`       | The PR is already at the resolved state on `origin/main`.      |
+| `clarification-required` | The repair-request was ambiguous; cooldown stop, no push.      |
+| `failed`                 | The worker errored before pushing.                             |
+| `label-cleanup-required` | Stale labels left behind after a partial run.                  |
+
+## Step 3: normalize via `result-summary`
+
+```bash
+intent-cli worker result-summary \
+  --kind pr-comment-fix \
+  --repo "$REPO" \
+  --pr "$PR_NUMBER" \
+  --outcome "$OUTCOME" \
+  --format json
+```
+
+For the happy `repair-pushed` path the recommended advice is a single
+swap action: `intent-pr-update-in-progress` → `intent-pr-rereview-ready`
+on the PR. The controlling automation applies the swap via its own gh
+layer; this prompt MUST NOT call `gh pr edit` directly.
+
+## Verification (deterministic)
+
+- `intent-cli worker next-action --format json` → a PR URL.
+- AI worker pushes a single repair commit and posts the update note.
+- `intent-cli worker result-summary` returns `valid: true` for the
+  outcome.
+- The host's recurring deterministic-rereview comment is no longer
+  classified as `repair-required` once the label-state advances to
+  `intent-pr-rereview-ready`.
+
+## What this template forbids
+
+- Selecting a different PR than the one returned by `next-action`.
+- Widening the repair beyond the latest host repair-request comment.
+- Posting more than one "Update — fix applied" comment per wake.
+- Calling `intent-cli run`.
+- Asking `intent-cli` to launch the AI worker.
+- Adding/removing `intent-target` on the PR (this loop never owns
+  `intent-target`).


### PR DESCRIPTION
## Summary

- Adds operator-dogfooding prompt templates under `docs/automation-templates/` that drive a local Claude/Codex coding automation loop entirely through the deterministic `intent-cli` worker and metadata commands (G202–G208) instead of embedding target-selection or label-walking logic in prompt text.
- Files added: `README.md` (index + hard rules), `coding-automation-loop.md` (combined per-wake loop using `worker next-action`), `issue-to-pr-execution.md` (issue handoff + `worker result-summary`), `pr-comment-fix-execution.md` (PR repair handoff + `worker result-summary`), `metadata-safety.md` (`metadata validate` before / `metadata update` with explicit mode).
- Files updated: top-level `README.md` adds a link to the new docs index.
- The templates explicitly state the issue-required rules: prompts MUST use `worker next-action` for target selection (no manual label-walking); MUST NOT call `intent-cli run`; MUST NOT ask `intent-cli` to launch any AI provider; `intent-pr-created` belongs on the source ISSUE, not the PR; single-target cap per wake; `metadata update --root` is required and supports only the bounded `completed-closeout` mode in this slice.

## Paths added or updated

- `docs/automation-templates/README.md` (new)
- `docs/automation-templates/coding-automation-loop.md` (new)
- `docs/automation-templates/issue-to-pr-execution.md` (new)
- `docs/automation-templates/pr-comment-fix-execution.md` (new)
- `docs/automation-templates/metadata-safety.md` (new)
- `README.md` (link added to docs index)

## Local workflow covered

| Wake step | Command(s) used by the prompt |
|-----------|-------------------------------|
| Pick at most one target | `intent-cli worker next-action --format json` |
| Issue-to-PR handoff     | external `gh-issue-to-pr` workflow on the returned issue URL |
| PR repair handoff       | external repair workflow on the returned PR URL |
| Post-run normalization  | `intent-cli worker result-summary --kind <kind> --outcome <outcome> --format json` |
| Metadata pre-check      | `intent-cli metadata validate --root <host> --execution-unit <ID>` |
| Metadata closeout write | `intent-cli metadata update --root <host> --execution-unit <ID> --mode completed-closeout --linked-pr <n> [--head-sha …] [--merge-commit …]` |

## Test plan

- [x] `git diff --check` — clean (docs only).
- [x] CLI project still builds (no source files modified): `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release --nologo` → 0 Error(s).
- [x] No documentation snapshot tests exist for this directory; per the issue's Verification section, the narrowest relevant validation is `git diff --check`.

## Confirmation

- The PR adds NO provider-launch behavior to `intent-cli`. (The templates explicitly forbid prompts asking `intent-cli` to launch Claude / Codex.)
- The PR adds NO GitHub mutation commands to the templates. (Label edits are advisory output from `worker result-summary`; the controlling automation applies them via its own gh layer.)
- The PR adds NO scheduler/cron registration.
- The PR adds NO `intent-cli run` behavior or any change to the `run` command surface. (The templates explicitly state that `intent-cli run` is out of scope for this local coding-automation path.)
- The PR does NOT change any parent-host file or any `MyIntentHost` content from this child repository.
- The PR does NOT add any new worker command. The slice is purely documentation/template additions consuming the existing G202–G208 surface.

Closes #523