### PR TITLE
G227 Add host review selection preflight command

### DIFF
--- a/docs/automation-templates/host-review-loop.md
+++ b/docs/automation-templates/host-review-loop.md
@@ -58,6 +58,20 @@ write surface.
 
 ## Step 2: ask the worker / next-action selector for context
 
+Run the read-only host selector before manual review judgement:
+
+```bash
+intent-cli automation host-review-preflight \
+  --repo "<owner>/<repo>" \
+  --format json
+```
+
+Use `action` as the mechanical host-loop branch:
+`review-pr`, `skip-next-slice-due-to-wip`, `candidate-ready`,
+`no-actionable-item`, or `clarification-required`. The command does
+not mutate labels, claim PRs, create issues, run providers, or perform
+semantic review; it only reports target ids and WIP context.
+
 The implementation-side `worker next-action` selector tells you
 which child PRs are currently `repair-required`, which are
 `ready-to-implement`, and which are idle. Use that read as the

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewPreflightCommand.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -12,6 +13,10 @@ internal static class AutomationHostReviewPreflightCommand
 {
     private const string FormatText = "text";
     private const string FormatJson = "json";
+
+    private static readonly Regex ClosesIssueRegex = new(
+        @"(?i)\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+(?:(?<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(?<number>\d+)\b",
+        RegexOptions.Compiled);
 
     public static Func<IGitHubAutomationCandidateLister>? CandidateListerFactory { get; set; }
 
@@ -57,12 +62,21 @@ internal static class AutomationHostReviewPreflightCommand
             return 1;
         }
 
-        IReadOnlyList<GitHubAutomationPrCandidate> prs;
-        IReadOnlyList<GitHubAutomationIssueCandidate> issues;
+        IReadOnlyList<GitHubAutomationPrCandidate> intentTargetPrs;
+        IReadOnlyList<GitHubAutomationPrCandidate> allOpenPrs;
+        IReadOnlyList<GitHubAutomationIssueCandidate> intentTargetIssues;
+        IReadOnlyList<GitHubAutomationIssueCandidate> publishedIntentTargetIssues;
         try
         {
-            prs = lister.ListPullRequests(repo!, [WorkerNextActionConstants.Labels.IntentTarget]);
-            issues = lister.ListIssues(repo!, [WorkerNextActionConstants.Labels.IntentTarget]);
+            intentTargetPrs = lister.ListPullRequests(repo!, [WorkerNextActionConstants.Labels.IntentTarget]);
+            allOpenPrs = lister.ListPullRequests(repo!, []);
+            intentTargetIssues = lister.ListIssues(repo!, [WorkerNextActionConstants.Labels.IntentTarget]);
+            publishedIntentTargetIssues = lister.ListIssues(
+                repo!,
+                [
+                    WorkerNextActionConstants.Labels.IntentTarget,
+                    WorkerNextActionConstants.Labels.IntentPrCreated
+                ]);
         }
         catch (Exception exception) when (
             exception is InvalidOperationException
@@ -72,7 +86,12 @@ internal static class AutomationHostReviewPreflightCommand
             return 1;
         }
 
-        var result = Analyze(repo!, prs, issues, candidate, clarificationRequired);
+        var reviewCandidatePrs = AddIssueLinkedReviewFallbacks(
+            repo!,
+            intentTargetPrs,
+            allOpenPrs,
+            publishedIntentTargetIssues);
+        var result = Analyze(repo!, reviewCandidatePrs, intentTargetIssues, candidate, clarificationRequired);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
@@ -192,14 +211,108 @@ internal static class AutomationHostReviewPreflightCommand
     private static bool IsReadyForHostReview(GitHubAutomationPrCandidate pr)
     {
         var labels = LabelNames(pr.Labels);
-        var hasRereviewReady = labels.Contains(WorkerNextActionConstants.Labels.IntentPrRereviewReady, StringComparer.Ordinal);
         var hasBlockingState =
             labels.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrReviewing, StringComparer.Ordinal)
             || labels.Contains(WorkerNextActionConstants.Labels.IntentPrRequestUpdate, StringComparer.Ordinal)
             || labels.Contains(WorkerNextActionConstants.Labels.IntentPrUpdateInProgress, StringComparer.Ordinal)
             || labels.Contains(WorkerNextActionConstants.Labels.IntentPrApproved, StringComparer.Ordinal);
 
