### PR TITLE
G214 Add automation complete worktree entrypoint

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -27,6 +27,8 @@ These templates assume:
 | G206  | `intent-cli worker next-action`         | Pick at most one target |
 | G207  | `intent-cli metadata validate`          | Mechanical packet validator |
 | G208  | `intent-cli metadata update`            | Bounded controlled writer |
+| G213  | `intent-cli automation check`           | Worktree-aware next-action entrypoint |
+| G214  | `intent-cli automation complete`        | Worktree-aware outcome completion entrypoint |
 
 ## Template index
 
@@ -56,7 +58,8 @@ against …" section for the explicit comparison tables.
 ## Hard rules these templates enforce
 
 - **Single source of truth for target selection**: prompts must call
-  `intent-cli worker next-action --format json` and act on its result.
+  `intent-cli automation check --format json` (or the lower-level
+  `worker next-action` wrapper path) and act on its result.
   No manual label-walking in the prompt body.
 - **No provider launch from `intent-cli`**: `intent-cli` is deterministic
   support tooling; it must NEVER spawn Claude / Codex / any AI provider.
@@ -66,8 +69,8 @@ against …" section for the explicit comparison tables.
   semantics and is out of scope here.
 - **Label policy invariant**: `intent-pr-created` belongs on the source
   ISSUE, not on the PR. Prompts and post-run summaries that imply
-  otherwise are a bug — `worker result-summary` will surface this as a
-  warning automatically when it detects misuse.
+  otherwise are a bug — `automation complete` / `worker result-summary`
+  surface this as a warning automatically when they detect misuse.
 - **Single-target cap**: at most ONE branch/PR is touched per wake. If
   `worker next-action` returns `none`, the wake is idle and ends without
   pushing anything.

--- a/docs/automation-templates/coding-automation-loop.md
+++ b/docs/automation-templates/coding-automation-loop.md
@@ -61,25 +61,25 @@ If `warnings[]` is non-empty, surface each warning verbatim in the wake
 summary so the operator sees label-policy issues such as
 `intent-pr-created` being misplaced on a PR.
 
-## Step 3: post-run summary (after the AI worker returns)
+## Step 3: post-run completion (after the AI worker returns)
 
 When the dispatched handoff has finished and produced an outcome string
 (e.g. `pr-created`, `repair-pushed`, `clarification-required`, `failed`),
 ask the operator (or the controlling automation) to run:
 
 ```bash
-intent-cli worker result-summary \
+intent-cli automation complete \
   --kind <issue-to-pr|pr-comment-fix> \
-  --repo "$REPO" \
   [--issue <n>] [--pr <n>] \
   --outcome <outcome> \
   --format json
 ```
 
-Use the JSON `recommended_label_actions[]` and `warnings[]` to render the
-wake summary. Do NOT mutate labels from this prompt — those actions are
-advisory; the controlling automation applies them via its own gh CLI
-layer.
+By default this is dry-run and emits `recommended_label_actions[]`,
+`planned_label_actions[]`, `applied_label_actions[]`, `warnings[]`,
+and `summary`. To apply the supported completion label transition,
+the controlling automation must pass `--write` explicitly. Do NOT
+mutate labels outside the `automation complete --write` path.
 
 ## Idempotency
 

--- a/docs/automation-templates/dry-run-checklist.md
+++ b/docs/automation-templates/dry-run-checklist.md
@@ -136,18 +136,17 @@ If the selector instead returns an actionable workflow on an
 already-quiet repo, stop and inspect — the prompt must not fabricate
 a target on top of a non-action selector result.
 
-## 5. Smoke-test `worker result-summary` (issue-to-PR outcome)
+## 5. Smoke-test `automation complete` (issue-to-PR outcome)
 
