### PR TITLE
G212: add host review-loop and next-slice prompt templates

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -30,6 +30,14 @@ These templates assume:
 
 ## Template index
 
+The templates are split into two groups by **side** of the host ↔
+child boundary. Child-side templates author or repair implementation
+output; host-side templates review or plan. The two sides MUST NOT
+be mixed inside a single wake — see each template's "Boundary
+against …" section for the explicit comparison tables.
+
+### Child-side (implementation repo)
+
 | File | Path | What it covers |
 |------|------|----------------|
 | [`coding-automation-loop.md`](./coding-automation-loop.md)         | combined loop | One wake: choose between PR repair / issue-to-PR / none |
@@ -37,6 +45,13 @@ These templates assume:
 | [`pr-comment-fix-execution.md`](./pr-comment-fix-execution.md)     | PR repair handoff | Apply repair on the returned PR URL, summarize result |
 | [`metadata-safety.md`](./metadata-safety.md)                       | metadata boundaries | Validate before / after, controlled update only when explicit |
 | [`dry-run-checklist.md`](./dry-run-checklist.md)                   | operator dry-run | Read-only pre-flight to confirm wrapper / commands / no-action / metadata wiring before arming the loop |
+
+### Host-side (parent-host repo)
+
+| File | Path | What it covers |
+|------|------|----------------|
+| [`host-review-loop.md`](./host-review-loop.md)                     | host review | Per-wake review verdict on a child PR (accept / request-update / accept-as-rereview-ready / clarification) with the matching label transition |
+| [`host-next-slice-loop.md`](./host-next-slice-loop.md)             | host planning | Post-merge metadata closeout + pick at most one next-slice candidate (planning artifact only — no implementation, no provider launch) |
 
 ## Hard rules these templates enforce
 
@@ -57,12 +72,34 @@ These templates assume:
   `worker next-action` returns `none`, the wake is idle and ends without
   pushing anything.
 
+## Host-side hard rules (in addition to the rules above)
+
+The host-side templates ([`host-review-loop.md`](./host-review-loop.md)
+and [`host-next-slice-loop.md`](./host-next-slice-loop.md)) keep the
+same `intent-cli` invariants and add:
+
+- **Side discipline**: host-side templates run on the parent-host
+  side. They MUST NOT author or push child-repo implementation
+  changes. Coding-automation work belongs to
+  [`coding-automation-loop.md`](./coding-automation-loop.md).
+- **Bounded writes only into host packets**: any host-packet
+  mutation goes through `intent-cli metadata update` with an
+  explicit supported transition mode (currently
+  `completed-closeout`). See
+  [`metadata-safety.md`](./metadata-safety.md).
+- **No cross-loop shortcuts**: the host review loop and the host
+  next-slice loop run as separate wakes. Neither calls the
+  child-side coding-automation loop directly; the implementation
+  repo's child loop picks up newly-published `intent-target` issues
+  via `intent-cli worker next-action` on its own next wake.
+
 ## What is intentionally out of scope here
 
 - new worker commands;
 - changes to `intent-cli run`;
 - scheduler / cron registration;
-- mutating GitHub issues or PRs from prompts;
-- writing into the parent-host `MyIntentHost` repository from this
-  child repository's prompts;
+- mutating GitHub issues or PRs from coding-automation prompts;
+- writing into the parent-host `MyIntentHost` repository from
+  child-side coding-automation prompts (host-side templates do
+  write — but only via the bounded `metadata update` surface);
 - distributing these templates as a public package.

