### PR TITLE
G228 Add host PR review-start claim command

### DIFF
--- a/docs/automation-templates/host-review-loop.md
+++ b/docs/automation-templates/host-review-loop.md
@@ -166,7 +166,8 @@ intent-cli automation pr-transition \
 ```
 
 `review-start` adds `intent-target` and `intent-pr-reviewing` while
-clearing stale `intent-pr-rereview-ready`. `approved` removes
+clearing stale `intent-pr-rereview-ready` and legacy `rereview-ready`.
+`approved` removes
 `intent-pr-reviewing` and adds `intent-pr-approved`. These commands are
 the supported installed path for those host-owned PR label transitions.
 

--- a/src/IntentSystem.Cli/Commands/AutomationDoctorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationDoctorCommand.cs
@@ -53,7 +53,7 @@ internal static class AutomationDoctorCommand
                 Command = "intent-cli automation pr-transition",
                 Transition = "review-start",
                 Usage = "intent-cli automation pr-transition --transition review-start --write",
-                Purpose = "Host review-start transition: add intent-target and intent-pr-reviewing, remove intent-pr-rereview-ready",
+                Purpose = "Host review-start transition: add intent-target and intent-pr-reviewing, remove intent-pr-rereview-ready and legacy rereview-ready",
                 Available = true,
             },
             new AutomationDoctorRequiredCommand

--- a/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
@@ -143,6 +143,7 @@ internal static class AutomationPrTransitionCommand
                 RemoveLabels:
                 [
                     WorkerNextActionConstants.Labels.IntentPrRereviewReady,
+                    "rereview-ready",
                 ]),
             TransitionApproved => new TransitionPlan(
                 AddLabels:

--- a/src/IntentSystem.Cli/Commands/AutomationSummaryResult.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationSummaryResult.cs
@@ -91,7 +91,7 @@ internal static class AutomationSummaryConstants
 
     public static readonly IReadOnlyList<string> HostPrTransitionCommands =
     [
-        "intent-cli automation pr-transition --transition review-start --write adds intent-target and intent-pr-reviewing, and removes intent-pr-rereview-ready",
+        "intent-cli automation pr-transition --transition review-start --write adds intent-target and intent-pr-reviewing, and removes intent-pr-rereview-ready plus legacy rereview-ready",
         "intent-cli automation pr-transition --transition approved --write removes intent-pr-reviewing and adds intent-pr-approved"
     ];
 

--- a/tests/IntentSystem.Cli.Tests/AutomationDoctorCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationDoctorCommandTests.cs
@@ -30,6 +30,7 @@ public sealed class AutomationDoctorCommandTests
         Assert.Contains("intent-target", output, StringComparison.Ordinal);
         Assert.Contains("intent-pr-reviewing", output, StringComparison.Ordinal);
         Assert.Contains("intent-pr-rereview-ready", output, StringComparison.Ordinal);
+        Assert.Contains("legacy rereview-ready", output, StringComparison.Ordinal);
         Assert.Contains("intent-pr-approved", output, StringComparison.Ordinal);
     }
 

--- a/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
@@ -26,7 +26,7 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
         workspace.WriteOriginRemote("https://github.com/J-Tech-Japan/intent-system.git");
         var mutator = new FakeMutator
         {
-            Labels = new[] { "intent-pr-rereview-ready" },
+            Labels = new[] { "intent-pr-rereview-ready", "rereview-ready" },
         };
         AutomationPrTransitionCommand.MutatorFactory = () => mutator;
 
@@ -51,6 +51,7 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
         Assert.Contains("intent-target", result.AddLabels);
         Assert.Contains("intent-pr-reviewing", result.AddLabels);
         Assert.Contains("intent-pr-rereview-ready", result.RemoveLabels);
+        Assert.Contains("rereview-ready", result.RemoveLabels);
         Assert.Empty(mutator.AppliedTransitions);
     }
 
@@ -60,7 +61,7 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
         using var workspace = new AutomationPrTransitionWorkspace();
         var mutator = new FakeMutator
         {
-            Labels = new[] { "intent-pr-rereview-ready" },
+            Labels = new[] { "intent-pr-rereview-ready", "rereview-ready" },
         };
         AutomationPrTransitionCommand.MutatorFactory = () => mutator;
 
@@ -87,6 +88,7 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
         Assert.Contains("intent-target", transition.AddLabels);
         Assert.Contains("intent-pr-reviewing", transition.AddLabels);
         Assert.Contains("intent-pr-rereview-ready", transition.RemoveLabels);
+        Assert.Contains("rereview-ready", transition.RemoveLabels);
         Assert.DoesNotContain("intent-pr-created", transition.AddLabels);
         Assert.DoesNotContain("intent-pr-created", transition.RemoveLabels);
     }


### PR DESCRIPTION
Closes #561

## Summary
- update host review-start transition to clear both `intent-pr-rereview-ready` and legacy `rereview-ready`
- cover dry-run and write review-start claim plans with focused tests
- document legacy rereview label cleanup in host automation guidance

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~AutomationPrTransitionCommandTests|FullyQualifiedName~AutomationDoctorCommandTests"`
- `git diff --check`
