### PR TITLE
G210: add local automation dry-run checklist

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -36,6 +36,7 @@ These templates assume:
 | [`issue-to-pr-execution.md`](./issue-to-pr-execution.md)           | issue handoff | Run `gh-issue-to-pr` workflow on the returned issue URL, summarize result |
 | [`pr-comment-fix-execution.md`](./pr-comment-fix-execution.md)     | PR repair handoff | Apply repair on the returned PR URL, summarize result |
 | [`metadata-safety.md`](./metadata-safety.md)                       | metadata boundaries | Validate before / after, controlled update only when explicit |
+| [`dry-run-checklist.md`](./dry-run-checklist.md)                   | operator dry-run | Read-only pre-flight to confirm wrapper / commands / no-action / metadata wiring before arming the loop |
 
 ## Hard rules these templates enforce
 

--- a/docs/automation-templates/dry-run-checklist.md
+++ b/docs/automation-templates/dry-run-checklist.md
@@ -1,0 +1,289 @@
+# Local Automation Dry-Run Checklist
+
+Operator-dogfooding pre-flight checklist for the local Claude/Codex
+coding automation loop. Run this BEFORE arming any scheduler / cron /
+session loop so that the first real wake doesn't fail on wrapper /
+PATH / command-shape drift.
+
+This checklist is **read-only by default**. Every step here is either
+a `--help`-style discovery call, a JSON-emitting selector that does
+not mutate state, a fixture-driven sample render, or a packet
+validator that never writes. No step in this checklist creates or
+mutates GitHub issues, PRs, labels, branches, runs, or parent-host
+queue state, and no step launches Claude, Codex, or any AI provider.
+
+> **Hard rules** (do not paraphrase):
+> - `intent-cli` is deterministic support tooling. It MUST NOT launch
+>   Claude, Codex, or any AI provider — not from this checklist, not
+>   from the local coding automation loop, not from prompts.
+> - This local coding automation path MUST NOT call `intent-cli run`.
+>   `intent-cli run` is a separate command family with different
+>   semantics (integration smoke / deterministic replay / local
+>   dogfooding) and is intentionally out of scope here.
+> - Prompts MUST NOT manually reimplement label-selection logic when
+>   `intent-cli worker next-action` is available. Target selection is
+>   single-sourced through the worker selector.
+> - `intent-pr-created` belongs on the source ISSUE, not on the PR.
+>   `worker result-summary` surfaces this misuse as a warning; the
+>   checklist preserves that invariant.
+
+## When to run this checklist
+
+- Before enabling a fresh local automation session for the first
+  time on a given machine.
+- After upgrading `intent-cli` or rotating the local wrapper that
+  exposes it on `PATH`.
+- After updating any prompt template under `docs/automation-templates/`.
+- When a wake produced an unexpected `worker next-action` shape and
+  you want to confirm the installed CLI matches the prompts on disk.
+
+If every step below succeeds with the expected shape, the loop is
+safe to arm. If any step fails, fix the underlying configuration —
+do NOT paper over it inside the prompt.
+
+## 1. Verify the wrapper / PATH
+
+The local automation loop assumes `intent-cli` resolves through the
+operator's `PATH`, optionally via a pinned wrapper.
+
+```bash
+command -v intent-cli
+intent-cli --version
+```
+
+Expected:
+
+- `command -v` prints a single absolute path.
+- `--version` prints the installed tool's version string and exits 0.
+
+If `command -v` prints nothing, the wrapper is not on `PATH` — fix
+the wrapper / shell configuration and re-run this step. Do not
+hard-code an absolute path in the prompt templates.
+
+## 2. Verify command discovery
+
+`intent-cli` exposes the layered worker / metadata surface that the
+prompts depend on. Confirm the binary on `PATH` actually exposes
+those subcommands.
+
+```bash
+intent-cli --help
+intent-cli worker --help
+intent-cli metadata --help
+```
+
+Expected (at minimum, names — exact help text may evolve):
+
+- `worker` lists `issue-preflight`, `pr-review-preflight`,
+  `pr-comment-preflight`, `result-summary`, `next-action`.
+- `metadata` lists `validate`, `update`.
+
+If any of those names is missing, the installed `intent-cli` is
+older than the prompt templates expect. Upgrade before continuing.
+
+## 3. Smoke-test `worker next-action` (target selection)
+
+`worker next-action` is the single source of truth for "what does
+this wake do?". Confirm it returns parseable JSON with the expected
+shape, against the live repo, in a no-op state.
+
+```bash
+intent-cli worker next-action \
+  --repo "<owner>/<repo>" \
+  --format json
+```
+
+Expected:
+
+- exit code 0,
+- stdout is a single JSON object,
+- top-level keys include at least `recommendedWorkflow` and
+  `sourceClassification`.
+
+Pipe through `jq` to confirm parseability:
+
+```bash
+intent-cli worker next-action \
+  --repo "<owner>/<repo>" \
+  --format json \
+  | jq '{recommendedWorkflow, sourceClassification}'
+```
+
+If the call cannot reach GitHub, fix the auth path (`gh auth status`)
+before continuing. Do NOT fall back to manual label-walking inside
+the prompt body — the loop is not safe to arm until this command
+works end-to-end.
+
+## 4. Smoke-test the no-action path
+
+Verify the loop's idle behavior. When there is no eligible target,
+`worker next-action` must be explicit about it; the prompt then
+treats the wake as idle and stops without pushing anything.
+
+```bash
+intent-cli worker next-action \
+  --repo "<owner>/<repo>" \
+  --format json \
+  | jq -r '.recommendedWorkflow'
+```
+
+Expected on an idle repo (no `intent-target` issues, no
+`intent-pr-request-update` PRs ready for repair): the output is
+either `none` or another non-action value documented by the
+selector. The local loop interprets that as **idle: do nothing,
+push nothing, mutate no labels**.
+
+If the selector instead returns an actionable workflow on an
+already-quiet repo, stop and inspect — the prompt must not fabricate
+a target on top of a non-action selector result.
+
+## 5. Smoke-test `worker result-summary` (issue-to-PR outcome)
+
+`worker result-summary` is how each wake's result is normalized into
+a stable JSON shape that downstream summaries / status comments can
+consume without re-deriving labels. Confirm it can render an
+issue-to-PR outcome shape without mutation.
+
+```bash
+intent-cli worker result-summary \
+  --kind issue-to-pr \
+  --outcome pr-created \
+  --repo "<owner>/<repo>" \
+  --issue 123 \
+  --pr 124 \
+  --format json
+```
+
+Expected:
+
+- exit code 0,
+- stdout is a single JSON object with at least `kind`, `outcome`,
+  `status`, `recommendedLabelActions[]`, and `summary`.
+
+Important: this is a **render-only** call. It does NOT touch
+GitHub. The numbers above can be placeholders; pick values that
+exist if you want a richer dry run, but do not pass values that
+would imply mutation downstream.
+
+## 6. Smoke-test `worker result-summary` (PR comment-fix outcome)
+
+Repeat the same render-only check for the PR repair workflow. This
+is the path the loop uses after a `gh-fix-pr-comment`-style fix.
+
+```bash
+intent-cli worker result-summary \
+  --kind pr-comment-fix \
+  --outcome update-applied \
+  --repo "<owner>/<repo>" \
+  --pr 124 \
+  --format json
+```
+
+Expected:
+
+- exit code 0,
+- the JSON's `recommendedLabelActions[]` reflects the
+  reviewing → rereview-ready handoff, NOT a fresh
+  `intent-pr-created` on the PR.
+- `intent-pr-created` does not appear as a recommended add on a PR.
+  If it does, treat it as a bug — `intent-pr-created` belongs on
+  the source ISSUE, not on the PR.
+
+## 7. Validate metadata against a sample / selected root
+
+`metadata validate` is a pure read against parent-host packet
+artifacts under a host-style `--root`. It NEVER writes. Use this
+step to confirm both that the binary supports the expected packet
+schema and that the operator's host root is wired correctly.
+
+```bash
+intent-cli metadata validate \
+  --root "$HOST_ROOT" \
+  --execution-unit "$EXEC_UNIT" \
+  --format json
+```
+
+Expected:
+
+- exit code 0 when the packet is valid.
+- exit code non-zero on hard inconsistency. The JSON includes
+  `valid`, `executionUnit`, `errors[]`, `warnings[]`, and
+  `checkedFiles[]`.
+
+If `$HOST_ROOT` / `$EXEC_UNIT` is not yet known, run against a
+known-good fixture or skip this step — but do NOT arm the loop with
+unverified metadata wiring on a path that the loop is expected to
+touch.
+
+This step performs no GitHub mutation, no file mutation, no queue
+or runs mutation, no branch / worktree creation, no PR / issue
+creation, no comment posting, no merge, and no provider launch.
+
+## 8. Confirm controlled metadata-update boundaries
+
+`metadata update` is a bounded controlled writer. It is **not**
+part of dry-run smoke; it is mentioned here so the operator
+internalizes its boundaries before the loop is armed.
+
+Allowed:
+
+- `metadata update --root <host> --execution-unit <ID> --mode completed-closeout …`
+  with the full set of required arguments. Pre-validates with G207;
+  refuses to clobber an already-completed item or a `publish.yaml`
+  that already has a `pr:` block.
+
+Not allowed (treat any of these as a clarification stop, not a
+prompt patch):
+
+- calling `metadata update` without `--root` (the flag is REQUIRED;
+  there is no fallback to the process working directory),
+- using `metadata update` for transitions other than the supported
+  mode (new transitions go through a new G2xx slice that adds the
+  mode + tests),
+- mass-editing arbitrary packet content,
+- touching parent host git state from this child repository's
+  prompts.
+
+See [`metadata-safety.md`](./metadata-safety.md) for the canonical
+description of the bounded write surface.
+
+## 9. Confirm prompt-template invariants
+
+Before arming the loop, re-read the per-template hard rules:
+
+- [`README.md`](./README.md) — index, layered surface, and the
+  global "no provider launch / no `intent-cli run` / single source
+  of target selection / `intent-pr-created` is an issue label /
+  single-target cap" rules.
+- [`coding-automation-loop.md`](./coding-automation-loop.md) — the
+  combined per-wake loop that gates on `worker next-action`.
+- [`issue-to-pr-execution.md`](./issue-to-pr-execution.md) —
+  issue handoff + `worker result-summary` on completion.
+- [`pr-comment-fix-execution.md`](./pr-comment-fix-execution.md) —
+  PR repair handoff + `worker result-summary` on completion.
+- [`metadata-safety.md`](./metadata-safety.md) — validate before /
+  controlled update only on an explicit supported mode.
+
+If any prompt body has drifted away from those invariants — for
+example by reintroducing manual label-walking, or by calling
+`intent-cli run`, or by recommending `intent-pr-created` on a PR —
+fix the prompt before arming the loop.
+
+## 10. Confirm what this checklist does NOT do
+
+Explicit out-of-scope, by design:
+
+- Does NOT register a scheduler, cron job, session loop, or daemon.
+- Does NOT launch Claude, Codex, or any AI provider.
+- Does NOT create or mutate GitHub issues, PRs, labels, comments,
+  branches, or worktrees.
+- Does NOT mutate parent-host queue state, runs logs, or packet
+  files.
+- Does NOT change `intent-cli run` behavior. The local coding
+  automation path does not call `intent-cli run`.
+- Does NOT distribute these templates as a public package.
+
+If a future slice adds a machine-readable readiness command (e.g.
+`intent-cli worker readiness`) the steps above are the manual
+shape that command would encode; until then, this checklist is the
+authoritative dry-run gate.


