### PR TITLE
G213 Add automation check worktree entrypoint

### DIFF
--- a/docs/automation-templates/coding-automation-loop.md
+++ b/docs/automation-templates/coding-automation-loop.md
@@ -1,11 +1,11 @@
 # Combined Coding Automation Loop
 
 Use this prompt at the top of one wake of the local coding automation
-loop. It picks at most ONE target via `intent-cli worker next-action`
+loop. It picks at most ONE target via `intent-cli automation check`
 and dispatches to the appropriate execution-handoff template.
 
 > **Hard rules** (do not paraphrase):
-> - Use `intent-cli worker next-action --format json` to choose work.
+> - Use `intent-cli automation check --format json` to choose work.
 >   Do NOT walk labels manually in this prompt.
 > - At most ONE branch/PR per wake.
 > - `intent-cli` MUST NOT launch any AI provider. The external AI
@@ -14,14 +14,22 @@ and dispatches to the appropriate execution-handoff template.
 
 ## Inputs
 
-- `--repo <owner/repo>` — child repo this loop targets.
+- `--repo <owner/repo>` — optional child repo override. When omitted,
+  `intent-cli automation check` infers it from the current worktree or
+  `--workdir`.
+- `--workdir <path>` — optional child worktree path.
 
 ## Step 1: pick the next action
 
 ```bash
-intent-cli worker next-action \
-  --repo "$REPO" \
-  --format json
+intent-cli automation check --format json
+```
+
+When the controlling loop runs outside the child worktree, pass the
+child path explicitly:
+
+```bash
+intent-cli automation check --workdir "$WORKDIR" --format json
 ```
 
 The output has a stable shape (G206):

--- a/docs/automation-templates/dry-run-checklist.md
+++ b/docs/automation-templates/dry-run-checklist.md
@@ -81,15 +81,16 @@ Expected (at minimum, names — exact help text may evolve):
 If any of those names is missing, the installed `intent-cli` is
 older than the prompt templates expect. Upgrade before continuing.
 
-## 3. Smoke-test `worker next-action` (target selection)
+## 3. Smoke-test `automation check` (target selection)
 
-`worker next-action` is the single source of truth for "what does
-this wake do?". Confirm it returns parseable JSON with the expected
-shape, against the live repo, in a no-op state.
+`automation check` is the preferred entrypoint for "what does this
+wake do?". It infers the repo from the current worktree (or
+`--workdir`) and delegates to the same selection semantics as
+`worker next-action`. Confirm it returns parseable JSON with the
+expected shape, against the live repo, in a no-op state.
 
 ```bash
-intent-cli worker next-action \
-  --repo "<owner>/<repo>" \
+intent-cli automation check \
   --format json
 ```
 
@@ -103,8 +104,7 @@ Expected:
 Pipe through `jq` to confirm parseability:
 
 ```bash
-intent-cli worker next-action \
-  --repo "<owner>/<repo>" \
+intent-cli automation check \
   --format json \
   | jq '{recommendedWorkflow, sourceClassification}'
 ```
@@ -117,12 +117,11 @@ works end-to-end.
 ## 4. Smoke-test the no-action path
 
 Verify the loop's idle behavior. When there is no eligible target,
-`worker next-action` must be explicit about it; the prompt then
+`automation check` must be explicit about it; the prompt then
 treats the wake as idle and stops without pushing anything.
 
 ```bash
-intent-cli worker next-action \
-  --repo "<owner>/<repo>" \
+intent-cli automation check \
   --format json \
   | jq -r '.recommendedWorkflow'
 ```

