### PR TITLE
G233 Detect stale host-local automation CLI

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -52,6 +52,14 @@ intent-cli automation doctor --format json
 intent-cli automation host-review-preflight --repo "$CHILD_REPO" --format json
 ```
 
+Both commands must report the host-local installed CLI path and all
+required installed surfaces as available: `automation summary`,
+`automation host-review-preflight`, `automation issue-publish`, and
+`automation pr-transition` for `review-start`, `request-update`, and
+`approved`. If either command reports `stale-host-cli` or a missing
+surface, abort and refresh the installed CLI; do not substitute raw
+`gh` label mutation.
+
 Supported installed transitions:
 
 ```bash

--- a/docs/automation-templates/dry-run-checklist.md
+++ b/docs/automation-templates/dry-run-checklist.md
@@ -156,7 +156,7 @@ export PR_NUMBER="<published-child-pr-number>"
 
 ```bash
 intent-cli automation doctor --format json \
-  | jq '{status, readOnly, transitions: [.requiredCommands[].transition]}'
+  | jq '{status, readOnly, installedCliPath, commands: [.requiredCommands[] | {command, transition, available}]}'
 ```
 
 Expected:
@@ -165,13 +165,22 @@ Expected:
 {
   "status": "ok",
   "readOnly": true,
-  "transitions": ["review-start", "request-update", "approved"]
+  "installedCliPath": "/path/to/host/.intent-cli/bin/intent-cli",
+  "commands": [
+    {"command": "intent-cli automation summary", "transition": null, "available": true},
+    {"command": "intent-cli automation host-review-preflight", "transition": null, "available": true},
+    {"command": "intent-cli automation issue-publish", "transition": null, "available": true},
+    {"command": "intent-cli automation pr-transition", "transition": "review-start", "available": true},
+    {"command": "intent-cli automation pr-transition", "transition": "request-update", "available": true},
+    {"command": "intent-cli automation pr-transition", "transition": "approved", "available": true}
+  ]
 }
 ```
 
-If a transition is missing, the installed CLI is stale. Refresh the
-wrapper/tool before using host runbooks; do not fall back to raw `gh pr
-edit` label mutation for installed transitions.
+If `status` is `stale-host-cli`, or any command is unavailable, abort
+the runbook and refresh the wrapper/tool before using host runbooks; do
+not fall back to raw `gh issue edit` or `gh pr edit` label mutation for
+installed transitions.
 
 ### Host review target preflight
 

--- a/ops/intent-automation-label-state-machine.md
+++ b/ops/intent-automation-label-state-machine.md
@@ -88,8 +88,12 @@ intent-cli automation pr-transition --repo "$CHILD_REPO" --pr "$PR_NUMBER" --tra
 Use `intent-cli automation doctor --format json` and
 `intent-cli automation host-review-preflight --repo "$CHILD_REPO"
 --format json` as stale-CLI/readiness checks before host-side PR
-transition mutation. `intent-pr-created` remains issue-only and must not
-be applied to PRs by installed commands or fallback paths.
+transition mutation. These checks must name the host-local installed CLI
+path and fail with stale/missing surface detail before mutation when
+`automation summary`, `automation host-review-preflight`,
+`automation issue-publish`, or any `automation pr-transition`
+transition is unavailable. `intent-pr-created` remains issue-only and
+must not be applied to PRs by installed commands or fallback paths.
 
 For local smoke testing, run the dry-run examples in
 `docs/automation-templates/dry-run-checklist.md` before enabling

--- a/src/IntentSystem.Cli/Commands/AutomationDoctorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationDoctorCommand.cs
@@ -31,7 +31,7 @@ internal static class AutomationDoctorCommand
             return 1;
         }
 
-        var result = BuildResult();
+        var result = BuildResult(context);
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
             writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
@@ -41,47 +41,64 @@ internal static class AutomationDoctorCommand
             WriteText(writer, result);
         }
 
-        return 0;
+        return string.Equals(result.Status, "ok", StringComparison.Ordinal) ? 0 : 1;
     }
 
-    private static AutomationDoctorResult BuildResult()
+    private static AutomationDoctorResult BuildResult(CliContext context)
     {
-        var requiredCommands = new[]
-        {
-            new AutomationDoctorRequiredCommand
+        var surfaceReport = AutomationInstalledCliSurfaceProbe.Check(context);
+        var requiredCommands = surfaceReport.Checks
+            .Select(check => new AutomationDoctorRequiredCommand
             {
-                Command = "intent-cli automation pr-transition",
-                Transition = "review-start",
-                Usage = "intent-cli automation pr-transition --transition review-start --write",
-                Purpose = "Host review-start transition: add intent-target and intent-pr-reviewing, remove intent-pr-rereview-ready and legacy rereview-ready",
-                Available = true,
-            },
-            new AutomationDoctorRequiredCommand
-            {
-                Command = "intent-cli automation pr-transition",
-                Transition = "request-update",
-                Usage = "intent-cli automation pr-transition --transition request-update --write",
-                Purpose = "Host request-update transition: remove intent-pr-reviewing and add intent-pr-request-update",
-                Available = true,
-            },
-            new AutomationDoctorRequiredCommand
-            {
-                Command = "intent-cli automation pr-transition",
-                Transition = "approved",
-                Usage = "intent-cli automation pr-transition --transition approved --write",
-                Purpose = "Host approved transition: remove intent-pr-reviewing and add intent-pr-approved",
-                Available = true,
-            },
-        };
+                Command = check.Command,
+                Transition = check.Transition,
+                Usage = BuildUsage(check.Command, check.Transition),
+                Purpose = BuildPurpose(check.Command, check.Transition),
+                Available = check.Available,
+                Reason = check.Reason,
+            })
+            .ToArray();
+
+        var missing = requiredCommands
+            .Where(command => !command.Available)
+            .ToArray();
 
         return new AutomationDoctorResult
         {
-            Status = "ok",
+            Status = surfaceReport.Available ? "ok" : "stale-host-cli",
             ReadOnly = true,
+            InstalledCliPath = surfaceReport.InstalledCliPath,
             RequiredCommands = requiredCommands,
-            Summary = "Host automation command preflight passed: required automation pr-transition commands are available.",
+            Summary = surfaceReport.Available
+                ? "Host automation command preflight passed: required installed automation command surfaces are available."
+                : $"Host automation command preflight failed: installed CLI at {surfaceReport.InstalledCliPath} is missing or stale for {string.Join(", ", missing.Select(command => command.Usage))}. Abort before label transitions; refresh the installed CLI instead of falling back to raw gh label mutation.",
         };
     }
+
+    private static string BuildUsage(string command, string? transition) =>
+        command switch
+        {
+            "intent-cli automation summary" => "intent-cli automation summary --format json",
+            "intent-cli automation host-review-preflight" => "intent-cli automation host-review-preflight --format json",
+            "intent-cli automation issue-publish" => "intent-cli automation issue-publish --issue <n> --write --format json",
+            "intent-cli automation pr-transition" => $"intent-cli automation pr-transition --transition {transition} --write --format json",
+            _ => command,
+        };
+
+    private static string BuildPurpose(string command, string? transition) =>
+        command switch
+        {
+            "intent-cli automation summary" => "Read-only installed command contract summary used by host runbooks.",
+            "intent-cli automation host-review-preflight" => "Read-only host review preflight before any host-owned PR label transition.",
+            "intent-cli automation issue-publish" => "Host issue-publish transition: add intent-target to a child issue.",
+            "intent-cli automation pr-transition" when string.Equals(transition, "review-start", StringComparison.Ordinal) =>
+                "Host review-start transition: add intent-target and intent-pr-reviewing, remove intent-pr-rereview-ready and legacy rereview-ready",
+            "intent-cli automation pr-transition" when string.Equals(transition, "request-update", StringComparison.Ordinal) =>
+                "Host request-update transition: remove intent-pr-reviewing and add intent-pr-request-update",
+            "intent-cli automation pr-transition" when string.Equals(transition, "approved", StringComparison.Ordinal) =>
+                "Host approved transition: remove intent-pr-reviewing and add intent-pr-approved",
+            _ => "Required host automation command surface.",
+        };
 
     private static bool TryParseArguments(
         string[] args,
@@ -129,14 +146,19 @@ internal static class AutomationDoctorCommand
         writer.WriteLine("# Automation doctor");
         writer.WriteLine($"status: {result.Status}");
         writer.WriteLine($"read_only: {result.ReadOnly.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"installed_cli_path: {result.InstalledCliPath}");
         writer.WriteLine(result.Summary);
         writer.WriteLine();
-        writer.WriteLine("## Required host PR transition commands");
+        writer.WriteLine("## Required installed automation command surfaces");
         foreach (var command in result.RequiredCommands)
         {
             writer.WriteLine($"- {command.Usage}");
             writer.WriteLine($"  transition: {command.Transition}");
             writer.WriteLine($"  available: {command.Available.ToString().ToLowerInvariant()}");
+            if (!string.IsNullOrEmpty(command.Reason))
+            {
+                writer.WriteLine($"  reason: {command.Reason}");
+            }
             writer.WriteLine($"  purpose: {command.Purpose}");
         }
     }
@@ -152,6 +174,12 @@ internal sealed record AutomationDoctorResult
 
     [JsonPropertyName("readOnly")]
     public bool ReadOnlyCamel => ReadOnly;
+
+    [JsonPropertyName("installed_cli_path")]
+    public required string InstalledCliPath { get; init; }
+
+    [JsonPropertyName("installedCliPath")]
+    public string InstalledCliPathCamel => InstalledCliPath;
 
     [JsonPropertyName("required_commands")]
     public required IReadOnlyList<AutomationDoctorRequiredCommand> RequiredCommands { get; init; }
@@ -169,7 +197,7 @@ internal sealed record AutomationDoctorRequiredCommand
     public required string Command { get; init; }
 
     [JsonPropertyName("transition")]
-    public required string Transition { get; init; }
+    public required string? Transition { get; init; }
 
     [JsonPropertyName("usage")]
     public required string Usage { get; init; }
@@ -179,4 +207,7 @@ internal sealed record AutomationDoctorRequiredCommand
 
     [JsonPropertyName("available")]
     public required bool Available { get; init; }
+
+    [JsonPropertyName("reason")]
+    public required string? Reason { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewPreflightCommand.cs
@@ -34,6 +34,12 @@ internal static class AutomationHostReviewPreflightCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
         if (!TryParseArguments(args, out var repo, out var workdir, out var candidate, out var clarificationRequired, out var format, out var error))
         {
             writer.WriteLine(error);
@@ -45,6 +51,22 @@ internal static class AutomationHostReviewPreflightCommand
             && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
         {
             writer.WriteLine(error);
+            return 1;
+        }
+
+        var surfaceReport = AutomationInstalledCliSurfaceProbe.Check(context);
+        if (!surfaceReport.Available)
+        {
+            var staleResult = BuildStaleHostCliResult(repo!, surfaceReport);
+            if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+            {
+                writer.WriteLine(JsonSerializer.Serialize(staleResult, JsonOptions));
+            }
+            else
+            {
+                WriteText(writer, staleResult);
+            }
+
             return 1;
         }
 
@@ -217,7 +239,35 @@ internal static class AutomationHostReviewPreflightCommand
             CandidateExecutionUnit = string.IsNullOrWhiteSpace(candidateExecutionUnit) ? null : candidateExecutionUnit,
             Reason = reason,
             Warnings = Array.Empty<string>(),
+            InstalledCliPath = null,
+            MissingCommandSurfaces = Array.Empty<InstalledCliSurfaceCheck>(),
         };
+
+    private static AutomationHostReviewPreflightResult BuildStaleHostCliResult(
+        string repo,
+        InstalledCliSurfaceReport surfaceReport)
+    {
+        var missing = surfaceReport.Checks
+            .Where(check => !check.Available)
+            .ToArray();
+
+        return new AutomationHostReviewPreflightResult
+        {
+            Action = "stale-host-cli",
+            Repo = repo,
+            TargetPr = null,
+            TargetPrUrl = null,
+            InFlightPrs = Array.Empty<int>(),
+            InFlightIssues = Array.Empty<int>(),
+            CandidateExecutionUnit = null,
+            Reason = $"installed CLI at {surfaceReport.InstalledCliPath} is missing or stale for required automation command surfaces; abort before label transitions and refresh the installed CLI instead of falling back to raw gh label mutation",
+            Warnings = missing
+                .Select(check => $"{check.Command}{(string.IsNullOrWhiteSpace(check.Transition) ? string.Empty : $" --transition {check.Transition}")}: {check.Reason}")
+                .ToArray(),
+            InstalledCliPath = surfaceReport.InstalledCliPath,
+            MissingCommandSurfaces = missing,
+        };
+    }
 
     private static bool IsReadyForHostReview(GitHubAutomationPrCandidate pr)
     {
@@ -442,6 +492,21 @@ internal static class AutomationHostReviewPreflightCommand
         {
             writer.WriteLine($"- candidate_execution_unit: {result.CandidateExecutionUnit}");
         }
+        if (!string.IsNullOrEmpty(result.InstalledCliPath))
+        {
+            writer.WriteLine($"- installed_cli_path: {result.InstalledCliPath}");
+        }
+        foreach (var warning in result.Warnings)
+        {
+            writer.WriteLine($"- warning: {warning}");
+        }
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("automation host-review-preflight");
+        writer.WriteLine("Usage: intent-cli automation host-review-preflight [--repo <owner/repo>] [--workdir <path>] [--candidate <execution-unit>] [--clarification-required] [--format text|json]");
+        writer.WriteLine("Checks installed CLI command surfaces before selecting host review-loop work.");
     }
 }
 
@@ -488,4 +553,16 @@ internal sealed record AutomationHostReviewPreflightResult
 
     [JsonPropertyName("warnings")]
     public required IReadOnlyList<string> Warnings { get; init; }
+
+    [JsonPropertyName("installed_cli_path")]
+    public required string? InstalledCliPath { get; init; }
+
+    [JsonPropertyName("installedCliPath")]
+    public string? InstalledCliPathCamel => InstalledCliPath;
+
+    [JsonPropertyName("missing_command_surfaces")]
+    public required IReadOnlyList<InstalledCliSurfaceCheck> MissingCommandSurfaces { get; init; }
+
+    [JsonPropertyName("missingCommandSurfaces")]
+    public IReadOnlyList<InstalledCliSurfaceCheck> MissingCommandSurfacesCamel => MissingCommandSurfaces;
 }

--- a/src/IntentSystem.Cli/Commands/AutomationInstalledCliSurfaceProbe.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationInstalledCliSurfaceProbe.cs
@@ -1,0 +1,160 @@
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+using IntentSystem.Cli;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class AutomationInstalledCliSurfaceProbe
+{
+    public static Func<string, IReadOnlyList<string>, InstalledCliProbeResult>? ProbeRunner { get; set; }
+
+    public static InstalledCliSurfaceReport Check(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var installedCliPath = ResolveInstalledCliPath(context.RepoRoot);
+        var checks = RequiredSurfaces
+            .Select(surface => CheckSurface(installedCliPath, surface))
+            .ToArray();
+
+        return new InstalledCliSurfaceReport(
+            installedCliPath,
+            checks.All(check => check.Available),
+            checks);
+    }
+
+    private static InstalledCliSurfaceCheck CheckSurface(string installedCliPath, RequiredSurface surface)
+    {
+        if (!File.Exists(installedCliPath))
+        {
+            return Missing(surface, "installed intent-cli was not found");
+        }
+
+        InstalledCliProbeResult probe;
+        try
+        {
+            probe = ProbeRunner?.Invoke(installedCliPath, surface.Arguments)
+                ?? RunInstalledCli(installedCliPath, surface.Arguments);
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            return Missing(surface, exception.Message);
+        }
+
+        var output = $"{probe.Stdout}\n{probe.Stderr}";
+        var hasSurface = probe.ExitCode == 0
+            && surface.ExpectedTokens.All(token => output.Contains(token, StringComparison.Ordinal));
+        if (hasSurface)
+        {
+            return new InstalledCliSurfaceCheck(
+                surface.Command,
+                surface.Transition,
+                true,
+                null);
+        }
+
+        var reason = output.Contains("not yet implemented", StringComparison.OrdinalIgnoreCase)
+            ? "installed CLI reports the command surface is not yet implemented"
+            : $"installed CLI help did not expose required surface tokens: {string.Join(", ", surface.ExpectedTokens)}";
+
+        return Missing(surface, reason);
+    }
+
+    private static InstalledCliSurfaceCheck Missing(RequiredSurface surface, string reason) =>
+        new(
+            surface.Command,
+            surface.Transition,
+            false,
+            reason);
+
+    private static InstalledCliProbeResult RunInstalledCli(string installedCliPath, IReadOnlyList<string> arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = installedCliPath,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"failed to start installed intent-cli at {installedCliPath}");
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return new InstalledCliProbeResult(process.ExitCode, stdout, stderr);
+    }
+
+    private static string ResolveInstalledCliPath(string repoRoot)
+    {
+        var executableName = OperatingSystem.IsWindows() ? "intent-cli.exe" : "intent-cli";
+        return Path.Combine(repoRoot, CliRuntimeContracts.IntentCliDirectoryName, "bin", executableName);
+    }
+
+    private static readonly IReadOnlyList<RequiredSurface> RequiredSurfaces =
+    [
+        new(
+            "intent-cli automation summary",
+            null,
+            ["automation", "summary", "--help"],
+            ["automation summary"]),
+        new(
+            "intent-cli automation host-review-preflight",
+            null,
+            ["automation", "host-review-preflight", "--help"],
+            ["automation host-review-preflight"]),
+        new(
+            "intent-cli automation issue-publish",
+            null,
+            ["automation", "issue-publish", "--help"],
+            ["automation issue-publish"]),
+        new(
+            "intent-cli automation pr-transition",
+            "review-start",
+            ["automation", "pr-transition", "--help"],
+            ["automation pr-transition", "review-start"]),
+        new(
+            "intent-cli automation pr-transition",
+            "request-update",
+            ["automation", "pr-transition", "--help"],
+            ["automation pr-transition", "request-update"]),
+        new(
+            "intent-cli automation pr-transition",
+            "approved",
+            ["automation", "pr-transition", "--help"],
+            ["automation pr-transition", "approved"]),
+    ];
+
+    private sealed record RequiredSurface(
+        string Command,
+        string? Transition,
+        IReadOnlyList<string> Arguments,
+        IReadOnlyList<string> ExpectedTokens);
+}
+
+internal sealed record InstalledCliSurfaceReport(
+    string InstalledCliPath,
+    bool Available,
+    IReadOnlyList<InstalledCliSurfaceCheck> Checks);
+
+internal sealed record InstalledCliSurfaceCheck(
+    [property: JsonPropertyName("command")]
+    string Command,
+    [property: JsonPropertyName("transition")]
+    string? Transition,
+    [property: JsonPropertyName("available")]
+    bool Available,
+    [property: JsonPropertyName("reason")]
+    string? Reason);
+
+internal sealed record InstalledCliProbeResult(
+    int ExitCode,
+    string Stdout,
+    string Stderr);

--- a/src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs
@@ -31,6 +31,12 @@ internal static class AutomationIssuePublishCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
         if (!TryParseArguments(
                 args,
                 out var repo,
@@ -277,6 +283,13 @@ internal static class AutomationIssuePublishCommand
         writer.WriteLine($"applied_label: {result.AppliedLabel}");
         writer.WriteLine($"applied: {result.Applied.ToString().ToLowerInvariant()}");
         writer.WriteLine($"published_at: {result.PublishedAt:O}");
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("automation issue-publish");
+        writer.WriteLine("Usage: intent-cli automation issue-publish --repo <owner/repo> --issue <n> [--write] [--dry-run] [--format text|json]");
+        writer.WriteLine("Publishes a child issue by applying the host-owned intent-target transition.");
     }
 }
 

--- a/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
@@ -31,6 +31,12 @@ internal static class AutomationPrTransitionCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
         if (!TryParseArguments(
                 args,
                 out var repo,
@@ -351,6 +357,16 @@ internal static class AutomationPrTransitionCommand
         writer.WriteLine($"repo: {result.Repo}");
         writer.WriteLine($"pr: {result.Pr.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
         writer.WriteLine($"applied: {result.Applied.ToString().ToLowerInvariant()}");
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("automation pr-transition");
+        writer.WriteLine("Usage: intent-cli automation pr-transition --repo <owner/repo> --pr <n> --transition <review-start|request-update|approved> [--write] [--dry-run] [--format text|json]");
+        writer.WriteLine("Supported transitions:");
+        writer.WriteLine("- review-start");
+        writer.WriteLine("- request-update");
+        writer.WriteLine("- approved");
     }
 
     private sealed record TransitionPlan(

--- a/src/IntentSystem.Cli/Commands/AutomationSummaryCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationSummaryCommand.cs
@@ -19,6 +19,12 @@ internal static class AutomationSummaryCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
         if (!TryParseArguments(args, out var domainOverride, out var format, out var error))
         {
             writer.WriteLine(error);
@@ -91,5 +97,12 @@ internal static class AutomationSummaryCommand
         }
 
         return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("automation summary");
+        writer.WriteLine("Usage: intent-cli automation summary [--domain <name>] [--format text|json]");
+        writer.WriteLine("Emits the read-only label-driven automation contract.");
     }
 }

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -64,7 +64,9 @@ internal static class Program
                 || string.Equals(args[1], "complete", StringComparison.Ordinal)
                 || string.Equals(args[1], "doctor", StringComparison.Ordinal)
                 || string.Equals(args[1], "host-review-preflight", StringComparison.Ordinal)
-                || string.Equals(args[1], "issue-publish", StringComparison.Ordinal));
+                || string.Equals(args[1], "issue-publish", StringComparison.Ordinal)
+                || string.Equals(args[1], "pr-transition", StringComparison.Ordinal)
+                || string.Equals(args[1], "summary", StringComparison.Ordinal));
     }
 
     private static CliContext CreateBootstrapContext(string currentDirectory, string[] args)

--- a/tests/IntentSystem.Cli.Tests/AutomationDoctorCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationDoctorCommandTests.cs
@@ -24,6 +24,7 @@ public sealed class AutomationDoctorCommandTests
         Assert.Contains("# Automation doctor", output, StringComparison.Ordinal);
         Assert.Contains("status: ok", output, StringComparison.Ordinal);
         Assert.Contains("read_only: true", output, StringComparison.Ordinal);
+        Assert.Contains("installed_cli_path:", output, StringComparison.Ordinal);
         Assert.Contains("intent-cli automation pr-transition", output, StringComparison.Ordinal);
         Assert.Contains("--transition review-start", output, StringComparison.Ordinal);
         Assert.Contains("--transition request-update", output, StringComparison.Ordinal);
@@ -51,12 +52,15 @@ public sealed class AutomationDoctorCommandTests
         var result = JsonSerializer.Deserialize<AutomationDoctorResult>(writer.ToString())!;
         Assert.Equal("ok", result.Status);
         Assert.True(result.ReadOnly);
-        Assert.Equal(3, result.RequiredCommands.Count);
-        Assert.All(result.RequiredCommands, command =>
-        {
-            Assert.Equal("intent-cli automation pr-transition", command.Command);
-            Assert.True(command.Available);
-        });
+        Assert.EndsWith(Path.Combine(".intent-cli", "bin", "intent-cli"), result.InstalledCliPath, StringComparison.Ordinal);
+        Assert.Equal(6, result.RequiredCommands.Count);
+        Assert.All(result.RequiredCommands, command => Assert.True(command.Available));
+        Assert.Contains(result.RequiredCommands, command =>
+            string.Equals(command.Command, "intent-cli automation summary", StringComparison.Ordinal));
+        Assert.Contains(result.RequiredCommands, command =>
+            string.Equals(command.Command, "intent-cli automation host-review-preflight", StringComparison.Ordinal));
+        Assert.Contains(result.RequiredCommands, command =>
+            string.Equals(command.Command, "intent-cli automation issue-publish", StringComparison.Ordinal));
         Assert.Contains(result.RequiredCommands, command =>
             string.Equals(command.Transition, "review-start", StringComparison.Ordinal)
             && command.Usage.Contains("--transition review-start", StringComparison.Ordinal));
@@ -70,7 +74,32 @@ public sealed class AutomationDoctorCommandTests
         using var document = JsonDocument.Parse(writer.ToString());
         var root = document.RootElement;
         Assert.True(root.TryGetProperty("required_commands", out var requiredCommands));
-        Assert.Equal(3, requiredCommands.GetArrayLength());
+        Assert.Equal(6, requiredCommands.GetArrayLength());
+        Assert.True(root.TryGetProperty("installed_cli_path", out _));
+    }
+
+    [Fact]
+    public void Execute_StaleInstalledCliReportsMissingSurfaceAndFails()
+    {
+        using var workspace = new AutomationDoctorWorkspace();
+        workspace.WriteInstalledCliScript(stalePrTransition: true);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationDoctorCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationDoctorResult>(writer.ToString())!;
+        Assert.Equal("stale-host-cli", result.Status);
+        Assert.Contains(".intent-cli", result.InstalledCliPath, StringComparison.Ordinal);
+        Assert.Contains(result.RequiredCommands, command =>
+            string.Equals(command.Command, "intent-cli automation pr-transition", StringComparison.Ordinal)
+            && string.Equals(command.Transition, "review-start", StringComparison.Ordinal)
+            && !command.Available
+            && command.Reason!.Contains("not yet implemented", StringComparison.Ordinal));
+        Assert.Contains("Abort before label transitions", result.Summary, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -131,12 +160,13 @@ public sealed class AutomationDoctorCommandTests
 
             var exitCode = Program.Main(["automation", "doctor", "--format", "json"]);
 
-            Assert.Equal(0, exitCode);
-            Assert.Equal(string.Empty, stderr.ToString());
-            Assert.DoesNotContain("Command 'automation doctor' is not yet implemented.", stdout.ToString(), StringComparison.Ordinal);
-            var result = JsonSerializer.Deserialize<AutomationDoctorResult>(stdout.ToString())!;
-            Assert.Equal("ok", result.Status);
-            Assert.True(result.ReadOnly);
+        Assert.Equal(1, exitCode);
+        Assert.Equal(string.Empty, stderr.ToString());
+        Assert.DoesNotContain("Command 'automation doctor' is not yet implemented.", stdout.ToString(), StringComparison.Ordinal);
+        var result = JsonSerializer.Deserialize<AutomationDoctorResult>(stdout.ToString())!;
+        Assert.Equal("stale-host-cli", result.Status);
+        Assert.True(result.ReadOnly);
+        Assert.Contains(".intent-cli", result.InstalledCliPath, StringComparison.Ordinal);
         }
         finally
         {
@@ -187,7 +217,7 @@ public sealed class AutomationDoctorCommandTests
         {
             if (createIntentCliDirectory)
             {
-                Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+                WriteInstalledCliScript(stalePrTransition: false);
             }
 
             Context = new CliContext
@@ -209,6 +239,40 @@ public sealed class AutomationDoctorCommandTests
         public void WriteSentinel()
         {
             File.WriteAllText(Path.Combine(rootPath, "sentinel.txt"), "unchanged");
+        }
+
+        public void WriteInstalledCliScript(bool stalePrTransition)
+        {
+            var binPath = Path.Combine(rootPath, ".intent-cli", "bin");
+            Directory.CreateDirectory(binPath);
+            var scriptPath = Path.Combine(binPath, "intent-cli");
+            var prTransitionBlock = stalePrTransition
+                ? "  echo \"Command 'automation pr-transition' is not yet implemented.\"\n  exit 1\n"
+                : "  echo 'automation pr-transition'\n  echo 'review-start'\n  echo 'request-update'\n  echo 'approved'\n  exit 0\n";
+            File.WriteAllText(
+                scriptPath,
+                "#!/bin/sh\n"
+                + "case \"$*\" in\n"
+                + "  'automation summary --help') echo 'automation summary'; exit 0 ;;\n"
+                + "  'automation host-review-preflight --help') echo 'automation host-review-preflight'; exit 0 ;;\n"
+                + "  'automation issue-publish --help') echo 'automation issue-publish'; exit 0 ;;\n"
+                + "  'automation pr-transition --help')\n"
+                + prTransitionBlock
+                + "    ;;\n"
+                + "  *) echo \"unexpected probe: $*\"; exit 1 ;;\n"
+                + "esac\n");
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(
+                    scriptPath,
+                    UnixFileMode.UserRead
+                    | UnixFileMode.UserWrite
+                    | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead
+                    | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead
+                    | UnixFileMode.OtherExecute);
+            }
         }
 
         public IReadOnlyDictionary<string, string> SnapshotWorkspace()

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewPreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewPreflightCommandTests.cs
@@ -17,6 +17,7 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
     {
         AutomationHostReviewPreflightCommand.CandidateListerFactory = null;
         AutomationHostReviewPreflightCommand.NestedProviderLauncher = null;
+        AutomationInstalledCliSurfaceProbe.ProbeRunner = null;
     }
 
     [Fact]
@@ -277,6 +278,50 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_StaleInstalledCliStopsBeforeListingCandidates()
+    {
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        var lister = new ThrowingLister();
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => lister;
+        workspace.WriteInstalledCliScript(stalePrTransition: true);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewPreflightCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal("stale-host-cli", result.Action);
+        Assert.Contains(".intent-cli", result.InstalledCliPath, StringComparison.Ordinal);
+        Assert.NotEmpty(result.MissingCommandSurfaces);
+        Assert.Contains(result.MissingCommandSurfaces, surface =>
+            string.Equals(surface.Command, "intent-cli automation pr-transition", StringComparison.Ordinal)
+            && string.Equals(surface.Transition, "review-start", StringComparison.Ordinal)
+            && !surface.Available);
+        Assert.Contains(result.Warnings, warning =>
+            warning.Contains("automation pr-transition", StringComparison.Ordinal)
+            && warning.Contains("not yet implemented", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_HelpSurfacesHostReviewPreflightWithoutCandidateListing()
+    {
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => new ThrowingLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewPreflightCommand.Execute(
+            workspace.Context,
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("automation host-review-preflight", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CommandRouter_RegistersAutomationHostReviewPreflight()
     {
         using var workspace = new AutomationHostReviewPreflightWorkspace();
@@ -350,12 +395,25 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
                 : Issues;
     }
 
+    private sealed class ThrowingLister : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) =>
+            throw new InvalidOperationException("candidate listing should not run");
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) =>
+            throw new InvalidOperationException("candidate listing should not run");
+    }
+
     private sealed class AutomationHostReviewPreflightWorkspace : IDisposable
     {
         public AutomationHostReviewPreflightWorkspace()
         {
             RootPath = Directory.CreateTempSubdirectory("automation-host-review-preflight-tests-").FullName;
-            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            WriteInstalledCliScript(stalePrTransition: false);
             Context = new CliContext
             {
                 RepoRoot = RootPath,
@@ -373,6 +431,40 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
         public string RootPath { get; }
 
         public CliContext Context { get; }
+
+        public void WriteInstalledCliScript(bool stalePrTransition)
+        {
+            var binPath = Path.Combine(RootPath, ".intent-cli", "bin");
+            Directory.CreateDirectory(binPath);
+            var scriptPath = Path.Combine(binPath, "intent-cli");
+            var prTransitionBlock = stalePrTransition
+                ? "  echo \"Command 'automation pr-transition' is not yet implemented.\"\n  exit 1\n"
+                : "  echo 'automation pr-transition'\n  echo 'review-start'\n  echo 'request-update'\n  echo 'approved'\n  exit 0\n";
+            File.WriteAllText(
+                scriptPath,
+                "#!/bin/sh\n"
+                + "case \"$*\" in\n"
+                + "  'automation summary --help') echo 'automation summary'; exit 0 ;;\n"
+                + "  'automation host-review-preflight --help') echo 'automation host-review-preflight'; exit 0 ;;\n"
+                + "  'automation issue-publish --help') echo 'automation issue-publish'; exit 0 ;;\n"
+                + "  'automation pr-transition --help')\n"
+                + prTransitionBlock
+                + "    ;;\n"
+                + "  *) echo \"unexpected probe: $*\"; exit 1 ;;\n"
+                + "esac\n");
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(
+                    scriptPath,
+                    UnixFileMode.UserRead
+                    | UnixFileMode.UserWrite
+                    | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead
+                    | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead
+                    | UnixFileMode.OtherExecute);
+            }
+        }
 
         public void Dispose()
         {


### PR DESCRIPTION
## Summary
- add an installed CLI surface probe used by automation doctor and host-review-preflight before host label transitions
- report stale-host-cli with the installed path and missing command surfaces for summary, host-review-preflight, issue-publish, and pr-transition transitions
- add read-only --help surfaces and update fallback-free docs/smoke guidance

Closes #571

## Verification
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~AutomationDoctorCommandTests|FullyQualifiedName~AutomationHostReviewPreflightCommandTests"
- git diff --check

Note: a full test-project run started before the final test isolation fix reported an unrelated existing temp-directory cleanup failure in RunFixCommandTests and one stale pre-patch failure; the focused slice tests pass after the fix.