### PR DESCRIPTION
Closes #525

## Summary

- Adds `docs/automation-templates/dry-run-checklist.md`, a read-only operator pre-flight checklist for the local Claude/Codex coding automation loop.
- Updates `docs/automation-templates/README.md` to link the new checklist from the template index.

## Paths added or updated

- `docs/automation-templates/dry-run-checklist.md` (new)
- `docs/automation-templates/README.md` (link added to template index)

## Dry-run checklist steps covered

1. Verify the wrapper / PATH (`command -v intent-cli`, `--version`).
2. Verify command discovery (`intent-cli --help`, `worker --help`, `metadata --help`).
3. Smoke-test `worker next-action` (target selection JSON shape, parseable via jq).
4. Smoke-test the no-action / idle path (selector returning `none` => idle wake, no push, no label mutation).
5. Smoke-test `worker result-summary` for the issue-to-pr outcome (render-only).
6. Smoke-test `worker result-summary` for the pr-comment-fix outcome, including the assertion that `intent-pr-created` is NOT recommended on the PR.
7. `metadata validate` against a host-style `--root` (read-only).
8. `metadata update` boundaries (allowed `completed-closeout` mode, required `--root`, refuse-to-clobber semantics).
9. Re-confirm prompt-template invariants under `docs/automation-templates/`.
10. Explicit out-of-scope list (no scheduler, no provider launch, no GitHub mutation, no parent-host writes, no `intent-cli run`).

## Confirmation that the checklist is read-only by default

Every step is either a `--help`-style discovery call, a JSON-emitting selector that does not mutate state, a render-only `result-summary` call, or a packet validator that never writes. The `metadata update` step is mentioned only to internalize boundaries; it is not part of the dry-run smoke.

## Confirmation of what was NOT added

- No scheduler / cron / session-loop registration.
- No new worker or metadata commands.
- No changes to `intent-cli run` behavior.
- No GitHub mutation (no issues/PRs/labels/comments created or modified by the checklist).
- No mutation of parent-host queue state, runs logs, or packet files.
- No provider launch — `intent-cli` does not spawn Claude / Codex / any AI provider, and the checklist preserves that invariant.

## Test plan

- [ ] Render the new checklist and confirm it reads as a coherent operator pre-flight.
- [ ] Confirm the README index now links `dry-run-checklist.md`.
- [ ] Confirm no command in the checklist mutates GitHub, packet, or queue state when followed literally.