### PR TITLE
G230 Make host review-start transition tolerate absent rereview labels

### DIFF
--- a/docs/automation-templates/host-review-loop.md
+++ b/docs/automation-templates/host-review-loop.md
@@ -179,6 +179,8 @@ intent-cli automation pr-transition \
 
 `review-start` adds `intent-target` and `intent-pr-reviewing` while
 clearing stale `intent-pr-rereview-ready` and legacy `rereview-ready`.
+Those rereview-ready labels are optional cleanup labels; if either is
+already absent, the installed command treats it as already cleared.
 `request-update` removes `intent-pr-reviewing` and adds
 `intent-pr-request-update`. `approved` removes `intent-pr-reviewing` and
 adds `intent-pr-approved`. These commands are the supported installed

--- a/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
@@ -85,6 +85,8 @@ internal static class AutomationPrTransitionCommand
             return 1;
         }
 
+        var removeLabels = ResolveRemoveLabelsForMode(transition!, mode, plan.RemoveLabels, currentLabels);
+
         var applied = false;
         if (string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal))
         {
@@ -95,7 +97,7 @@ internal static class AutomationPrTransitionCommand
                     GhCliGitHubLabelMutator.Kinds.Pr,
                     pr!.Value,
                     plan.AddLabels,
-                    plan.RemoveLabels);
+                    removeLabels);
                 applied = true;
             }
             catch (Exception exception) when (
@@ -115,9 +117,9 @@ internal static class AutomationPrTransitionCommand
             Mode = mode,
             Applied = applied,
             AddLabels = plan.AddLabels,
-            RemoveLabels = plan.RemoveLabels,
+            RemoveLabels = removeLabels,
             CurrentLabels = currentLabels,
-            Summary = BuildSummary(transition!, plan.AddLabels, plan.RemoveLabels),
+            Summary = BuildSummary(transition!, plan.AddLabels, removeLabels),
         };
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
@@ -166,6 +168,24 @@ internal static class AutomationPrTransitionCommand
                 ]),
             _ => throw new ArgumentOutOfRangeException(nameof(transition), transition, "Unsupported PR transition."),
         };
+
+    private static IReadOnlyList<string> ResolveRemoveLabelsForMode(
+        string transition,
+        string mode,
+        IReadOnlyList<string> plannedRemoveLabels,
+        IReadOnlyList<string> currentLabels)
+    {
+        if (!string.Equals(transition, TransitionReviewStart, StringComparison.Ordinal)
+            || !string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal))
+        {
+            return plannedRemoveLabels;
+        }
+
+        var currentLabelSet = new HashSet<string>(currentLabels, StringComparer.Ordinal);
+        return plannedRemoveLabels
+            .Where(label => currentLabelSet.Contains(label))
+            .ToArray();
+    }
 
     private static bool TryParseArguments(
         string[] args,

--- a/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
@@ -94,6 +94,106 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_ReviewStart_DryRunSucceedsWhenOptionalRereviewLabelsAreAbsent()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "542",
+                "--transition", "review-start",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.False(result.Applied);
+        Assert.Contains("intent-pr-reviewing", result.AddLabels);
+        Assert.Contains("intent-pr-rereview-ready", result.RemoveLabels);
+        Assert.Contains("rereview-ready", result.RemoveLabels);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_ReviewStart_WriteSkipsAbsentOptionalRereviewLabels()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "542",
+                "--transition", "review-start",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+        Assert.Contains("intent-pr-reviewing", result.AddLabels);
+        Assert.Empty(result.RemoveLabels);
+
+        var transition = Assert.Single(mutator.AppliedTransitions);
+        Assert.Contains("intent-pr-reviewing", transition.AddLabels);
+        Assert.Empty(transition.RemoveLabels);
+        Assert.DoesNotContain("intent-pr-created", transition.AddLabels);
+        Assert.DoesNotContain("intent-pr-created", transition.RemoveLabels);
+    }
+
+    [Fact]
+    public void Execute_ReviewStart_WriteRemovesOnlyPresentRereviewLabels()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-rereview-ready" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "542",
+                "--transition", "review-start",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var transition = Assert.Single(mutator.AppliedTransitions);
+        Assert.Contains("intent-pr-reviewing", transition.AddLabels);
+        Assert.Contains("intent-pr-rereview-ready", transition.RemoveLabels);
+        Assert.DoesNotContain("rereview-ready", transition.RemoveLabels);
+        Assert.DoesNotContain("intent-pr-created", transition.AddLabels);
+        Assert.DoesNotContain("intent-pr-created", transition.RemoveLabels);
+    }
+
+    [Fact]
     public void Execute_Approved_WriteAppliesExactApprovedLabels()
     {
         using var workspace = new AutomationPrTransitionWorkspace();
@@ -300,6 +400,15 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
                     || removeLabels.Contains("intent-pr-created", StringComparer.Ordinal)))
             {
                 throw new InvalidOperationException("'intent-pr-created' is issue-only.");
+            }
+
+            foreach (var removeLabel in removeLabels)
+            {
+                if (!Labels.Contains(removeLabel, StringComparer.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"cannot remove absent label '{removeLabel}' in fake mutator");
+                }
             }
 
             AppliedTransitions.Add(new AppliedTransition(


### PR DESCRIPTION
Closes #565

## Summary
- make `review-start --write` skip optional rereview-ready removals when those labels are absent
- keep dry-run reporting the full cleanup plan while write mode applies only present cleanup labels
- add focused initial-review and rereview-state tests that reject absent-label removals
- document that rereview-ready cleanup labels are optional for review-start

## Validation
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~AutomationPrTransitionCommandTests"`
- `git diff --check`
