### PR TITLE
G216 Propagate review target to created PRs

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -72,6 +72,10 @@ against …" section for the explicit comparison tables.
   ISSUE, not on the PR. Prompts and post-run summaries that imply
   otherwise are a bug — `automation complete` / `worker result-summary`
   surface this as a warning automatically when they detect misuse.
+- **Review-target propagation**: after an issue-to-PR success,
+  `automation complete --write` is the supported path that marks the
+  created PR with `intent-target` for host review. Prompts must not add
+  that PR label directly.
 - **Single-target cap**: at most ONE branch/PR is touched per wake. If
   `worker next-action` returns `none`, the wake is idle and ends without
   pushing anything.

--- a/docs/automation-templates/coding-automation-loop.md
+++ b/docs/automation-templates/coding-automation-loop.md
@@ -110,4 +110,6 @@ selected work is already in progress (in-progress label set) returns
 - Calling `intent-cli run` instead of an external AI worker.
 - Asking `intent-cli` to launch Claude or Codex.
 - Adding `intent-pr-created` to a PR (it belongs on the source issue).
+- Adding `intent-target` to a created PR directly; that review-target
+  propagation belongs to `intent-cli automation complete --write`.
 - Touching more than one branch/PR per wake.

--- a/docs/automation-templates/issue-to-pr-execution.md
+++ b/docs/automation-templates/issue-to-pr-execution.md
@@ -28,7 +28,8 @@ returned issue URL. The prompt to the AI worker should include:
 
 - the issue URL verbatim,
 - a reminder that this worker MUST NOT add `intent-target` to the
-  created PR,
+  created PR directly; `intent-cli automation complete --write` owns
+  that supported propagation after the PR number is known,
 - a reminder that `intent-pr-created` (when applied) belongs on the
   source issue, not on the PR.
 
@@ -62,7 +63,9 @@ This emits stable `recommended_label_actions[]` and
 will recommend:
 
 - remove `intent-issue-in-progress` from the source issue,
-- add `intent-pr-created` to the source issue.
+- add `intent-pr-created` to the source issue,
+- add `intent-target` to the created PR so the host review loop can
+  select it.
 
 The controlling automation applies those edits only by calling
 `automation complete --write`. The prompt here MUST NOT call
@@ -92,7 +95,9 @@ intent-cli automation clarification-stop \
 ## What this template forbids
 
 - Selecting a different issue than the one returned by `next-action`.
-- Adding `intent-target` to the created PR.
+- Adding `intent-target` to the created PR directly. Use
+  `intent-cli automation complete --write` for the supported
+  propagation.
 - Adding `intent-pr-created` to the PR (it belongs on the source issue).
 - Calling `intent-cli run`.
 - Asking `intent-cli` to launch the AI worker.

--- a/src/IntentSystem.Cli/Commands/AutomationCompleteCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationCompleteCommand.cs
@@ -63,6 +63,12 @@ internal static class AutomationCompleteCommand
             return 1;
         }
 
+        if (RequiresCreatedPrTarget(workflowKind!, outcome!) && pr is null)
+        {
+            writer.WriteLine("--pr is required when --kind is issue-to-pr and --outcome is pr-created.");
+            return 1;
+        }
+
         WorkerResultSummaryResult summary;
         try
         {
@@ -110,16 +116,50 @@ internal static class AutomationCompleteCommand
 
         var currentNames = LabelNames(currentLabels);
         var decision = WorkerCompleteAnalyzer.Analyze(targetKind, outcome!, currentNames);
-        var plannedActions = BuildPlannedActions(targetKind, decision);
+        var issueLabelActions = BuildPlannedActions(targetKind, decision);
+
+        IReadOnlyList<string> createdPrCurrentLabels = Array.Empty<string>();
+        var createdPrDecision = CompleteDecisionForPrTarget.None;
+        if (RequiresCreatedPrTarget(workflowKind!, outcome!))
+        {
+            IReadOnlyList<GitHubAutomationLabel> createdPrLabels;
+            try
+            {
+                createdPrLabels = mutator.ReadLabels(repo!, GhCliGitHubLabelMutator.Kinds.Pr, pr!.Value);
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or IOException)
+            {
+                writer.WriteLine(
+                    $"failed to read current labels for created PR #{pr} in {repo}: {exception.Message}");
+                return 1;
+            }
+
+            createdPrCurrentLabels = LabelNames(createdPrLabels);
+            createdPrDecision = PlanCreatedPrTarget(createdPrCurrentLabels);
+        }
 
         var applied = false;
         if (decision.Proceed
+            && createdPrDecision.Proceed
             && string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal))
         {
             try
             {
                 mutator.ApplyLabelTransitions(
                     repo!, targetKind, targetNumber, decision.AddLabels, decision.RemoveLabels);
+                if (createdPrDecision.Proceed
+                    && createdPrDecision.AddLabels.Count > 0
+                    && pr is not null)
+                {
+                    mutator.ApplyLabelTransitions(
+                        repo!,
+                        GhCliGitHubLabelMutator.Kinds.Pr,
+                        pr.Value,
+                        createdPrDecision.AddLabels,
+                        Array.Empty<string>());
+                }
                 applied = true;
             }
             catch (Exception exception) when (
@@ -132,7 +172,17 @@ internal static class AutomationCompleteCommand
             }
         }
 
