### PR TITLE
G215 Add automation clarification-stop summary helper

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -29,6 +29,7 @@ These templates assume:
 | G208  | `intent-cli metadata update`            | Bounded controlled writer |
 | G213  | `intent-cli automation check`           | Worktree-aware next-action entrypoint |
 | G214  | `intent-cli automation complete`        | Worktree-aware outcome completion entrypoint |
+| G215  | `intent-cli automation clarification-stop` | Stable clarification-required stop summary |
 
 ## Template index
 

--- a/docs/automation-templates/coding-automation-loop.md
+++ b/docs/automation-templates/coding-automation-loop.md
@@ -81,6 +81,22 @@ and `summary`. To apply the supported completion label transition,
 the controlling automation must pass `--write` explicitly. Do NOT
 mutate labels outside the `automation complete --write` path.
 
+If the outcome is `clarification-required`, also emit an owner-facing
+cooldown summary:
+
+```bash
+intent-cli automation clarification-stop \
+  --kind <issue-to-pr|pr-comment-fix> \
+  --number <n> \
+  --url "$TARGET_URL" \
+  --reason "$REASON" \
+  --recommended-owner-action "$OWNER_ACTION" \
+  --format json
+```
+
+This helper is read-only. It exists so the wake summary has stable
+fields instead of free-form prompt prose.
+
 ## Idempotency
 
 This template is fully idempotent: running it again on a state where

--- a/docs/automation-templates/issue-to-pr-execution.md
+++ b/docs/automation-templates/issue-to-pr-execution.md
@@ -46,32 +46,45 @@ schema):
 | `failed`                         | Worker stopped with an error mid-run.                  |
 | `label-cleanup-required`         | Stale labels left behind after a partial run.          |
 
-## Step 3: normalize via `result-summary`
+## Step 3: normalize via `automation complete`
 
 ```bash
-intent-cli worker result-summary \
+intent-cli automation complete \
   --kind issue-to-pr \
-  --repo "$REPO" \
   --issue "$ISSUE_NUMBER" \
   [--pr "$PR_NUMBER"] \
   --outcome "$OUTCOME" \
   --format json
 ```
 
-This emits stable `recommended_label_actions[]` advice — for the
-happy `pr-created` path it will recommend:
+This emits stable `recommended_label_actions[]` and
+`planned_label_actions[]` advice. For the happy `pr-created` path it
+will recommend:
 
 - remove `intent-issue-in-progress` from the source issue,
 - add `intent-pr-created` to the source issue.
 
-The controlling automation applies those edits via its own gh layer.
-The prompt here MUST NOT call `gh issue edit` or `gh pr edit` directly.
+The controlling automation applies those edits only by calling
+`automation complete --write`. The prompt here MUST NOT call
+`gh issue edit` or `gh pr edit` directly.
+
+For `clarification-required`, also render the cooldown stop:
+
+```bash
+intent-cli automation clarification-stop \
+  --kind issue-to-pr \
+  --issue "$ISSUE_NUMBER" \
+  --url "$ISSUE_URL" \
+  --reason "$REASON" \
+  --recommended-owner-action "$OWNER_ACTION" \
+  --format json
+```
 
 ## Verification (deterministic)
 
 - `intent-cli worker next-action --format json` → an issue URL.
 - AI worker runs `gh-issue-to-pr` against that URL.
-- `intent-cli worker result-summary` returns `valid: true` and an
+- `intent-cli automation complete` returns JSON with an
   outcome whose `status` is one of `completed` / `declined` /
   `clarification-required` / `failed` / `label-cleanup-required`.
 - No additional GitHub mutations from this prompt.

--- a/docs/automation-templates/pr-comment-fix-execution.md
+++ b/docs/automation-templates/pr-comment-fix-execution.md
@@ -44,12 +44,11 @@ Classify the outcome as one of (G205 schema):
 | `failed`                 | The worker errored before pushing.                             |
 | `label-cleanup-required` | Stale labels left behind after a partial run.                  |
 