--- a/docs/automation-templates/host-next-slice-loop.md
+++ b/docs/automation-templates/host-next-slice-loop.md
@@ -1,0 +1,178 @@
+# Host Next-Slice Planning Loop Template
+
+Use this prompt at the top of one wake of the **parent-host
+next-slice planning loop**. It runs AFTER a child PR has been
+accepted and merged (per
+[`host-review-loop.md`](./host-review-loop.md)) and decides which
+slice (if any) to publish next as a child-issue contract. It does
+NOT publish issues itself; that step belongs to the host's
+issue-publish surface and is intentionally out of scope here.
+
+This template is a planning prompt, not a coding prompt. It NEVER
+opens a child PR, NEVER mutates child branches, and NEVER calls the
+implementation-repo coding-automation loop directly.
+
+> **Hard rules** (do not paraphrase):
+> - This template runs on the **host side**. It plans next-slice
+>   work but does NOT author or push implementation changes itself.
+> - `intent-cli` MUST NOT launch any AI provider. Planners (host
+>   operator, AI planner) consume `intent-cli` JSON; the CLI does
+>   not spawn them.
+> - Do NOT call `intent-cli run` from this path.
+> - Target selection for implementation-side wakes remains
+>   single-sourced through `intent-cli worker next-action`. This
+>   loop must NOT author "claim by hand" instructions for the child
+>   loop.
+> - `intent-pr-created` belongs on the source ISSUE. The next-slice
+>   loop does not flip PR-side labels at all; it operates on the
+>   parent-host packet surface and (eventually) the host's child
+>   issue surface.
+> - At most ONE next-slice candidate is promoted per wake.
+
+## Inputs
+
+- `--root <host-root>` — parent-host packet root (e.g. an
+  `MyIntentHost`-style `.intent-cli/` tree).
+- The execution unit ID just merged (or `none`, if this is a
+  cold-start planning wake).
+
+## Step 1: post-merge metadata closeout (when applicable)
+
+If a child PR was just accepted and merged, the host packet for
+that execution unit needs a closeout transition. Use the bounded
+controlled writer:
+
+```bash
+intent-cli metadata update \
+  --root "$HOST_ROOT" \
+  --execution-unit "$EXEC_UNIT" \
+  --mode completed-closeout \
+  --linked-pr "$PR_NUMBER" \
+  --linked-pr-repo "$REPO" \
+  --linked-pr-url "$PR_URL" \
+  --head-sha "$HEAD_SHA" \
+  --merge-commit "$MERGE_COMMIT" \
+  --format json
+```
+
+Boundaries (see [`metadata-safety.md`](./metadata-safety.md)):
+
+- `--root` is REQUIRED. There is no fallback to the process
+  working directory.
+- The only supported mode for now is `completed-closeout`. Any
+  other transition needs a new G2xx slice that adds the mode +
+  tests.
+- Refuse-to-clobber: `metadata update` will refuse if the queue
+  item is already completed or `publish.yaml` already has a `pr:`
+  block.
+
+If the merge state is unclear, do NOT run `metadata update`. Stop
+and open a clarification on the host side.
+
+## Step 2: validate the metadata graph after closeout
+
+Run the read-only validator to confirm the post-closeout graph is
+self-consistent (queue / publish / runs / review-context).
+
+```bash
+intent-cli metadata validate \
+  --root "$HOST_ROOT" \
+  --execution-unit "$EXEC_UNIT" \
+  --format json
+```
+
+If `errors[]` is non-empty after `metadata update`, treat as a
+host clarification stop — do not patch around it from this prompt.
+
+## Step 3: pick at most one next-slice candidate
+
+Inspect the host packet root for execution units that are:
+
+- contract-ready (issue body would pass the Child Issue Contract
+  gate, with all required standalone sections present);
+- not blocked by an unresolved dependency;
+- not already published (no open or merged child PR for the
+  execution unit);
+- not in cooldown.
+
+If multiple candidates exist, prefer the one whose acceptance is
+the smallest scope and whose verification is the cheapest to run.
+This is host-owner judgement; the prompt's job is to make the
+choice explicit, not to invent ranking automation here.
+
+If NO candidate is ready, the next-slice wake is **idle**. Do not
+mutate metadata, do not write child issues, do not push. Idle
+wakes leave the host packet root byte-identical.
+
+## Step 4: dry-run the publish for the chosen candidate
+
+Use the host's existing planning surface (NOT this template) to
+prepare the candidate for publication. Stop short of mutating any
+external system from inside this prompt. The published-issue surface
+on the host side is responsible for actually creating the child
+issue with the standalone contract sections; this template
+intentionally describes the planning step, not the publish step.
+
+If the host has a packet `--dry-run` shape for the publish step,
+emit it here and end the wake. Otherwise the wake's deliverable is
+the chosen `execution_unit` plus the rationale.
+
+## Step 5: hand off (do not call the child loop directly)
+
+The next-slice loop's output is a planning artifact:
+
+- the chosen execution unit ID,
+- the dependency / sequencing rationale,
+- a pointer to the host packet under `--root`.
+
+The actual publish step happens via the host's child-issue
+publication surface. The implementation-repo coding-automation loop
+will then pick the published issue up via `intent-cli worker
+next-action` on its next wake; this template MUST NOT shortcut that
+boundary by calling the child loop directly.
+
+## What this template forbids
+
+- Authoring implementation changes. Next-slice planning describes
+  what to publish; coding-automation produces the implementation.
+- Mutating child PRs / branches / issues from this prompt.
+- Adding or removing `intent-target` from the **child** loop's
+  perspective. The host's review-loop / publish-step / next-slice
+  step may flip `intent-target`; this is the host-side label
+  authority, not the child-side coding-automation authority.
+- Adding `intent-pr-created` anywhere. That label is an issue-side
+  completion marker applied during child-side
+  `worker complete --kind issue --outcome pr-created`; the
+  next-slice loop does not touch it.
+- Calling `intent-cli run`.
+- Asking `intent-cli` to launch an AI provider.
+- Mass-editing parent-host packet content. Use `metadata update`
+  only with an explicit supported mode.
+
+## Boundary against the coding-automation loop
+
+| Concern                  | Host next-slice loop (this template) | Coding automation loop ([`coding-automation-loop.md`](./coding-automation-loop.md)) |
+|--------------------------|--------------------------------------|---------------------------------------------------------------------------------------|
+| Side                     | host                                 | child / implementation                                                                |
+| Purpose                  | choose what to publish next          | implement what is already published                                                   |
+| Touches host packet      | yes — bounded `metadata update`      | no                                                                                    |
+| Touches child PR         | no                                   | yes — via `gh-issue-to-pr` / `gh-fix-pr-comment`                                      |
+| Calls `intent-cli run`   | no                                   | no                                                                                    |
+| Spawns AI provider via CLI| no                                  | no                                                                                    |
+| Output                   | a planning artifact (which slice)    | a draft PR (or a repair commit)                                                       |
+
+When in doubt, ask: "Is the deliverable a planning decision, or a
+code change?" Planning lives here; code changes live in
+[`coding-automation-loop.md`](./coding-automation-loop.md).
+
+## Boundary against the host review loop
+
+| Concern                  | Host review loop ([`host-review-loop.md`](./host-review-loop.md)) | Host next-slice loop (this template) |
+|--------------------------|--------------------------------------------------------------------|--------------------------------------|
+| Trigger                  | a child PR is awaiting review                                     | a child PR was just merged, OR cold-start planning |
+| Output                   | review verdict + label transition + comment                       | chosen next execution unit (planning artifact)     |
+| Mutates                  | review-side labels on the child PR                                | host packet metadata under `--root`                |
+
+Both run on the host side, but they should be separate wakes /
+prompts. Mixing them obscures which transition actually fired and
+makes failure modes harder to diagnose.