-`worker result-summary` is how each wake's result is normalized into
-a stable JSON shape that downstream summaries / status comments can
-consume without re-deriving labels. Confirm it can render an
-issue-to-PR outcome shape without mutation.
+`automation complete` is how each wake's result is normalized into a
+stable JSON shape and, only with explicit `--write`, converted into
+the supported completion label transition. Confirm it can render an
+issue-to-PR outcome shape in dry-run mode.
 
 ```bash
-intent-cli worker result-summary \
+intent-cli automation complete \
   --kind issue-to-pr \
   --outcome pr-created \
-  --repo "<owner>/<repo>" \
   --issue 123 \
   --pr 124 \
   --format json
@@ -157,23 +156,24 @@ Expected:
 
 - exit code 0,
 - stdout is a single JSON object with at least `kind`, `outcome`,
-  `status`, `recommendedLabelActions[]`, and `summary`.
+  `status`, `recommendedLabelActions[]`, `plannedLabelActions[]`,
+  `appliedLabelActions[]`, and `summary`.
 
 Important: this is a **render-only** call. It does NOT touch
-GitHub. The numbers above can be placeholders; pick values that
-exist if you want a richer dry run, but do not pass values that
-would imply mutation downstream.
+GitHub labels unless `--write` is present. Use an issue number that
+currently carries the claim label if you want `plannedLabelActions[]`
+to show the success transition; otherwise the command may correctly
+refuse as stale.
 
-## 6. Smoke-test `worker result-summary` (PR comment-fix outcome)
+## 6. Smoke-test `automation complete` (PR comment-fix outcome)
 
 Repeat the same render-only check for the PR repair workflow. This
 is the path the loop uses after a `gh-fix-pr-comment`-style fix.
 
 ```bash
-intent-cli worker result-summary \
+intent-cli automation complete \
   --kind pr-comment-fix \
