### PR TITLE
G226 Add automation issue publish transition command

### DIFF
--- a/docs/automation-templates/host-next-slice-loop.md
+++ b/docs/automation-templates/host-next-slice-loop.md
@@ -131,6 +131,21 @@ will then pick the published issue up via `intent-cli worker
 next-action` on its next wake; this template MUST NOT shortcut that
 boundary by calling the child loop directly.
 
+After the host creates the child issue and durable parent state has
+been written, the installed child CLI issue-publish transition is the
+supported way to apply the publish-boundary label:
+
+```bash
+intent-cli automation issue-publish \
+  --repo "$CHILD_REPO" \
+  --issue "$ISSUE_NUMBER" \
+  --write \
+  --format json
+```
+
+Dry-run the same command without `--write` to capture the planned
+`intent-target` label action and JSON publish metadata before mutation.
+
 ## What this template forbids
 
 - Authoring implementation changes. Next-slice planning describes

--- a/src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs
@@ -1,0 +1,335 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Host-owned issue publish boundary transition. Dry-run by default; with
+/// explicit <c>--write</c>, applies <c>intent-target</c> to the specified issue.
+/// </summary>
+internal static class AutomationIssuePublishCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+    private const string AppliedLabel = WorkerNextActionConstants.Labels.IntentTarget;
+
+    public static Func<IGitHubLabelMutator>? MutatorFactory { get; set; }
+
+    public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(
+                args,
+                out var repo,
+                out var workdir,
+                out var issue,
+                out var mode,
+                out var format,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        if (string.IsNullOrWhiteSpace(repo)
+            && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        IGitHubLabelMutator mutator;
+        try
+        {
+            mutator = MutatorFactory?.Invoke()
+                ?? new GhCliGitHubLabelMutator();
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub mutator: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<string> currentLabels;
+        try
+        {
+            currentLabels = mutator
+                .ReadLabels(repo!, GhCliGitHubLabelMutator.Kinds.Issue, issue!.Value)
+                .Select(label => label.Name)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .ToArray();
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine($"failed to read current labels for issue #{issue} in {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var applied = false;
+        var publishedAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow)
+            .ToUniversalTime();
+
+        if (string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal))
+        {
+            try
+            {
+                mutator.ApplyLabelTransitions(
+                    repo!,
+                    GhCliGitHubLabelMutator.Kinds.Issue,
+                    issue!.Value,
+                    [AppliedLabel],
+                    Array.Empty<string>());
+                applied = true;
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or IOException)
+            {
+                writer.WriteLine($"failed to apply issue publish transition on issue #{issue} in {repo}: {exception.Message}");
+                return 1;
+            }
+        }
+
+        var result = new AutomationIssuePublishResult
+        {
+            Repo = repo!,
+            Issue = issue!.Value,
+            IssueUrl = BuildIssueUrl(repo!, issue.Value),
+            Mode = mode,
+            Applied = applied,
+            AppliedLabel = AppliedLabel,
+            AddLabels = [AppliedLabel],
+            RemoveLabels = Array.Empty<string>(),
+            CurrentLabels = currentLabels,
+            PublishedAt = publishedAt,
+            Summary = BuildSummary(issue.Value, AppliedLabel),
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string? workdir,
+        out int? issue,
+        out string mode,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        workdir = null;
+        issue = null;
+        mode = WorkerClaimCompleteConstants.Modes.DryRun;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--workdir":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--workdir requires a value.";
+                        return false;
+                    }
+                    workdir = args[index + 1];
+                    index++;
+                    break;
+
+                case "--issue":
+                    if (!TryReadPositiveInt(args, index, "--issue", out var issueNumber, out error))
+                    {
+                        return false;
+                    }
+                    issue = issueNumber;
+                    index++;
+                    break;
+
+                case "--write":
+                    mode = WorkerClaimCompleteConstants.Modes.Write;
+                    break;
+
+                case "--dry-run":
+                    mode = WorkerClaimCompleteConstants.Modes.DryRun;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                case "--pr":
+                    error = "--pr is not supported by automation issue-publish; issue publish only targets issues.";
+                    return false;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: [--repo <owner/repo>] [--workdir <path>] --issue <n> [--write] [--dry-run] [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (issue is null)
+        {
+            error = "--issue is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadPositiveInt(
+        string[] args,
+        int index,
+        string option,
+        out int value,
+        out string error)
+    {
+        value = 0;
+        error = string.Empty;
+        if (index + 1 >= args.Length
+            || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out value)
+            || value <= 0)
+        {
+            error = $"{option} requires a positive integer.";
+            return false;
+        }
+        return true;
+    }
+
+    private static string ResolveWorkdir(CliContext context, string? workdir)
+    {
+        if (string.IsNullOrWhiteSpace(workdir))
+        {
+            return context.RepoRoot;
+        }
+
+        return Path.IsPathRooted(workdir)
+            ? workdir
+            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
+    }
+
+    private static string BuildIssueUrl(string repo, int issue) =>
+        $"https://github.com/{repo}/issues/{issue.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+
+    private static string BuildSummary(int issue, string label) =>
+        $"Would publish issue #{issue.ToString(System.Globalization.CultureInfo.InvariantCulture)} by adding {label}.";
+
+    private static void WriteText(TextWriter writer, AutomationIssuePublishResult result)
+    {
+        writer.WriteLine(result.Summary);
+        writer.WriteLine($"mode: {result.Mode}");
+        writer.WriteLine($"repo: {result.Repo}");
+        writer.WriteLine($"issue: {result.Issue.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+        writer.WriteLine($"issue_url: {result.IssueUrl}");
+        writer.WriteLine($"applied_label: {result.AppliedLabel}");
+        writer.WriteLine($"applied: {result.Applied.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"published_at: {result.PublishedAt:O}");
+    }
+}
+
+internal sealed record AutomationIssuePublishResult
+{
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("issue")]
+    public required int Issue { get; init; }
+
+    [JsonPropertyName("issue_url")]
+    public required string IssueUrl { get; init; }
+
+    [JsonPropertyName("issueUrl")]
+    public string IssueUrlCamel => IssueUrl;
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("applied_label")]
+    public required string AppliedLabel { get; init; }
+
+    [JsonPropertyName("appliedLabel")]
+    public string AppliedLabelCamel => AppliedLabel;
+
+    [JsonPropertyName("add_labels")]
+    public required IReadOnlyList<string> AddLabels { get; init; }
+
+    [JsonPropertyName("addLabels")]
+    public IReadOnlyList<string> AddLabelsCamel => AddLabels;
+
+    [JsonPropertyName("remove_labels")]
+    public required IReadOnlyList<string> RemoveLabels { get; init; }
+
+    [JsonPropertyName("removeLabels")]
+    public IReadOnlyList<string> RemoveLabelsCamel => RemoveLabels;
+
+    [JsonPropertyName("current_labels")]
+    public required IReadOnlyList<string> CurrentLabels { get; init; }
+
+    [JsonPropertyName("currentLabels")]
+    public IReadOnlyList<string> CurrentLabelsCamel => CurrentLabels;
+
+    [JsonPropertyName("published_at")]
+    public required DateTimeOffset PublishedAt { get; init; }
+
+    [JsonPropertyName("publishedAt")]
+    public DateTimeOffset PublishedAtCamel => PublishedAt;
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -33,6 +33,7 @@ internal static class CommandRouter
         "automation clarification-stop",
         "automation complete",
         "automation doctor",
+        "automation issue-publish --issue <n> --write",
         "automation pr-transition --transition review-start --write",
         "automation pr-transition --transition approved --write",
         "automation summary"
@@ -135,6 +136,7 @@ internal static class CommandRouter
                 ["clarification-stop"] = AutomationClarificationStopCommand.Execute,
                 ["complete"] = AutomationCompleteCommand.Execute,
                 ["doctor"] = AutomationDoctorCommand.Execute,
+                ["issue-publish"] = AutomationIssuePublishCommand.Execute,
                 ["pr-transition"] = AutomationPrTransitionCommand.Execute,
                 ["summary"] = AutomationSummaryCommand.Execute
             },

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -62,7 +62,8 @@ internal static class Program
             && (string.Equals(args[1], "check", StringComparison.Ordinal)
                 || string.Equals(args[1], "clarification-stop", StringComparison.Ordinal)
                 || string.Equals(args[1], "complete", StringComparison.Ordinal)
-                || string.Equals(args[1], "doctor", StringComparison.Ordinal));
+                || string.Equals(args[1], "doctor", StringComparison.Ordinal)
+                || string.Equals(args[1], "issue-publish", StringComparison.Ordinal));
     }
 
     private static CliContext CreateBootstrapContext(string currentDirectory, string[] args)