-## Step 3: normalize via `result-summary`
+## Step 3: normalize via `automation complete`
 
 ```bash
-intent-cli worker result-summary \
+intent-cli automation complete \
   --kind pr-comment-fix \
-  --repo "$REPO" \
   --pr "$PR_NUMBER" \
   --outcome "$OUTCOME" \
   --format json
@@ -57,14 +56,27 @@ intent-cli worker result-summary \
 
 For the happy `repair-pushed` path the recommended advice is a single
 swap action: `intent-pr-update-in-progress` → `intent-pr-rereview-ready`
-on the PR. The controlling automation applies the swap via its own gh
-layer; this prompt MUST NOT call `gh pr edit` directly.
+on the PR. The controlling automation applies the swap only by calling
+`automation complete --write`; this prompt MUST NOT call `gh pr edit`
+directly.
+
+For `clarification-required`, also render the cooldown stop:
+
+```bash
+intent-cli automation clarification-stop \
+  --kind pr-comment-fix \
+  --pr "$PR_NUMBER" \
+  --url "$PR_URL" \
+  --reason "$REASON" \
+  --recommended-owner-action "$OWNER_ACTION" \
+  --format json
+```
 
 ## Verification (deterministic)
 
 - `intent-cli worker next-action --format json` → a PR URL.
 - AI worker pushes a single repair commit and posts the update note.
-- `intent-cli worker result-summary` returns `valid: true` for the
+- `intent-cli automation complete` returns JSON for the
   outcome.
 - The host's recurring deterministic-rereview comment is no longer
   classified as `repair-required` once the label-state advances to

--- a/src/IntentSystem.Cli/Commands/AutomationClarificationStopCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationClarificationStopCommand.cs
@@ -1,0 +1,340 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G215: <c>intent-cli automation clarification-stop</c> renders a stable,
+/// read-only summary for local automation wakes that must stop for owner
+/// clarification instead of guessing or mutating labels.
+/// </summary>
+internal static class AutomationClarificationStopCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    /// <summary>Test sentinel: this command must never launch a provider.</summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(
+                args,
+                out var kind,
+                out var repoOverride,
+                out var workdir,
+                out var number,
+                out var targetUrl,
+                out var reason,
+                out var recommendedOwnerAction,
+                out var cooldown,
+                out var format,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var repo = repoOverride;
+        if (string.IsNullOrWhiteSpace(targetUrl) && string.IsNullOrWhiteSpace(repo))
+        {
+            var resolvedWorkdir = ResolveWorkdir(context, workdir);
+            if (!AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
+            {
+                writer.WriteLine(error);
+                return 1;
+            }
+        }
+
+        targetUrl ??= BuildTargetUrl(repo!, kind!, number);
+        var result = new AutomationClarificationStopResult
+        {
+            Kind = kind!,
+            Status = WorkerResultSummaryConstants.Outcomes.ClarificationRequired,
+            TargetNumber = number,
+            TargetUrl = targetUrl,
+            Reason = reason!,
+            RecommendedOwnerAction = recommendedOwnerAction!,
+            Cooldown = cooldown,
+            Mutated = false,
+            Warnings = Array.Empty<string>(),
+            Summary = $"Clarification required for {kind} target #{number}: {reason}",
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? kind,
+        out string? repo,
+        out string? workdir,
+        out int number,
+        out string? targetUrl,
+        out string? reason,
+        out string? recommendedOwnerAction,
+        out string? cooldown,
+        out string format,
+        out string error)
+    {
+        kind = null;
+        repo = null;
+        workdir = null;
+        number = 0;
+        targetUrl = null;
+        reason = null;
+        recommendedOwnerAction = null;
+        cooldown = null;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--kind":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--kind requires a value (issue-to-pr or pr-comment-fix).";
+                        return false;
+                    }
+                    kind = args[index + 1];
+                    index++;
+                    break;
+
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--workdir":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--workdir requires a value.";
+                        return false;
+                    }
+                    workdir = args[index + 1];
+                    index++;
+                    break;
+
+                case "--number":
+                case "--issue":
+                case "--pr":
+                    if (!TryReadPositiveInt(args, index, argument, out number, out error))
+                    {
+                        return false;
+                    }
+                    index++;
+                    break;
+
+                case "--url":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--url requires a value.";
+                        return false;
+                    }
+                    targetUrl = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--reason":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--reason requires a value.";
+                        return false;
+                    }
+                    reason = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--recommended-owner-action":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--recommended-owner-action requires a value.";
+                        return false;
+                    }
+                    recommendedOwnerAction = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--cooldown":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--cooldown requires a value.";
+                        return false;
+                    }
+                    cooldown = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --kind <issue-to-pr|pr-comment-fix> --number <n> [--url <url>] [--repo <owner/repo>] [--workdir <path>] --reason <text> --recommended-owner-action <text> [--cooldown <text>] [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (!string.Equals(kind, WorkerResultSummaryConstants.Kinds.IssueToPr, StringComparison.Ordinal)
+            && !string.Equals(kind, WorkerResultSummaryConstants.Kinds.PrCommentFix, StringComparison.Ordinal))
+        {
+            error = "--kind must be 'issue-to-pr' or 'pr-comment-fix'.";
+            return false;
+        }
+        if (number <= 0)
+        {
+            error = "--number is required and must be a positive integer.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            error = "--reason is required.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(recommendedOwnerAction))
+        {
+            error = "--recommended-owner-action is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadPositiveInt(
+        string[] args,
+        int index,
+        string option,
+        out int value,
+        out string error)
+    {
+        value = 0;
+        error = string.Empty;
+        if (index + 1 >= args.Length
+            || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out value)
+            || value <= 0)
+        {
+            error = $"{option} requires a positive integer.";
+            return false;
+        }
+        return true;
+    }
+
+    private static string ResolveWorkdir(CliContext context, string? workdir)
+    {
+        if (string.IsNullOrWhiteSpace(workdir))
+        {
+            return context.RepoRoot;
+        }
+
+        return Path.GetFullPath(workdir);
+    }
+
+    private static string BuildTargetUrl(string repo, string kind, int number)
+    {
+        var pathPart = string.Equals(kind, WorkerResultSummaryConstants.Kinds.IssueToPr, StringComparison.Ordinal)
+            ? "issues"
+            : "pull";
+        return $"https://github.com/{repo}/{pathPart}/{number.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+    }
+
+    private static void WriteText(TextWriter writer, AutomationClarificationStopResult result)
+    {
+        writer.WriteLine($"# Automation clarification stop ({result.Kind})");
+        writer.WriteLine();
+        writer.WriteLine($"- status: {result.Status}");
+        writer.WriteLine($"- target: #{result.TargetNumber}");
+        writer.WriteLine($"- url: {result.TargetUrl}");
+        writer.WriteLine($"- reason: {result.Reason}");
+        writer.WriteLine($"- recommended_owner_action: {result.RecommendedOwnerAction}");
+        if (!string.IsNullOrWhiteSpace(result.Cooldown))
+        {
+            writer.WriteLine($"- cooldown: {result.Cooldown}");
+        }
+        writer.WriteLine($"- mutated: {result.Mutated}");
+        writer.WriteLine();
+        writer.WriteLine(result.Summary);
+    }
+}
+
+internal sealed record AutomationClarificationStopResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("target_number")]
+    public required int TargetNumber { get; init; }
+
+    [JsonPropertyName("targetNumber")]
+    public int TargetNumberCamelCase => TargetNumber;
+
+    [JsonPropertyName("target_url")]
+    public required string TargetUrl { get; init; }
+
+    [JsonPropertyName("targetUrl")]
+    public string TargetUrlCamelCase => TargetUrl;
+
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
+
+    [JsonPropertyName("recommended_owner_action")]
+    public required string RecommendedOwnerAction { get; init; }
+
+    [JsonPropertyName("recommendedOwnerAction")]
+    public string RecommendedOwnerActionCamelCase => RecommendedOwnerAction;
+
+    [JsonPropertyName("cooldown")]
+    public string? Cooldown { get; init; }
+
+    [JsonPropertyName("mutated")]
+    public required bool Mutated { get; init; }
+
+    [JsonPropertyName("warnings")]
+    public required IReadOnlyList<string> Warnings { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -121,6 +121,7 @@ internal static class CommandRouter
             ["automation"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["check"] = AutomationCheckCommand.Execute,
+                ["clarification-stop"] = AutomationClarificationStopCommand.Execute,
                 ["complete"] = AutomationCompleteCommand.Execute,
                 ["summary"] = AutomationSummaryCommand.Execute
             },

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -60,6 +60,7 @@ internal static class Program
         return args.Length >= 2
             && string.Equals(args[0], "automation", StringComparison.Ordinal)
             && (string.Equals(args[1], "check", StringComparison.Ordinal)
+                || string.Equals(args[1], "clarification-stop", StringComparison.Ordinal)
                 || string.Equals(args[1], "complete", StringComparison.Ordinal));
     }
 

--- a/tests/IntentSystem.Cli.Tests/AutomationClarificationStopCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationClarificationStopCommandTests.cs
@@ -1,0 +1,313 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G215: Tests for <c>intent-cli automation clarification-stop</c>. The
+/// helper renders a deterministic owner-facing stop summary and never
+/// mutates GitHub, labels, files, branches, or launches a provider.
+/// </summary>
+public sealed class AutomationClarificationStopCommandTests : IDisposable
+{
+    public AutomationClarificationStopCommandTests()
+    {
+        AutomationClarificationStopCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        AutomationClarificationStopCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void Execute_IssueToPrContext_EmitsStableJsonWithOwnerAction()
+    {
+        using var workspace = new AutomationClarificationStopWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationClarificationStopCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--issue", "535",
+                "--reason", "Issue contract is missing acceptance criteria.",
+                "--recommended-owner-action", "Repair the issue body into a standalone contract.",
+                "--cooldown", "Do not retry until the owner updates the issue.",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationClarificationStopResult>(writer.ToString())!;
+        Assert.Equal("issue-to-pr", result.Kind);
+        Assert.Equal("clarification-required", result.Status);
+        Assert.Equal(535, result.TargetNumber);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/535", result.TargetUrl);
+        Assert.Contains("missing acceptance criteria", result.Reason, StringComparison.Ordinal);
+        Assert.Contains("standalone contract", result.RecommendedOwnerAction, StringComparison.Ordinal);
+        Assert.False(result.Mutated);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Execute_PrCommentFixContext_UsesPullUrl()
+    {
+        using var workspace = new AutomationClarificationStopWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationClarificationStopCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "pr-comment-fix",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "536",
+                "--reason", "Review thread is ambiguous.",
+                "--recommended-owner-action", "Clarify the requested repair in the PR thread.",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationClarificationStopResult>(writer.ToString())!;
+        Assert.Equal("pr-comment-fix", result.Kind);
+        Assert.Equal(536, result.TargetNumber);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/536", result.TargetUrl);
+        Assert.False(result.Mutated);
+    }
+
+    [Fact]
+    public void Execute_ExplicitUrlOverridesRepoInference()
+    {
+        using var workspace = new AutomationClarificationStopWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationClarificationStopCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--number", "535",
+                "--url", "https://github.example.local/custom/535",
+                "--reason", "Ambiguous contract.",
+                "--recommended-owner-action", "Update the issue.",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationClarificationStopResult>(writer.ToString())!;
+        Assert.Equal("https://github.example.local/custom/535", result.TargetUrl);
+    }
+
+    [Fact]
+    public void Execute_MissingReasonFailsDeterministically()
+    {
+        using var workspace = new AutomationClarificationStopWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationClarificationStopCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "535",
+                "--recommended-owner-action", "Update the issue.",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("--reason is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommandRouter_RegistersAutomationClarificationStop()
+    {
+        using var workspace = new AutomationClarificationStopWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            new[]
+            {
+                "automation",
+                "clarification-stop",
+                "--kind", "issue-to-pr",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "535",
+                "--reason", "Ambiguous issue.",
+                "--recommended-owner-action", "Repair the issue.",
+                "--format", "json",
+            },
+            workspace.Context,
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationClarificationStopResult>(writer.ToString())!;
+        Assert.Equal("clarification-required", result.Status);
+    }
+
+    [Fact]
+    public void ProgramMain_AutomationClarificationStopDoesNotRequireIntentCliDirectory()
+    {
+        using var workspace = new AutomationClarificationStopWorkspace();
+        var originalDirectory = Directory.GetCurrentDirectory();
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+
+        try
+        {
+            Directory.SetCurrentDirectory(workspace.RootPath);
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+
+            var exitCode = Program.Main(new[]
+            {
+                "automation",
+                "clarification-stop",
+                "--kind", "issue-to-pr",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "535",
+                "--reason", "Ambiguous issue.",
+                "--recommended-owner-action", "Repair the issue.",
+                "--format", "json",
+            });
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(string.Empty, stderr.ToString());
+            var result = JsonSerializer.Deserialize<AutomationClarificationStopResult>(stdout.ToString())!;
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/535", result.TargetUrl);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+            Directory.SetCurrentDirectory(originalDirectory);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesNestedProviderLauncher()
+    {
+        using var workspace = new AutomationClarificationStopWorkspace();
+        var launcherInvoked = false;
+        AutomationClarificationStopCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, AutomationClarificationStopCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "535",
+                "--reason", "Ambiguous issue.",
+                "--recommended-owner-action", "Repair the issue.",
+                "--format", "json",
+            },
+            writer));
+
+        Assert.False(launcherInvoked);
+    }
+
+    [Fact]
+    public void Execute_LeavesWorkspaceByteEquivalent()
+    {
+        using var workspace = new AutomationClarificationStopWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var before = workspace.SnapshotWorkspace();
+
+        using (var writer = new StringWriter())
+        {
+            Assert.Equal(0, AutomationClarificationStopCommand.Execute(
+                workspace.Context,
+                new[]
+                {
+                    "--kind", "issue-to-pr",
+                    "--issue", "535",
+                    "--reason", "Ambiguous issue.",
+                    "--recommended-owner-action", "Repair the issue.",
+                    "--format", "json",
+                },
+                writer));
+        }
+
+        var after = workspace.SnapshotWorkspace();
+        Assert.Equal(before.Count, after.Count);
+        foreach (var (path, hash) in before)
+        {
+            Assert.True(after.TryGetValue(path, out var afterHash),
+                $"file disappeared after run: {path}");
+            Assert.Equal(hash, afterHash);
+        }
+    }
+
+    private sealed class AutomationClarificationStopWorkspace : IDisposable
+    {
+        public AutomationClarificationStopWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("automation-clarification-stop-tests-").FullName;
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public void WriteOriginRemote(string remoteUrl)
+        {
+            var gitDirectory = Path.Combine(RootPath, ".git");
+            Directory.CreateDirectory(gitDirectory);
+            File.WriteAllText(
+                Path.Combine(gitDirectory, "config"),
+                $"""
+                [remote "origin"]
+                    url = {remoteUrl}
+                """);
+        }
+
+        public IReadOnlyDictionary<string, string> SnapshotWorkspace()
+        {
+            var snapshot = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(RootPath, "*", SearchOption.AllDirectories))
+            {
+                var bytes = File.ReadAllBytes(path);
+                var hash = Convert.ToHexString(SHA256.HashData(bytes));
+                snapshot[path] = hash;
+            }
+            return snapshot;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `intent-cli automation clarification-stop` as a read-only helper for clarification-required automation stops.
- Emit stable JSON with kind, status, target number/url, reason, recommended owner action, optional cooldown, warnings, and summary.
- Support both `issue-to-pr` and `pr-comment-fix` contexts, including repo/workdir URL construction or explicit URL override.
- Update local automation docs to use the helper for clarification-required cooldown summaries.

Closes #535

## Verification

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter AutomationClarificationStopCommandTests`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "AutomationCheckCommandTests|AutomationCompleteCommandTests|AutomationClarificationStopCommandTests"`
- `git diff --check`

## Covered cases

- issue-to-PR clarification JSON with owner action and cooldown
- PR comment-fix clarification JSON with pull URL
- explicit URL override
- missing required reason failure
- command routing and bootstrap without `.intent-cli`
- no provider launch/no workspace mutation

## No-mutation confirmation

The helper is render-only. It does not mutate labels, GitHub state, files, branches, issues, PRs, comments, queue/runs state, or launch a provider.