### PR TITLE
G221 Add host PR transition commands

### DIFF
--- a/docs/automation-templates/host-review-loop.md
+++ b/docs/automation-templates/host-review-loop.md
@@ -104,7 +104,7 @@ GitHub labels.
 
 | Verdict                | Label transition                                                                          |
 |------------------------|--------------------------------------------------------------------------------------------|
-| accept-and-merge       | remove `intent-pr-reviewing`; the PR is then merged via the host's merge step.            |
+| accept-and-merge       | remove `intent-pr-reviewing`; add `intent-pr-approved`; the PR is then merged via the host's merge step. |
 | request-update         | remove `intent-pr-reviewing` (if present); add `intent-pr-request-update` with comment(s).|
 | accept-as-rereview-ready | (post-repair) remove `intent-pr-update-in-progress`; add `intent-pr-rereview-ready`.   |
 | reject-clarification   | leave a host clarification comment with the cooldown marker; do NOT flip review labels.    |
@@ -116,6 +116,32 @@ Notes:
   PR-state marker.
 - `intent-target` is owned by the host's labeling policy. The
   child-side automation NEVER adds or removes it; host review may.
+- Host-owned review transitions should use the installed command
+  surface when available:
+
+```bash
+intent-cli automation pr-transition \
+  --repo "$CHILD_REPO" \
+  --pr "$PR_NUMBER" \
+  --transition review-start \
+  --write \
+  --format json
+```
+
+```bash
+intent-cli automation pr-transition \
+  --repo "$CHILD_REPO" \
+  --pr "$PR_NUMBER" \
+  --transition approved \
+  --write \
+  --format json
+```
+
+`review-start` adds `intent-target` and `intent-pr-reviewing` while
+clearing stale `intent-pr-rereview-ready`. `approved` removes
+`intent-pr-reviewing` and adds `intent-pr-approved`. These commands are
+the supported installed path for those host-owned PR label transitions;
+raw `gh pr edit` blocks are transitional fallback only.
 
 ## Step 5: write the review verdict comment
 