--- a/src/IntentSystem.Cli/Commands/AutomationCheckCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationCheckCommand.cs
@@ -1,0 +1,298 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G213: <c>intent-cli automation check</c> is a local convenience wrapper
+/// around <c>worker next-action</c>. It owns worktree-to-GitHub-repo inference
+/// so prompt templates do not need shell snippets for common origin remotes.
+/// The command is read-only and delegates selection to the existing worker
+/// implementation.
+/// </summary>
+internal static class AutomationCheckCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var repoOverride, out var workdir, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        var repo = repoOverride;
+        if (string.IsNullOrWhiteSpace(repo)
+            && !TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var workerArgs = new List<string>
+        {
+            "--repo", repo!,
+            "--workdir", resolvedWorkdir,
+            "--format", format
+        };
+
+        return WorkerNextActionCommand.Execute(context, workerArgs.ToArray(), writer);
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string? workdir,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        workdir = null;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+
+                    repo = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--workdir":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--workdir requires a value.";
+                        return false;
+                    }
+
+                    workdir = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: [--repo <owner/repo>] [--workdir <path>] [--format text|json].";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string ResolveWorkdir(CliContext context, string? workdir)
+    {
+        if (string.IsNullOrWhiteSpace(workdir))
+        {
+            return context.RepoRoot;
+        }
+
+        return Path.GetFullPath(workdir);
+    }
+
+    internal static bool TryInferGitHubRepo(string workdir, out string? repo, out string error)
+    {
+        repo = null;
+        error = string.Empty;
+
+        if (!Directory.Exists(workdir))
+        {
+            error = $"Cannot infer repo: workdir does not exist: {workdir}";
+            return false;
+        }
+
+        if (!TryFindGitDirectory(workdir, out var gitDirectory, out error))
+        {
+            return false;
+        }
+
+        if (!TryReadOriginRemoteUrl(gitDirectory, out var remoteUrl, out error))
+        {
+            return false;
+        }
+
+        if (!TryParseGitHubRepo(remoteUrl!, out repo))
+        {
+            error = $"Cannot infer GitHub repo from origin remote '{remoteUrl}' in {workdir}. Expected a github.com owner/repo remote.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryFindGitDirectory(string workdir, out string gitDirectory, out string error)
+    {
+        var directory = new DirectoryInfo(workdir);
+        while (directory is not null)
+        {
+            var gitPath = Path.Combine(directory.FullName, ".git");
+            if (Directory.Exists(gitPath))
+            {
+                gitDirectory = gitPath;
+                error = string.Empty;
+                return true;
+            }
+
+            if (File.Exists(gitPath))
+            {
+                var line = File.ReadLines(gitPath).FirstOrDefault() ?? string.Empty;
+                const string prefix = "gitdir:";
+                if (!line.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    gitDirectory = string.Empty;
+                    error = $"Cannot infer repo: {gitPath} is not a gitdir pointer.";
+                    return false;
+                }
+
+                var gitDirValue = line[prefix.Length..].Trim();
+                gitDirectory = Path.IsPathRooted(gitDirValue)
+                    ? Path.GetFullPath(gitDirValue)
+                    : Path.GetFullPath(Path.Combine(directory.FullName, gitDirValue));
+                error = string.Empty;
+                return true;
+            }
+
+            directory = directory.Parent;
+        }
+
+        gitDirectory = string.Empty;
+        error = $"Cannot infer repo: no .git directory found from {workdir}.";
+        return false;
+    }
+
+    private static bool TryReadOriginRemoteUrl(string gitDirectory, out string? remoteUrl, out string error)
+    {
+        remoteUrl = null;
+        error = string.Empty;
+
+        foreach (var configPath in EnumerateConfigPaths(gitDirectory))
+        {
+            if (!File.Exists(configPath))
+            {
+                continue;
+            }
+
+            if (TryReadOriginRemoteUrlFromConfig(configPath, out remoteUrl))
+            {
+                return true;
+            }
+        }
+
+        error = $"Cannot infer repo: no origin remote URL found in git config for {gitDirectory}.";
+        return false;
+    }
+
+    private static IEnumerable<string> EnumerateConfigPaths(string gitDirectory)
+    {
+        yield return Path.Combine(gitDirectory, "config");
+
+        var commonDirPath = Path.Combine(gitDirectory, "commondir");
+        if (File.Exists(commonDirPath))
+        {
+            var commonDirValue = File.ReadAllText(commonDirPath).Trim();
+            if (!string.IsNullOrWhiteSpace(commonDirValue))
+            {
+                var commonDir = Path.IsPathRooted(commonDirValue)
+                    ? Path.GetFullPath(commonDirValue)
+                    : Path.GetFullPath(Path.Combine(gitDirectory, commonDirValue));
+                yield return Path.Combine(commonDir, "config");
+            }
+        }
+    }
+
+    private static bool TryReadOriginRemoteUrlFromConfig(string configPath, out string? remoteUrl)
+    {
+        remoteUrl = null;
+        var inOriginRemote = false;
+        foreach (var rawLine in File.ReadLines(configPath))
+        {
+            var line = rawLine.Trim();
+            if (line.StartsWith("[", StringComparison.Ordinal))
+            {
+                inOriginRemote = string.Equals(line, "[remote \"origin\"]", StringComparison.Ordinal);
+                continue;
+            }
+
+            if (!inOriginRemote || !line.StartsWith("url", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var separator = line.IndexOf('=', StringComparison.Ordinal);
+            if (separator < 0)
+            {
+                continue;
+            }
+
+            remoteUrl = line[(separator + 1)..].Trim();
+            return !string.IsNullOrWhiteSpace(remoteUrl);
+        }
+
+        return false;
+    }
+
+    internal static bool TryParseGitHubRepo(string remoteUrl, out string? repo)
+    {
+        repo = null;
+        var normalized = remoteUrl.Trim();
+
+        const string httpsPrefix = "https://github.com/";
+        const string sshPrefix = "git@github.com:";
+        if (normalized.StartsWith(httpsPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized[httpsPrefix.Length..];
+        }
+        else if (normalized.StartsWith(sshPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized[sshPrefix.Length..];
+        }
+        else
+        {
+            return false;
+        }
+
+        if (normalized.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized[..^4];
+        }
+
+        var parts = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length != 2)
+        {
+            return false;
+        }
+
+        repo = $"{parts[0]}/{parts[1]}";
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -120,6 +120,7 @@ internal static class CommandRouter
             },
             ["automation"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
+                ["check"] = AutomationCheckCommand.Execute,
                 ["summary"] = AutomationSummaryCommand.Execute
             },
             ["safety"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -21,7 +21,7 @@ internal static class Program
             }
 
             var currentDirectory = Directory.GetCurrentDirectory();
-            if (IsIntakeInitCommand(args))
+            if (IsIntakeInitCommand(args) || IsAutomationCheckCommand(args))
             {
                 return CommandRouter.Execute(args, CreateBootstrapContext(currentDirectory, args), Console.Out);
             }
@@ -53,6 +53,13 @@ internal static class Program
         return args.Length >= 2
             && string.Equals(args[0], "intake", StringComparison.Ordinal)
             && string.Equals(args[1], "init", StringComparison.Ordinal);
+    }
+
+    private static bool IsAutomationCheckCommand(string[] args)
+    {
+        return args.Length >= 2
+            && string.Equals(args[0], "automation", StringComparison.Ordinal)
+            && string.Equals(args[1], "check", StringComparison.Ordinal);
     }
 
     private static CliContext CreateBootstrapContext(string currentDirectory, string[] args)

--- a/tests/IntentSystem.Cli.Tests/AutomationCheckCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationCheckCommandTests.cs
@@ -1,0 +1,343 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G213: Tests for <c>intent-cli automation check</c>. The command infers a
+/// GitHub repo from a local worktree and delegates to worker next-action
+/// without mutating files, labels, issues, PRs, branches, or launching a
+/// provider.
+/// </summary>
+public sealed class AutomationCheckCommandTests : IDisposable
+{
+    public AutomationCheckCommandTests()
+    {
+        WorkerNextActionCommand.CandidateListerFactory = null;
+        WorkerNextActionCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        WorkerNextActionCommand.CandidateListerFactory = null;
+        WorkerNextActionCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void Execute_InfersRepoFromHttpsOriginRemote()
+    {
+        using var workspace = new AutomationCheckWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var lister = new CapturingLister
+        {
+            Issues = new[]
+            {
+                BuildIssue(531, "G213", "https://github.com/J-Tech-Japan/intent-system/issues/531",
+                    "2026-05-01T00:00:00Z", new[] { "intent-target" }),
+            },
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCheckCommand.Execute(
+            workspace.Context,
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("J-Tech-Japan/intent-system", lister.SeenRepo);
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal("J-Tech-Japan/intent-system", result.Repo);
+        Assert.Equal(WorkerNextActionConstants.Actions.IssueToPr, result.Action);
+        Assert.Equal(531, result.Number);
+    }
+
+    [Fact]
+    public void Execute_InfersRepoFromSshOriginRemote()
+    {
+        using var workspace = new AutomationCheckWorkspace();
+        workspace.WriteOriginRemote("git@github.com:J-Tech-Japan/intent-system.git");
+        var lister = new CapturingLister();
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCheckCommand.Execute(
+            workspace.Context,
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("J-Tech-Japan/intent-system", lister.SeenRepo);
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal(WorkerNextActionConstants.Actions.None, result.Action);
+    }
+
+    [Fact]
+    public void Execute_RepoOverrideSkipsWorktreeInference()
+    {
+        using var workspace = new AutomationCheckWorkspace();
+        var lister = new CapturingLister();
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCheckCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "Override/Repo", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("Override/Repo", lister.SeenRepo);
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal("Override/Repo", result.Repo);
+    }
+
+    [Fact]
+    public void Execute_WorkdirChangesRepoInferenceRoot()
+    {
+        using var workspace = new AutomationCheckWorkspace();
+        var child = workspace.CreateChildWorkdir("child");
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/wrong.git");
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system", child);
+        var lister = new CapturingLister();
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCheckCommand.Execute(
+            workspace.Context,
+            new[] { "--workdir", child, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("J-Tech-Japan/intent-system", lister.SeenRepo);
+    }
+
+    [Fact]
+    public void Execute_InferenceFailureReturnsActionableError()
+    {
+        using var workspace = new AutomationCheckWorkspace();
+        workspace.WriteOriginRemote("https://example.com/J-Tech-Japan/intent-system.git");
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCheckCommand.Execute(
+            workspace.Context,
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("Cannot infer GitHub repo", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Expected a github.com owner/repo remote", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommandRouter_RegistersAutomationCheck()
+    {
+        using var workspace = new AutomationCheckWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        WorkerNextActionCommand.CandidateListerFactory = () => new CapturingLister();
+
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            new[] { "automation", "check", "--format", "json" },
+            workspace.Context,
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal(WorkerNextActionConstants.Actions.None, result.Action);
+    }
+
+    [Fact]
+    public void ProgramMain_AutomationCheckDoesNotRequireIntentCliDirectory()
+    {
+        using var workspace = new AutomationCheckWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        WorkerNextActionCommand.CandidateListerFactory = () => new CapturingLister();
+        var originalDirectory = Directory.GetCurrentDirectory();
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+
+        try
+        {
+            Directory.SetCurrentDirectory(workspace.RootPath);
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+
+            var exitCode = Program.Main(new[] { "automation", "check", "--format", "json" });
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(string.Empty, stderr.ToString());
+            var result = JsonSerializer.Deserialize<WorkerNextActionResult>(stdout.ToString())!;
+            Assert.Equal("J-Tech-Japan/intent-system", result.Repo);
+            Assert.Equal(WorkerNextActionConstants.Actions.None, result.Action);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+            Directory.SetCurrentDirectory(originalDirectory);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesNestedProviderLauncher()
+    {
+        using var workspace = new AutomationCheckWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var launcherInvoked = false;
+        WorkerNextActionCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => new CapturingLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCheckCommand.Execute(
+            workspace.Context,
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(launcherInvoked,
+            "AutomationCheckCommand must never invoke NestedProviderLauncher.");
+    }
+
+    [Fact]
+    public void Execute_LeavesWorkspaceByteEquivalent()
+    {
+        using var workspace = new AutomationCheckWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var before = workspace.SnapshotWorkspace();
+        WorkerNextActionCommand.CandidateListerFactory = () => new CapturingLister();
+
+        using (var writer = new StringWriter())
+        {
+            Assert.Equal(0, AutomationCheckCommand.Execute(
+                workspace.Context,
+                new[] { "--format", "json" },
+                writer));
+        }
+
+        var after = workspace.SnapshotWorkspace();
+        Assert.Equal(before.Count, after.Count);
+        foreach (var (path, hash) in before)
+        {
+            Assert.True(after.TryGetValue(path, out var afterHash),
+                $"file disappeared after run: {path}");
+            Assert.Equal(hash, afterHash);
+        }
+    }
+
+    private static GitHubAutomationIssueCandidate BuildIssue(
+        int number,
+        string title,
+        string url,
+        string createdAt,
+        string[] labels)
+    {
+        return new GitHubAutomationIssueCandidate
+        {
+            Number = number,
+            Title = title,
+            Url = url,
+            CreatedAt = createdAt,
+            Labels = labels.Select(n => new GitHubAutomationLabel { Name = n }).ToArray(),
+        };
+    }
+
+    private sealed class CapturingLister : IGitHubAutomationCandidateLister
+    {
+        public string? SeenRepo { get; private set; }
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> Prs { get; init; }
+            = Array.Empty<GitHubAutomationPrCandidate>();
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> Issues { get; init; }
+            = Array.Empty<GitHubAutomationIssueCandidate>();
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels)
+        {
+            SeenRepo = repo;
+            return Prs;
+        }
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels)
+        {
+            SeenRepo = repo;
+            return Issues;
+        }
+    }
+
+    private sealed class AutomationCheckWorkspace : IDisposable
+    {
+        public AutomationCheckWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("automation-check-tests-").FullName;
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public string CreateChildWorkdir(string name)
+        {
+            var path = Path.Combine(RootPath, name);
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        public void WriteOriginRemote(string remoteUrl, string? workdir = null)
+        {
+            var root = workdir ?? RootPath;
+            var gitDirectory = Path.Combine(root, ".git");
+            Directory.CreateDirectory(gitDirectory);
+            File.WriteAllText(
+                Path.Combine(gitDirectory, "config"),
+                $"""
+                [remote "origin"]
+                    url = {remoteUrl}
+                """);
+        }
+
+        public IReadOnlyDictionary<string, string> SnapshotWorkspace()
+        {
+            var snapshot = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(RootPath, "*", SearchOption.AllDirectories))
+            {
+                var bytes = File.ReadAllBytes(path);
+                var hash = Convert.ToHexString(SHA256.HashData(bytes));
+                snapshot[path] = hash;
+            }
+            return snapshot;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `intent-cli automation check [--repo <owner/repo>] [--workdir <path>] [--format text|json]` as a read-only wrapper around `worker next-action`.
- Infer GitHub repos from `origin` remotes for HTTPS and SSH github.com URL forms, with `--repo` as an explicit override.
- Allow `automation check` to bootstrap from child worktrees without a `.intent-cli` directory, then delegate to the existing worker selection and JSON shape.
- Update automation templates to prefer `intent-cli automation check --format json`.

Closes #531

## Verification

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter AutomationCheckCommandTests`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter WorkerNextActionCommandTests`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` (fails: existing temp-directory cleanup failure in `DirectRunLauncherTests.Launch_GivenWrappedCodexProcessEndsAfterCliReturns_DetachedCaptureAppendsBackendExitProviderEvent`; 1423 passed, 1 skipped)

## Repo inference cases covered

- HTTPS origin: `https://github.com/J-Tech-Japan/intent-system.git`
- HTTPS origin without `.git`: `https://github.com/J-Tech-Japan/intent-system`
- SSH origin: `git@github.com:J-Tech-Japan/intent-system.git`
- `--repo` override skips inference
- `--workdir` changes the inference root
- non-GitHub origin returns a non-zero actionable error

## Sample JSON output

```json
{
  "action": "issue-to-pr",
  "repo": "J-Tech-Japan/intent-system",
  "number": 531,
  "url": "https://github.com/J-Tech-Japan/intent-system/issues/531",
  "reason": "oldest open intent-target issue without in-progress or pr-created state",
  "recommended_workflow": "gh-issue-to-pr",
  "recommendedWorkflow": "gh-issue-to-pr",
  "warnings": [],
  "source_classification": "ready-to-implement",
  "sourceClassification": "ready-to-implement"
}
```

## No-mutation confirmation

The command delegates to the existing read-only `worker next-action` selection path. It performs no GitHub mutation, label mutation, file mutation, branch/worktree creation, issue/PR creation, merge, or provider launch.