### PR TITLE
G224 Add automation host command preflight

### DIFF
--- a/docs/automation-templates/host-review-loop.md
+++ b/docs/automation-templates/host-review-loop.md
@@ -97,6 +97,18 @@ not push, do not flip labels.
 
 ## Step 4: produce a deterministic review verdict
 
+Before applying any host-owned PR label transition, run the installed
+binary preflight:
+
+```bash
+intent-cli automation doctor --format json
+```
+
+The preflight is read-only. It must report the required
+`intent-cli automation pr-transition` command surface, including both
+`review-start` and `approved`, before the host loop attempts a GitHub
+label mutation.
+
 Choose ONE of the following review verdicts. Each has an explicit
 label transition. For host-owned review-start and approved transitions,
 the normal installed path is `intent-cli automation pr-transition

--- a/src/IntentSystem.Cli/Commands/AutomationDoctorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationDoctorCommand.cs
@@ -1,0 +1,174 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Read-only host automation command freshness preflight. The command reports
+/// the installed binary surfaces required by host PR label transitions without
+/// mutating GitHub, queue state, parent files, or child repo files.
+/// </summary>
+internal static class AutomationDoctorCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var result = BuildResult();
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static AutomationDoctorResult BuildResult()
+    {
+        var requiredCommands = new[]
+        {
+            new AutomationDoctorRequiredCommand
+            {
+                Command = "intent-cli automation pr-transition",
+                Transition = "review-start",
+                Usage = "intent-cli automation pr-transition --transition review-start --write",
+                Purpose = "Host review-start transition: add intent-target and intent-pr-reviewing, remove intent-pr-rereview-ready",
+                Available = true,
+            },
+            new AutomationDoctorRequiredCommand
+            {
+                Command = "intent-cli automation pr-transition",
+                Transition = "approved",
+                Usage = "intent-cli automation pr-transition --transition approved --write",
+                Purpose = "Host approved transition: remove intent-pr-reviewing and add intent-pr-approved",
+                Available = true,
+            },
+        };
+
+        return new AutomationDoctorResult
+        {
+            Status = "ok",
+            ReadOnly = true,
+            RequiredCommands = requiredCommands,
+            Summary = "Host automation command preflight passed: required automation pr-transition commands are available.",
+        };
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string format,
+        out string error)
+    {
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --format text|json.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteText(TextWriter writer, AutomationDoctorResult result)
+    {
+        writer.WriteLine("# Automation doctor");
+        writer.WriteLine($"status: {result.Status}");
+        writer.WriteLine($"read_only: {result.ReadOnly.ToString().ToLowerInvariant()}");
+        writer.WriteLine(result.Summary);
+        writer.WriteLine();
+        writer.WriteLine("## Required host PR transition commands");
+        foreach (var command in result.RequiredCommands)
+        {
+            writer.WriteLine($"- {command.Usage}");
+            writer.WriteLine($"  transition: {command.Transition}");
+            writer.WriteLine($"  available: {command.Available.ToString().ToLowerInvariant()}");
+            writer.WriteLine($"  purpose: {command.Purpose}");
+        }
+    }
+}
+
+internal sealed record AutomationDoctorResult
+{
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("read_only")]
+    public required bool ReadOnly { get; init; }
+
+    [JsonPropertyName("readOnly")]
+    public bool ReadOnlyCamel => ReadOnly;
+
+    [JsonPropertyName("required_commands")]
+    public required IReadOnlyList<AutomationDoctorRequiredCommand> RequiredCommands { get; init; }
+
+    [JsonPropertyName("requiredCommands")]
+    public IReadOnlyList<AutomationDoctorRequiredCommand> RequiredCommandsCamel => RequiredCommands;
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}
+
+internal sealed record AutomationDoctorRequiredCommand
+{
+    [JsonPropertyName("command")]
+    public required string Command { get; init; }
+
+    [JsonPropertyName("transition")]
+    public required string Transition { get; init; }
+
+    [JsonPropertyName("usage")]
+    public required string Usage { get; init; }
+
+    [JsonPropertyName("purpose")]
+    public required string Purpose { get; init; }
+
+    [JsonPropertyName("available")]
+    public required bool Available { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -32,6 +32,7 @@ internal static class CommandRouter
         "automation check",
         "automation clarification-stop",
         "automation complete",
+        "automation doctor",
         "automation pr-transition --transition review-start --write",
         "automation pr-transition --transition approved --write",
         "automation summary"
@@ -133,6 +134,7 @@ internal static class CommandRouter
                 ["check"] = AutomationCheckCommand.Execute,
                 ["clarification-stop"] = AutomationClarificationStopCommand.Execute,
                 ["complete"] = AutomationCompleteCommand.Execute,
+                ["doctor"] = AutomationDoctorCommand.Execute,
                 ["pr-transition"] = AutomationPrTransitionCommand.Execute,
                 ["summary"] = AutomationSummaryCommand.Execute
             },

--- a/tests/IntentSystem.Cli.Tests/AutomationDoctorCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationDoctorCommandTests.cs
@@ -1,0 +1,189 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class AutomationDoctorCommandTests
+{
+    [Fact]
+    public void Execute_TextOutputSurfacesRequiredHostPrTransitions()
+    {
+        using var workspace = new AutomationDoctorWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationDoctorCommand.Execute(
+            workspace.Context,
+            ["--format", "text"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Automation doctor", output, StringComparison.Ordinal);
+        Assert.Contains("status: ok", output, StringComparison.Ordinal);
+        Assert.Contains("read_only: true", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli automation pr-transition", output, StringComparison.Ordinal);
+        Assert.Contains("--transition review-start", output, StringComparison.Ordinal);
+        Assert.Contains("--transition approved", output, StringComparison.Ordinal);
+        Assert.Contains("intent-target", output, StringComparison.Ordinal);
+        Assert.Contains("intent-pr-reviewing", output, StringComparison.Ordinal);
+        Assert.Contains("intent-pr-rereview-ready", output, StringComparison.Ordinal);
+        Assert.Contains("intent-pr-approved", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_JsonOutputExposesStableRequiredCommandList()
+    {
+        using var workspace = new AutomationDoctorWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationDoctorCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationDoctorResult>(writer.ToString())!;
+        Assert.Equal("ok", result.Status);
+        Assert.True(result.ReadOnly);
+        Assert.Equal(2, result.RequiredCommands.Count);
+        Assert.All(result.RequiredCommands, command =>
+        {
+            Assert.Equal("intent-cli automation pr-transition", command.Command);
+            Assert.True(command.Available);
+        });
+        Assert.Contains(result.RequiredCommands, command =>
+            string.Equals(command.Transition, "review-start", StringComparison.Ordinal)
+            && command.Usage.Contains("--transition review-start", StringComparison.Ordinal));
+        Assert.Contains(result.RequiredCommands, command =>
+            string.Equals(command.Transition, "approved", StringComparison.Ordinal)
+            && command.Usage.Contains("--transition approved", StringComparison.Ordinal));
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.TryGetProperty("required_commands", out var requiredCommands));
+        Assert.Equal(2, requiredCommands.GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_NeverWritesAnyFile()
+    {
+        using var workspace = new AutomationDoctorWorkspace();
+        workspace.WriteSentinel();
+        var beforeSnapshot = workspace.SnapshotWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationDoctorCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var afterSnapshot = workspace.SnapshotWorkspace();
+        Assert.Equal(beforeSnapshot.Count, afterSnapshot.Count);
+        foreach (var (path, hash) in beforeSnapshot)
+        {
+            Assert.True(afterSnapshot.TryGetValue(path, out var afterHash),
+                $"file disappeared during command execution: {path}");
+            Assert.Equal(hash, afterHash);
+        }
+    }
+
+    [Fact]
+    public void CommandRouter_RegistersAutomationDoctor()
+    {
+        using var workspace = new AutomationDoctorWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["automation", "doctor", "--format", "json"],
+            workspace.Context,
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationDoctorResult>(writer.ToString())!;
+        Assert.Equal("ok", result.Status);
+    }
+
+    [Fact]
+    public void CommandRouter_HelpSurfacesAutomationDoctor()
+    {
+        using var workspace = new AutomationDoctorWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute([], workspace.Context, writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("automation doctor", output, StringComparison.Ordinal);
+        Assert.Contains("automation pr-transition", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownFormat_ReturnsNonZero()
+    {
+        using var workspace = new AutomationDoctorWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationDoctorCommand.Execute(
+            workspace.Context,
+            ["--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private sealed class AutomationDoctorWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("automation-doctor-tests-")
+            .FullName;
+
+        public AutomationDoctorWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public void WriteSentinel()
+        {
+            File.WriteAllText(Path.Combine(rootPath, "sentinel.txt"), "unchanged");
+        }
+
+        public IReadOnlyDictionary<string, string> SnapshotWorkspace()
+        {
+            var snapshot = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var path in Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories))
+            {
+                var bytes = File.ReadAllBytes(path);
+                var hash = Convert.ToHexString(SHA256.HashData(bytes));
+                snapshot[path] = hash;
+            }
+            return snapshot;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #553

## Summary
- add read-only `intent-cli automation doctor` preflight with text and JSON output
- expose required host PR transition command usages for `review-start` and `approved`
- register the command in CLI help and document the host preflight step

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~Automation"`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~AutomationDoctorCommandTests"`
- `rg -n "automation doctor|review-start|approved|pr-transition" src/IntentSystem.Cli tests/IntentSystem.Cli.Tests docs/automation-templates`
- `git diff --check`