-        var warnings = summary.Warnings.Concat(decision.Warnings).ToArray();
+        var issueAndPrLabelActions = issueLabelActions
+            .Concat(createdPrDecision.LabelActions)
+            .ToArray();
+        var warnings = summary.Warnings
+            .Concat(decision.Warnings)
+            .Concat(createdPrDecision.Warnings)
+            .ToArray();
+        var errors = decision.Errors
+            .Concat(createdPrDecision.Errors)
+            .ToArray();
+        var proceed = decision.Proceed && createdPrDecision.Proceed;
         var result = new AutomationCompleteResult
         {
             Kind = workflowKind!,
@@ -144,15 +194,20 @@ internal static class AutomationCompleteCommand
             Mode = mode,
             TargetKind = targetKind,
             TargetNumber = targetNumber,
-            Proceed = decision.Proceed,
+            Proceed = proceed,
             Applied = applied,
             RecommendedLabelActions = summary.RecommendedLabelActions,
-            PlannedLabelActions = plannedActions,
-            AppliedLabelActions = applied ? plannedActions : Array.Empty<WorkerResultSummaryLabelAction>(),
+            PlannedLabelActions = issueAndPrLabelActions,
+            AppliedLabelActions = applied ? issueAndPrLabelActions : Array.Empty<WorkerResultSummaryLabelAction>(),
+            SourceIssueLabelActions = string.Equals(targetKind, GhCliGitHubLabelMutator.Kinds.Issue, StringComparison.Ordinal)
+                ? issueLabelActions
+                : Array.Empty<WorkerResultSummaryLabelAction>(),
+            CreatedPrLabelActions = createdPrDecision.LabelActions,
             CurrentLabels = currentNames,
-            Errors = decision.Errors,
+            CreatedPrCurrentLabels = createdPrCurrentLabels,
+            Errors = errors,
             Warnings = warnings,
-            Summary = $"{summary.Summary} {decision.Summary}",
+            Summary = $"{summary.Summary} {decision.Summary}{createdPrDecision.SummarySuffix}",
         };
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
@@ -164,7 +219,7 @@ internal static class AutomationCompleteCommand
             WriteText(writer, result);
         }
 
-        return decision.Proceed ? 0 : 2;
+        return proceed ? 0 : 2;
     }
 
     private static bool TryParseArguments(
@@ -420,6 +475,63 @@ internal static class AutomationCompleteCommand
         return actions;
     }
 