-  --outcome update-applied \
-  --repo "<owner>/<repo>" \
+  --outcome repair-pushed \
   --pr 124 \
   --format json
 ```
@@ -181,9 +181,9 @@ intent-cli worker result-summary \
 Expected:
 
 - exit code 0,
-- the JSON's `recommendedLabelActions[]` reflects the
-  reviewing → rereview-ready handoff, NOT a fresh
-  `intent-pr-created` on the PR.
+- the JSON's `plannedLabelActions[]` reflects the
+  update-in-progress → rereview-ready handoff, NOT a fresh
+  `intent-pr-created` on the PR,
 - `intent-pr-created` does not appear as a recommended add on a PR.
   If it does, treat it as a bug — `intent-pr-created` belongs on
   the source ISSUE, not on the PR.

--- a/src/IntentSystem.Cli/Commands/AutomationCompleteCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationCompleteCommand.cs
@@ -1,0 +1,537 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G214: <c>intent-cli automation complete</c> is the automation-level
+/// post-run entrypoint. It normalizes a worker outcome and, with explicit
+/// <c>--write</c>, applies only the supported completion transition already
+/// modeled by <c>worker complete</c>.
+/// </summary>
+internal static class AutomationCompleteCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    /// <summary>Test seam shared with worker complete's GitHub label mutator.</summary>
+    public static Func<IGitHubLabelMutator>? MutatorFactory { get; set; }
+
+    /// <summary>Test sentinel: must never be invoked by this command.</summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(
+                args,
+                out var workflowKind,
+                out var repoOverride,
+                out var workdir,
+                out var issue,
+                out var pr,
+                out var outcome,
+                out var mode,
+                out var format,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        var repo = repoOverride;
+        if (string.IsNullOrWhiteSpace(repo)
+            && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        if (!TryMapCompletionTarget(workflowKind!, issue, pr, out var targetKind, out var targetNumber, out error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        WorkerResultSummaryResult summary;
+        try
+        {
+            summary = WorkerResultSummaryAnalyzer.Analyze(
+                workflowKind!,
+                outcome!,
+                repo!,
+                issue,
+                pr);
+        }
+        catch (ArgumentException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+
+        IGitHubLabelMutator mutator;
+        try
+        {
+            mutator = MutatorFactory?.Invoke()
+                ?? WorkerCompleteCommand.MutatorFactory?.Invoke()
+                ?? new GhCliGitHubLabelMutator();
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub mutator: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<GitHubAutomationLabel> currentLabels;
+        try
+        {
+            currentLabels = mutator.ReadLabels(repo!, targetKind, targetNumber);
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine(
+                $"failed to read current labels for {targetKind} #{targetNumber} in {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var currentNames = LabelNames(currentLabels);
+        var decision = WorkerCompleteAnalyzer.Analyze(targetKind, outcome!, currentNames);
+        var plannedActions = BuildPlannedActions(targetKind, decision);
+
+        var applied = false;
+        if (decision.Proceed
+            && string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal))
+        {
+            try
+            {
+                mutator.ApplyLabelTransitions(
+                    repo!, targetKind, targetNumber, decision.AddLabels, decision.RemoveLabels);
+                applied = true;
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or IOException)
+            {
+                writer.WriteLine(
+                    $"failed to apply complete transition on {targetKind} #{targetNumber} in {repo}: {exception.Message}");
+                return 1;
+            }
+        }
+
+        var warnings = summary.Warnings.Concat(decision.Warnings).ToArray();
+        var result = new AutomationCompleteResult
+        {
+            Kind = workflowKind!,
+            Repo = repo!,
+            Issue = issue,
+            Pr = pr,
+            Outcome = outcome!,
+            Status = summary.Status,
+            Mode = mode,
+            TargetKind = targetKind,
+            TargetNumber = targetNumber,
+            Proceed = decision.Proceed,
+            Applied = applied,
+            RecommendedLabelActions = summary.RecommendedLabelActions,
+            PlannedLabelActions = plannedActions,
+            AppliedLabelActions = applied ? plannedActions : Array.Empty<WorkerResultSummaryLabelAction>(),
+            CurrentLabels = currentNames,
+            Errors = decision.Errors,
+            Warnings = warnings,
+            Summary = $"{summary.Summary} {decision.Summary}",
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return decision.Proceed ? 0 : 2;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? kind,
+        out string? repo,
+        out string? workdir,
+        out int? issue,
+        out int? pr,
+        out string? outcome,
+        out string mode,
+        out string format,
+        out string error)
+    {
+        kind = null;
+        repo = null;
+        workdir = null;
+        issue = null;
+        pr = null;
+        outcome = null;
+        mode = WorkerClaimCompleteConstants.Modes.DryRun;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--kind":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--kind requires a value (issue-to-pr or pr-comment-fix).";
+                        return false;
+                    }
+                    kind = args[index + 1];
+                    index++;
+                    break;
+
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--workdir":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--workdir requires a value.";
+                        return false;
+                    }
+                    workdir = args[index + 1];
+                    index++;
+                    break;
+
+                case "--issue":
+                    if (!TryReadPositiveInt(args, index, "--issue", out var issueNumber, out error))
+                    {
+                        return false;
+                    }
+                    issue = issueNumber;
+                    index++;
+                    break;
+
+                case "--pr":
+                    if (!TryReadPositiveInt(args, index, "--pr", out var prNumber, out error))
+                    {
+                        return false;
+                    }
+                    pr = prNumber;
+                    index++;
+                    break;
+
+                case "--outcome":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--outcome requires a value.";
+                        return false;
+                    }
+                    outcome = args[index + 1];
+                    index++;
+                    break;
+
+                case "--write":
+                    mode = WorkerClaimCompleteConstants.Modes.Write;
+                    break;
+
+                case "--dry-run":
+                    mode = WorkerClaimCompleteConstants.Modes.DryRun;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --kind <issue-to-pr|pr-comment-fix> [--repo <owner/repo>] [--workdir <path>] [--issue <n>] [--pr <n>] --outcome <outcome> [--write] [--dry-run] [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(kind))
+        {
+            error = "--kind is required (issue-to-pr or pr-comment-fix).";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(outcome))
+        {
+            error = "--outcome is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadPositiveInt(
+        string[] args,
+        int index,
+        string option,
+        out int value,
+        out string error)
+    {
+        value = 0;
+        error = string.Empty;
+        if (index + 1 >= args.Length
+            || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out value)
+            || value <= 0)
+        {
+            error = $"{option} requires a positive integer.";
+            return false;
+        }
+        return true;
+    }
+
+    private static string ResolveWorkdir(CliContext context, string? workdir)
+    {
+        if (string.IsNullOrWhiteSpace(workdir))
+        {
+            return context.RepoRoot;
+        }
+
+        return Path.GetFullPath(workdir);
+    }
+
+    private static bool TryMapCompletionTarget(
+        string workflowKind,
+        int? issue,
+        int? pr,
+        out string targetKind,
+        out int targetNumber,
+        out string error)
+    {
+        targetKind = string.Empty;
+        targetNumber = 0;
+        error = string.Empty;
+
+        switch (workflowKind)
+        {
+            case WorkerResultSummaryConstants.Kinds.IssueToPr:
+                if (issue is null)
+                {
+                    error = "--issue is required when --kind is issue-to-pr.";
+                    return false;
+                }
+                targetKind = GhCliGitHubLabelMutator.Kinds.Issue;
+                targetNumber = issue.Value;
+                return true;
+
+            case WorkerResultSummaryConstants.Kinds.PrCommentFix:
+                if (pr is null)
+                {
+                    error = "--pr is required when --kind is pr-comment-fix.";
+                    return false;
+                }
+                targetKind = GhCliGitHubLabelMutator.Kinds.Pr;
+                targetNumber = pr.Value;
+                return true;
+
+            default:
+                error = $"--kind must be 'issue-to-pr' or 'pr-comment-fix' (got '{workflowKind}').";
+                return false;
+        }
+    }
+
+    private static IReadOnlyList<string> LabelNames(IReadOnlyList<GitHubAutomationLabel>? labels)
+    {
+        if (labels is null || labels.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var names = new List<string>(labels.Count);
+        foreach (var label in labels)
+        {
+            if (!string.IsNullOrEmpty(label.Name))
+            {
+                names.Add(label.Name);
+            }
+        }
+        return names;
+    }
+
+    private static IReadOnlyList<WorkerResultSummaryLabelAction> BuildPlannedActions(
+        string targetKind,
+        WorkerCompleteAnalyzer.CompleteDecision decision)
+    {
+        if (!decision.Proceed)
+        {
+            return Array.Empty<WorkerResultSummaryLabelAction>();
+        }
+
+        var target = string.Equals(targetKind, GhCliGitHubLabelMutator.Kinds.Issue, StringComparison.Ordinal)
+            ? WorkerResultSummaryConstants.LabelActionTargets.Issue
+            : WorkerResultSummaryConstants.LabelActionTargets.Pr;
+        var actions = new List<WorkerResultSummaryLabelAction>();
+        foreach (var label in decision.RemoveLabels)
+        {
+            actions.Add(new WorkerResultSummaryLabelAction
+            {
+                Action = WorkerResultSummaryConstants.LabelActionVerbs.Remove,
+                Target = target,
+                Label = label,
+            });
+        }
+        foreach (var label in decision.AddLabels)
+        {
+            actions.Add(new WorkerResultSummaryLabelAction
+            {
+                Action = WorkerResultSummaryConstants.LabelActionVerbs.Add,
+                Target = target,
+                Label = label,
+            });
+        }
+        return actions;
+    }
+
+    private static void WriteText(TextWriter writer, AutomationCompleteResult result)
+    {
+        writer.WriteLine($"# Automation complete for {result.Repo} ({result.Kind})");
+        writer.WriteLine();
+        writer.WriteLine($"- outcome: {result.Outcome}");
+        writer.WriteLine($"- status: {result.Status}");
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- target: {result.TargetKind} #{result.TargetNumber}");
+        writer.WriteLine($"- proceed: {result.Proceed}");
+        writer.WriteLine($"- applied: {result.Applied}");
+        writer.WriteLine();
+        writer.WriteLine("## Planned label actions");
+        if (result.PlannedLabelActions.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var action in result.PlannedLabelActions)
+            {
+                writer.WriteLine($"- {action.Action} {action.Label} on {action.Target}");
+            }
+        }
+        writer.WriteLine();
+        writer.WriteLine("## Warnings");
+        if (result.Warnings.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var warning in result.Warnings)
+            {
+                writer.WriteLine($"- {warning}");
+            }
+        }
+        writer.WriteLine();
+        writer.WriteLine(result.Summary);
+    }
+}
+
+internal sealed record AutomationCompleteResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("issue")]
+    public int? Issue { get; init; }
+
+    [JsonPropertyName("pr")]
+    public int? Pr { get; init; }
+
+    [JsonPropertyName("outcome")]
+    public required string Outcome { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("target_kind")]
+    public required string TargetKind { get; init; }
+
+    [JsonPropertyName("targetKind")]
+    public string TargetKindCamelCase => TargetKind;
+
+    [JsonPropertyName("target_number")]
+    public required int TargetNumber { get; init; }
+
+    [JsonPropertyName("targetNumber")]
+    public int TargetNumberCamelCase => TargetNumber;
+
+    [JsonPropertyName("proceed")]
+    public required bool Proceed { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("recommended_label_actions")]
+    public required IReadOnlyList<WorkerResultSummaryLabelAction> RecommendedLabelActions { get; init; }
+
+    [JsonPropertyName("recommendedLabelActions")]
+    public IReadOnlyList<WorkerResultSummaryLabelAction> RecommendedLabelActionsCamelCase => RecommendedLabelActions;
+
+    [JsonPropertyName("planned_label_actions")]
+    public required IReadOnlyList<WorkerResultSummaryLabelAction> PlannedLabelActions { get; init; }
+
+    [JsonPropertyName("plannedLabelActions")]
+    public IReadOnlyList<WorkerResultSummaryLabelAction> PlannedLabelActionsCamelCase => PlannedLabelActions;
+
+    [JsonPropertyName("applied_label_actions")]
+    public required IReadOnlyList<WorkerResultSummaryLabelAction> AppliedLabelActions { get; init; }
+
+    [JsonPropertyName("appliedLabelActions")]
+    public IReadOnlyList<WorkerResultSummaryLabelAction> AppliedLabelActionsCamelCase => AppliedLabelActions;
+
+    [JsonPropertyName("current_labels")]
+    public required IReadOnlyList<string> CurrentLabels { get; init; }
+
+    [JsonPropertyName("currentLabels")]
+    public IReadOnlyList<string> CurrentLabelsCamelCase => CurrentLabels;
+
+    [JsonPropertyName("errors")]
+    public required IReadOnlyList<string> Errors { get; init; }
+
+    [JsonPropertyName("warnings")]
+    public required IReadOnlyList<string> Warnings { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -121,6 +121,7 @@ internal static class CommandRouter
             ["automation"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["check"] = AutomationCheckCommand.Execute,
+                ["complete"] = AutomationCompleteCommand.Execute,
                 ["summary"] = AutomationSummaryCommand.Execute
             },
             ["safety"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -21,7 +21,7 @@ internal static class Program
             }
 
             var currentDirectory = Directory.GetCurrentDirectory();
-            if (IsIntakeInitCommand(args) || IsAutomationCheckCommand(args))
+            if (IsIntakeInitCommand(args) || IsAutomationWorktreeCommand(args))
             {
                 return CommandRouter.Execute(args, CreateBootstrapContext(currentDirectory, args), Console.Out);
             }
@@ -55,11 +55,12 @@ internal static class Program
             && string.Equals(args[1], "init", StringComparison.Ordinal);
     }
 
-    private static bool IsAutomationCheckCommand(string[] args)
+    private static bool IsAutomationWorktreeCommand(string[] args)
     {
         return args.Length >= 2
             && string.Equals(args[0], "automation", StringComparison.Ordinal)
-            && string.Equals(args[1], "check", StringComparison.Ordinal);
+            && (string.Equals(args[1], "check", StringComparison.Ordinal)
+                || string.Equals(args[1], "complete", StringComparison.Ordinal));
     }
 
     private static CliContext CreateBootstrapContext(string currentDirectory, string[] args)

--- a/tests/IntentSystem.Cli.Tests/AutomationCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationCompleteCommandTests.cs
@@ -1,0 +1,473 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G214: Tests for <c>intent-cli automation complete</c>. The command
+/// combines result-summary normalization with the supported worker-complete
+/// transition, defaults to dry-run, and only writes labels when explicitly
+/// requested.
+/// </summary>
+public sealed class AutomationCompleteCommandTests : IDisposable
+{
+    public AutomationCompleteCommandTests()
+    {
+        AutomationCompleteCommand.MutatorFactory = null;
+        AutomationCompleteCommand.NestedProviderLauncher = null;
+        WorkerCompleteCommand.MutatorFactory = null;
+        WorkerCompleteCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        AutomationCompleteCommand.MutatorFactory = null;
+        AutomationCompleteCommand.NestedProviderLauncher = null;
+        WorkerCompleteCommand.MutatorFactory = null;
+        WorkerCompleteCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void Execute_IssueToPrPrCreated_DryRunPlansCompletionWithoutApplying()
+    {
+        using var workspace = new AutomationCompleteWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        AutomationCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--issue", "533",
+                "--pr", "534",
+                "--outcome", "pr-created",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationCompleteResult>(writer.ToString())!;
+        Assert.Equal("J-Tech-Japan/intent-system", result.Repo);
+        Assert.Equal("issue", result.TargetKind);
+        Assert.Equal(533, result.TargetNumber);
+        Assert.Equal("dry-run", result.Mode);
+        Assert.True(result.Proceed);
+        Assert.False(result.Applied);
+        Assert.Empty(result.AppliedLabelActions);
+        Assert.Contains(result.PlannedLabelActions, a =>
+            a.Action == "remove" && a.Target == "issue" && a.Label == "intent-issue-in-progress");
+        Assert.Contains(result.PlannedLabelActions, a =>
+            a.Action == "add" && a.Target == "issue" && a.Label == "intent-pr-created");
+        Assert.Empty(mutator.AppliedTransitions);
+        Assert.Contains(result.Warnings, w => w.Contains("intent-pr-created", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_IssueToPrPrCreated_WriteAppliesSupportedTransition()
+    {
+        using var workspace = new AutomationCompleteWorkspace();
+        workspace.WriteOriginRemote("git@github.com:J-Tech-Japan/intent-system.git");
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        AutomationCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--issue", "533",
+                "--pr", "534",
+                "--outcome", "pr-created",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationCompleteResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+        Assert.Equal(result.PlannedLabelActions.Count, result.AppliedLabelActions.Count);
+        Assert.Single(mutator.AppliedTransitions);
+        Assert.Equal("issue", mutator.AppliedTransitions[0].Kind);
+        Assert.Contains("intent-pr-created", mutator.AppliedTransitions[0].AddLabels);
+        Assert.Contains("intent-issue-in-progress", mutator.AppliedTransitions[0].RemoveLabels);
+    }
+
+    [Fact]
+    public void Execute_PrCommentFixRepairPushed_WriteAppliesPrRereviewTransition()
+    {
+        using var workspace = new AutomationCompleteWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-request-update", "intent-pr-update-in-progress" },
+        };
+        AutomationCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "pr-comment-fix",
+                "--pr", "535",
+                "--outcome", "repair-pushed",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationCompleteResult>(writer.ToString())!;
+        Assert.Equal("pr", result.TargetKind);
+        Assert.Equal(535, result.TargetNumber);
+        Assert.DoesNotContain(result.PlannedLabelActions, a => a.Label == "intent-pr-created");
+        Assert.Contains(result.PlannedLabelActions, a =>
+            a.Action == "remove" && a.Target == "pr" && a.Label == "intent-pr-update-in-progress");
+        Assert.Contains(result.PlannedLabelActions, a =>
+            a.Action == "add" && a.Target == "pr" && a.Label == "intent-pr-rereview-ready");
+        Assert.Single(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedKindOutcomeFailsDeterministically()
+    {
+        using var workspace = new AutomationCompleteWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        AutomationCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--issue", "533",
+                "--outcome", "repair-pushed",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("not supported", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_RepoOverrideSkipsInference()
+    {
+        using var workspace = new AutomationCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        AutomationCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--repo", "Override/Repo",
+                "--issue", "533",
+                "--outcome", "failed",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("Override/Repo", mutator.SeenRepo);
+        var result = JsonSerializer.Deserialize<AutomationCompleteResult>(writer.ToString())!;
+        Assert.Equal("Override/Repo", result.Repo);
+    }
+
+    [Fact]
+    public void Execute_WorkdirChangesRepoInferenceRoot()
+    {
+        using var workspace = new AutomationCompleteWorkspace();
+        var child = workspace.CreateChildWorkdir("child");
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/wrong.git");
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git", child);
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        AutomationCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--workdir", child,
+                "--issue", "533",
+                "--outcome", "failed",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("J-Tech-Japan/intent-system", mutator.SeenRepo);
+    }
+
+    [Fact]
+    public void CommandRouter_RegistersAutomationComplete()
+    {
+        using var workspace = new AutomationCompleteWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        AutomationCompleteCommand.MutatorFactory = () => new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            new[]
+            {
+                "automation",
+                "complete",
+                "--kind", "issue-to-pr",
+                "--issue", "533",
+                "--outcome", "failed",
+                "--format", "json",
+            },
+            workspace.Context,
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationCompleteResult>(writer.ToString())!;
+        Assert.Equal("failed", result.Outcome);
+    }
+
+    [Fact]
+    public void ProgramMain_AutomationCompleteDoesNotRequireIntentCliDirectory()
+    {
+        using var workspace = new AutomationCompleteWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        AutomationCompleteCommand.MutatorFactory = () => new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        var originalDirectory = Directory.GetCurrentDirectory();
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+
+        try
+        {
+            Directory.SetCurrentDirectory(workspace.RootPath);
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+
+            var exitCode = Program.Main(new[]
+            {
+                "automation",
+                "complete",
+                "--kind", "issue-to-pr",
+                "--issue", "533",
+                "--outcome", "failed",
+                "--format", "json",
+            });
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(string.Empty, stderr.ToString());
+            var result = JsonSerializer.Deserialize<AutomationCompleteResult>(stdout.ToString())!;
+            Assert.Equal("J-Tech-Japan/intent-system", result.Repo);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+            Directory.SetCurrentDirectory(originalDirectory);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesNestedProviderLauncher()
+    {
+        using var workspace = new AutomationCompleteWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var launcherInvoked = false;
+        AutomationCompleteCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+        AutomationCompleteCommand.MutatorFactory = () => new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, AutomationCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--issue", "533",
+                "--outcome", "failed",
+                "--format", "json",
+            },
+            writer));
+
+        Assert.False(launcherInvoked,
+            "AutomationCompleteCommand must never invoke NestedProviderLauncher.");
+    }
+
+    [Fact]
+    public void Execute_DryRunLeavesWorkspaceByteEquivalent()
+    {
+        using var workspace = new AutomationCompleteWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var before = workspace.SnapshotWorkspace();
+        AutomationCompleteCommand.MutatorFactory = () => new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+
+        using (var writer = new StringWriter())
+        {
+            Assert.Equal(0, AutomationCompleteCommand.Execute(
+                workspace.Context,
+                new[]
+                {
+                    "--kind", "issue-to-pr",
+                    "--issue", "533",
+                    "--outcome", "failed",
+                    "--format", "json",
+                },
+                writer));
+        }
+
+        var after = workspace.SnapshotWorkspace();
+        Assert.Equal(before.Count, after.Count);
+        foreach (var (path, hash) in before)
+        {
+            Assert.True(after.TryGetValue(path, out var afterHash),
+                $"file disappeared after run: {path}");
+            Assert.Equal(hash, afterHash);
+        }
+    }
+
+    private sealed class FakeMutator : IGitHubLabelMutator
+    {
+        public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+
+        public string? SeenRepo { get; private set; }
+
+        public List<AppliedTransition> AppliedTransitions { get; } = new();
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number)
+        {
+            SeenRepo = repo;
+            return Labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
+        }
+
+        public void ApplyLabelTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels)
+        {
+            SeenRepo = repo;
+            AppliedTransitions.Add(new AppliedTransition(
+                repo,
+                kind,
+                number,
+                addLabels.ToArray(),
+                removeLabels.ToArray()));
+        }
+    }
+
+    private sealed record AppliedTransition(
+        string Repo,
+        string Kind,
+        int Number,
+        IReadOnlyList<string> AddLabels,
+        IReadOnlyList<string> RemoveLabels);
+
+    private sealed class AutomationCompleteWorkspace : IDisposable
+    {
+        public AutomationCompleteWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("automation-complete-tests-").FullName;
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public string CreateChildWorkdir(string name)
+        {
+            var path = Path.Combine(RootPath, name);
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        public void WriteOriginRemote(string remoteUrl, string? workdir = null)
+        {
+            var root = workdir ?? RootPath;
+            var gitDirectory = Path.Combine(root, ".git");
+            Directory.CreateDirectory(gitDirectory);
+            File.WriteAllText(
+                Path.Combine(gitDirectory, "config"),
+                $"""
+                [remote "origin"]
+                    url = {remoteUrl}
+                """);
+        }
+
+        public IReadOnlyDictionary<string, string> SnapshotWorkspace()
+        {
+            var snapshot = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(RootPath, "*", SearchOption.AllDirectories))
+            {
+                var bytes = File.ReadAllBytes(path);
+                var hash = Convert.ToHexString(SHA256.HashData(bytes));
+                snapshot[path] = hash;
+            }
+            return snapshot;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `intent-cli automation complete` as a worktree-aware post-run entrypoint.
- Normalize issue-to-PR and PR comment-fix outcomes, infer repos consistently with `automation check`, and default to dry-run.
- Support explicit `--write` for only the existing worker-complete label transitions.
- Update automation template docs to use `automation complete` for post-run completion.

Closes #533

## Verification

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter AutomationCompleteCommandTests`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "WorkerCompleteCommandTests|WorkerResultSummaryCommandTests"`
- `git diff --check`

## Covered cases

- issue-to-PR dry-run planned transition
- issue-to-PR explicit write transition
- PR comment-fix explicit write transition
- unsupported kind/outcome deterministic failure
- repo override and workdir-based inference
- command routing and bootstrap without `.intent-cli`
- no provider launch/no dry-run workspace mutation

## Sample JSON shape

```json
{
  "kind": "issue-to-pr",
  "repo": "J-Tech-Japan/intent-system",
  "issue": 533,
  "pr": 534,
  "outcome": "pr-created",
  "status": "completed",
  "mode": "dry-run",
  "target_kind": "issue",
  "targetNumber": 533,
  "proceed": true,
  "applied": false,
  "recommendedLabelActions": [],
  "plannedLabelActions": [],
  "appliedLabelActions": [],
  "warnings": [],
  "summary": "..."
}
```

## No-mutation confirmation

Dry-run reads labels and emits the planned transition only. `--write` is required before labels are changed. The command does not create issues, PRs, branches, comments, merges, queue/runs state, or provider launches.