### PR TITLE
G211: add optional worker claim and complete commands

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -132,7 +132,9 @@ internal static class CommandRouter
                 ["pr-review-preflight"] = WorkerPrReviewPreflightCommand.Execute,
                 ["pr-comment-preflight"] = WorkerPrCommentPreflightCommand.Execute,
                 ["result-summary"] = WorkerResultSummaryCommand.Execute,
-                ["next-action"] = WorkerNextActionCommand.Execute
+                ["next-action"] = WorkerNextActionCommand.Execute,
+                ["claim"] = WorkerClaimCommand.Execute,
+                ["complete"] = WorkerCompleteCommand.Execute
             },
             ["metadata"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/IGitHubLabelMutator.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubLabelMutator.cs
@@ -1,0 +1,263 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G211: Testability seam for the <c>intent-cli worker claim</c> and
+/// <c>intent-cli worker complete</c> commands. The production
+/// implementation shells out to <c>gh issue/pr view --json labels</c>
+/// (read) and <c>gh issue/pr edit --add-label / --remove-label</c>
+/// (write); tests inject a fake to avoid GitHub network access and to
+/// verify the dry-run / write split.
+/// </summary>
+internal interface IGitHubLabelMutator
+{
+    /// <summary>
+    /// Read the current labels on the issue/PR identified by
+    /// <paramref name="repo"/>, <paramref name="kind"/>, and
+    /// <paramref name="number"/>. Read-only — never mutates GitHub.
+    /// </summary>
+    IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number);
+
+    /// <summary>
+    /// Apply the requested add/remove transitions in a single round
+    /// trip per direction. Implementations MUST reject inputs that
+    /// imply <c>intent-pr-created</c> on a PR target — that label is
+    /// issue-only by policy.
+    /// </summary>
+    void ApplyLabelTransitions(
+        string repo,
+        string kind,
+        int number,
+        IReadOnlyCollection<string> addLabels,
+        IReadOnlyCollection<string> removeLabels);
+}
+
+/// <summary>
+/// G211: Default mutator that shells out to <c>gh</c>. The only file
+/// in the worker claim/complete surface permitted to call
+/// <c>Process.Start</c> — analyzer and command layers stay pure. The
+/// add/remove arguments are issued in a single <c>gh edit</c> call so
+/// the operation is roughly atomic from GitHub's perspective.
+///
+/// All gh edit calls go through the policy-checking
+/// <see cref="ApplyLabelTransitions"/> entry point; direct shell-out is
+/// not exposed.
+/// </summary>
+internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator
+{
+    /// <summary>
+    /// G211: stable kind tokens accepted by <see cref="ReadLabels"/> and
+    /// <see cref="ApplyLabelTransitions"/>. Exposed internally so the
+    /// command layer can validate before calling the mutator.
+    /// </summary>
+    public static class Kinds
+    {
+        public const string Issue = "issue";
+        public const string Pr = "pr";
+    }
+
+    /// <summary>
+    /// G211: <c>gh view --json labels</c> field name. Exposed so
+    /// adapter-shape tests can lock the supported subset.
+    /// </summary>
+    internal const string ViewJsonFields = "labels";
+
+    /// <summary>
+    /// G211: build the <c>gh issue/pr view</c> argument list shared by
+    /// the live adapter and adapter-shape tests.
+    /// </summary>
+    internal static IReadOnlyList<string> BuildViewArguments(string repo, string kind, int number)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        if (number <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(number),
+                "issue/PR number must be positive.");
+        }
+        if (!string.Equals(kind, Kinds.Issue, StringComparison.Ordinal)
+            && !string.Equals(kind, Kinds.Pr, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"unrecognized kind '{kind}'. Supported: '{Kinds.Issue}', '{Kinds.Pr}'.",
+                nameof(kind));
+        }
+
+        return new List<string>
+        {
+            kind,
+            "view",
+            number.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            "--repo", repo,
+            "--json", ViewJsonFields,
+        };
+    }
+
+    /// <summary>
+    /// G211: build the <c>gh issue/pr edit</c> argument list. Empty
+    /// add/remove sets short-circuit — the caller skips the call.
+    /// </summary>
+    internal static IReadOnlyList<string> BuildEditArguments(
+        string repo,
+        string kind,
+        int number,
+        IReadOnlyCollection<string> addLabels,
+        IReadOnlyCollection<string> removeLabels)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        ArgumentNullException.ThrowIfNull(addLabels);
+        ArgumentNullException.ThrowIfNull(removeLabels);
+        if (number <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(number),
+                "issue/PR number must be positive.");
+        }
+        if (!string.Equals(kind, Kinds.Issue, StringComparison.Ordinal)
+            && !string.Equals(kind, Kinds.Pr, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"unrecognized kind '{kind}'. Supported: '{Kinds.Issue}', '{Kinds.Pr}'.",
+                nameof(kind));
+        }
+
+        var args = new List<string>
+        {
+            kind,
+            "edit",
+            number.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            "--repo", repo,
+        };
+        foreach (var label in addLabels)
+        {
+            if (string.IsNullOrWhiteSpace(label))
+            {
+                continue;
+            }
+            args.Add("--add-label");
+            args.Add(label);
+        }
+        foreach (var label in removeLabels)
+        {
+            if (string.IsNullOrWhiteSpace(label))
+            {
+                continue;
+            }
+            args.Add("--remove-label");
+            args.Add(label);
+        }
+        return args;
+    }
+
+    public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number)
+    {
+        var args = BuildViewArguments(repo, kind, number);
+        var stdout = RunGh(args, $"read labels on {kind} #{number} in {repo}");
+        return DeserializeLabels(stdout, $"`gh {kind} view #{number}` for {repo}");
+    }
+
+    public void ApplyLabelTransitions(
+        string repo,
+        string kind,
+        int number,
+        IReadOnlyCollection<string> addLabels,
+        IReadOnlyCollection<string> removeLabels)
+    {
+        ArgumentNullException.ThrowIfNull(addLabels);
+        ArgumentNullException.ThrowIfNull(removeLabels);
+
+        // Policy guard: intent-pr-created is issue-only. The analyzer
+        // already refuses this combination, but we also reject it at
+        // the mutator boundary so direct callers can't bypass policy.
+        if (string.Equals(kind, Kinds.Pr, StringComparison.Ordinal)
+            && (addLabels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal)
+                || removeLabels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal)))
+        {
+            throw new InvalidOperationException(
+                $"label policy violation: '{WorkerNextActionConstants.Labels.IntentPrCreated}' is issue-only and must not be applied to a PR.");
+        }
+
+        if (addLabels.Count == 0 && removeLabels.Count == 0)
+        {
+            return; // nothing to do
+        }
+
+        var args = BuildEditArguments(repo, kind, number, addLabels, removeLabels);
+        RunGh(args,
+            $"apply label transitions on {kind} #{number} in {repo}");
+    }
+
+    private static string RunGh(IReadOnlyList<string> arguments, string description)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        string stdout;
+        string stderr;
+        int exitCode;
+        try
+        {
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException(
+                    $"failed to start `gh` process to {description}");
+            stdout = process.StandardOutput.ReadToEnd();
+            stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            exitCode = process.ExitCode;
+        }
+        catch (Exception exception) when (
+            exception is System.ComponentModel.Win32Exception
+            or InvalidOperationException
+            or IOException)
+        {
+            throw new InvalidOperationException(
+                $"could not invoke `gh` to {description}: {exception.Message}",
+                exception);
+        }
+
+        if (exitCode != 0)
+        {
+            var errorBody = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+            throw new InvalidOperationException(
+                $"`gh` failed to {description} with exit {exitCode}: {errorBody.Trim()}");
+        }
+
+        return stdout;
+    }
+
+    private static IReadOnlyList<GitHubAutomationLabel> DeserializeLabels(
+        string stdout,
+        string callDescription)
+    {
+        try
+        {
+            var view = JsonSerializer.Deserialize<LabelView>(stdout);
+            return view?.Labels ?? (IReadOnlyList<GitHubAutomationLabel>)Array.Empty<GitHubAutomationLabel>();
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException(
+                $"could not parse {callDescription} JSON: {exception.Message}",
+                exception);
+        }
+    }
+
+    private sealed record LabelView
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("labels")]
+        public IReadOnlyList<GitHubAutomationLabel> Labels { get; init; }
+            = Array.Empty<GitHubAutomationLabel>();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerClaimAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerClaimAnalyzer.cs
@@ -1,0 +1,165 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G211: Pure deterministic mapper for <c>intent-cli worker claim</c>.
+/// Given the kind and the issue/PR's current label set, computes the
+/// claim transition (add / remove) plus any stale-selection errors and
+/// policy warnings.
+///
+/// Pure: no I/O, no Process.Start, no GitHub network, no provider
+/// launch. The command layer reads current labels via the mutator
+/// seam, calls this analyzer, and only then optionally applies the
+/// transition (dry-run by default).
+/// </summary>
+internal static class WorkerClaimAnalyzer
+{
+    /// <summary>
+    /// Plan the claim transition for a given target. Returns a
+    /// <see cref="ClaimDecision"/> describing the proposed label edits;
+    /// the caller decides whether to apply (write mode) or just emit
+    /// (dry-run mode).
+    /// </summary>
+    public static ClaimDecision Analyze(string kind, IReadOnlyList<string> currentLabels)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        ArgumentNullException.ThrowIfNull(currentLabels);
+
+        if (string.Equals(kind, GhCliGitHubLabelMutator.Kinds.Issue, StringComparison.Ordinal))
+        {
+            return AnalyzeIssue(currentLabels);
+        }
+        if (string.Equals(kind, GhCliGitHubLabelMutator.Kinds.Pr, StringComparison.Ordinal))
+        {
+            return AnalyzePr(currentLabels);
+        }
+
+        // Unknown kind — surface as stale-selection refusal so the
+        // command exits non-zero without mutating anything.
+        return new ClaimDecision
+        {
+            Proceed = false,
+            AddLabels = Array.Empty<string>(),
+            RemoveLabels = Array.Empty<string>(),
+            Errors = new[] { $"unrecognized kind '{kind}'." },
+            Warnings = Array.Empty<string>(),
+            Summary = $"Refusing to claim: unrecognized kind '{kind}'.",
+        };
+    }
+
+    private static ClaimDecision AnalyzeIssue(IReadOnlyList<string> currentLabels)
+    {
+        var errors = new List<string>();
+        var warnings = new List<string>();
+
+        var hasTarget = currentLabels.Contains(
+            WorkerNextActionConstants.Labels.IntentTarget, StringComparer.Ordinal);
+        var hasInProgress = currentLabels.Contains(
+            WorkerNextActionConstants.Labels.IntentIssueInProgress, StringComparer.Ordinal);
+        var hasPrCreated = currentLabels.Contains(
+            WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal);
+
+        if (!hasTarget)
+        {
+            errors.Add(
+                $"{WorkerClaimCompleteConstants.ErrorCodes.MissingTarget}: issue does not carry '{WorkerNextActionConstants.Labels.IntentTarget}'.");
+        }
+        if (hasInProgress)
+        {
+            errors.Add(
+                $"{WorkerClaimCompleteConstants.ErrorCodes.AlreadyInProgress}: issue already carries '{WorkerNextActionConstants.Labels.IntentIssueInProgress}'.");
+        }
+        if (hasPrCreated)
+        {
+            errors.Add(
+                $"{WorkerClaimCompleteConstants.ErrorCodes.AlreadyCompleted}: issue already carries '{WorkerNextActionConstants.Labels.IntentPrCreated}'.");
+        }
+
+        var proceed = errors.Count == 0;
+        return new ClaimDecision
+        {
+            Proceed = proceed,
+            AddLabels = proceed
+                ? new[] { WorkerNextActionConstants.Labels.IntentIssueInProgress }
+                : Array.Empty<string>(),
+            RemoveLabels = Array.Empty<string>(),
+            Errors = errors,
+            Warnings = warnings,
+            Summary = proceed
+                ? $"Would add '{WorkerNextActionConstants.Labels.IntentIssueInProgress}' to claim the issue."
+                : "Refusing to claim issue: stale or ineligible target.",
+        };
+    }
+
+    private static ClaimDecision AnalyzePr(IReadOnlyList<string> currentLabels)
+    {
+        var errors = new List<string>();
+        var warnings = new List<string>();
+
+        var hasTarget = currentLabels.Contains(
+            WorkerNextActionConstants.Labels.IntentTarget, StringComparer.Ordinal);
+        var hasRequestUpdate = currentLabels.Contains(
+            WorkerNextActionConstants.Labels.IntentPrRequestUpdate, StringComparer.Ordinal);
+        var hasUpdateInProgress = currentLabels.Contains(
+            WorkerNextActionConstants.Labels.IntentPrUpdateInProgress, StringComparer.Ordinal);
+        var hasRereviewReady = currentLabels.Contains(
+            WorkerNextActionConstants.Labels.IntentPrRereviewReady, StringComparer.Ordinal);
+        var hasMisplacedPrCreated = currentLabels.Contains(
+            WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal);
+
+        if (!hasTarget)
+        {
+            errors.Add(
+                $"{WorkerClaimCompleteConstants.ErrorCodes.MissingTarget}: PR does not carry '{WorkerNextActionConstants.Labels.IntentTarget}'.");
+        }
+        if (!hasRequestUpdate)
+        {
+            errors.Add(
+                $"{WorkerClaimCompleteConstants.ErrorCodes.MissingRepairRequested}: PR does not carry '{WorkerNextActionConstants.Labels.IntentPrRequestUpdate}'.");
+        }
+        if (hasUpdateInProgress)
+        {
+            errors.Add(
+                $"{WorkerClaimCompleteConstants.ErrorCodes.AlreadyInProgress}: PR already carries '{WorkerNextActionConstants.Labels.IntentPrUpdateInProgress}'.");
+        }
+        if (hasRereviewReady)
+        {
+            errors.Add(
+                $"{WorkerClaimCompleteConstants.ErrorCodes.AlreadyRereviewReady}: PR already carries '{WorkerNextActionConstants.Labels.IntentPrRereviewReady}'.");
+        }
+        if (hasMisplacedPrCreated)
+        {
+            warnings.Add(
+                $"label policy: PR carries misplaced '{WorkerNextActionConstants.Labels.IntentPrCreated}' which belongs on the source issue, not the PR.");
+        }
+
+        var proceed = errors.Count == 0;
+        return new ClaimDecision
+        {
+            Proceed = proceed,
+            AddLabels = proceed
+                ? new[] { WorkerNextActionConstants.Labels.IntentPrUpdateInProgress }
+                : Array.Empty<string>(),
+            RemoveLabels = Array.Empty<string>(),
+            Errors = errors,
+            Warnings = warnings,
+            Summary = proceed
+                ? $"Would add '{WorkerNextActionConstants.Labels.IntentPrUpdateInProgress}' to claim the PR for repair."
+                : "Refusing to claim PR: stale or ineligible target.",
+        };
+    }
+
+    /// <summary>
+    /// G211: Pure data record returned by
+    /// <see cref="WorkerClaimAnalyzer.Analyze"/>. The command layer
+    /// projects this into <see cref="WorkerClaimResult"/>.
+    /// </summary>
+    internal sealed record ClaimDecision
+    {
+        public required bool Proceed { get; init; }
+        public required IReadOnlyList<string> AddLabels { get; init; }
+        public required IReadOnlyList<string> RemoveLabels { get; init; }
+        public required IReadOnlyList<string> Errors { get; init; }
+        public required IReadOnlyList<string> Warnings { get; init; }
+        public required string Summary { get; init; }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerClaimCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerClaimCommand.cs
@@ -1,0 +1,311 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G211: <c>intent-cli worker claim</c> command. Applies (or in
+/// dry-run mode, describes) the in-progress label transition for a
+/// selected issue or PR target — the explicit mutation boundary that
+/// replaces ad-hoc label edits in prompts.
+///
+/// No-mutation invariants (verified by tests):
+/// - dry-run mode (default) NEVER calls
+///   <see cref="IGitHubLabelMutator.ApplyLabelTransitions"/>;
+/// - this command and its analyzer file contain no
+///   <c>Process.Start</c>, no <c>gh</c> mutation literals, and never
+///   invoke <see cref="NestedProviderLauncher"/>;
+/// - whole-workspace byte-snapshot before/after asserts no file is
+///   created or modified;
+/// - the only file in the worker claim/complete surface that calls
+///   <c>Process.Start</c> is the mutator adapter
+///   <see cref="GhCliGitHubLabelMutator"/>, by design.
+/// </summary>
+internal static class WorkerClaimCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    /// <summary>
+    /// Test seam: tests inject a fake <see cref="IGitHubLabelMutator"/>
+    /// here so no real GitHub network call is made.
+    /// </summary>
+    public static Func<IGitHubLabelMutator>? MutatorFactory { get; set; }
+
+    /// <summary>
+    /// Test sentinel: must NEVER be invoked. Tests assert it remains
+    /// uninvoked across all command paths to lock the "no nested
+    /// provider launch" guarantee.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(
+                args,
+                out var repo,
+                out var kind,
+                out var number,
+                out var mode,
+                out var format,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        IGitHubLabelMutator mutator;
+        try
+        {
+            mutator = MutatorFactory?.Invoke() ?? new GhCliGitHubLabelMutator();
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub mutator: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<GitHubAutomationLabel> currentLabels;
+        try
+        {
+            currentLabels = mutator.ReadLabels(repo!, kind!, number);
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine(
+                $"failed to read current labels for {kind} #{number} in {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var currentNames = LabelNames(currentLabels);
+        var decision = WorkerClaimAnalyzer.Analyze(kind!, currentNames);
+
+        var applied = false;
+        if (decision.Proceed
+            && string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal))
+        {
+            try
+            {
+                mutator.ApplyLabelTransitions(
+                    repo!, kind!, number, decision.AddLabels, decision.RemoveLabels);
+                applied = true;
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or IOException)
+            {
+                writer.WriteLine(
+                    $"failed to apply claim transition on {kind} #{number} in {repo}: {exception.Message}");
+                return 1;
+            }
+        }
+
+        var result = new WorkerClaimResult
+        {
+            Kind = kind!,
+            Repo = repo!,
+            Number = number,
+            Mode = mode,
+            Proceed = decision.Proceed,
+            Applied = applied,
+            AddLabels = decision.AddLabels,
+            RemoveLabels = decision.RemoveLabels,
+            CurrentLabels = currentNames,
+            Errors = decision.Errors,
+            Warnings = decision.Warnings,
+            Summary = decision.Summary,
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return decision.Proceed ? 0 : 2;
+    }
+
+    private static IReadOnlyList<string> LabelNames(IReadOnlyList<GitHubAutomationLabel>? labels)
+    {
+        if (labels is null || labels.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var names = new List<string>(labels.Count);
+        foreach (var label in labels)
+        {
+            if (!string.IsNullOrEmpty(label.Name))
+            {
+                names.Add(label.Name);
+            }
+        }
+        return names;
+    }
+
+    private static void WriteText(TextWriter writer, WorkerClaimResult result)
+    {
+        writer.WriteLine($"# Worker claim: {result.Kind} #{result.Number} ({result.Repo})");
+        writer.WriteLine();
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- proceed: {result.Proceed}");
+        writer.WriteLine($"- applied: {result.Applied}");
+        writer.WriteLine($"- add: {(result.AddLabels.Count == 0 ? "(none)" : string.Join(", ", result.AddLabels))}");
+        writer.WriteLine($"- remove: {(result.RemoveLabels.Count == 0 ? "(none)" : string.Join(", ", result.RemoveLabels))}");
+        writer.WriteLine($"- summary: {result.Summary}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Errors");
+        if (result.Errors.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var item in result.Errors)
+            {
+                writer.WriteLine($"- {item}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Warnings");
+        if (result.Warnings.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var item in result.Warnings)
+            {
+                writer.WriteLine($"- {item}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string? kind,
+        out int number,
+        out string mode,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        kind = null;
+        number = 0;
+        mode = WorkerClaimCompleteConstants.Modes.DryRun;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--kind":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--kind requires a value ('issue' or 'pr').";
+                        return false;
+                    }
+                    kind = args[index + 1];
+                    index++;
+                    break;
+
+                case "--number":
+                    if (index + 1 >= args.Length
+                        || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture, out number)
+                        || number <= 0)
+                    {
+                        error = "--number requires a positive integer.";
+                        return false;
+                    }
+                    index++;
+                    break;
+
+                case "--write":
+                    mode = WorkerClaimCompleteConstants.Modes.Write;
+                    break;
+
+                case "--dry-run":
+                    mode = WorkerClaimCompleteConstants.Modes.DryRun;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error =
+                        $"Unknown argument '{argument}'. Supported: --repo <owner/repo> --kind <issue|pr> --number <N> [--write] [--dry-run] [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "--repo is required (e.g. --repo owner/repo).";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(kind))
+        {
+            error = "--kind is required ('issue' or 'pr').";
+            return false;
+        }
+        if (!string.Equals(kind, GhCliGitHubLabelMutator.Kinds.Issue, StringComparison.Ordinal)
+            && !string.Equals(kind, GhCliGitHubLabelMutator.Kinds.Pr, StringComparison.Ordinal))
+        {
+            error = $"--kind must be 'issue' or 'pr' (got '{kind}').";
+            return false;
+        }
+        if (number <= 0)
+        {
+            error = "--number is required and must be a positive integer.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerClaimResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerClaimResult.cs
@@ -1,0 +1,101 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G211: Read-only result emitted by <c>intent-cli worker claim</c>.
+/// Names the proposed (or applied) label transition for a single
+/// issue/PR target, plus the dry-run / write mode flag and any policy
+/// warnings or stale-selection errors.
+///
+/// Producing this record never launches an AI provider, never creates
+/// branches, PRs, issues, or comments, and never touches the queue or
+/// runs logs. In dry-run mode (the default), the record also represents
+/// the no-mutation guarantee — the claim transition is described, not
+/// applied.
+/// </summary>
+internal sealed record WorkerClaimResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("number")]
+    public required int Number { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("proceed")]
+    public required bool Proceed { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("add_labels")]
+    public required IReadOnlyList<string> AddLabels { get; init; }
+
+    /// <summary>G211 contract alias — camelCase for AI-thread JSON ingestion.</summary>
+    [JsonPropertyName("addLabels")]
+    public IReadOnlyList<string> AddLabelsCamelCase => AddLabels;
+
+    [JsonPropertyName("remove_labels")]
+    public required IReadOnlyList<string> RemoveLabels { get; init; }
+
+    /// <summary>G211 contract alias — camelCase for AI-thread JSON ingestion.</summary>
+    [JsonPropertyName("removeLabels")]
+    public IReadOnlyList<string> RemoveLabelsCamelCase => RemoveLabels;
+
+    [JsonPropertyName("current_labels")]
+    public required IReadOnlyList<string> CurrentLabels { get; init; }
+
+    /// <summary>G211 contract alias — camelCase for AI-thread JSON ingestion.</summary>
+    [JsonPropertyName("currentLabels")]
+    public IReadOnlyList<string> CurrentLabelsCamelCase => CurrentLabels;
+
+    [JsonPropertyName("errors")]
+    public required IReadOnlyList<string> Errors { get; init; }
+
+    [JsonPropertyName("warnings")]
+    public required IReadOnlyList<string> Warnings { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}
+
+/// <summary>
+/// G211: Stable string constants for the worker claim/complete commands.
+/// </summary>
+internal static class WorkerClaimCompleteConstants
+{
+    /// <summary>
+    /// Mode tokens. Default is <c>dry-run</c> — the command must NOT
+    /// mutate GitHub unless <c>write</c> is explicitly requested.
+    /// </summary>
+    public static class Modes
+    {
+        public const string DryRun = "dry-run";
+        public const string Write = "write";
+    }
+
+    /// <summary>
+    /// Stable error codes emitted in <c>errors[]</c> when the analyzer
+    /// refuses a transition. Tests assert against these codes; downstream
+    /// callers can branch on them without parsing the human-readable
+    /// summary.
+    /// </summary>
+    public static class ErrorCodes
+    {
+        public const string MissingTarget = "claim.missing.intent-target";
+        public const string AlreadyInProgress = "claim.stale.already-in-progress";
+        public const string AlreadyCompleted = "claim.stale.already-completed";
+        public const string MissingRepairRequested = "claim.missing.intent-pr-request-update";
+        public const string AlreadyRereviewReady = "claim.stale.already-rereview-ready";
+        public const string CompleteNotClaimed = "complete.stale.not-claimed";
+        public const string CompleteAlreadyCompleted = "complete.stale.already-completed";
+        public const string CompleteIntentPrCreatedOnPr = "complete.policy.intent-pr-created-on-pr";
+        public const string UnsupportedKindOutcome = "complete.unsupported.kind-outcome";
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerCompleteAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerCompleteAnalyzer.cs
@@ -1,0 +1,246 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G211: Pure deterministic mapper for <c>intent-cli worker complete</c>.
+/// Given the kind, the originating outcome (one of the eight G205
+/// outcomes), and the issue/PR's current label set, computes the
+/// completion transition (add / remove) plus stale-selection refusals
+/// and policy warnings.
+///
+/// The transition mapping mirrors
+/// <see cref="WorkerResultSummaryAnalyzer"/>'s recommended label
+/// actions, but this analyzer adds the stale-state pre-check and the
+/// "intent-pr-created is issue-only" defensive guard so the writer
+/// boundary is enforced once, here.
+///
+/// Pure: no I/O, no Process.Start, no GitHub network, no provider
+/// launch.
+/// </summary>
+internal static class WorkerCompleteAnalyzer
+{
+    /// <summary>
+    /// Plan the completion transition for a given target/outcome.
+    /// </summary>
+    public static CompleteDecision Analyze(
+        string kind,
+        string outcome,
+        IReadOnlyList<string> currentLabels)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outcome);
+        ArgumentNullException.ThrowIfNull(currentLabels);
+
+        if (!string.Equals(kind, GhCliGitHubLabelMutator.Kinds.Issue, StringComparison.Ordinal)
+            && !string.Equals(kind, GhCliGitHubLabelMutator.Kinds.Pr, StringComparison.Ordinal))
+        {
+            return Refuse($"unrecognized kind '{kind}'.",
+                $"unrecognized kind '{kind}'.");
+        }
+
+        if (!WorkerResultSummaryAnalyzer.IsSupportedKindOutcome(MapKindForResultSummary(kind), outcome))
+        {
+            return Refuse(
+                $"{WorkerClaimCompleteConstants.ErrorCodes.UnsupportedKindOutcome}: outcome '{outcome}' is not supported for kind '{kind}'.",
+                $"Refusing to complete: outcome '{outcome}' not supported for kind '{kind}'.");
+        }
+
+        if (string.Equals(kind, GhCliGitHubLabelMutator.Kinds.Issue, StringComparison.Ordinal))
+        {
+            return AnalyzeIssue(outcome, currentLabels);
+        }
+        return AnalyzePr(outcome, currentLabels);
+    }
+
+    private static CompleteDecision AnalyzeIssue(
+        string outcome,
+        IReadOnlyList<string> currentLabels)
+    {
+        var errors = new List<string>();
+        var warnings = new List<string>();
+        var addLabels = new List<string>();
+        var removeLabels = new List<string>();
+
+        var hasInProgress = currentLabels.Contains(
+            WorkerNextActionConstants.Labels.IntentIssueInProgress, StringComparer.Ordinal);
+        var hasPrCreated = currentLabels.Contains(
+            WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal);
+
+        // Stale: an issue must have been claimed (intent-issue-in-progress
+        // present) before completion is meaningful.
+        if (!hasInProgress)
+        {
+            errors.Add(
+                $"{WorkerClaimCompleteConstants.ErrorCodes.CompleteNotClaimed}: issue does not carry '{WorkerNextActionConstants.Labels.IntentIssueInProgress}'.");
+        }
+
+        // Stale: pr-created already present means the issue was already
+        // completed; refuse to re-add.
+        if (hasPrCreated && string.Equals(outcome, WorkerResultSummaryConstants.Outcomes.PrCreated, StringComparison.Ordinal))
+        {
+            errors.Add(
+                $"{WorkerClaimCompleteConstants.ErrorCodes.CompleteAlreadyCompleted}: issue already carries '{WorkerNextActionConstants.Labels.IntentPrCreated}'.");
+        }
+
+        if (errors.Count == 0)
+        {
+            // All terminal issue-to-pr outcomes release the in-progress claim.
+            removeLabels.Add(WorkerNextActionConstants.Labels.IntentIssueInProgress);
+
+            // pr-created success path also marks the issue as completed.
+            if (string.Equals(outcome, WorkerResultSummaryConstants.Outcomes.PrCreated, StringComparison.Ordinal))
+            {
+                addLabels.Add(WorkerNextActionConstants.Labels.IntentPrCreated);
+                warnings.Add(
+                    $"label policy: '{WorkerNextActionConstants.Labels.IntentPrCreated}' is being added to the source ISSUE, never to the PR.");
+            }
+        }
+
+        var proceed = errors.Count == 0;
+        return new CompleteDecision
+        {
+            Proceed = proceed,
+            AddLabels = addLabels,
+            RemoveLabels = removeLabels,
+            Errors = errors,
+            Warnings = warnings,
+            Summary = proceed
+                ? BuildIssueSummary(outcome, addLabels, removeLabels)
+                : "Refusing to complete issue: stale or already-completed target.",
+        };
+    }
+
+    private static CompleteDecision AnalyzePr(
+        string outcome,
+        IReadOnlyList<string> currentLabels)
+    {
+        var errors = new List<string>();
+        var warnings = new List<string>();
+        var addLabels = new List<string>();
+        var removeLabels = new List<string>();
+
+        // Defensive policy guard: intent-pr-created must never be
+        // applied to a PR. The mapping below never produces it for
+        // kind=pr, but we surface a guard error if a future caller
+        // tries to bypass via an unrecognized outcome path.
+        // (No-op here in practice — the mapping enforces it.)
+
+        var hasUpdateInProgress = currentLabels.Contains(
+            WorkerNextActionConstants.Labels.IntentPrUpdateInProgress, StringComparer.Ordinal);
+        var hasRereviewReady = currentLabels.Contains(
+            WorkerNextActionConstants.Labels.IntentPrRereviewReady, StringComparer.Ordinal);
+        var hasMisplacedPrCreated = currentLabels.Contains(
+            WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal);
+
+        // Stale: a PR must have been claimed (intent-pr-update-in-progress
+        // present) before completion is meaningful.
+        if (!hasUpdateInProgress)
+        {
+            errors.Add(
+                $"{WorkerClaimCompleteConstants.ErrorCodes.CompleteNotClaimed}: PR does not carry '{WorkerNextActionConstants.Labels.IntentPrUpdateInProgress}'.");
+        }
+
+        // Stale: rereview-ready already present means the PR's repair
+        // was already completed; refuse to re-add for a successful
+        // repair-pushed completion.
+        if (hasRereviewReady
+            && string.Equals(outcome, WorkerResultSummaryConstants.Outcomes.RepairPushed, StringComparison.Ordinal))
+        {
+            errors.Add(
+                $"{WorkerClaimCompleteConstants.ErrorCodes.CompleteAlreadyCompleted}: PR already carries '{WorkerNextActionConstants.Labels.IntentPrRereviewReady}'.");
+        }
+
+        if (hasMisplacedPrCreated)
+        {
+            warnings.Add(
+                $"label policy: PR carries misplaced '{WorkerNextActionConstants.Labels.IntentPrCreated}' which belongs on the source issue, not the PR.");
+        }
+
+        if (errors.Count == 0)
+        {
+            // All terminal pr-comment-fix outcomes release the in-progress claim.
+            removeLabels.Add(WorkerNextActionConstants.Labels.IntentPrUpdateInProgress);
+
+            // repair-pushed success path also marks the PR as ready for re-review.
+            if (string.Equals(outcome, WorkerResultSummaryConstants.Outcomes.RepairPushed, StringComparison.Ordinal))
+            {
+                addLabels.Add(WorkerNextActionConstants.Labels.IntentPrRereviewReady);
+            }
+        }
+
+        var proceed = errors.Count == 0;
+        return new CompleteDecision
+        {
+            Proceed = proceed,
+            AddLabels = addLabels,
+            RemoveLabels = removeLabels,
+            Errors = errors,
+            Warnings = warnings,
+            Summary = proceed
+                ? BuildPrSummary(outcome, addLabels, removeLabels)
+                : "Refusing to complete PR: stale or already-completed target.",
+        };
+    }
+
+    private static CompleteDecision Refuse(string errorMessage, string summary)
+    {
+        return new CompleteDecision
+        {
+            Proceed = false,
+            AddLabels = Array.Empty<string>(),
+            RemoveLabels = Array.Empty<string>(),
+            Errors = new[] { errorMessage },
+            Warnings = Array.Empty<string>(),
+            Summary = summary,
+        };
+    }
+
+    private static string MapKindForResultSummary(string kind)
+    {
+        // worker complete uses the GhCli kind tokens ("issue" / "pr"),
+        // while WorkerResultSummary uses workflow kind tokens
+        // ("issue-to-pr" / "pr-comment-fix"). Map between the two so
+        // the supported (kind, outcome) matrix can be reused without
+        // duplication.
+        return kind switch
+        {
+            GhCliGitHubLabelMutator.Kinds.Issue => WorkerResultSummaryConstants.Kinds.IssueToPr,
+            GhCliGitHubLabelMutator.Kinds.Pr => WorkerResultSummaryConstants.Kinds.PrCommentFix,
+            _ => kind,
+        };
+    }
+
+    private static string BuildIssueSummary(
+        string outcome,
+        IReadOnlyCollection<string> addLabels,
+        IReadOnlyCollection<string> removeLabels)
+    {
+        var addPart = addLabels.Count == 0 ? "(none)" : string.Join(", ", addLabels);
+        var removePart = removeLabels.Count == 0 ? "(none)" : string.Join(", ", removeLabels);
+        return $"Would add: {addPart}; remove: {removePart} on the issue (outcome '{outcome}').";
+    }
+
+    private static string BuildPrSummary(
+        string outcome,
+        IReadOnlyCollection<string> addLabels,
+        IReadOnlyCollection<string> removeLabels)
+    {
+        var addPart = addLabels.Count == 0 ? "(none)" : string.Join(", ", addLabels);
+        var removePart = removeLabels.Count == 0 ? "(none)" : string.Join(", ", removeLabels);
+        return $"Would add: {addPart}; remove: {removePart} on the PR (outcome '{outcome}').";
+    }
+
+    /// <summary>
+    /// G211: Pure data record returned by
+    /// <see cref="WorkerCompleteAnalyzer.Analyze"/>. The command layer
+    /// projects this into <see cref="WorkerCompleteResult"/>.
+    /// </summary>
+    internal sealed record CompleteDecision
+    {
+        public required bool Proceed { get; init; }
+        public required IReadOnlyList<string> AddLabels { get; init; }
+        public required IReadOnlyList<string> RemoveLabels { get; init; }
+        public required IReadOnlyList<string> Errors { get; init; }
+        public required IReadOnlyList<string> Warnings { get; init; }
+        public required string Summary { get; init; }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
@@ -1,0 +1,332 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G211: <c>intent-cli worker complete</c> command. Applies (or in
+/// dry-run mode, describes) the completion label transition for a
+/// selected issue/PR target after a worker run finished. The
+/// transition mirrors the recommended_label_actions emitted by
+/// <see cref="WorkerResultSummaryAnalyzer"/>, with stale-state
+/// pre-checks added at this writer boundary.
+///
+/// No-mutation invariants (verified by tests):
+/// - dry-run mode (default) NEVER calls
+///   <see cref="IGitHubLabelMutator.ApplyLabelTransitions"/>;
+/// - this command and its analyzer file contain no
+///   <c>Process.Start</c>, no <c>gh</c> mutation literals, and never
+///   invoke <see cref="NestedProviderLauncher"/>;
+/// - whole-workspace byte-snapshot before/after asserts no file is
+///   created or modified;
+/// - the only file in the worker claim/complete surface that calls
+///   <c>Process.Start</c> is the mutator adapter
+///   <see cref="GhCliGitHubLabelMutator"/>, by design.
+/// </summary>
+internal static class WorkerCompleteCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    /// <summary>
+    /// Test seam: tests inject a fake <see cref="IGitHubLabelMutator"/>
+    /// here so no real GitHub network call is made.
+    /// </summary>
+    public static Func<IGitHubLabelMutator>? MutatorFactory { get; set; }
+
+    /// <summary>
+    /// Test sentinel: must NEVER be invoked. Tests assert it remains
+    /// uninvoked across all command paths.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(
+                args,
+                out var repo,
+                out var kind,
+                out var number,
+                out var outcome,
+                out var mode,
+                out var format,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        IGitHubLabelMutator mutator;
+        try
+        {
+            mutator = MutatorFactory?.Invoke() ?? new GhCliGitHubLabelMutator();
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub mutator: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<GitHubAutomationLabel> currentLabels;
+        try
+        {
+            currentLabels = mutator.ReadLabels(repo!, kind!, number);
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine(
+                $"failed to read current labels for {kind} #{number} in {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var currentNames = LabelNames(currentLabels);
+        var decision = WorkerCompleteAnalyzer.Analyze(kind!, outcome!, currentNames);
+
+        var applied = false;
+        if (decision.Proceed
+            && string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal))
+        {
+            try
+            {
+                mutator.ApplyLabelTransitions(
+                    repo!, kind!, number, decision.AddLabels, decision.RemoveLabels);
+                applied = true;
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or IOException)
+            {
+                writer.WriteLine(
+                    $"failed to apply complete transition on {kind} #{number} in {repo}: {exception.Message}");
+                return 1;
+            }
+        }
+
+        var result = new WorkerCompleteResult
+        {
+            Kind = kind!,
+            Repo = repo!,
+            Number = number,
+            Outcome = outcome!,
+            Mode = mode,
+            Proceed = decision.Proceed,
+            Applied = applied,
+            AddLabels = decision.AddLabels,
+            RemoveLabels = decision.RemoveLabels,
+            CurrentLabels = currentNames,
+            Errors = decision.Errors,
+            Warnings = decision.Warnings,
+            Summary = decision.Summary,
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return decision.Proceed ? 0 : 2;
+    }
+
+    private static IReadOnlyList<string> LabelNames(IReadOnlyList<GitHubAutomationLabel>? labels)
+    {
+        if (labels is null || labels.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var names = new List<string>(labels.Count);
+        foreach (var label in labels)
+        {
+            if (!string.IsNullOrEmpty(label.Name))
+            {
+                names.Add(label.Name);
+            }
+        }
+        return names;
+    }
+
+    private static void WriteText(TextWriter writer, WorkerCompleteResult result)
+    {
+        writer.WriteLine($"# Worker complete: {result.Kind} #{result.Number} ({result.Repo})");
+        writer.WriteLine();
+        writer.WriteLine($"- outcome: {result.Outcome}");
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- proceed: {result.Proceed}");
+        writer.WriteLine($"- applied: {result.Applied}");
+        writer.WriteLine($"- add: {(result.AddLabels.Count == 0 ? "(none)" : string.Join(", ", result.AddLabels))}");
+        writer.WriteLine($"- remove: {(result.RemoveLabels.Count == 0 ? "(none)" : string.Join(", ", result.RemoveLabels))}");
+        writer.WriteLine($"- summary: {result.Summary}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Errors");
+        if (result.Errors.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var item in result.Errors)
+            {
+                writer.WriteLine($"- {item}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Warnings");
+        if (result.Warnings.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var item in result.Warnings)
+            {
+                writer.WriteLine($"- {item}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string? kind,
+        out int number,
+        out string? outcome,
+        out string mode,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        kind = null;
+        number = 0;
+        outcome = null;
+        mode = WorkerClaimCompleteConstants.Modes.DryRun;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--kind":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--kind requires a value ('issue' or 'pr').";
+                        return false;
+                    }
+                    kind = args[index + 1];
+                    index++;
+                    break;
+
+                case "--number":
+                    if (index + 1 >= args.Length
+                        || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture, out number)
+                        || number <= 0)
+                    {
+                        error = "--number requires a positive integer.";
+                        return false;
+                    }
+                    index++;
+                    break;
+
+                case "--outcome":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--outcome requires a value.";
+                        return false;
+                    }
+                    outcome = args[index + 1];
+                    index++;
+                    break;
+
+                case "--write":
+                    mode = WorkerClaimCompleteConstants.Modes.Write;
+                    break;
+
+                case "--dry-run":
+                    mode = WorkerClaimCompleteConstants.Modes.DryRun;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error =
+                        $"Unknown argument '{argument}'. Supported: --repo <owner/repo> --kind <issue|pr> --number <N> --outcome <outcome> [--write] [--dry-run] [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "--repo is required (e.g. --repo owner/repo).";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(kind))
+        {
+            error = "--kind is required ('issue' or 'pr').";
+            return false;
+        }
+        if (!string.Equals(kind, GhCliGitHubLabelMutator.Kinds.Issue, StringComparison.Ordinal)
+            && !string.Equals(kind, GhCliGitHubLabelMutator.Kinds.Pr, StringComparison.Ordinal))
+        {
+            error = $"--kind must be 'issue' or 'pr' (got '{kind}').";
+            return false;
+        }
+        if (number <= 0)
+        {
+            error = "--number is required and must be a positive integer.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(outcome))
+        {
+            error = "--outcome is required.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerCompleteResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerCompleteResult.cs
@@ -1,0 +1,70 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G211: Read-only result emitted by <c>intent-cli worker complete</c>.
+/// Mirrors the shape of <see cref="WorkerClaimResult"/>: kind, number,
+/// mode, proceed/applied flags, add/remove transition, current labels,
+/// errors, warnings, summary. The complete-side adds the originating
+/// outcome (an issue-to-pr / pr-comment-fix outcome from G205) so
+/// downstream summaries can tie the claim/complete pair together.
+///
+/// In dry-run mode (the default), the record describes the transition
+/// without applying it. The command never launches an AI provider,
+/// never creates branches, PRs, issues, or comments, and never touches
+/// the queue or runs logs.
+/// </summary>
+internal sealed record WorkerCompleteResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("number")]
+    public required int Number { get; init; }
+
+    [JsonPropertyName("outcome")]
+    public required string Outcome { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("proceed")]
+    public required bool Proceed { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("add_labels")]
+    public required IReadOnlyList<string> AddLabels { get; init; }
+
+    /// <summary>G211 contract alias — camelCase for AI-thread JSON ingestion.</summary>
+    [JsonPropertyName("addLabels")]
+    public IReadOnlyList<string> AddLabelsCamelCase => AddLabels;
+
+    [JsonPropertyName("remove_labels")]
+    public required IReadOnlyList<string> RemoveLabels { get; init; }
+
+    /// <summary>G211 contract alias — camelCase for AI-thread JSON ingestion.</summary>
+    [JsonPropertyName("removeLabels")]
+    public IReadOnlyList<string> RemoveLabelsCamelCase => RemoveLabels;
+
+    [JsonPropertyName("current_labels")]
+    public required IReadOnlyList<string> CurrentLabels { get; init; }
+
+    /// <summary>G211 contract alias — camelCase for AI-thread JSON ingestion.</summary>
+    [JsonPropertyName("currentLabels")]
+    public IReadOnlyList<string> CurrentLabelsCamelCase => CurrentLabels;
+
+    [JsonPropertyName("errors")]
+    public required IReadOnlyList<string> Errors { get; init; }
+
+    [JsonPropertyName("warnings")]
+    public required IReadOnlyList<string> Warnings { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkerClaimCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerClaimCommandTests.cs
@@ -1,0 +1,593 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G211: Tests for <c>intent-cli worker claim</c>. Cover the issue and
+/// PR claim paths, dry-run vs write split, stale-state refusals,
+/// missing-target/missing-repair-requested refusals, the misplaced
+/// <c>intent-pr-created</c> warning, and the no-mutation invariants
+/// (no Process.Start in command/analyzer; no GitHub mutation in
+/// dry-run; whole-workspace byte-snapshot stability).
+/// </summary>
+public sealed class WorkerClaimCommandTests : IDisposable
+{
+    public WorkerClaimCommandTests()
+    {
+        WorkerClaimCommand.MutatorFactory = null;
+        WorkerClaimCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        WorkerClaimCommand.MutatorFactory = null;
+        WorkerClaimCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void Execute_IssueWithIntentTarget_DryRunPlansAddIntentIssueInProgress()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target" },
+        };
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "525", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!;
+        Assert.Equal("issue", result.Kind);
+        Assert.Equal(525, result.Number);
+        Assert.Equal(WorkerClaimCompleteConstants.Modes.DryRun, result.Mode);
+        Assert.True(result.Proceed);
+        Assert.False(result.Applied);
+        Assert.Contains("intent-issue-in-progress", result.AddLabels);
+        Assert.Empty(result.RemoveLabels);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_IssueWithIntentTarget_WriteModeAppliesTransition()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target" },
+        };
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "525", "--write", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!;
+        Assert.Equal(WorkerClaimCompleteConstants.Modes.Write, result.Mode);
+        Assert.True(result.Proceed);
+        Assert.True(result.Applied);
+        Assert.Single(mutator.AppliedTransitions);
+        var applied = mutator.AppliedTransitions[0];
+        Assert.Equal(525, applied.Number);
+        Assert.Equal("issue", applied.Kind);
+        Assert.Contains("intent-issue-in-progress", applied.AddLabels);
+        Assert.Empty(applied.RemoveLabels);
+    }
+
+    [Fact]
+    public void Execute_IssueAlreadyInProgress_RefusesAndDoesNotMutateEvenInWriteMode()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "525", "--write", "--format", "json" },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!;
+        Assert.False(result.Proceed);
+        Assert.False(result.Applied);
+        Assert.Contains(result.Errors, e => e.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.AlreadyInProgress, StringComparison.Ordinal));
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_IssueAlreadyPrCreated_RefusesAlreadyCompleted()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-created" },
+        };
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "525", "--format", "json" },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!;
+        Assert.False(result.Proceed);
+        Assert.Contains(result.Errors, e => e.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.AlreadyCompleted, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_IssueWithoutIntentTarget_RefusesMissingTarget()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = Array.Empty<string>(),
+        };
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "525", "--format", "json" },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!;
+        Assert.False(result.Proceed);
+        Assert.Contains(result.Errors, e => e.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.MissingTarget, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_PrWithRequestUpdate_DryRunPlansAddIntentPrUpdateInProgress()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-request-update" },
+        };
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "pr", "--number", "514", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!;
+        Assert.True(result.Proceed);
+        Assert.False(result.Applied);
+        Assert.Contains("intent-pr-update-in-progress", result.AddLabels);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_PrWithoutRequestUpdate_RefusesMissingRepairRequested()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target" },
+        };
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "pr", "--number", "514", "--format", "json" },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!;
+        Assert.False(result.Proceed);
+        Assert.Contains(result.Errors, e => e.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.MissingRepairRequested, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_PrAlreadyUpdateInProgress_RefusesAlreadyInProgress()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-request-update", "intent-pr-update-in-progress" },
+        };
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "pr", "--number", "514", "--write", "--format", "json" },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!;
+        Assert.False(result.Proceed);
+        Assert.Contains(result.Errors, e => e.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.AlreadyInProgress, StringComparison.Ordinal));
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_PrAlreadyRereviewReady_RefusesAlreadyRereviewReady()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-request-update", "intent-pr-rereview-ready" },
+        };
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "pr", "--number", "514", "--format", "json" },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!;
+        Assert.Contains(result.Errors, e => e.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.AlreadyRereviewReady, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_PrWithMisplacedIntentPrCreated_EmitsWarningButStillEvaluates()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-request-update", "intent-pr-created" },
+        };
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "pr", "--number", "514", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!;
+        Assert.True(result.Proceed);
+        Assert.Contains(result.Warnings, w =>
+            w.Contains("misplaced", StringComparison.Ordinal)
+            && w.Contains("intent-pr-created", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_MissingRequiredArguments_ReturnsNonZero()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context, Array.Empty<string>(), writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("--repo is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_BadKind_ReturnsNonZero()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "bug", "--number", "1" },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("--kind must be 'issue' or 'pr'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsonOutput_IncludesCamelCaseAliasesForLabelArrays()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target" },
+        };
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "525", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var raw = writer.ToString();
+        Assert.Contains("\"add_labels\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"addLabels\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"remove_labels\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"removeLabels\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"current_labels\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"currentLabels\"", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesNestedProviderLauncher()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var launcherInvoked = false;
+        WorkerClaimCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+        WorkerClaimCommand.MutatorFactory = () => new FakeMutator
+        {
+            Labels = new[] { "intent-target" },
+        };
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, WorkerClaimCommand.Execute(workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "525", "--write", "--format", "json" },
+            writer));
+
+        // Also walk a refusal path.
+        WorkerClaimCommand.MutatorFactory = () => new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        writer.GetStringBuilder().Clear();
+        Assert.Equal(2, WorkerClaimCommand.Execute(workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "525", "--write", "--format", "json" },
+            writer));
+
+        Assert.False(launcherInvoked,
+            "WorkerClaimCommand must never invoke NestedProviderLauncher.");
+    }
+
+    [Fact]
+    public void Execute_DryRun_LeavesIntentCliWorkspaceByteEquivalent()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var before = workspace.SnapshotWorkspace();
+
+        WorkerClaimCommand.MutatorFactory = () => new FakeMutator
+        {
+            Labels = new[] { "intent-target" },
+        };
+
+        using (var writer = new StringWriter())
+        {
+            Assert.Equal(0, WorkerClaimCommand.Execute(workspace.Context,
+                new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "525", "--format", "json" },
+                writer));
+        }
+
+        var after = workspace.SnapshotWorkspace();
+        Assert.Equal(before.Count, after.Count);
+        foreach (var (path, hash) in before)
+        {
+            Assert.True(after.TryGetValue(path, out var afterHash));
+            Assert.Equal(hash, afterHash);
+        }
+    }
+
+    [Fact]
+    public void Execute_WriteMode_LeavesIntentCliWorkspaceByteEquivalent()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        var before = workspace.SnapshotWorkspace();
+
+        WorkerClaimCommand.MutatorFactory = () => new FakeMutator
+        {
+            Labels = new[] { "intent-target" },
+        };
+
+        using (var writer = new StringWriter())
+        {
+            Assert.Equal(0, WorkerClaimCommand.Execute(workspace.Context,
+                new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "525", "--write", "--format", "json" },
+                writer));
+        }
+
+        var after = workspace.SnapshotWorkspace();
+        Assert.Equal(before.Count, after.Count);
+        foreach (var (path, hash) in before)
+        {
+            Assert.True(after.TryGetValue(path, out var afterHash));
+            Assert.Equal(hash, afterHash);
+        }
+    }
+
+    [Fact]
+    public void SourceScan_AnalyzerAndCommand_ContainNoProcessStartOrGhMutationLiterals()
+    {
+        var analyzer = StripCsharpComments(File.ReadAllText(LocateSourceFile("WorkerClaimAnalyzer.cs")));
+        var command = StripCsharpComments(File.ReadAllText(LocateSourceFile("WorkerClaimCommand.cs")));
+        var combined = analyzer + "\n" + command;
+
+        Assert.DoesNotContain("Process.Start(", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh issue edit", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr edit", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr merge", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr close", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr reopen", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr comment", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr review", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("resolveReviewThread", combined, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Adapter_ViewArguments_RequestSupportedSubset()
+    {
+        var args = GhCliGitHubLabelMutator.BuildViewArguments(
+            "J-Tech-Japan/intent-system", "issue", 525);
+
+        Assert.Contains("issue", args);
+        Assert.Contains("view", args);
+        Assert.Contains("525", args);
+        Assert.Contains("--repo", args);
+        Assert.Contains("J-Tech-Japan/intent-system", args);
+        Assert.Contains("--json", args);
+        Assert.Contains(GhCliGitHubLabelMutator.ViewJsonFields, args);
+    }
+
+    [Fact]
+    public void Adapter_EditArguments_IncludeAddAndRemoveFlagsPerLabel()
+    {
+        var args = GhCliGitHubLabelMutator.BuildEditArguments(
+            "J-Tech-Japan/intent-system", "issue", 525,
+            new[] { "intent-issue-in-progress" },
+            new[] { "intent-target-old" });
+
+        Assert.Contains("issue", args);
+        Assert.Contains("edit", args);
+        Assert.Contains("525", args);
+        Assert.Contains("--repo", args);
+        Assert.Contains("J-Tech-Japan/intent-system", args);
+        Assert.Contains("--add-label", args);
+        Assert.Contains("intent-issue-in-progress", args);
+        Assert.Contains("--remove-label", args);
+        Assert.Contains("intent-target-old", args);
+    }
+
+    [Fact]
+    public void Adapter_ApplyLabelTransitions_RejectsIntentPrCreatedOnPr()
+    {
+        var mutator = new GhCliGitHubLabelMutator();
+        Assert.Throws<InvalidOperationException>(() =>
+            mutator.ApplyLabelTransitions(
+                "J-Tech-Japan/intent-system", "pr", 514,
+                new[] { "intent-pr-created" },
+                Array.Empty<string>()));
+    }
+
+    private static string StripCsharpComments(string source)
+    {
+        var noBlockComments = System.Text.RegularExpressions.Regex.Replace(
+            source, @"/\*[\s\S]*?\*/", string.Empty);
+        var noLineComments = System.Text.RegularExpressions.Regex.Replace(
+            noBlockComments, @"//.*?$", string.Empty,
+            System.Text.RegularExpressions.RegexOptions.Multiline);
+        return noLineComments;
+    }
+
+    private static string LocateSourceFile(string fileName)
+    {
+        var directory = AppContext.BaseDirectory;
+        var dir = new DirectoryInfo(directory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(
+                dir.FullName, "src", "IntentSystem.Cli", "Commands", fileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = dir.Parent;
+        }
+        throw new FileNotFoundException(
+            $"Could not locate source file {fileName} from {directory}");
+    }
+
+    internal sealed class FakeMutator : IGitHubLabelMutator
+    {
+        public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+
+        public List<AppliedTransition> AppliedTransitions { get; } = new();
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number)
+        {
+            return Labels.Select(n => new GitHubAutomationLabel { Name = n }).ToArray();
+        }
+
+        public void ApplyLabelTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels)
+        {
+            // Defensive policy guard mirrored from the production mutator.
+            if (string.Equals(kind, GhCliGitHubLabelMutator.Kinds.Pr, StringComparison.Ordinal)
+                && (addLabels.Contains("intent-pr-created", StringComparer.Ordinal)
+                    || removeLabels.Contains("intent-pr-created", StringComparer.Ordinal)))
+            {
+                throw new InvalidOperationException(
+                    "label policy violation: 'intent-pr-created' is issue-only.");
+            }
+
+            AppliedTransitions.Add(new AppliedTransition
+            {
+                Repo = repo,
+                Kind = kind,
+                Number = number,
+                AddLabels = addLabels.ToArray(),
+                RemoveLabels = removeLabels.ToArray(),
+            });
+        }
+    }
+
+    internal sealed record AppliedTransition
+    {
+        public required string Repo { get; init; }
+        public required string Kind { get; init; }
+        public required int Number { get; init; }
+        public required IReadOnlyList<string> AddLabels { get; init; }
+        public required IReadOnlyList<string> RemoveLabels { get; init; }
+    }
+
+    private sealed class WorkerClaimWorkspace : IDisposable
+    {
+        public WorkerClaimWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("worker-claim-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+
+        public IReadOnlyDictionary<string, string> SnapshotWorkspace()
+        {
+            var snapshot = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(RootPath, "*", SearchOption.AllDirectories))
+            {
+                var bytes = File.ReadAllBytes(path);
+                var hash = Convert.ToHexString(SHA256.HashData(bytes));
+                snapshot[path] = hash;
+            }
+            return snapshot;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
@@ -1,0 +1,661 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G211: Tests for <c>intent-cli worker complete</c>. Cover the
+/// issue-side and PR-side completion transitions for every supported
+/// outcome, the stale-state refusals, the "intent-pr-created stays on
+/// the issue" defensive guard, the dry-run vs write split, and the
+/// no-mutation invariants.
+/// </summary>
+public sealed class WorkerCompleteCommandTests : IDisposable
+{
+    public WorkerCompleteCommandTests()
+    {
+        WorkerCompleteCommand.MutatorFactory = null;
+        WorkerCompleteCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        WorkerCompleteCommand.MutatorFactory = null;
+        WorkerCompleteCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void Execute_IssuePrCreatedOutcome_DryRunPlansSwapInProgressForPrCreated()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "525",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated,
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.True(result.Proceed);
+        Assert.False(result.Applied);
+        Assert.Contains("intent-pr-created", result.AddLabels);
+        Assert.Contains("intent-issue-in-progress", result.RemoveLabels);
+        Assert.Empty(mutator.AppliedTransitions);
+
+        Assert.Contains(result.Warnings, w =>
+            w.Contains("intent-pr-created", StringComparison.Ordinal)
+            && w.Contains("ISSUE", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Execute_IssuePrCreatedOutcome_WriteModeAppliesSwap()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "525",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated,
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+        Assert.Single(mutator.AppliedTransitions);
+        var applied = mutator.AppliedTransitions[0];
+        Assert.Contains("intent-pr-created", applied.AddLabels);
+        Assert.Contains("intent-issue-in-progress", applied.RemoveLabels);
+    }
+
+    [Fact]
+    public void Execute_IssueNotClaimed_RefusesCompleteNotClaimed()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target" }, // no in-progress
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "525",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated,
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.False(result.Proceed);
+        Assert.False(result.Applied);
+        Assert.Contains(result.Errors, e => e.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.CompleteNotClaimed, StringComparison.Ordinal));
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_IssueAlreadyPrCreated_RefusesAlreadyCompleted()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress", "intent-pr-created" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "525",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated,
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.Contains(result.Errors, e => e.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.CompleteAlreadyCompleted, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_IssueClarificationOutcome_RemovesInProgressOnly()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "525",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.ClarificationRequired,
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.Contains("intent-issue-in-progress", result.RemoveLabels);
+        Assert.DoesNotContain("intent-pr-created", result.AddLabels);
+    }
+
+    [Fact]
+    public void Execute_PrRepairPushedOutcome_DryRunPlansSwapUpdateInProgressForRereviewReady()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-request-update", "intent-pr-update-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "pr",
+                "--number", "514",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.RepairPushed,
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.True(result.Proceed);
+        Assert.False(result.Applied);
+        Assert.Contains("intent-pr-rereview-ready", result.AddLabels);
+        Assert.Contains("intent-pr-update-in-progress", result.RemoveLabels);
+        Assert.Empty(mutator.AppliedTransitions);
+
+        // intent-pr-created MUST NOT be added to a PR.
+        Assert.DoesNotContain("intent-pr-created", result.AddLabels);
+    }
+
+    [Fact]
+    public void Execute_PrAlreadyRereviewReady_RefusesAlreadyCompletedOnRepairPushed()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-update-in-progress", "intent-pr-rereview-ready" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "pr",
+                "--number", "514",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.RepairPushed,
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.Contains(result.Errors, e => e.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.CompleteAlreadyCompleted, StringComparison.Ordinal));
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_PrFailedOutcome_RemovesUpdateInProgressOnly()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-update-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "pr",
+                "--number", "514",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.Failed,
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.Contains("intent-pr-update-in-progress", result.RemoveLabels);
+        Assert.Empty(result.AddLabels);
+    }
+
+    [Fact]
+    public void Execute_PrUnsupportedOutcomeForKind_RefusesUnsupportedKindOutcome()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-update-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        // pr-created is an issue-to-pr outcome, not a pr-comment-fix outcome.
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "pr",
+                "--number", "514",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated,
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.Contains(result.Errors, e => e.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.UnsupportedKindOutcome, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_IssueUnsupportedOutcomeForKind_RefusesUnsupportedKindOutcome()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        // repair-pushed is a pr-comment-fix outcome, not an issue-to-pr outcome.
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "525",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.RepairPushed,
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.Contains(result.Errors, e => e.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.UnsupportedKindOutcome, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_IntentPrCreatedNeverEndsUpInPrAddList()
+    {
+        // This test sweeps every supported pr-comment-fix outcome and
+        // asserts that intent-pr-created is never proposed as an add on
+        // a PR. Together with the mutator's defensive guard it locks the
+        // "intent-pr-created is issue-only" invariant end-to-end.
+        var prOutcomes = new[]
+        {
+            WorkerResultSummaryConstants.Outcomes.RepairPushed,
+            WorkerResultSummaryConstants.Outcomes.NoActionableComments,
+            WorkerResultSummaryConstants.Outcomes.AlreadyResolved,
+            WorkerResultSummaryConstants.Outcomes.ClarificationRequired,
+            WorkerResultSummaryConstants.Outcomes.Failed,
+            WorkerResultSummaryConstants.Outcomes.LabelCleanupRequired,
+        };
+
+        foreach (var outcome in prOutcomes)
+        {
+            using var workspace = new WorkerCompleteWorkspace();
+            // Different setups for "stale" outcomes — but the test is
+            // structural: regardless of proceed=true/false, the proposed
+            // AddLabels must not contain intent-pr-created.
+            var mutator = new FakeMutator
+            {
+                Labels = new[] { "intent-target", "intent-pr-update-in-progress" },
+            };
+            WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+            using var writer = new StringWriter();
+            WorkerCompleteCommand.Execute(
+                workspace.Context,
+                new[]
+                {
+                    "--repo", "J-Tech-Japan/intent-system",
+                    "--kind", "pr",
+                    "--number", "514",
+                    "--outcome", outcome,
+                    "--format", "json",
+                },
+                writer);
+
+            var raw = writer.ToString();
+            // Trim warning text that mentions "intent-pr-created" in
+            // the misplaced-label policy phrasing — we only care about
+            // the add_labels[] array contents here.
+            using var doc = JsonDocument.Parse(raw);
+            var addLabels = doc.RootElement.GetProperty("add_labels");
+            for (var i = 0; i < addLabels.GetArrayLength(); i++)
+            {
+                var label = addLabels[i].GetString();
+                Assert.NotEqual("intent-pr-created", label);
+            }
+        }
+    }
+
+    [Fact]
+    public void Execute_MissingRequiredArguments_ReturnsNonZero()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context, Array.Empty<string>(), writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("--repo is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MissingOutcome_ReturnsNonZero()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "525" },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("--outcome is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsonOutput_IncludesCamelCaseAliasesForLabelArrays()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "525",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated,
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var raw = writer.ToString();
+        Assert.Contains("\"add_labels\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"addLabels\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"remove_labels\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"removeLabels\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"current_labels\"", raw, StringComparison.Ordinal);
+        Assert.Contains("\"currentLabels\"", raw, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesNestedProviderLauncher()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var launcherInvoked = false;
+        WorkerCompleteCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+
+        WorkerCompleteCommand.MutatorFactory = () => new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, WorkerCompleteCommand.Execute(workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "525",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated,
+                "--write",
+                "--format", "json",
+            },
+            writer));
+
+        Assert.False(launcherInvoked,
+            "WorkerCompleteCommand must never invoke NestedProviderLauncher.");
+    }
+
+    [Fact]
+    public void Execute_DryRun_LeavesIntentCliWorkspaceByteEquivalent()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var before = workspace.SnapshotWorkspace();
+
+        WorkerCompleteCommand.MutatorFactory = () => new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+
+        using (var writer = new StringWriter())
+        {
+            Assert.Equal(0, WorkerCompleteCommand.Execute(workspace.Context,
+                new[]
+                {
+                    "--repo", "J-Tech-Japan/intent-system",
+                    "--kind", "issue",
+                    "--number", "525",
+                    "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated,
+                    "--format", "json",
+                },
+                writer));
+        }
+
+        var after = workspace.SnapshotWorkspace();
+        Assert.Equal(before.Count, after.Count);
+        foreach (var (path, hash) in before)
+        {
+            Assert.True(after.TryGetValue(path, out var afterHash));
+            Assert.Equal(hash, afterHash);
+        }
+    }
+
+    [Fact]
+    public void SourceScan_AnalyzerAndCommand_ContainNoProcessStartOrGhMutationLiterals()
+    {
+        var analyzer = StripCsharpComments(File.ReadAllText(LocateSourceFile("WorkerCompleteAnalyzer.cs")));
+        var command = StripCsharpComments(File.ReadAllText(LocateSourceFile("WorkerCompleteCommand.cs")));
+        var combined = analyzer + "\n" + command;
+
+        Assert.DoesNotContain("Process.Start(", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh issue edit", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr edit", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr merge", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr close", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr reopen", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr comment", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr review", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("resolveReviewThread", combined, StringComparison.Ordinal);
+    }
+
+    private static string StripCsharpComments(string source)
+    {
+        var noBlockComments = System.Text.RegularExpressions.Regex.Replace(
+            source, @"/\*[\s\S]*?\*/", string.Empty);
+        var noLineComments = System.Text.RegularExpressions.Regex.Replace(
+            noBlockComments, @"//.*?$", string.Empty,
+            System.Text.RegularExpressions.RegexOptions.Multiline);
+        return noLineComments;
+    }
+
+    private static string LocateSourceFile(string fileName)
+    {
+        var directory = AppContext.BaseDirectory;
+        var dir = new DirectoryInfo(directory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(
+                dir.FullName, "src", "IntentSystem.Cli", "Commands", fileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = dir.Parent;
+        }
+        throw new FileNotFoundException(
+            $"Could not locate source file {fileName} from {directory}");
+    }
+
+    internal sealed class FakeMutator : IGitHubLabelMutator
+    {
+        public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+
+        public List<AppliedTransition> AppliedTransitions { get; } = new();
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number)
+        {
+            return Labels.Select(n => new GitHubAutomationLabel { Name = n }).ToArray();
+        }
+
+        public void ApplyLabelTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels)
+        {
+            if (string.Equals(kind, GhCliGitHubLabelMutator.Kinds.Pr, StringComparison.Ordinal)
+                && (addLabels.Contains("intent-pr-created", StringComparer.Ordinal)
+                    || removeLabels.Contains("intent-pr-created", StringComparer.Ordinal)))
+            {
+                throw new InvalidOperationException(
+                    "label policy violation: 'intent-pr-created' is issue-only.");
+            }
+
+            AppliedTransitions.Add(new AppliedTransition
+            {
+                Repo = repo,
+                Kind = kind,
+                Number = number,
+                AddLabels = addLabels.ToArray(),
+                RemoveLabels = removeLabels.ToArray(),
+            });
+        }
+    }
+
+    internal sealed record AppliedTransition
+    {
+        public required string Repo { get; init; }
+        public required string Kind { get; init; }
+        public required int Number { get; init; }
+        public required IReadOnlyList<string> AddLabels { get; init; }
+        public required IReadOnlyList<string> RemoveLabels { get; init; }
+    }
+
+    private sealed class WorkerCompleteWorkspace : IDisposable
+    {
+        public WorkerCompleteWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("worker-complete-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+
+        public IReadOnlyDictionary<string, string> SnapshotWorkspace()
+        {
+            var snapshot = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(RootPath, "*", SearchOption.AllDirectories))
+            {
+                var bytes = File.ReadAllBytes(path);
+                var hash = Convert.ToHexString(SHA256.HashData(bytes));
+                snapshot[path] = hash;
+            }
+            return snapshot;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #527

## Summary

Adds the optional `worker claim` and `worker complete` mutation commands so prompts can move claim/complete label transitions out of free-form gh edits and onto a deterministic, dry-run-by-default writer boundary.

- `worker claim --kind <issue|pr> --number N [--write]` — plans (or applies) the in-progress label add. Refuses stale selections.
- `worker complete --kind <issue|pr> --number N --outcome <X> [--write]` — plans (or applies) the completion transition for one of the eight G205 outcomes. Refuses stale selections. Refuses `intent-pr-created` on a PR target (issue-only policy).

Both commands default to dry-run; nothing mutates GitHub unless `--write` is passed explicitly.

## Acceptance criteria coverage

- ✅ Claim and complete commands are registered (in `CommandRouter` under the `worker` group) and discoverable via the existing CLI help surface.
- ✅ Dry-run mode shows intended label changes without writing (verified by `Empty(mutator.AppliedTransitions)` in the dry-run tests, plus whole-workspace byte-snapshot stability).
- ✅ Explicit write mode applies only supported label transitions (verified by tests asserting the exact `AddLabels`/`RemoveLabels` recorded by the fake mutator).
- ✅ Stale selections are refused (refuses `claim` on already-in-progress / already-completed / missing-target / missing-repair-requested / already-rereview-ready; refuses `complete` on not-claimed / already-completed / unsupported-kind-outcome). Refusal returns exit code 2 and surfaces stable error codes in the JSON `errors[]`.
- ✅ `intent-pr-created` remains issue-only:
  - `WorkerCompleteAnalyzer` never proposes `intent-pr-created` as an add for `kind=pr`, swept across every supported PR outcome (`Execute_IntentPrCreatedNeverEndsUpInPrAddList`).
  - `GhCliGitHubLabelMutator.ApplyLabelTransitions` rejects the combination at the mutator boundary as a defensive guard (`Adapter_ApplyLabelTransitions_RejectsIntentPrCreatedOnPr`).
  - `WorkerClaimAnalyzer` warns when a PR carries the misplaced label.

## Out-of-scope (per the issue body)

- ❌ No provider launch — `NestedProviderLauncher` sentinel asserts no path invokes it.
- ❌ No branch / PR / issue creation — neither command creates GitHub objects.
- ❌ No scheduler registration — purely CLI.
- ❌ No target selection changes — `worker next-action` (G206) remains the single source of truth.

## No-mutation invariants

- Source-scan tests assert the analyzer + command files contain no `Process.Start(`, no `gh issue edit` / `gh pr edit` / `gh pr merge` / `gh pr close` / `gh pr reopen` / `gh pr comment` / `gh pr review`, and no `resolveReviewThread`. The adapter file is exempt by design.
- Whole-workspace byte-snapshot tests cover both dry-run and write paths; the local FS is byte-identical before/after either run.
- The default mutator's policy guard refuses `intent-pr-created` on a PR even if a direct caller bypasses the analyzer.

## Verification

```
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --nologo
# 1415 passed, 1 skipped (pre-existing), 0 failed
git diff --check  # clean
git diff --cached --check  # clean
```

## Files changed

- `src/IntentSystem.Cli/Commands/IGitHubLabelMutator.cs` — testability seam + default `gh` adapter
- `src/IntentSystem.Cli/Commands/WorkerClaim{Result,Analyzer,Command}.cs`
- `src/IntentSystem.Cli/Commands/WorkerComplete{Result,Analyzer,Command}.cs`
- `src/IntentSystem.Cli/Commands/CommandRouter.cs` — registers `worker claim` / `worker complete`
- `tests/IntentSystem.Cli.Tests/WorkerClaim{,Complete}CommandTests.cs`

## Test plan

- [ ] Verify both commands register under `worker` and run with `--help`-style discovery.
- [ ] Verify dry-run JSON output shape (snake_case + camelCase alias) for both commands.
- [ ] Verify stale-refusal exit code 2 + error codes for representative paths.
- [ ] Verify `intent-pr-created` policy: not in `add_labels[]` for any PR completion path.