-        return !hasBlockingState || hasRereviewReady;
+        return !hasBlockingState;
+    }
+
+    private static IReadOnlyList<GitHubAutomationPrCandidate> AddIssueLinkedReviewFallbacks(
+        string repo,
+        IReadOnlyList<GitHubAutomationPrCandidate> intentTargetPrs,
+        IReadOnlyList<GitHubAutomationPrCandidate> allOpenPrs,
+        IReadOnlyList<GitHubAutomationIssueCandidate> publishedIntentTargetIssues)
+    {
+        var reviewCandidates = new List<GitHubAutomationPrCandidate>(intentTargetPrs);
+        var seenPrNumbers = new HashSet<int>(intentTargetPrs.Select(pr => pr.Number));
+        var publishedIssueNumbers = publishedIntentTargetIssues
+            .Where(IsPublishedIntentTargetIssue)
+            .Select(issue => issue.Number)
+            .ToHashSet();
+
+        if (publishedIssueNumbers.Count == 0)
+        {
+            return reviewCandidates;
+        }
+
+        foreach (var pr in allOpenPrs)
+        {
+            if (!seenPrNumbers.Add(pr.Number))
+            {
+                continue;
+            }
+
+            var labels = LabelNames(pr.Labels);
+            if (labels.Contains(WorkerNextActionConstants.Labels.IntentTarget, StringComparer.Ordinal))
+            {
+                reviewCandidates.Add(pr);
+                continue;
+            }
+
+            if (LinksPublishedIntentTargetIssue(pr, repo, publishedIssueNumbers))
+            {
+                reviewCandidates.Add(pr);
+            }
+        }
+
+        return reviewCandidates;
+    }
+
+    private static bool IsPublishedIntentTargetIssue(GitHubAutomationIssueCandidate issue)
+    {
+        var labels = LabelNames(issue.Labels);
+        return labels.Contains(WorkerNextActionConstants.Labels.IntentTarget, StringComparer.Ordinal)
+            && labels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal);
+    }
+
+    private static bool LinksPublishedIntentTargetIssue(
+        GitHubAutomationPrCandidate pr,
+        string repo,
+        IReadOnlySet<int> publishedIssueNumbers)
+    {
+        foreach (var reference in pr.ClosingIssuesReferences)
+        {
+            if (reference.Number <= 0 || !publishedIssueNumbers.Contains(reference.Number))
+            {
+                continue;
+            }
+
+            var referenceRepo = repo;
+            if (reference.Repository is { Name.Length: > 0, Owner.Login.Length: > 0 } repository)
+            {
+                referenceRepo = $"{repository.Owner.Login}/{repository.Name}";
+            }
+
+            if (string.Equals(referenceRepo, repo, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        foreach (Match match in ClosesIssueRegex.Matches(pr.Body ?? string.Empty))
+        {
+            var linkedRepo = match.Groups["repo"].Value;
+            if (!string.IsNullOrWhiteSpace(linkedRepo)
+                && !string.Equals(linkedRepo, repo, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (int.TryParse(
+                    match.Groups["number"].Value,
+                    System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out var issueNumber)
+                && publishedIssueNumbers.Contains(issueNumber))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static IReadOnlyCollection<string> LabelNames(IReadOnlyList<GitHubAutomationLabel>? labels)

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewPreflightCommand.cs
@@ -86,13 +86,21 @@ internal static class AutomationHostReviewPreflightCommand
             return 1;
         }
 
-        var reviewCandidatePrs = intentTargetPrs.Count > 0
-            ? intentTargetPrs
+        var eligiblePrimaryPrs = intentTargetPrs
+            .Where(IsReadyForHostReview)
+            .ToArray();
+        var reviewCandidatePrs = eligiblePrimaryPrs.Length > 0
+            ? eligiblePrimaryPrs
             : FindIssueLinkedReviewFallbacks(
                 repo!,
                 allOpenPrs,
                 publishedIntentTargetIssues);
-        var result = Analyze(repo!, reviewCandidatePrs, intentTargetIssues, candidate, clarificationRequired);
+        var inFlightPrs = intentTargetPrs
+            .Concat(reviewCandidatePrs)
+            .GroupBy(pr => pr.Number)
+            .Select(group => group.First())
+            .ToArray();
+        var result = Analyze(repo!, reviewCandidatePrs, inFlightPrs, intentTargetIssues, candidate, clarificationRequired);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
@@ -108,16 +116,18 @@ internal static class AutomationHostReviewPreflightCommand
 
     internal static AutomationHostReviewPreflightResult Analyze(
         string repo,
-        IReadOnlyList<GitHubAutomationPrCandidate> intentTargetPrs,
+        IReadOnlyList<GitHubAutomationPrCandidate> reviewCandidatePrs,
+        IReadOnlyList<GitHubAutomationPrCandidate> inFlightPrCandidates,
         IReadOnlyList<GitHubAutomationIssueCandidate> intentTargetIssues,
         string? candidateExecutionUnit,
         bool clarificationRequired)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
-        ArgumentNullException.ThrowIfNull(intentTargetPrs);
+        ArgumentNullException.ThrowIfNull(reviewCandidatePrs);
+        ArgumentNullException.ThrowIfNull(inFlightPrCandidates);
         ArgumentNullException.ThrowIfNull(intentTargetIssues);
 
-        var inFlightPrs = intentTargetPrs.Select(pr => pr.Number).Order().ToArray();
+        var inFlightPrs = inFlightPrCandidates.Select(pr => pr.Number).Order().ToArray();
         var inFlightIssues = intentTargetIssues.Select(issue => issue.Number).Order().ToArray();
 
         if (clarificationRequired)
@@ -133,7 +143,7 @@ internal static class AutomationHostReviewPreflightCommand
                 candidateExecutionUnit);
         }
 
-        var reviewPr = intentTargetPrs
+        var reviewPr = reviewCandidatePrs
             .Where(IsReadyForHostReview)
             .OrderBy(GetReviewSortTime, StringComparer.Ordinal)
             .FirstOrDefault();

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewPreflightCommand.cs
@@ -86,11 +86,12 @@ internal static class AutomationHostReviewPreflightCommand
             return 1;
         }
 
-        var reviewCandidatePrs = AddIssueLinkedReviewFallbacks(
-            repo!,
-            intentTargetPrs,
-            allOpenPrs,
-            publishedIntentTargetIssues);
+        var reviewCandidatePrs = intentTargetPrs.Count > 0
+            ? intentTargetPrs
+            : FindIssueLinkedReviewFallbacks(
+                repo!,
+                allOpenPrs,
+                publishedIntentTargetIssues);
         var result = Analyze(repo!, reviewCandidatePrs, intentTargetIssues, candidate, clarificationRequired);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
@@ -134,14 +135,14 @@ internal static class AutomationHostReviewPreflightCommand
 
         var reviewPr = intentTargetPrs
             .Where(IsReadyForHostReview)
-            .OrderBy(pr => pr.CreatedAt, StringComparer.Ordinal)
+            .OrderBy(GetReviewSortTime, StringComparer.Ordinal)
             .FirstOrDefault();
         if (reviewPr is not null)
         {
             return BuildResult(
                 repo,
                 "review-pr",
-                "oldest open intent-target PR with no blocking review-side state",
+                "oldest updated open review PR with no blocking review-side state",
                 reviewPr.Number,
                 reviewPr.Url,
                 inFlightPrs,
@@ -220,14 +221,16 @@ internal static class AutomationHostReviewPreflightCommand
         return !hasBlockingState;
     }
 
-    private static IReadOnlyList<GitHubAutomationPrCandidate> AddIssueLinkedReviewFallbacks(
+    private static string GetReviewSortTime(GitHubAutomationPrCandidate pr) =>
+        string.IsNullOrWhiteSpace(pr.UpdatedAt) ? pr.CreatedAt : pr.UpdatedAt;
+
+    private static IReadOnlyList<GitHubAutomationPrCandidate> FindIssueLinkedReviewFallbacks(
         string repo,
-        IReadOnlyList<GitHubAutomationPrCandidate> intentTargetPrs,
         IReadOnlyList<GitHubAutomationPrCandidate> allOpenPrs,
         IReadOnlyList<GitHubAutomationIssueCandidate> publishedIntentTargetIssues)
     {
-        var reviewCandidates = new List<GitHubAutomationPrCandidate>(intentTargetPrs);
-        var seenPrNumbers = new HashSet<int>(intentTargetPrs.Select(pr => pr.Number));
+        var reviewCandidates = new List<GitHubAutomationPrCandidate>();
+        var seenPrNumbers = new HashSet<int>();
         var publishedIssueNumbers = publishedIntentTargetIssues
             .Where(IsPublishedIntentTargetIssue)
             .Select(issue => issue.Number)

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewPreflightCommand.cs
@@ -1,0 +1,365 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Read-only selector for the host review loop's next mechanical action.
+/// It reports PR review targets, WIP blocks, or a preloaded next-slice
+/// candidate without mutating labels, issues, PRs, files, or provider state.
+/// </summary>
+internal static class AutomationHostReviewPreflightCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    public static Func<IGitHubAutomationCandidateLister>? CandidateListerFactory { get; set; }
+
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var repo, out var workdir, out var candidate, out var clarificationRequired, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        if (string.IsNullOrWhiteSpace(repo)
+            && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        IGitHubAutomationCandidateLister lister;
+        try
+        {
+            lister = CandidateListerFactory?.Invoke()
+                ?? new GhCliGitHubAutomationCandidateLister();
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub lister: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<GitHubAutomationPrCandidate> prs;
+        IReadOnlyList<GitHubAutomationIssueCandidate> issues;
+        try
+        {
+            prs = lister.ListPullRequests(repo!, [WorkerNextActionConstants.Labels.IntentTarget]);
+            issues = lister.ListIssues(repo!, [WorkerNextActionConstants.Labels.IntentTarget]);
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine($"failed to list host review candidates for {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var result = Analyze(repo!, prs, issues, candidate, clarificationRequired);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return 0;
+    }
+
+    internal static AutomationHostReviewPreflightResult Analyze(
+        string repo,
+        IReadOnlyList<GitHubAutomationPrCandidate> intentTargetPrs,
+        IReadOnlyList<GitHubAutomationIssueCandidate> intentTargetIssues,
+        string? candidateExecutionUnit,
+        bool clarificationRequired)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentNullException.ThrowIfNull(intentTargetPrs);
+        ArgumentNullException.ThrowIfNull(intentTargetIssues);
+
+        var inFlightPrs = intentTargetPrs.Select(pr => pr.Number).Order().ToArray();
+        var inFlightIssues = intentTargetIssues.Select(issue => issue.Number).Order().ToArray();
+
+        if (clarificationRequired)
+        {
+            return BuildResult(
+                repo,
+                "clarification-required",
+                "host review preflight was told a clarification is required",
+                null,
+                null,
+                inFlightPrs,
+                inFlightIssues,
+                candidateExecutionUnit);
+        }
+
+        var reviewPr = intentTargetPrs
+            .Where(IsReadyForHostReview)
+            .OrderBy(pr => pr.CreatedAt, StringComparer.Ordinal)
+            .FirstOrDefault();
+        if (reviewPr is not null)
+        {
+            return BuildResult(
+                repo,
+                "review-pr",
+                "oldest open intent-target PR with no blocking review-side state",
+                reviewPr.Number,
+                reviewPr.Url,
+                inFlightPrs,
+                inFlightIssues,
+                candidateExecutionUnit);
+        }
+
+        if (inFlightIssues.Length > 0 || inFlightPrs.Length > 0)
+        {
+            return BuildResult(
+                repo,
+                "skip-next-slice-due-to-wip",
+                "open intent-target issue or PR is still in flight; WIP cap blocks new issue publication",
+                null,
+                null,
+                inFlightPrs,
+                inFlightIssues,
+                candidateExecutionUnit);
+        }
+
+        if (!string.IsNullOrWhiteSpace(candidateExecutionUnit))
+        {
+            return BuildResult(
+                repo,
+                "candidate-ready",
+                "no child WIP is open and a host next-slice candidate was provided",
+                null,
+                null,
+                inFlightPrs,
+                inFlightIssues,
+                candidateExecutionUnit);
+        }
+
+        return BuildResult(
+            repo,
+            "no-actionable-item",
+            "no review PR, no child WIP, and no next-slice candidate was provided",
+            null,
+            null,
+            inFlightPrs,
+            inFlightIssues,
+            candidateExecutionUnit);
+    }
+
+    private static AutomationHostReviewPreflightResult BuildResult(
+        string repo,
+        string action,
+        string reason,
+        int? targetPr,
+        string? targetPrUrl,
+        IReadOnlyList<int> inFlightPrs,
+        IReadOnlyList<int> inFlightIssues,
+        string? candidateExecutionUnit) =>
+        new()
+        {
+            Action = action,
+            Repo = repo,
+            TargetPr = targetPr,
+            TargetPrUrl = targetPrUrl,
+            InFlightPrs = inFlightPrs,
+            InFlightIssues = inFlightIssues,
+            CandidateExecutionUnit = string.IsNullOrWhiteSpace(candidateExecutionUnit) ? null : candidateExecutionUnit,
+            Reason = reason,
+            Warnings = Array.Empty<string>(),
+        };
+
+    private static bool IsReadyForHostReview(GitHubAutomationPrCandidate pr)
+    {
+        var labels = LabelNames(pr.Labels);
+        var hasRereviewReady = labels.Contains(WorkerNextActionConstants.Labels.IntentPrRereviewReady, StringComparer.Ordinal);
+        var hasBlockingState =
+            labels.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrReviewing, StringComparer.Ordinal)
+            || labels.Contains(WorkerNextActionConstants.Labels.IntentPrRequestUpdate, StringComparer.Ordinal)
+            || labels.Contains(WorkerNextActionConstants.Labels.IntentPrUpdateInProgress, StringComparer.Ordinal)
+            || labels.Contains(WorkerNextActionConstants.Labels.IntentPrApproved, StringComparer.Ordinal);
+
+        return !hasBlockingState || hasRereviewReady;
+    }
+
+    private static IReadOnlyCollection<string> LabelNames(IReadOnlyList<GitHubAutomationLabel>? labels)
+    {
+        if (labels is null || labels.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        return labels
+            .Select(label => label.Name)
+            .Where(name => !string.IsNullOrEmpty(name))
+            .ToArray();
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string? workdir,
+        out string? candidate,
+        out bool clarificationRequired,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        workdir = null;
+        candidate = null;
+        clarificationRequired = false;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1].Trim();
+                    index++;
+                    break;
+                case "--workdir":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--workdir requires a value.";
+                        return false;
+                    }
+                    workdir = args[index + 1];
+                    index++;
+                    break;
+                case "--candidate":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--candidate requires an execution unit value.";
+                        return false;
+                    }
+                    candidate = args[index + 1].Trim();
+                    index++;
+                    break;
+                case "--clarification-required":
+                    clarificationRequired = true;
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: [--repo <owner/repo>] [--workdir <path>] [--candidate <execution-unit>] [--clarification-required] [--format text|json].";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string ResolveWorkdir(CliContext context, string? workdir)
+    {
+        if (string.IsNullOrWhiteSpace(workdir))
+        {
+            return context.RepoRoot;
+        }
+
+        return Path.IsPathRooted(workdir)
+            ? workdir
+            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
+    }
+
+    private static void WriteText(TextWriter writer, AutomationHostReviewPreflightResult result)
+    {
+        writer.WriteLine($"# Host review preflight for {result.Repo}");
+        writer.WriteLine($"- action: {result.Action}");
+        writer.WriteLine($"- reason: {result.Reason}");
+        if (result.TargetPr is { } targetPr)
+        {
+            writer.WriteLine($"- target_pr: {targetPr.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+        }
+        if (!string.IsNullOrEmpty(result.CandidateExecutionUnit))
+        {
+            writer.WriteLine($"- candidate_execution_unit: {result.CandidateExecutionUnit}");
+        }
+    }
+}
+
+internal sealed record AutomationHostReviewPreflightResult
+{
+    [JsonPropertyName("action")]
+    public required string Action { get; init; }
+
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("target_pr")]
+    public required int? TargetPr { get; init; }
+
+    [JsonPropertyName("targetPr")]
+    public int? TargetPrCamel => TargetPr;
+
+    [JsonPropertyName("target_pr_url")]
+    public required string? TargetPrUrl { get; init; }
+
+    [JsonPropertyName("targetPrUrl")]
+    public string? TargetPrUrlCamel => TargetPrUrl;
+
+    [JsonPropertyName("in_flight_prs")]
+    public required IReadOnlyList<int> InFlightPrs { get; init; }
+
+    [JsonPropertyName("inFlightPrs")]
+    public IReadOnlyList<int> InFlightPrsCamel => InFlightPrs;
+
+    [JsonPropertyName("in_flight_issues")]
+    public required IReadOnlyList<int> InFlightIssues { get; init; }
+
+    [JsonPropertyName("inFlightIssues")]
+    public IReadOnlyList<int> InFlightIssuesCamel => InFlightIssues;
+
+    [JsonPropertyName("candidate_execution_unit")]
+    public required string? CandidateExecutionUnit { get; init; }
+
+    [JsonPropertyName("candidateExecutionUnit")]
+    public string? CandidateExecutionUnitCamel => CandidateExecutionUnit;
+
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
+
+    [JsonPropertyName("warnings")]
+    public required IReadOnlyList<string> Warnings { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -33,6 +33,7 @@ internal static class CommandRouter
         "automation clarification-stop",
         "automation complete",
         "automation doctor",
+        "automation host-review-preflight",
         "automation issue-publish --issue <n> --write",
         "automation pr-transition --transition review-start --write",
         "automation pr-transition --transition approved --write",
@@ -136,6 +137,7 @@ internal static class CommandRouter
                 ["clarification-stop"] = AutomationClarificationStopCommand.Execute,
                 ["complete"] = AutomationCompleteCommand.Execute,
                 ["doctor"] = AutomationDoctorCommand.Execute,
+                ["host-review-preflight"] = AutomationHostReviewPreflightCommand.Execute,
                 ["issue-publish"] = AutomationIssuePublishCommand.Execute,
                 ["pr-transition"] = AutomationPrTransitionCommand.Execute,
                 ["summary"] = AutomationSummaryCommand.Execute

--- a/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
@@ -36,12 +36,19 @@ internal sealed record GitHubAutomationPrCandidate
     [JsonPropertyName("url")]
     public string Url { get; init; } = string.Empty;
 
+    [JsonPropertyName("body")]
+    public string Body { get; init; } = string.Empty;
+
     [JsonPropertyName("createdAt")]
     public string CreatedAt { get; init; } = string.Empty;
 
     [JsonPropertyName("labels")]
     public IReadOnlyList<GitHubAutomationLabel> Labels { get; init; }
         = Array.Empty<GitHubAutomationLabel>();
+
+    [JsonPropertyName("closingIssuesReferences")]
+    public IReadOnlyList<GitHubPrClosingIssueReference> ClosingIssuesReferences { get; init; }
+        = Array.Empty<GitHubPrClosingIssueReference>();
 }
 
 /// <summary>
@@ -77,8 +84,9 @@ internal sealed record GitHubAutomationLabel
 /// G206: Default lister that shells out to <c>gh pr list</c> and
 /// <c>gh issue list</c>. The only file in the worker next-action surface
 /// permitted to call <c>Process.Start</c> — the analyzer and command layers
-/// must remain pure. Both calls request a stable supported field subset
-/// (<c>number,title,url,createdAt,labels</c>).
+/// must remain pure. Both calls request stable supported field subsets.
+/// PR listing also includes body and closing issue metadata so host selectors
+/// can model issue-linked PR fallback without extra mutation-capable calls.
 /// </summary>
 internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCandidateLister
 {
@@ -88,6 +96,8 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
     /// subset.
     /// </summary>
     internal const string ListJsonFields = "number,title,url,createdAt,labels";
+
+    internal const string PrListJsonFields = "number,title,url,body,createdAt,labels,closingIssuesReferences";
 
     /// <summary>
     /// G206: builds the <c>gh pr list</c> argument list shared by the live
@@ -106,7 +116,7 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
             "list",
             "--repo", repo,
             "--state", "open",
-            "--json", ListJsonFields,
+            "--json", PrListJsonFields,
             "--limit", "200"
         };
         foreach (var label in requiredLabels)

--- a/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
@@ -42,6 +42,9 @@ internal sealed record GitHubAutomationPrCandidate
     [JsonPropertyName("createdAt")]
     public string CreatedAt { get; init; } = string.Empty;
 
+    [JsonPropertyName("updatedAt")]
+    public string UpdatedAt { get; init; } = string.Empty;
+
     [JsonPropertyName("labels")]
     public IReadOnlyList<GitHubAutomationLabel> Labels { get; init; }
         = Array.Empty<GitHubAutomationLabel>();
@@ -97,7 +100,7 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
     /// </summary>
     internal const string ListJsonFields = "number,title,url,createdAt,labels";
 
-    internal const string PrListJsonFields = "number,title,url,body,createdAt,labels,closingIssuesReferences";
+    internal const string PrListJsonFields = "number,title,url,body,createdAt,updatedAt,labels,closingIssuesReferences";
 
     /// <summary>
     /// G206: builds the <c>gh pr list</c> argument list shared by the live

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -63,6 +63,7 @@ internal static class Program
                 || string.Equals(args[1], "clarification-stop", StringComparison.Ordinal)
                 || string.Equals(args[1], "complete", StringComparison.Ordinal)
                 || string.Equals(args[1], "doctor", StringComparison.Ordinal)
+                || string.Equals(args[1], "host-review-preflight", StringComparison.Ordinal)
                 || string.Equals(args[1], "issue-publish", StringComparison.Ordinal));
     }
 

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewPreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewPreflightCommandTests.cs
@@ -71,6 +71,66 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_IssueLinkedPrWithoutIntentTargetFallsBackToReviewPr()
+    {
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        var lister = new FakeLister
+        {
+            AllPrs =
+            [
+                BuildPr(560, "G227", "https://github.com/J-Tech-Japan/intent-system/pull/560",
+                    "2026-05-02T02:00:00Z", [], body: "Closes #559"),
+            ],
+            PublishedIssues =
+            [
+                BuildIssue(559, "G227", "https://github.com/J-Tech-Japan/intent-system/issues/559",
+                    "2026-05-02T01:00:00Z", ["intent-target", "intent-pr-created"]),
+            ],
+        };
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewPreflightCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal("review-pr", result.Action);
+        Assert.Equal(560, result.TargetPr);
+        Assert.Equal([560], result.InFlightPrs);
+    }
+
+    [Fact]
+    public void Execute_RereviewReadyDoesNotOverrideBlockingReviewState()
+    {
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        var lister = new FakeLister
+        {
+            Prs =
+            [
+                BuildPr(560, "blocked", "https://github.com/J-Tech-Japan/intent-system/pull/560",
+                    "2026-05-02T02:00:00Z",
+                    ["intent-target", "intent-pr-rereview-ready", "intent-pr-request-update"]),
+            ],
+        };
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewPreflightCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--candidate", "G228", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal("skip-next-slice-due-to-wip", result.Action);
+        Assert.Null(result.TargetPr);
+        Assert.Equal([560], result.InFlightPrs);
+    }
+
+    [Fact]
     public void Execute_WipIssueBlocksCandidate()
     {
         using var workspace = new AutomationHostReviewPreflightWorkspace();
@@ -158,12 +218,14 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
         string title,
         string url,
         string createdAt,
-        IReadOnlyList<string> labels) =>
+        IReadOnlyList<string> labels,
+        string body = "") =>
         new()
         {
             Number = number,
             Title = title,
             Url = url,
+            Body = body,
             CreatedAt = createdAt,
             Labels = labels.Select(label => new GitHubAutomationLabel { Name = label }).ToArray(),
         };
@@ -187,15 +249,23 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
     {
         public IReadOnlyList<GitHubAutomationPrCandidate> Prs { get; init; } = Array.Empty<GitHubAutomationPrCandidate>();
 
+        public IReadOnlyList<GitHubAutomationPrCandidate> AllPrs { get; init; } = Array.Empty<GitHubAutomationPrCandidate>();
+
         public IReadOnlyList<GitHubAutomationIssueCandidate> Issues { get; init; } = Array.Empty<GitHubAutomationIssueCandidate>();
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> PublishedIssues { get; init; } = Array.Empty<GitHubAutomationIssueCandidate>();
 
         public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
             string repo,
-            IReadOnlyCollection<string> requiredLabels) => Prs;
+            IReadOnlyCollection<string> requiredLabels) =>
+            requiredLabels.Count == 0 ? AllPrs : Prs;
 
         public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
             string repo,
-            IReadOnlyCollection<string> requiredLabels) => Issues;
+            IReadOnlyCollection<string> requiredLabels) =>
+            requiredLabels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal)
+                ? PublishedIssues
+                : Issues;
     }
 
     private sealed class AutomationHostReviewPreflightWorkspace : IDisposable

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewPreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewPreflightCommandTests.cs
@@ -1,0 +1,233 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
+{
+    public AutomationHostReviewPreflightCommandTests()
+    {
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = null;
+        AutomationHostReviewPreflightCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = null;
+        AutomationHostReviewPreflightCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void Execute_EmptyQueueReturnsNoActionableItem()
+    {
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        var lister = new FakeLister();
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewPreflightCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal("no-actionable-item", result.Action);
+        Assert.Null(result.TargetPr);
+        Assert.Empty(result.InFlightPrs);
+        Assert.Empty(result.InFlightIssues);
+    }
+
+    [Fact]
+    public void Execute_PrReadySelectsOldestReviewPr()
+    {
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        var lister = new FakeLister
+        {
+            Prs =
+            [
+                BuildPr(30, "newer", "https://github.com/J-Tech-Japan/intent-system/pull/30",
+                    "2026-05-02T02:00:00Z", ["intent-target"]),
+                BuildPr(20, "older", "https://github.com/J-Tech-Japan/intent-system/pull/20",
+                    "2026-05-02T01:00:00Z", ["intent-target", "intent-pr-rereview-ready"]),
+            ],
+        };
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewPreflightCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal("review-pr", result.Action);
+        Assert.Equal(20, result.TargetPr);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/20", result.TargetPrUrl);
+        Assert.Equal([20, 30], result.InFlightPrs);
+    }
+
+    [Fact]
+    public void Execute_WipIssueBlocksCandidate()
+    {
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        var lister = new FakeLister
+        {
+            Issues =
+            [
+                BuildIssue(559, "wip", "https://github.com/J-Tech-Japan/intent-system/issues/559",
+                    "2026-05-02T01:00:00Z", ["intent-target"]),
+            ],
+        };
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewPreflightCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--candidate", "G228", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal("skip-next-slice-due-to-wip", result.Action);
+        Assert.Equal([559], result.InFlightIssues);
+        Assert.Equal("G228", result.CandidateExecutionUnit);
+    }
+
+    [Fact]
+    public void Execute_CandidateReadyWhenNoWip()
+    {
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => new FakeLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewPreflightCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--candidate", "G228", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal("candidate-ready", result.Action);
+        Assert.Equal("G228", result.CandidateExecutionUnit);
+    }
+
+    [Fact]
+    public void Execute_ClarificationRequiredWins()
+    {
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => new FakeLister
+        {
+            Prs = [BuildPr(20, "ready", "https://github.com/J-Tech-Japan/intent-system/pull/20", "2026-05-02T01:00:00Z", ["intent-target"])],
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewPreflightCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--clarification-required", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal("clarification-required", result.Action);
+        Assert.Null(result.TargetPr);
+    }
+
+    [Fact]
+    public void CommandRouter_RegistersAutomationHostReviewPreflight()
+    {
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => new FakeLister();
+
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["automation", "host-review-preflight", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            workspace.Context,
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal("no-actionable-item", result.Action);
+    }
+
+    private static GitHubAutomationPrCandidate BuildPr(
+        int number,
+        string title,
+        string url,
+        string createdAt,
+        IReadOnlyList<string> labels) =>
+        new()
+        {
+            Number = number,
+            Title = title,
+            Url = url,
+            CreatedAt = createdAt,
+            Labels = labels.Select(label => new GitHubAutomationLabel { Name = label }).ToArray(),
+        };
+
+    private static GitHubAutomationIssueCandidate BuildIssue(
+        int number,
+        string title,
+        string url,
+        string createdAt,
+        IReadOnlyList<string> labels) =>
+        new()
+        {
+            Number = number,
+            Title = title,
+            Url = url,
+            CreatedAt = createdAt,
+            Labels = labels.Select(label => new GitHubAutomationLabel { Name = label }).ToArray(),
+        };
+
+    private sealed class FakeLister : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationPrCandidate> Prs { get; init; } = Array.Empty<GitHubAutomationPrCandidate>();
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> Issues { get; init; } = Array.Empty<GitHubAutomationIssueCandidate>();
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) => Prs;
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) => Issues;
+    }
+
+    private sealed class AutomationHostReviewPreflightWorkspace : IDisposable
+    {
+        public AutomationHostReviewPreflightWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("automation-host-review-preflight-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewPreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewPreflightCommandTests.cs
@@ -112,6 +112,45 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_BlockedPrimaryFallsBackToIssueLinkedPr()
+    {
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        var lister = new FakeLister
+        {
+            Prs =
+            [
+                BuildPr(30, "blocked primary", "https://github.com/J-Tech-Japan/intent-system/pull/30",
+                    "2026-05-02T02:00:00Z", ["intent-target", "intent-pr-request-update"],
+                    updatedAt: "2026-05-02T03:00:00Z"),
+            ],
+            AllPrs =
+            [
+                BuildPr(20, "fallback", "https://github.com/J-Tech-Japan/intent-system/pull/20",
+                    "2026-05-02T01:00:00Z", [], body: "Closes #559",
+                    updatedAt: "2026-05-02T02:00:00Z"),
+            ],
+            PublishedIssues =
+            [
+                BuildIssue(559, "G227", "https://github.com/J-Tech-Japan/intent-system/issues/559",
+                    "2026-05-02T01:00:00Z", ["intent-target", "intent-pr-created"]),
+            ],
+        };
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewPreflightCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal("review-pr", result.Action);
+        Assert.Equal(20, result.TargetPr);
+        Assert.Equal([20, 30], result.InFlightPrs);
+    }
+
+    [Fact]
     public void Execute_IssueLinkedPrWithoutIntentTargetFallsBackToReviewPr()
     {
         using var workspace = new AutomationHostReviewPreflightWorkspace();

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewPreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewPreflightCommandTests.cs
@@ -41,17 +41,19 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_PrReadySelectsOldestReviewPr()
+    public void Execute_PrReadySelectsOldestUpdatedReviewPr()
     {
         using var workspace = new AutomationHostReviewPreflightWorkspace();
         var lister = new FakeLister
         {
             Prs =
             [
-                BuildPr(30, "newer", "https://github.com/J-Tech-Japan/intent-system/pull/30",
-                    "2026-05-02T02:00:00Z", ["intent-target"]),
-                BuildPr(20, "older", "https://github.com/J-Tech-Japan/intent-system/pull/20",
-                    "2026-05-02T01:00:00Z", ["intent-target", "intent-pr-rereview-ready"]),
+                BuildPr(30, "created earlier", "https://github.com/J-Tech-Japan/intent-system/pull/30",
+                    "2026-05-02T01:00:00Z", ["intent-target"],
+                    updatedAt: "2026-05-02T03:00:00Z"),
+                BuildPr(20, "updated earlier", "https://github.com/J-Tech-Japan/intent-system/pull/20",
+                    "2026-05-02T02:00:00Z", ["intent-target", "intent-pr-rereview-ready"],
+                    updatedAt: "2026-05-02T02:30:00Z"),
             ],
         };
         AutomationHostReviewPreflightCommand.CandidateListerFactory = () => lister;
@@ -68,6 +70,45 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
         Assert.Equal(20, result.TargetPr);
         Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/20", result.TargetPrUrl);
         Assert.Equal([20, 30], result.InFlightPrs);
+    }
+
+    [Fact]
+    public void Execute_PrimaryIntentTargetPrWinsOverOlderIssueLinkedFallback()
+    {
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        var lister = new FakeLister
+        {
+            Prs =
+            [
+                BuildPr(30, "primary", "https://github.com/J-Tech-Japan/intent-system/pull/30",
+                    "2026-05-02T02:00:00Z", ["intent-target"],
+                    updatedAt: "2026-05-02T03:00:00Z"),
+            ],
+            AllPrs =
+            [
+                BuildPr(20, "fallback", "https://github.com/J-Tech-Japan/intent-system/pull/20",
+                    "2026-05-02T01:00:00Z", [], body: "Closes #559",
+                    updatedAt: "2026-05-02T02:00:00Z"),
+            ],
+            PublishedIssues =
+            [
+                BuildIssue(559, "G227", "https://github.com/J-Tech-Japan/intent-system/issues/559",
+                    "2026-05-02T01:00:00Z", ["intent-target", "intent-pr-created"]),
+            ],
+        };
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewPreflightCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal("review-pr", result.Action);
+        Assert.Equal(30, result.TargetPr);
+        Assert.Equal([30], result.InFlightPrs);
     }
 
     [Fact]
@@ -219,7 +260,8 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
         string url,
         string createdAt,
         IReadOnlyList<string> labels,
-        string body = "") =>
+        string body = "",
+        string? updatedAt = null) =>
         new()
         {
             Number = number,
@@ -227,6 +269,7 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
             Url = url,
             Body = body,
             CreatedAt = createdAt,
+            UpdatedAt = updatedAt ?? createdAt,
             Labels = labels.Select(label => new GitHubAutomationLabel { Name = label }).ToArray(),
         };
 

--- a/tests/IntentSystem.Cli.Tests/WorkerNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerNextActionCommandTests.cs
@@ -349,7 +349,7 @@ public sealed class WorkerNextActionCommandTests : IDisposable
         Assert.Contains("--state", args);
         Assert.Contains("open", args);
         Assert.Contains("--json", args);
-        Assert.Contains(GhCliGitHubAutomationCandidateLister.ListJsonFields, args);
+        Assert.Contains(GhCliGitHubAutomationCandidateLister.PrListJsonFields, args);
         Assert.Contains("--label", args);
         Assert.Contains("intent-target", args);
     }


### PR DESCRIPTION
Closes #559

## Summary
- add read-only `intent-cli automation host-review-preflight` selector for host review loop mechanical actions
- report review PR targets, WIP-blocked state, next-slice candidate readiness, idle, or clarification-required in JSON
- register the command in CLI help/bootstrap routing and document host runbook usage

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~AutomationHostReviewPreflightCommandTests"`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName=IntentSystem.Cli.Tests.AutomationCompleteCommandTests.ProgramMain_AutomationCompleteDoesNotRequireIntentCliDirectory"`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName=IntentSystem.Cli.Tests.AutomationIssuePublishCommandTests.ProgramMain_AutomationIssuePublishDoesNotRequireIntentCliDirectory"`
- `rg -n "automation host-review-preflight|review-pr|skip-next-slice-due-to-wip|candidate-ready|no-actionable-item|clarification-required" src/IntentSystem.Cli tests/IntentSystem.Cli.Tests docs/automation-templates`
- `git diff --check`

Note: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~Automation"` showed two Program.Main output-capture failures when run as a broader parallel slice; both failed tests passed when rerun individually.