--- a/docs/automation-templates/host-review-loop.md
+++ b/docs/automation-templates/host-review-loop.md
@@ -1,0 +1,174 @@
+# Host Review Loop Template
+
+Use this prompt at the top of one wake of the **parent-host review
+loop**. It looks at child PRs that the implementation repo has
+published for review and either records a deterministic review
+verdict for the host owner, or flips the PR back to a labeled state
+that asks for repair / re-review / closeout — all WITHOUT mixing in
+implementation-repo coding-automation work.
+
+This template is the host-side counterpart to
+[`coding-automation-loop.md`](./coding-automation-loop.md). The two
+loops MUST NOT be combined in a single wake. Host review is about
+deciding what to do with finished implementation output; coding
+automation is about producing implementation output. They sit on
+opposite sides of the host ↔ child boundary and have different
+write-surface expectations.
+
+> **Hard rules** (do not paraphrase):
+> - This template runs on the **host side** (parent-host repo),
+>   reviewing PRs published by the **child** implementation repo.
+>   Do NOT use this loop to author implementation changes.
+> - `intent-cli` MUST NOT launch any AI provider. Reviewers (host
+>   operator and/or AI reviewer) consume `intent-cli` JSON; the CLI
+>   itself does not spawn them.
+> - Do NOT call `intent-cli run` from this path.
+> - Target selection is single-sourced through the deterministic
+>   worker / metadata commands. Prompts MUST NOT manually walk labels
+>   in natural language.
+> - `intent-pr-created` belongs on the source ISSUE, not on the PR.
+>   This invariant holds during review-side label decisions too — the
+>   review loop never adds `intent-pr-created` to a PR.
+> - At most ONE PR is touched per wake (single-target cap).
+
+## Inputs
+
+- `--repo <owner/repo>` — the child implementation repo whose PRs
+  are being reviewed.
+- A host operator (or AI reviewer) prepared to make a verdict per
+  PR.
+
+## Step 1: confirm metadata is reviewable
+
+Before flipping any review-side label, validate the parent-host
+packet for the execution unit being reviewed. This step is
+read-only.
+
+```bash
+intent-cli metadata validate \
+  --root "$HOST_ROOT" \
+  --execution-unit "$EXEC_UNIT" \
+  --format json
+```
+
+If `errors[]` is non-empty, treat the review as a clarification stop
+on the host side. Do not patch metadata from inside this prompt;
+follow [`metadata-safety.md`](./metadata-safety.md) for the bounded
+write surface.
+
+## Step 2: ask the worker / next-action selector for context
+
+The implementation-side `worker next-action` selector tells you
+which child PRs are currently `repair-required`, which are
+`ready-to-implement`, and which are idle. Use that read as the
+deterministic context for review decisions — even though the review
+loop's actual target list is the set of child PRs in
+`intent-pr-rereview-ready` / `intent-pr-created` / open-default
+states.
+
+```bash
+intent-cli worker next-action \
+  --repo "<owner>/<repo>" \
+  --format json
+```
+
+Treat the JSON as advisory: it tells you whether the implementation
+side currently has a claim in flight or is idle, which informs your
+review pacing. The review loop itself does NOT consume the
+`recommendedWorkflow` field for action — it consumes it as a
+"don't-step-on-the-implementer" hint.
+
+## Step 3: pick at most one PR for review
+
+From the host's review queue (the set of open PRs published by the
+child repo for review), pick at most ONE PR to act on this wake.
+Selection criteria (host-owner judgement):
+
+- Is the PR contract-complete? (issue body was a sufficient
+  standalone contract; PR scope matches.)
+- Does the implementation match the slice's In Scope / Out Of Scope?
+- Are the verification artifacts referenced in the PR description
+  present and runnable?
+
+If none meet the bar, the wake is **idle on the review side**. Do
+not push, do not flip labels.
+
+## Step 4: produce a deterministic review verdict
+
+Choose ONE of the following review verdicts. Each has an explicit
+label transition. The review loop applies labels via the host's own
+gh CLI / label policy layer; this prompt does not directly mutate
+GitHub labels.
+
+| Verdict                | Label transition                                                                          |
+|------------------------|--------------------------------------------------------------------------------------------|
+| accept-and-merge       | remove `intent-pr-reviewing`; the PR is then merged via the host's merge step.            |
+| request-update         | remove `intent-pr-reviewing` (if present); add `intent-pr-request-update` with comment(s).|
+| accept-as-rereview-ready | (post-repair) remove `intent-pr-update-in-progress`; add `intent-pr-rereview-ready`.   |
+| reject-clarification   | leave a host clarification comment with the cooldown marker; do NOT flip review labels.    |
+
+Notes:
+
+- `intent-pr-created` MUST NOT appear in the add column for any
+  verdict above. It is an issue-side completion marker, not a
+  PR-state marker.
+- `intent-target` is owned by the host's labeling policy. The
+  child-side automation NEVER adds or removes it; host review may.
+
+## Step 5: write the review verdict comment
+
+The review verdict must be recorded as a PR comment that the
+implementation repo's child loop can consume on its next wake. The
+comment language matches the verdict:
+
+- **accept-and-merge**: state the merge intent and reference the
+  passed verification.
+- **request-update**: state the narrow acceptable fix the
+  implementer should apply on next wake. Be precise: list the file
+  / behavior / single-line change so the child loop can apply only
+  the narrow fix without widening scope.
+- **accept-as-rereview-ready**: state that the repair was acceptable
+  and re-review is requested.
+- **reject-clarification**: leave the cooldown marker
+  `<!-- intent-automation-cooldown YYYY-MM-DDTHH:MM:SSZ -->` so the
+  child loop can detect a stop.
+
+## Step 6: optional — emit a structured next-slice classification
+
+If the review verdict is `accept-and-merge`, the host loop hands off
+to the next-slice loop. See
+[`host-next-slice-loop.md`](./host-next-slice-loop.md) for the
+intent of that handoff. Do NOT inline next-slice planning in this
+review prompt.
+
+## What this template forbids
+
+- Authoring implementation changes from the host loop. Host review
+  describes what should change; child coding automation makes the
+  change.
+- Adding `intent-pr-created` to a PR. It is an issue-side label.
+- Adding or removing `intent-target` from the **child** loop. The
+  host's review loop may flip it; the child's coding-automation
+  loop never does.
+- Calling `intent-cli run`. The local coding automation path and
+  the host review path both exclude `intent-cli run`.
+- Mass-editing metadata. Use `metadata update` only with an
+  explicit supported transition mode (see
+  [`metadata-safety.md`](./metadata-safety.md)).
+- Asking `intent-cli` to spawn an AI provider.
+
+## Boundary against the coding-automation loop
+
+| Concern                  | Host review loop (this template) | Coding automation loop ([`coding-automation-loop.md`](./coding-automation-loop.md)) |
+|--------------------------|----------------------------------|---------------------------------------------------------------------------------------|
+| Side                     | host                             | child / implementation                                                                |
+| Purpose                  | verdict on finished work         | produce work                                                                          |
+| Label authority          | review-side labels + `intent-target` (host-owned) | implementation-side labels (`intent-issue-in-progress`, `intent-pr-update-in-progress`, `intent-pr-rereview-ready`, `intent-pr-created` issue-side) |
+| Touches `intent-cli run` | no                               | no                                                                                    |
+| Spawns AI provider via CLI| no                              | no                                                                                    |
+| Writes to parent host    | yes — via bounded `metadata update` only | no — host packet is read-only from the child side                              |
+
+If a wake's intent is genuinely "review what the child built", use
+this template. If it is "build the next slice", use
+[`coding-automation-loop.md`](./coding-automation-loop.md). Never
+mix.