--- a/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
@@ -1,0 +1,366 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Installed host-side PR label transition surface for review-loop state
+/// changes that previously required raw <c>gh pr edit</c> fallback blocks.
+/// </summary>
+internal static class AutomationPrTransitionCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+    private const string TransitionReviewStart = "review-start";
+    private const string TransitionApproved = "approved";
+
+    public static Func<IGitHubLabelMutator>? MutatorFactory { get; set; }
+
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(
+                args,
+                out var repo,
+                out var workdir,
+                out var pr,
+                out var transition,
+                out var mode,
+                out var format,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        if (string.IsNullOrWhiteSpace(repo)
+            && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var plan = PlanTransition(transition!);
+        IGitHubLabelMutator mutator;
+        try
+        {
+            mutator = MutatorFactory?.Invoke()
+                ?? new GhCliGitHubLabelMutator();
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub mutator: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<string> currentLabels;
+        try
+        {
+            currentLabels = mutator
+                .ReadLabels(repo!, GhCliGitHubLabelMutator.Kinds.Pr, pr!.Value)
+                .Select(label => label.Name)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .ToArray();
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine($"failed to read current labels for PR #{pr} in {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var applied = false;
+        if (string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal))
+        {
+            try
+            {
+                mutator.ApplyLabelTransitions(
+                    repo!,
+                    GhCliGitHubLabelMutator.Kinds.Pr,
+                    pr!.Value,
+                    plan.AddLabels,
+                    plan.RemoveLabels);
+                applied = true;
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or IOException)
+            {
+                writer.WriteLine($"failed to apply PR transition on PR #{pr} in {repo}: {exception.Message}");
+                return 1;
+            }
+        }
+
+        var result = new AutomationPrTransitionResult
+        {
+            Repo = repo!,
+            Pr = pr!.Value,
+            Transition = transition!,
+            Mode = mode,
+            Applied = applied,
+            AddLabels = plan.AddLabels,
+            RemoveLabels = plan.RemoveLabels,
+            CurrentLabels = currentLabels,
+            Summary = BuildSummary(transition!, plan.AddLabels, plan.RemoveLabels),
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static TransitionPlan PlanTransition(string transition) =>
+        transition switch
+        {
+            TransitionReviewStart => new TransitionPlan(
+                AddLabels:
+                [
+                    WorkerNextActionConstants.Labels.IntentTarget,
+                    WorkerPrReviewPreflightConstants.Labels.IntentPrReviewing,
+                ],
+                RemoveLabels:
+                [
+                    WorkerNextActionConstants.Labels.IntentPrRereviewReady,
+                ]),
+            TransitionApproved => new TransitionPlan(
+                AddLabels:
+                [
+                    WorkerPrReviewPreflightConstants.Labels.IntentPrApproved,
+                ],
+                RemoveLabels:
+                [
+                    WorkerPrReviewPreflightConstants.Labels.IntentPrReviewing,
+                ]),
+            _ => throw new ArgumentOutOfRangeException(nameof(transition), transition, "Unsupported PR transition."),
+        };
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string? workdir,
+        out int? pr,
+        out string? transition,
+        out string mode,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        workdir = null;
+        pr = null;
+        transition = null;
+        mode = WorkerClaimCompleteConstants.Modes.DryRun;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--workdir":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--workdir requires a value.";
+                        return false;
+                    }
+                    workdir = args[index + 1];
+                    index++;
+                    break;
+
+                case "--pr":
+                    if (!TryReadPositiveInt(args, index, "--pr", out var prNumber, out error))
+                    {
+                        return false;
+                    }
+                    pr = prNumber;
+                    index++;
+                    break;
+
+                case "--transition":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--transition requires a value (review-start or approved).";
+                        return false;
+                    }
+                    transition = args[index + 1].Trim();
+                    if (!string.Equals(transition, TransitionReviewStart, StringComparison.Ordinal)
+                        && !string.Equals(transition, TransitionApproved, StringComparison.Ordinal))
+                    {
+                        error = $"--transition must be '{TransitionReviewStart}' or '{TransitionApproved}' (got '{transition}').";
+                        return false;
+                    }
+                    index++;
+                    break;
+
+                case "--write":
+                    mode = WorkerClaimCompleteConstants.Modes.Write;
+                    break;
+
+                case "--dry-run":
+                    mode = WorkerClaimCompleteConstants.Modes.DryRun;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: [--repo <owner/repo>] [--workdir <path>] --pr <n> --transition <review-start|approved> [--write] [--dry-run] [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (pr is null)
+        {
+            error = "--pr is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(transition))
+        {
+            error = "--transition is required (review-start or approved).";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadPositiveInt(
+        string[] args,
+        int index,
+        string option,
+        out int value,
+        out string error)
+    {
+        value = 0;
+        error = string.Empty;
+        if (index + 1 >= args.Length
+            || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out value)
+            || value <= 0)
+        {
+            error = $"{option} requires a positive integer.";
+            return false;
+        }
+        return true;
+    }
+
+    private static string ResolveWorkdir(CliContext context, string? workdir)
+    {
+        if (string.IsNullOrWhiteSpace(workdir))
+        {
+            return context.RepoRoot;
+        }
+
+        return Path.IsPathRooted(workdir)
+            ? workdir
+            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
+    }
+
+    private static string BuildSummary(
+        string transition,
+        IReadOnlyCollection<string> addLabels,
+        IReadOnlyCollection<string> removeLabels)
+    {
+        var addPart = addLabels.Count == 0 ? "(none)" : string.Join(", ", addLabels);
+        var removePart = removeLabels.Count == 0 ? "(none)" : string.Join(", ", removeLabels);
+        return $"Would apply host PR transition '{transition}': add {addPart}; remove {removePart}.";
+    }
+
+    private static void WriteText(TextWriter writer, AutomationPrTransitionResult result)
+    {
+        writer.WriteLine(result.Summary);
+        writer.WriteLine($"mode: {result.Mode}");
+        writer.WriteLine($"repo: {result.Repo}");
+        writer.WriteLine($"pr: {result.Pr.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+        writer.WriteLine($"applied: {result.Applied.ToString().ToLowerInvariant()}");
+    }
+
+    private sealed record TransitionPlan(
+        IReadOnlyList<string> AddLabels,
+        IReadOnlyList<string> RemoveLabels);
+}
+
+internal sealed record AutomationPrTransitionResult
+{
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("pr")]
+    public required int Pr { get; init; }
+
+    [JsonPropertyName("transition")]
+    public required string Transition { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("add_labels")]
+    public required IReadOnlyList<string> AddLabels { get; init; }
+
+    [JsonPropertyName("addLabels")]
+    public IReadOnlyList<string> AddLabelsCamel => AddLabels;
+
+    [JsonPropertyName("remove_labels")]
+    public required IReadOnlyList<string> RemoveLabels { get; init; }
+
+    [JsonPropertyName("removeLabels")]
+    public IReadOnlyList<string> RemoveLabelsCamel => RemoveLabels;
+
+    [JsonPropertyName("current_labels")]
+    public required IReadOnlyList<string> CurrentLabels { get; init; }
+
+    [JsonPropertyName("currentLabels")]
+    public IReadOnlyList<string> CurrentLabelsCamel => CurrentLabels;
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -123,6 +123,7 @@ internal static class CommandRouter
                 ["check"] = AutomationCheckCommand.Execute,
                 ["clarification-stop"] = AutomationClarificationStopCommand.Execute,
                 ["complete"] = AutomationCompleteCommand.Execute,
+                ["pr-transition"] = AutomationPrTransitionCommand.Execute,
                 ["summary"] = AutomationSummaryCommand.Execute
             },
             ["safety"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)

--- a/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
@@ -1,0 +1,275 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class AutomationPrTransitionCommandTests : IDisposable
+{
+    public AutomationPrTransitionCommandTests()
+    {
+        AutomationPrTransitionCommand.MutatorFactory = null;
+        AutomationPrTransitionCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        AutomationPrTransitionCommand.MutatorFactory = null;
+        AutomationPrTransitionCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void Execute_ReviewStart_DryRunPlansHostReviewLabelsWithoutApplying()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-pr-rereview-ready" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--pr", "542",
+                "--transition", "review-start",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.Equal("J-Tech-Japan/intent-system", result.Repo);
+        Assert.Equal(542, result.Pr);
+        Assert.Equal("review-start", result.Transition);
+        Assert.Equal("dry-run", result.Mode);
+        Assert.False(result.Applied);
+        Assert.Contains("intent-target", result.AddLabels);
+        Assert.Contains("intent-pr-reviewing", result.AddLabels);
+        Assert.Contains("intent-pr-rereview-ready", result.RemoveLabels);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_ReviewStart_WriteAppliesExactHostReviewLabels()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-pr-rereview-ready" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "542",
+                "--transition", "review-start",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+
+        var transition = Assert.Single(mutator.AppliedTransitions);
+        Assert.Equal("pr", transition.Kind);
+        Assert.Equal(542, transition.Number);
+        Assert.Contains("intent-target", transition.AddLabels);
+        Assert.Contains("intent-pr-reviewing", transition.AddLabels);
+        Assert.Contains("intent-pr-rereview-ready", transition.RemoveLabels);
+        Assert.DoesNotContain("intent-pr-created", transition.AddLabels);
+        Assert.DoesNotContain("intent-pr-created", transition.RemoveLabels);
+    }
+
+    [Fact]
+    public void Execute_Approved_WriteAppliesExactApprovedLabels()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-reviewing" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "542",
+                "--transition", "approved",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+        Assert.Contains("intent-pr-approved", result.AddLabels);
+        Assert.Contains("intent-pr-reviewing", result.RemoveLabels);
+
+        var transition = Assert.Single(mutator.AppliedTransitions);
+        Assert.Contains("intent-pr-approved", transition.AddLabels);
+        Assert.Contains("intent-pr-reviewing", transition.RemoveLabels);
+        Assert.DoesNotContain("intent-pr-created", transition.AddLabels);
+        Assert.DoesNotContain("intent-pr-created", transition.RemoveLabels);
+    }
+
+    [Fact]
+    public void CommandRouter_RegistersAutomationPrTransition()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-reviewing" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            [
+                "automation",
+                "pr-transition",
+                "--repo",
+                "J-Tech-Japan/intent-system",
+                "--pr",
+                "542",
+                "--transition",
+                "approved",
+                "--format",
+                "json",
+            ],
+            workspace.Context,
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.Equal("approved", result.Transition);
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesNestedProviderLauncher()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var launcherInvoked = false;
+        AutomationPrTransitionCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-reviewing" },
+        };
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "542",
+                "--transition", "approved",
+                "--format", "json",
+            },
+            writer));
+
+        Assert.False(launcherInvoked,
+            "AutomationPrTransitionCommand must never invoke NestedProviderLauncher.");
+    }
+
+    private sealed class FakeMutator : IGitHubLabelMutator
+    {
+        public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+
+        public List<AppliedTransition> AppliedTransitions { get; } = new();
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
+            Labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
+
+        public void ApplyLabelTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels)
+        {
+            if (string.Equals(kind, "pr", StringComparison.Ordinal)
+                && (addLabels.Contains("intent-pr-created", StringComparer.Ordinal)
+                    || removeLabels.Contains("intent-pr-created", StringComparer.Ordinal)))
+            {
+                throw new InvalidOperationException("'intent-pr-created' is issue-only.");
+            }
+
+            AppliedTransitions.Add(new AppliedTransition(
+                repo,
+                kind,
+                number,
+                addLabels.ToArray(),
+                removeLabels.ToArray()));
+        }
+    }
+
+    private sealed record AppliedTransition(
+        string Repo,
+        string Kind,
+        int Number,
+        IReadOnlyList<string> AddLabels,
+        IReadOnlyList<string> RemoveLabels);
+
+    private sealed class AutomationPrTransitionWorkspace : IDisposable
+    {
+        public AutomationPrTransitionWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("automation-pr-transition-tests-").FullName;
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public void WriteOriginRemote(string remoteUrl)
+        {
+            var gitDirectory = Path.Combine(RootPath, ".git");
+            Directory.CreateDirectory(gitDirectory);
+            File.WriteAllText(
+                Path.Combine(gitDirectory, "config"),
+                $"""
+                [remote "origin"]
+                    url = {remoteUrl}
+                """);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add installed intent-cli automation pr-transition support for host-owned review-start and approved PR label transitions.
- Register the command under the automation group and keep writes behind explicit --write.
- Document the installed host review-loop command path and add focused transition tests.

## Verification
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~AutomationPrTransitionCommandTests"
- rg -n "pr-transition|review-start|intent-pr-reviewing|intent-pr-approved|intent-pr-created" src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs src/IntentSystem.Cli/Commands/CommandRouter.cs tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs docs/automation-templates/host-review-loop.md
- git diff --check

Closes #547