### PR TITLE
G219 Clear request-update on rereview completion

### DIFF
--- a/docs/automation-templates/pr-comment-fix-execution.md
+++ b/docs/automation-templates/pr-comment-fix-execution.md
@@ -54,11 +54,11 @@ intent-cli automation complete \
   --format json
 ```
 
-For the happy `repair-pushed` path the recommended advice is a single
-swap action: `intent-pr-update-in-progress` → `intent-pr-rereview-ready`
-on the PR. The controlling automation applies the swap only by calling
-`automation complete --write`; this prompt MUST NOT call `gh pr edit`
-directly.
+For the happy `repair-pushed` path the recommended advice swaps
+`intent-pr-update-in-progress` → `intent-pr-rereview-ready` and clears
+the stale `intent-pr-request-update` state on the PR. The controlling
+automation applies those edits only by calling `automation complete --write`;
+this prompt MUST NOT call `gh pr edit` directly.
 
 For `clarification-required`, also render the cooldown stop:
 

--- a/src/IntentSystem.Cli/Commands/WorkerCompleteAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerCompleteAnalyzer.cs
@@ -160,9 +160,11 @@ internal static class WorkerCompleteAnalyzer
             // All terminal pr-comment-fix outcomes release the in-progress claim.
             removeLabels.Add(WorkerNextActionConstants.Labels.IntentPrUpdateInProgress);
 
-            // repair-pushed success path also marks the PR as ready for re-review.
+            // repair-pushed success path clears the old request-update state
+            // and marks the PR as ready for re-review.
             if (string.Equals(outcome, WorkerResultSummaryConstants.Outcomes.RepairPushed, StringComparison.Ordinal))
             {
+                removeLabels.Add(WorkerNextActionConstants.Labels.IntentPrRequestUpdate);
                 addLabels.Add(WorkerNextActionConstants.Labels.IntentPrRereviewReady);
             }
         }

--- a/src/IntentSystem.Cli/Commands/WorkerResultSummaryAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerResultSummaryAnalyzer.cs
@@ -165,9 +165,10 @@ internal static class WorkerResultSummaryAnalyzer
                 break;
 
             case WorkerResultSummaryConstants.Outcomes.RepairPushed:
-                // The PR claim label flips from update-in-progress to
-                // rereview-ready. Modeled as a single swap action so the
-                // caller can apply both edits atomically.
+                // The PR claim label and the old request-update state both
+                // clear as the PR becomes rereview-ready. Keep the primary
+                // in-progress -> rereview-ready transition as a swap, and
+                // make the stale request-update cleanup explicit.
                 actions.Add(new WorkerResultSummaryLabelAction
                 {
                     Action = WorkerResultSummaryConstants.LabelActionVerbs.Swap,
@@ -175,6 +176,10 @@ internal static class WorkerResultSummaryAnalyzer
                     Label = $"{WorkerResultSummaryConstants.Labels.IntentPrUpdateInProgress}->" +
                             WorkerResultSummaryConstants.Labels.IntentPrRereviewReady,
                 });
+                actions.Add(MakeAction(
+                    WorkerResultSummaryConstants.LabelActionVerbs.Remove,
+                    WorkerResultSummaryConstants.LabelActionTargets.Pr,
+                    WorkerResultSummaryConstants.Labels.IntentPrRequestUpdate));
                 break;
 
             case WorkerResultSummaryConstants.Outcomes.LabelCleanupRequired:

--- a/tests/IntentSystem.Cli.Tests/AutomationCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationCompleteCommandTests.cs
@@ -220,8 +220,13 @@ public sealed class AutomationCompleteCommandTests : IDisposable
         Assert.Contains(result.PlannedLabelActions, a =>
             a.Action == "remove" && a.Target == "pr" && a.Label == "intent-pr-update-in-progress");
         Assert.Contains(result.PlannedLabelActions, a =>
+            a.Action == "remove" && a.Target == "pr" && a.Label == "intent-pr-request-update");
+        Assert.Contains(result.PlannedLabelActions, a =>
             a.Action == "add" && a.Target == "pr" && a.Label == "intent-pr-rereview-ready");
-        Assert.Single(mutator.AppliedTransitions);
+        var transition = Assert.Single(mutator.AppliedTransitions);
+        Assert.Contains("intent-pr-rereview-ready", transition.AddLabels);
+        Assert.Contains("intent-pr-update-in-progress", transition.RemoveLabels);
+        Assert.Contains("intent-pr-request-update", transition.RemoveLabels);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
@@ -215,6 +215,7 @@ public sealed class WorkerCompleteCommandTests : IDisposable
         Assert.False(result.Applied);
         Assert.Contains("intent-pr-rereview-ready", result.AddLabels);
         Assert.Contains("intent-pr-update-in-progress", result.RemoveLabels);
+        Assert.Contains("intent-pr-request-update", result.RemoveLabels);
         Assert.Empty(mutator.AppliedTransitions);
 
         // intent-pr-created MUST NOT be added to a PR.
@@ -249,6 +250,44 @@ public sealed class WorkerCompleteCommandTests : IDisposable
         var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
         Assert.Contains(result.Errors, e => e.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.CompleteAlreadyCompleted, StringComparison.Ordinal));
         Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_PrRepairPushedOutcome_WriteRemovesRequestUpdateWhenAddingRereviewReady()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-request-update", "intent-pr-update-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "pr",
+                "--number", "514",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.RepairPushed,
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.True(result.Proceed);
+        Assert.True(result.Applied);
+        Assert.Contains("intent-pr-rereview-ready", result.AddLabels);
+        Assert.Contains("intent-pr-update-in-progress", result.RemoveLabels);
+        Assert.Contains("intent-pr-request-update", result.RemoveLabels);
+
+        var transition = Assert.Single(mutator.AppliedTransitions);
+        Assert.Contains("intent-pr-rereview-ready", transition.AddLabels);
+        Assert.Contains("intent-pr-update-in-progress", transition.RemoveLabels);
+        Assert.Contains("intent-pr-request-update", transition.RemoveLabels);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/WorkerResultSummaryCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerResultSummaryCommandTests.cs
@@ -91,12 +91,16 @@ public sealed class WorkerResultSummaryCommandTests : IDisposable
         var result = JsonSerializer.Deserialize<WorkerResultSummaryResult>(writer.ToString())!;
         Assert.Equal(WorkerResultSummaryConstants.Statuses.Completed, result.Status);
 
-        // Single swap action: update-in-progress -> rereview-ready on the PR.
+        // Primary swap action: update-in-progress -> rereview-ready on the PR.
         Assert.Contains(result.RecommendedLabelActions, a =>
             a.Action == "swap"
             && a.Target == "pr"
             && a.Label.Contains(WorkerResultSummaryConstants.Labels.IntentPrUpdateInProgress, StringComparison.Ordinal)
             && a.Label.Contains(WorkerResultSummaryConstants.Labels.IntentPrRereviewReady, StringComparison.Ordinal));
+        Assert.Contains(result.RecommendedLabelActions, a =>
+            a.Action == "remove"
+            && a.Target == "pr"
+            && a.Label == WorkerResultSummaryConstants.Labels.IntentPrRequestUpdate);
 
         // No spurious "remove in-progress" action — the swap covers it.
         Assert.DoesNotContain(result.RecommendedLabelActions, a =>


### PR DESCRIPTION
## Summary
- Update PR repair completion so repair-pushed removes intent-pr-request-update while adding intent-pr-rereview-ready.
- Update result-summary advice to include explicit stale request-update cleanup.
- Add focused worker/automation completion tests and refresh the repair handoff docs.

## Verification
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~WorkerCompleteCommandTests|FullyQualifiedName~AutomationCompleteCommandTests|FullyQualifiedName~WorkerResultSummaryCommandTests"
- rg -n "IntentPrRequestUpdate|intent-pr-request-update|repair-pushed" src/IntentSystem.Cli/Commands/WorkerCompleteAnalyzer.cs src/IntentSystem.Cli/Commands/WorkerResultSummaryAnalyzer.cs tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs tests/IntentSystem.Cli.Tests/AutomationCompleteCommandTests.cs tests/IntentSystem.Cli.Tests/WorkerResultSummaryCommandTests.cs docs/automation-templates/pr-comment-fix-execution.md
- git diff --check

Closes #543