### PR TITLE
G225 Implement missing automation doctor command

### DIFF
--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -61,7 +61,8 @@ internal static class Program
             && string.Equals(args[0], "automation", StringComparison.Ordinal)
             && (string.Equals(args[1], "check", StringComparison.Ordinal)
                 || string.Equals(args[1], "clarification-stop", StringComparison.Ordinal)
-                || string.Equals(args[1], "complete", StringComparison.Ordinal));
+                || string.Equals(args[1], "complete", StringComparison.Ordinal)
+                || string.Equals(args[1], "doctor", StringComparison.Ordinal));
     }
 
     private static CliContext CreateBootstrapContext(string currentDirectory, string[] args)

--- a/tests/IntentSystem.Cli.Tests/AutomationDoctorCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationDoctorCommandTests.cs
@@ -108,6 +108,39 @@ public sealed class AutomationDoctorCommandTests
     }
 
     [Fact]
+    public void ProgramMain_AutomationDoctorDoesNotRequireIntentCliDirectory()
+    {
+        using var workspace = new AutomationDoctorWorkspace(createIntentCliDirectory: false);
+        var originalDirectory = Directory.GetCurrentDirectory();
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+
+        try
+        {
+            Directory.SetCurrentDirectory(workspace.RootPath);
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+
+            var exitCode = Program.Main(["automation", "doctor", "--format", "json"]);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(string.Empty, stderr.ToString());
+            Assert.DoesNotContain("Command 'automation doctor' is not yet implemented.", stdout.ToString(), StringComparison.Ordinal);
+            var result = JsonSerializer.Deserialize<AutomationDoctorResult>(stdout.ToString())!;
+            Assert.Equal("ok", result.Status);
+            Assert.True(result.ReadOnly);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+            Directory.SetCurrentDirectory(originalDirectory);
+        }
+    }
+
+    [Fact]
     public void CommandRouter_HelpSurfacesAutomationDoctor()
     {
         using var workspace = new AutomationDoctorWorkspace();
@@ -142,9 +175,15 @@ public sealed class AutomationDoctorCommandTests
             .CreateTempSubdirectory("automation-doctor-tests-")
             .FullName;
 
-        public AutomationDoctorWorkspace()
+        public string RootPath => rootPath;
+
+        public AutomationDoctorWorkspace(bool createIntentCliDirectory = true)
         {
-            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            if (createIntentCliDirectory)
+            {
+                Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            }
+
             Context = new CliContext
             {
                 RepoRoot = rootPath,


### PR DESCRIPTION
Closes #555

## Summary
- route `automation doctor` through bootstrap mode so it works from child worktrees without `.intent-cli`
- add a `Program.Main` regression test proving the executable path no longer returns the not-implemented/missing-runtime response
- preserve the existing read-only doctor output and host PR transition freshness surface

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~AutomationDoctorCommandTests"`
- `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- automation doctor --format json`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~Automation"`
- `rg -n "automation doctor|Command 'automation doctor'|review-start|approved|pr-transition|IsAutomationWorktreeCommand" src/IntentSystem.Cli tests/IntentSystem.Cli.Tests docs/automation-templates`
- `git diff --check`
