### PR TITLE
G217 Pass created PR id through automation prompts

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -74,8 +74,10 @@ against …" section for the explicit comparison tables.
   surface this as a warning automatically when they detect misuse.
 - **Review-target propagation**: after an issue-to-PR success,
   `automation complete --write` is the supported path that marks the
-  created PR with `intent-target` for host review. Prompts must not add
-  that PR label directly.
+  created PR with `intent-target` for host review. The completion call
+  must pass the created PR number with `--pr`; if the worker reports a
+  PR URL, resolve or extract the number before completion. Prompts must
+  not add that PR label directly.
 - **Single-target cap**: at most ONE branch/PR is touched per wake. If
   `worker next-action` returns `none`, the wake is idle and ends without
   pushing anything.

--- a/docs/automation-templates/coding-automation-loop.md
+++ b/docs/automation-templates/coding-automation-loop.md
@@ -72,6 +72,22 @@ intent-cli automation complete \
   --kind <issue-to-pr|pr-comment-fix> \
   [--issue <n>] [--pr <n>] \
   --outcome <outcome> \
+  [--write] \
+  --format json
+```
+
+For `issue-to-pr` with outcome `pr-created`, the controlling automation
+MUST pass the created draft PR number with `--pr` and MUST use `--write`
+when applying completion. If the worker reports only a PR URL, resolve
+or extract its PR number before running this command:
+
+```bash
+intent-cli automation complete \
+  --kind issue-to-pr \
+  --issue "$ISSUE_NUMBER" \
+  --pr "$CREATED_PR_NUMBER" \
+  --outcome pr-created \
+  --write \
   --format json
 ```
 

--- a/docs/automation-templates/dry-run-checklist.md
+++ b/docs/automation-templates/dry-run-checklist.md
@@ -165,6 +165,12 @@ currently carries the claim label if you want `plannedLabelActions[]`
 to show the success transition; otherwise the command may correctly
 refuse as stale.
 
+The issue-to-PR `pr-created` example intentionally includes `--pr`.
+That value must be the created draft PR number in a real wake so
+`automation complete --write` can apply the supported `intent-target`
+transition to the PR. If the worker returns a PR URL, extract the number
+before completion. Workers must not add that label with `gh pr edit`.
+
 ## 6. Smoke-test `automation complete` (PR comment-fix outcome)
 
 Repeat the same render-only check for the PR repair workflow. This

--- a/docs/automation-templates/issue-to-pr-execution.md
+++ b/docs/automation-templates/issue-to-pr-execution.md
@@ -47,16 +47,27 @@ schema):
 | `failed`                         | Worker stopped with an error mid-run.                  |
 | `label-cleanup-required`         | Stale labels left behind after a partial run.          |
 
+For `pr-created`, capture the created draft PR number from the worker
+output before normalizing the wake. If the worker reports only a PR URL,
+resolve or extract its PR number before invoking completion. The PR
+identifier is required for the supported review-target propagation; do
+not rely on a later host-side fallback to rediscover the PR.
+
 ## Step 3: normalize via `automation complete`
 
 ```bash
 intent-cli automation complete \
   --kind issue-to-pr \
   --issue "$ISSUE_NUMBER" \
-  [--pr "$PR_NUMBER"] \
+  --pr "$CREATED_PR_NUMBER" \
   --outcome "$OUTCOME" \
+  --write \
   --format json
 ```
+
+When `$OUTCOME` is `pr-created`, `--pr` MUST identify the draft PR that
+the worker just opened. For non-PR outcomes, omit `--pr` only when no PR
+was created.
 
 This emits stable `recommended_label_actions[]` and
 `planned_label_actions[]` advice. For the happy `pr-created` path it
@@ -90,6 +101,8 @@ intent-cli automation clarification-stop \
 - `intent-cli automation complete` returns JSON with an
   outcome whose `status` is one of `completed` / `declined` /
   `clarification-required` / `failed` / `label-cleanup-required`.
+- For `pr-created`, the completion command includes both `--pr` with
+  the created PR identifier and `--write`.
 - No additional GitHub mutations from this prompt.
 
 ## What this template forbids


### PR DESCRIPTION
## Summary
- Require issue-to-PR pr-created completion prompts to pass the created PR number with --pr.
- Document extracting the PR number from a URL before completion and keeping PR label mutation inside automation complete --write.
- Update dry-run/template verification guidance for the created-PR handoff.

## Verification
- rg -n --fixed-strings -- '--pr ""' docs/automation-templates/issue-to-pr-execution.md docs/automation-templates/coding-automation-loop.md
- rg -n "worker reports only a PR URL|must pass the created PR number|automation complete --write|gh pr edit" docs/automation-templates/README.md docs/automation-templates/coding-automation-loop.md docs/automation-templates/issue-to-pr-execution.md docs/automation-templates/dry-run-checklist.md
- git diff --check

Closes #539