--- a/docs/automation-templates/host-review-loop.md
+++ b/docs/automation-templates/host-review-loop.md
@@ -63,8 +63,10 @@ which child PRs are currently `repair-required`, which are
 `ready-to-implement`, and which are idle. Use that read as the
 deterministic context for review decisions — even though the review
 loop's actual target list is the set of child PRs in
-`intent-pr-rereview-ready` / `intent-pr-created` / open-default
-states.
+`intent-pr-rereview-ready` / open-default / any host-owned
+review-side label states. `intent-pr-created` is NOT a PR-side
+state; it is the issue-side completion marker and never appears in
+the PR review queue.
 
 ```bash
 intent-cli worker next-action \


### PR DESCRIPTION
Closes #529

## Summary

Adds two host-side prompt templates so parent-host planning stays separate from implementation-repo coding automation:

- `docs/automation-templates/host-review-loop.md` — per-wake host review verdict + matching label transition.
- `docs/automation-templates/host-next-slice-loop.md` — post-merge metadata closeout + at-most-one next-slice candidate (planning artifact only).

Updates `docs/automation-templates/README.md` to split the template index into Child-side and Host-side groups, and adds a Host-side hard rules section.

## Acceptance criteria coverage

- ✅ Review-loop and next-slice-loop templates exist (`host-review-loop.md`, `host-next-slice-loop.md`).
- ✅ Templates clearly separate host planning from implementation-repo coding work — each has a "Boundary against the coding-automation loop" comparison table; the next-slice template additionally has a "Boundary against the host review loop" table; README split now puts Child-side and Host-side groups in distinct sections.
- ✅ Templates mention metadata validation/update boundaries — both link to `metadata-safety.md`, the next-slice template embeds the `metadata update --mode completed-closeout` invocation with the required `--root` flag and refuse-to-clobber semantics, and the review template starts with read-only `metadata validate` before any label transition.

## Out of scope (per the issue body)

- ❌ No scheduler / cron registration — both templates explicitly state they do not register schedulers.
- ❌ No provider launch — both templates restate the "intent-cli must not launch any AI provider" hard rule.
- ❌ No new command implementation — purely docs.

## Hard rules preserved

- `intent-cli` must not launch Claude / Codex / any AI provider.
- This local automation path must not call `intent-cli run`.
- Single source of target selection through `intent-cli worker next-action` (advisory in the host review loop, single-source in the child coding loop).
- `intent-pr-created` belongs on the source ISSUE, never the PR — the host review loop's verdict matrix excludes it from PR-side adds; the next-slice loop never touches it.
- Single-target cap: each wake touches at most one PR or one next-slice candidate.

## Verification

```
git diff --check        # clean
git diff --cached --check  # clean
```

Docs-only change; no source-code build or test impact. Existing template invariants are preserved (the README's existing "Hard rules these templates enforce" section is unchanged; new Host-side hard rules are additive).

## Files changed

- `docs/automation-templates/host-review-loop.md` (new)
- `docs/automation-templates/host-next-slice-loop.md` (new)
- `docs/automation-templates/README.md` (template index split + host-side hard-rules section)

## Test plan

- [ ] Render both new templates and confirm boundary tables are accurate.
- [ ] Confirm README index now visually separates Child-side and Host-side template groups.
- [ ] Confirm no checklist step in either template implies `intent-cli` spawning a provider, calling `intent-cli run`, mutating `intent-pr-created` on a PR, or doing manual label-walking when `worker next-action` is available.