+    private static bool RequiresCreatedPrTarget(string workflowKind, string outcome)
+    {
+        return string.Equals(workflowKind, WorkerResultSummaryConstants.Kinds.IssueToPr, StringComparison.Ordinal)
+            && string.Equals(outcome, WorkerResultSummaryConstants.Outcomes.PrCreated, StringComparison.Ordinal);
+    }
+
+    private static CompleteDecisionForPrTarget PlanCreatedPrTarget(IReadOnlyList<string> currentLabels)
+    {
+        if (currentLabels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal))
+        {
+            return new CompleteDecisionForPrTarget
+            {
+                Proceed = false,
+                AddLabels = Array.Empty<string>(),
+                LabelActions = Array.Empty<WorkerResultSummaryLabelAction>(),
+                Errors = new[]
+                {
+                    $"label policy violation: PR carries '{WorkerNextActionConstants.Labels.IntentPrCreated}', which belongs on the source issue."
+                },
+                Warnings = Array.Empty<string>(),
+                SummarySuffix = " Refusing to mark created PR as review target because it carries an issue-only completion label.",
+            };
+        }
+
+        if (currentLabels.Contains(WorkerNextActionConstants.Labels.IntentTarget, StringComparer.Ordinal))
+        {
+            return new CompleteDecisionForPrTarget
+            {
+                Proceed = true,
+                AddLabels = Array.Empty<string>(),
+                LabelActions = Array.Empty<WorkerResultSummaryLabelAction>(),
+                Errors = Array.Empty<string>(),
+                Warnings = new[] { "created PR already carries 'intent-target'; no PR label add needed." },
+                SummarySuffix = " Created PR already carries intent-target.",
+            };
+        }
+
+        var actions = new[]
+        {
+            new WorkerResultSummaryLabelAction
+            {
+                Action = WorkerResultSummaryConstants.LabelActionVerbs.Add,
+                Target = WorkerResultSummaryConstants.LabelActionTargets.Pr,
+                Label = WorkerNextActionConstants.Labels.IntentTarget,
+            }
+        };
+        return new CompleteDecisionForPrTarget
+        {
+            Proceed = true,
+            AddLabels = new[] { WorkerNextActionConstants.Labels.IntentTarget },
+            LabelActions = actions,
+            Errors = Array.Empty<string>(),
+            Warnings = Array.Empty<string>(),
+            SummarySuffix = " Would add: intent-target on the created PR.",
+        };
+    }
+
     private static void WriteText(TextWriter writer, AutomationCompleteResult result)
     {
         writer.WriteLine($"# Automation complete for {result.Repo} ({result.Kind})");
@@ -520,11 +632,29 @@ internal sealed record AutomationCompleteResult
     [JsonPropertyName("appliedLabelActions")]
     public IReadOnlyList<WorkerResultSummaryLabelAction> AppliedLabelActionsCamelCase => AppliedLabelActions;
 
+    [JsonPropertyName("source_issue_label_actions")]
+    public required IReadOnlyList<WorkerResultSummaryLabelAction> SourceIssueLabelActions { get; init; }
+
+    [JsonPropertyName("sourceIssueLabelActions")]
+    public IReadOnlyList<WorkerResultSummaryLabelAction> SourceIssueLabelActionsCamelCase => SourceIssueLabelActions;
+
+    [JsonPropertyName("created_pr_label_actions")]
+    public required IReadOnlyList<WorkerResultSummaryLabelAction> CreatedPrLabelActions { get; init; }
+
+    [JsonPropertyName("createdPrLabelActions")]
+    public IReadOnlyList<WorkerResultSummaryLabelAction> CreatedPrLabelActionsCamelCase => CreatedPrLabelActions;
+
     [JsonPropertyName("current_labels")]
     public required IReadOnlyList<string> CurrentLabels { get; init; }
 
     [JsonPropertyName("currentLabels")]
     public IReadOnlyList<string> CurrentLabelsCamelCase => CurrentLabels;
+
+    [JsonPropertyName("created_pr_current_labels")]
+    public required IReadOnlyList<string> CreatedPrCurrentLabels { get; init; }
+
+    [JsonPropertyName("createdPrCurrentLabels")]
+    public IReadOnlyList<string> CreatedPrCurrentLabelsCamelCase => CreatedPrCurrentLabels;
 
     [JsonPropertyName("errors")]
     public required IReadOnlyList<string> Errors { get; init; }
@@ -534,4 +664,29 @@ internal sealed record AutomationCompleteResult
 
     [JsonPropertyName("summary")]
     public required string Summary { get; init; }
+}
+
+internal sealed record CompleteDecisionForPrTarget
+{
+    public static CompleteDecisionForPrTarget None { get; } = new()
+    {
+        Proceed = true,
+        AddLabels = Array.Empty<string>(),
+        LabelActions = Array.Empty<WorkerResultSummaryLabelAction>(),
+        Errors = Array.Empty<string>(),
+        Warnings = Array.Empty<string>(),
+        SummarySuffix = string.Empty,
+    };
+
+    public required bool Proceed { get; init; }
+
+    public required IReadOnlyList<string> AddLabels { get; init; }
+
+    public required IReadOnlyList<WorkerResultSummaryLabelAction> LabelActions { get; init; }
+
+    public required IReadOnlyList<string> Errors { get; init; }
+
+    public required IReadOnlyList<string> Warnings { get; init; }
+
+    public required string SummarySuffix { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/AutomationCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationCompleteCommandTests.cs
@@ -38,6 +38,10 @@ public sealed class AutomationCompleteCommandTests : IDisposable
         var mutator = new FakeMutator
         {
             Labels = new[] { "intent-target", "intent-issue-in-progress" },
+            LabelsByTarget =
+            {
+                ["pr:534"] = Array.Empty<string>(),
+            },
         };
         AutomationCompleteCommand.MutatorFactory = () => mutator;
 
@@ -67,6 +71,11 @@ public sealed class AutomationCompleteCommandTests : IDisposable
             a.Action == "remove" && a.Target == "issue" && a.Label == "intent-issue-in-progress");
         Assert.Contains(result.PlannedLabelActions, a =>
             a.Action == "add" && a.Target == "issue" && a.Label == "intent-pr-created");
+        Assert.Contains(result.PlannedLabelActions, a =>
+            a.Action == "add" && a.Target == "pr" && a.Label == "intent-target");
+        Assert.Contains(result.SourceIssueLabelActions, a => a.Target == "issue");
+        Assert.Contains(result.CreatedPrLabelActions, a =>
+            a.Target == "pr" && a.Label == "intent-target");
         Assert.Empty(mutator.AppliedTransitions);
         Assert.Contains(result.Warnings, w => w.Contains("intent-pr-created", StringComparison.Ordinal));
     }
