### PR TITLE
G231 Document host runbook adoption of installed transition commands

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -30,6 +30,60 @@ These templates assume:
 | G213  | `intent-cli automation check`           | Worktree-aware next-action entrypoint |
 | G214  | `intent-cli automation complete`        | Worktree-aware outcome completion entrypoint |
 | G215  | `intent-cli automation clarification-stop` | Stable clarification-required stop summary |
+| G226  | `intent-cli automation issue-publish`   | Host issue publish label transition |
+| G227  | `intent-cli automation host-review-preflight` | Host PR review target preflight |
+| G228  | `intent-cli automation pr-transition --transition review-start` | Host review-start PR transition |
+| G229  | `intent-cli automation pr-transition --transition request-update` | Host request-update PR transition |
+| G230  | `intent-cli automation pr-transition --transition review-start` | Robust absent-rereview-label cleanup |
+
+## Installed host transition command adoption
+
+Parent-host runbooks should use installed `intent-cli` transition
+commands for supported mechanical label changes. Raw `gh issue edit` /
+`gh pr edit` label mutation is not the normal path for these
+transitions.
+
+Before applying host-side label transitions, detect stale local CLI
+installations with the read-only command surfaces:
+
+```bash
+intent-cli automation doctor --format json
+intent-cli automation host-review-preflight --repo "$CHILD_REPO" --format json
+```
+
+Supported installed transitions:
+
+```bash
+intent-cli automation issue-publish \
+  --repo "$CHILD_REPO" \
+  --issue "$ISSUE_NUMBER" \
+  --write \
+  --format json
+
+intent-cli automation pr-transition \
+  --repo "$CHILD_REPO" \
+  --pr "$PR_NUMBER" \
+  --transition review-start \
+  --write \
+  --format json
+
+intent-cli automation pr-transition \
+  --repo "$CHILD_REPO" \
+  --pr "$PR_NUMBER" \
+  --transition request-update \
+  --write \
+  --format json
+
+intent-cli automation pr-transition \
+  --repo "$CHILD_REPO" \
+  --pr "$PR_NUMBER" \
+  --transition approved \
+  --write \
+  --format json
+```
+
+`intent-pr-created` remains issue-only. It must never be added to a PR
+by a template, fallback, or installed transition command.
 
 ## Template index
 

--- a/docs/automation-templates/host-next-slice-loop.md
+++ b/docs/automation-templates/host-next-slice-loop.md
@@ -145,6 +145,9 @@ intent-cli automation issue-publish \
 
 Dry-run the same command without `--write` to capture the planned
 `intent-target` label action and JSON publish metadata before mutation.
+Raw `gh issue edit` label mutation is not the normal path for this
+installed transition. If the command is missing or stale, refresh the
+installed CLI before mutating labels.
 
 ## What this template forbids
 

--- a/docs/automation-templates/host-review-loop.md
+++ b/docs/automation-templates/host-review-loop.md
@@ -118,10 +118,21 @@ binary preflight:
 intent-cli automation doctor --format json
 ```
 
+Also run the host review target preflight against the child repo before
+label mutation:
+
+```bash
+intent-cli automation host-review-preflight \
+  --repo "$CHILD_REPO" \
+  --format json
+```
+
 The preflight is read-only. It must report the required
 `intent-cli automation pr-transition` command surface, including
 `review-start`, `request-update`, and `approved`, before the host loop
-attempts a GitHub label mutation.
+attempts a GitHub label mutation. If either preflight reports a stale or
+missing command surface, stop and refresh the installed CLI; do not fall
+back to raw `gh pr edit` label mutation for installed transitions.
 
 Choose ONE of the following review verdicts. Each has an explicit
 label transition. For host-owned review-start, request-update, and

--- a/ops/intent-automation-label-state-machine.md
+++ b/ops/intent-automation-label-state-machine.md
@@ -74,6 +74,23 @@ This document explains the label contract used by the target-scoped automation f
 
 ## Transition Summary
 
+Supported mechanical label transitions should be applied through the
+installed `intent-cli` command surfaces, not by normal runbook raw
+`gh issue edit` / `gh pr edit` label mutation:
+
+```bash
+intent-cli automation issue-publish --repo "$CHILD_REPO" --issue "$ISSUE_NUMBER" --write --format json
+intent-cli automation pr-transition --repo "$CHILD_REPO" --pr "$PR_NUMBER" --transition review-start --write --format json
+intent-cli automation pr-transition --repo "$CHILD_REPO" --pr "$PR_NUMBER" --transition request-update --write --format json
+intent-cli automation pr-transition --repo "$CHILD_REPO" --pr "$PR_NUMBER" --transition approved --write --format json
+```
+
+Use `intent-cli automation doctor --format json` and
+`intent-cli automation host-review-preflight --repo "$CHILD_REPO"
+--format json` as stale-CLI/readiness checks before host-side PR
+transition mutation. `intent-pr-created` remains issue-only and must not
+be applied to PRs by installed commands or fallback paths.
+
 ## 1. Issue Runner
 
 The issue runner owns the Issue-to-PR transition.


### PR DESCRIPTION
Closes #567

## Summary
- document installed host transition command adoption in automation templates
- add examples for issue-publish, review-start, request-update, and approved transitions
- include doctor/host-review-preflight stale CLI checks
- clarify that raw `gh` label mutation is not the normal path and `intent-pr-created` remains issue-only

## Validation
- `rg -n "automation (issue-publish|pr-transition|doctor|host-review-preflight)|transition review-start|transition request-update|transition approved|intent-pr-created" docs/automation-templates ops/intent-automation-label-state-machine.md`
- `rg -n 'raw `gh|raw gh|gh (issue|pr) edit|normal path' docs/automation-templates ops/intent-automation-label-state-machine.md`
- `git diff --check`