--- a/tests/IntentSystem.Cli.Tests/AutomationIssuePublishCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssuePublishCommandTests.cs
@@ -1,0 +1,296 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class AutomationIssuePublishCommandTests : IDisposable
+{
+    private static readonly DateTimeOffset FixedNow =
+        new(2026, 5, 2, 1, 54, 0, TimeSpan.Zero);
+
+    public AutomationIssuePublishCommandTests()
+    {
+        AutomationIssuePublishCommand.MutatorFactory = null;
+        AutomationIssuePublishCommand.UtcNowFactory = () => FixedNow;
+        AutomationIssuePublishCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        AutomationIssuePublishCommand.MutatorFactory = null;
+        AutomationIssuePublishCommand.UtcNowFactory = null;
+        AutomationIssuePublishCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void Execute_DryRunReportsPlannedIssuePublishLabelAction()
+    {
+        using var workspace = new AutomationIssuePublishWorkspace();
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var mutator = new FakeMutator();
+        AutomationIssuePublishCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssuePublishCommand.Execute(
+            workspace.Context,
+            ["--issue", "557", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssuePublishResult>(writer.ToString())!;
+        Assert.Equal("J-Tech-Japan/intent-system", result.Repo);
+        Assert.Equal(557, result.Issue);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/557", result.IssueUrl);
+        Assert.Equal("dry-run", result.Mode);
+        Assert.False(result.Applied);
+        Assert.Equal("intent-target", result.AppliedLabel);
+        Assert.Contains("intent-target", result.AddLabels);
+        Assert.Empty(result.RemoveLabels);
+        Assert.Equal(FixedNow, result.PublishedAt);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_WriteAppliesIntentTargetToIssue()
+    {
+        using var workspace = new AutomationIssuePublishWorkspace();
+        var mutator = new FakeMutator();
+        AutomationIssuePublishCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssuePublishCommand.Execute(
+            workspace.Context,
+            [
+                "--repo", "J-Tech-Japan/intent-system",
+                "--issue", "557",
+                "--write",
+                "--format", "json",
+            ],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssuePublishResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+
+        var transition = Assert.Single(mutator.AppliedTransitions);
+        Assert.Equal("issue", transition.Kind);
+        Assert.Equal(557, transition.Number);
+        Assert.Contains("intent-target", transition.AddLabels);
+        Assert.Empty(transition.RemoveLabels);
+        Assert.DoesNotContain("intent-pr-created", transition.AddLabels);
+    }
+
+    [Fact]
+    public void Execute_TextOutputIncludesPublishMetadata()
+    {
+        using var workspace = new AutomationIssuePublishWorkspace();
+        var mutator = new FakeMutator();
+        AutomationIssuePublishCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssuePublishCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "557"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("issue: 557", output, StringComparison.Ordinal);
+        Assert.Contains("issue_url: https://github.com/J-Tech-Japan/intent-system/issues/557", output, StringComparison.Ordinal);
+        Assert.Contains("applied_label: intent-target", output, StringComparison.Ordinal);
+        Assert.Contains("published_at: 2026-05-02T01:54:00.0000000+00:00", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RejectsPrInput()
+    {
+        using var workspace = new AutomationIssuePublishWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssuePublishCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "557", "--pr", "12"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--pr is not supported", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MissingIssueReturnsNonZero()
+    {
+        using var workspace = new AutomationIssuePublishWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssuePublishCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--issue is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommandRouter_RegistersAutomationIssuePublish()
+    {
+        using var workspace = new AutomationIssuePublishWorkspace();
+        var mutator = new FakeMutator();
+        AutomationIssuePublishCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["automation", "issue-publish", "--repo", "J-Tech-Japan/intent-system", "--issue", "557", "--format", "json"],
+            workspace.Context,
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssuePublishResult>(writer.ToString())!;
+        Assert.Equal(557, result.Issue);
+    }
+
+    [Fact]
+    public void ProgramMain_AutomationIssuePublishDoesNotRequireIntentCliDirectory()
+    {
+        using var workspace = new AutomationIssuePublishWorkspace(createIntentCliDirectory: false);
+        workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
+        var mutator = new FakeMutator();
+        AutomationIssuePublishCommand.MutatorFactory = () => mutator;
+        var originalDirectory = Directory.GetCurrentDirectory();
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+
+        try
+        {
+            Directory.SetCurrentDirectory(workspace.RootPath);
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+
+            var exitCode = Program.Main(["automation", "issue-publish", "--issue", "557", "--format", "json"]);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(string.Empty, stderr.ToString());
+            var result = JsonSerializer.Deserialize<AutomationIssuePublishResult>(stdout.ToString())!;
+            Assert.Equal("J-Tech-Japan/intent-system", result.Repo);
+            Assert.Equal(557, result.Issue);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+            Directory.SetCurrentDirectory(originalDirectory);
+        }
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesNestedProviderLauncher()
+    {
+        using var workspace = new AutomationIssuePublishWorkspace();
+        var launcherInvoked = false;
+        AutomationIssuePublishCommand.NestedProviderLauncher = () =>
+        {
+            launcherInvoked = true;
+            return true;
+        };
+        AutomationIssuePublishCommand.MutatorFactory = () => new FakeMutator();
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, AutomationIssuePublishCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "557", "--format", "json"],
+            writer));
+
+        Assert.False(launcherInvoked,
+            "AutomationIssuePublishCommand must never invoke NestedProviderLauncher.");
+    }
+
+    private sealed class FakeMutator : IGitHubLabelMutator
+    {
+        public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+
+        public List<AppliedTransition> AppliedTransitions { get; } = new();
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
+            Labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
+
+        public void ApplyLabelTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels)
+        {
+            if (!string.Equals(kind, "issue", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("issue publish must only target issues.");
+            }
+
+            AppliedTransitions.Add(new AppliedTransition(
+                repo,
+                kind,
+                number,
+                addLabels.ToArray(),
+                removeLabels.ToArray()));
+        }
+    }
+
+    private sealed record AppliedTransition(
+        string Repo,
+        string Kind,
+        int Number,
+        IReadOnlyList<string> AddLabels,
+        IReadOnlyList<string> RemoveLabels);
+
+    private sealed class AutomationIssuePublishWorkspace : IDisposable
+    {
+        public AutomationIssuePublishWorkspace(bool createIntentCliDirectory = true)
+        {
+            RootPath = Directory.CreateTempSubdirectory("automation-issue-publish-tests-").FullName;
+            if (createIntentCliDirectory)
+            {
+                Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            }
+
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public void WriteOriginRemote(string remoteUrl)
+        {
+            var gitDirectory = Path.Combine(RootPath, ".git");
+            Directory.CreateDirectory(gitDirectory);
+            File.WriteAllText(
+                Path.Combine(gitDirectory, "config"),
+                $"""
+                [remote "origin"]
+                    url = {remoteUrl}
+                """);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #557

## Summary
- add dry-run-by-default `intent-cli automation issue-publish` for host issue publish boundary labels
- support explicit `--write` to apply `intent-target` to an issue and emit JSON publish metadata
- register the command in CLI help/bootstrap routing and document the host next-slice handoff usage

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~AutomationIssuePublishCommandTests"`
- `dotnet run --project src/IntentSystem.Cli/IntentSystem.Cli.csproj -- automation issue-publish --repo J-Tech-Japan/intent-system --issue 557 --format json`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~Automation"`
- `rg -n "automation issue-publish|intent-target|published_at|issue-publish" src/IntentSystem.Cli tests/IntentSystem.Cli.Tests docs/automation-templates`
- `git diff --check`