@@ -79,6 +88,10 @@ public sealed class AutomationCompleteCommandTests : IDisposable
         var mutator = new FakeMutator
         {
             Labels = new[] { "intent-target", "intent-issue-in-progress" },
+            LabelsByTarget =
+            {
+                ["pr:534"] = Array.Empty<string>(),
+            },
         };
         AutomationCompleteCommand.MutatorFactory = () => mutator;
 
@@ -100,10 +113,79 @@ public sealed class AutomationCompleteCommandTests : IDisposable
         var result = JsonSerializer.Deserialize<AutomationCompleteResult>(writer.ToString())!;
         Assert.True(result.Applied);
         Assert.Equal(result.PlannedLabelActions.Count, result.AppliedLabelActions.Count);
-        Assert.Single(mutator.AppliedTransitions);
-        Assert.Equal("issue", mutator.AppliedTransitions[0].Kind);
-        Assert.Contains("intent-pr-created", mutator.AppliedTransitions[0].AddLabels);
-        Assert.Contains("intent-issue-in-progress", mutator.AppliedTransitions[0].RemoveLabels);
+        Assert.Equal(2, mutator.AppliedTransitions.Count);
+        var issueTransition = mutator.AppliedTransitions.Single(t => t.Kind == "issue");
+        Assert.Contains("intent-pr-created", issueTransition.AddLabels);
+        Assert.Contains("intent-issue-in-progress", issueTransition.RemoveLabels);
+        var prTransition = mutator.AppliedTransitions.Single(t => t.Kind == "pr");
+        Assert.Contains("intent-target", prTransition.AddLabels);
+        Assert.Empty(prTransition.RemoveLabels);
+        Assert.DoesNotContain("intent-pr-created", prTransition.AddLabels);
+    }
+
+    [Fact]
+    public void Execute_IssueToPrPrCreated_MissingPrFailsDeterministically()
+    {
+        using var workspace = new AutomationCompleteWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        AutomationCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--issue", "533",
+                "--outcome", "pr-created",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("--pr is required", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_IssueToPrPrCreated_PrWithMisplacedPrCreatedRefuses()
+    {
+        using var workspace = new AutomationCompleteWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+            LabelsByTarget =
+            {
+                ["pr:534"] = new[] { "intent-pr-created" },
+            },
+        };
+        AutomationCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "issue-to-pr",
+                "--issue", "533",
+                "--pr", "534",
+                "--outcome", "pr-created",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationCompleteResult>(writer.ToString())!;
+        Assert.False(result.Proceed);
+        Assert.False(result.Applied);
+        Assert.Contains(result.Errors, e => e.Contains("intent-pr-created", StringComparison.Ordinal));
+        Assert.Empty(mutator.AppliedTransitions);
     }
 
     [Fact]
@@ -373,6 +455,8 @@ public sealed class AutomationCompleteCommandTests : IDisposable
     {
         public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
 
+        public Dictionary<string, IReadOnlyList<string>> LabelsByTarget { get; } = new(StringComparer.Ordinal);
+
         public string? SeenRepo { get; private set; }
 
         public List<AppliedTransition> AppliedTransitions { get; } = new();
@@ -380,7 +464,11 @@ public sealed class AutomationCompleteCommandTests : IDisposable
         public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number)
         {
             SeenRepo = repo;
-            return Labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
+            var key = $"{kind}:{number.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+            var labels = LabelsByTarget.TryGetValue(key, out var targetLabels)
+                ? targetLabels
+                : Labels;
+            return labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
         }
 
         public void ApplyLabelTransitions(


### PR DESCRIPTION
## Summary

- Extend `automation complete` for `issue-to-pr` + `pr-created` to require a created PR identifier and plan/apply `intent-target` on that PR.
- Keep `intent-pr-created` issue-only and refuse completion if the created PR carries that misplaced label.
- Emit separated `sourceIssueLabelActions` and `createdPrLabelActions` in JSON while preserving the combined planned/applied label action lists.
- Update automation docs so workers do not label PRs directly and rely on `intent-cli automation complete --write` for review-target propagation.

Closes #537

## Verification

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter AutomationCompleteCommandTests`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "AutomationCompleteCommandTests|WorkerCompleteCommandTests|WorkerResultSummaryCommandTests"`
- `git diff --check`

## Notes

- `intent-pr-created` remains source-issue only.
- The created PR receives only `intent-target` through the supported completion transition.
- Missing `--pr` for `pr-created` fails deterministically instead of guessing.