### PR TITLE
G220 Verify rereview cleanup final state

### DIFF
--- a/docs/automation-templates/dry-run-checklist.md
+++ b/docs/automation-templates/dry-run-checklist.md
@@ -219,8 +219,11 @@ Expected:
 
 - exit code 0,
 - the JSON's `plannedLabelActions[]` reflects the
-  update-in-progress → rereview-ready handoff, NOT a fresh
-  `intent-pr-created` on the PR,
+  update-in-progress → rereview-ready handoff,
+- the same planned transition removes `intent-pr-request-update` so
+  the PR cannot remain both repair-requested and rereview-ready,
+- the planned transition does NOT add a fresh `intent-pr-created` on
+  the PR,
 - `intent-pr-created` does not appear as a recommended add on a PR.
   If it does, treat it as a bug — `intent-pr-created` belongs on
   the source ISSUE, not on the PR.

--- a/docs/automation-templates/pr-comment-fix-execution.md
+++ b/docs/automation-templates/pr-comment-fix-execution.md
@@ -78,6 +78,9 @@ intent-cli automation clarification-stop \
 - AI worker pushes a single repair commit and posts the update note.
 - `intent-cli automation complete` returns JSON for the
   outcome.
+- For `repair-pushed`, `automation complete --write` removes
+  `intent-pr-request-update` and adds `intent-pr-rereview-ready`; the
+  resulting PR label set must not contain `intent-pr-request-update`.
 - The host's recurring deterministic-rereview comment is no longer
   classified as `repair-required` once the label-state advances to
   `intent-pr-rereview-ready`.

--- a/tests/IntentSystem.Cli.Tests/AutomationCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationCompleteCommandTests.cs
@@ -227,6 +227,13 @@ public sealed class AutomationCompleteCommandTests : IDisposable
         Assert.Contains("intent-pr-rereview-ready", transition.AddLabels);
         Assert.Contains("intent-pr-update-in-progress", transition.RemoveLabels);
         Assert.Contains("intent-pr-request-update", transition.RemoveLabels);
+
+        var finalLabels = mutator.Labels
+            .Except(transition.RemoveLabels, StringComparer.Ordinal)
+            .Concat(transition.AddLabels)
+            .ToArray();
+        Assert.Contains("intent-pr-rereview-ready", finalLabels);
+        Assert.DoesNotContain("intent-pr-request-update", finalLabels);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
@@ -288,6 +288,13 @@ public sealed class WorkerCompleteCommandTests : IDisposable
         Assert.Contains("intent-pr-rereview-ready", transition.AddLabels);
         Assert.Contains("intent-pr-update-in-progress", transition.RemoveLabels);
         Assert.Contains("intent-pr-request-update", transition.RemoveLabels);
+
+        var finalLabels = mutator.Labels
+            .Except(transition.RemoveLabels, StringComparer.Ordinal)
+            .Concat(transition.AddLabels)
+            .ToArray();
+        Assert.Contains("intent-pr-rereview-ready", finalLabels);
+        Assert.DoesNotContain("intent-pr-request-update", finalLabels);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add final-label assertions proving repair completion leaves intent-pr-rereview-ready and removes intent-pr-request-update.
- Update repair handoff docs and dry-run checklist to call out the absent request-update state after automation complete --write.
- Keep the normal worker path on intent-cli transitions, not raw gh label cleanup.

## Verification
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~WorkerCompleteCommandTests|FullyQualifiedName~AutomationCompleteCommandTests"
- rg -n "finalLabels|intent-pr-request-update|repair-pushed|rereview-ready" tests/IntentSystem.Cli.Tests/AutomationCompleteCommandTests.cs tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs docs/automation-templates/pr-comment-fix-execution.md docs/automation-templates/dry-run-checklist.md
- git diff --check

Closes #545