### PR TITLE
G234 Document host-local CLI refresh path

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -60,6 +60,61 @@ required installed surfaces as available: `automation summary`,
 surface, abort and refresh the installed CLI; do not substitute raw
 `gh` label mutation.
 
+### Refreshing the host-local installed CLI
+
+When the parent host has a newer `submodules/intent-system` checkout
+than the wrapper under `.intent-cli/bin/intent-cli`, refresh the
+host-local CLI from the host root. This is the supported local install
+path for host automation command surfaces:
+
+```bash
+cd "$HOST_ROOT"
+export CHILD_INTENT_SYSTEM="$HOST_ROOT/submodules/intent-system"
+
+git -C "$CHILD_INTENT_SYSTEM" rev-parse --show-toplevel
+dotnet pack "$CHILD_INTENT_SYSTEM/src/IntentSystem.Cli/IntentSystem.Cli.csproj" \
+  -o "$HOST_ROOT/.intent-cli/packages"
+
+mkdir -p "$HOST_ROOT/.intent-cli/bin"
+cat > "$HOST_ROOT/.intent-cli/bin/intent-cli.tmp" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+HOST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec dotnet tool exec \
+  --yes \
+  --source "$HOST_ROOT/.intent-cli/packages" \
+  --version 0.1.0 \
+  intent-cli \
+  "$@"
+EOF
+chmod +x "$HOST_ROOT/.intent-cli/bin/intent-cli.tmp"
+mv "$HOST_ROOT/.intent-cli/bin/intent-cli.tmp" "$HOST_ROOT/.intent-cli/bin/intent-cli"
+```
+
+Run the refresh from the parent host root, not from an arbitrary child
+worktree. The package source is the host's checked-out
+`submodules/intent-system`; the wrapper target is the host-local
+`.intent-cli/bin/intent-cli`. Do not write this wrapper into child
+implementation worktrees, and do not commit generated packages or other
+local install artifacts from `.intent-cli/packages`.
+
+After refreshing, verify the installed command surfaces before any label
+transition:
+
+```bash
+"$HOST_ROOT/.intent-cli/bin/intent-cli" automation doctor --format json \
+  | jq '{status, installedCliPath, unavailable: [.requiredCommands[] | select(.available == false)]}'
+
+"$HOST_ROOT/.intent-cli/bin/intent-cli" automation host-review-preflight \
+  --repo "$CHILD_REPO" \
+  --format json \
+  | jq '{action, installedCliPath, warnings}'
+```
+
+Both commands must succeed without unavailable command surfaces. If they
+still report `stale-host-cli`, stop and repair the local install; do not
+fall back to raw GitHub label mutation.
+
 Supported installed transitions:
 
 ```bash

--- a/docs/automation-templates/dry-run-checklist.md
+++ b/docs/automation-templates/dry-run-checklist.md
@@ -182,6 +182,46 @@ the runbook and refresh the wrapper/tool before using host runbooks; do
 not fall back to raw `gh issue edit` or `gh pr edit` label mutation for
 installed transitions.
 
+### Refresh stale host-local CLI
+
+If the availability check fails because the host-local
+`.intent-cli/bin/intent-cli` is stale, refresh it from the host root and
+the host's current child source checkout:
+
+```bash
+cd "$HOST_ROOT"
+export CHILD_INTENT_SYSTEM="$HOST_ROOT/submodules/intent-system"
+
+git -C "$CHILD_INTENT_SYSTEM" rev-parse --show-toplevel
+dotnet pack "$CHILD_INTENT_SYSTEM/src/IntentSystem.Cli/IntentSystem.Cli.csproj" \
+  -o "$HOST_ROOT/.intent-cli/packages"
+
+mkdir -p "$HOST_ROOT/.intent-cli/bin"
+cat > "$HOST_ROOT/.intent-cli/bin/intent-cli.tmp" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+HOST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec dotnet tool exec \
+  --yes \
+  --source "$HOST_ROOT/.intent-cli/packages" \
+  --version 0.1.0 \
+  intent-cli \
+  "$@"
+EOF
+chmod +x "$HOST_ROOT/.intent-cli/bin/intent-cli.tmp"
+mv "$HOST_ROOT/.intent-cli/bin/intent-cli.tmp" "$HOST_ROOT/.intent-cli/bin/intent-cli"
+```
+
+This refresh is worktree-safe when run from the parent host root: it
+packs the host's `submodules/intent-system` source and replaces only the
+host-local wrapper. It must not write into child implementation
+worktrees. Keep generated packages and wrapper artifacts out of child
+repo commits.
+
+Re-run the availability check immediately after refresh. If it still
+reports `stale-host-cli`, stop and repair the local install; do not
+continue to transition labels by hand.
+
 ### Host review target preflight
 
 ```bash

--- a/docs/automation-templates/host-next-slice-loop.md
+++ b/docs/automation-templates/host-next-slice-loop.md
@@ -147,7 +147,9 @@ Dry-run the same command without `--write` to capture the planned
 `intent-target` label action and JSON publish metadata before mutation.
 Raw `gh issue edit` label mutation is not the normal path for this
 installed transition. If the command is missing or stale, refresh the
-installed CLI before mutating labels.
+installed CLI using
+[`README.md`](./README.md#refreshing-the-host-local-installed-cli)
+before mutating labels.
 
 ## What this template forbids
 

--- a/docs/automation-templates/host-review-loop.md
+++ b/docs/automation-templates/host-review-loop.md
@@ -131,8 +131,11 @@ The preflight is read-only. It must report the required
 `intent-cli automation pr-transition` command surface, including
 `review-start`, `request-update`, and `approved`, before the host loop
 attempts a GitHub label mutation. If either preflight reports a stale or
-missing command surface, stop and refresh the installed CLI; do not fall
-back to raw `gh pr edit` label mutation for installed transitions.
+missing command surface, stop and refresh the installed CLI using the
+host-local procedure in
+[`README.md`](./README.md#refreshing-the-host-local-installed-cli);
+do not fall back to raw `gh pr edit` label mutation for installed
+transitions.
 
 Choose ONE of the following review verdicts. Each has an explicit
 label transition. For host-owned review-start, request-update, and

--- a/ops/intent-automation-label-state-machine.md
+++ b/ops/intent-automation-label-state-machine.md
@@ -103,6 +103,17 @@ command-only host runbooks. The smoke path uses `automation doctor`,
 `--write` only after the host publish/claim/verdict boundary is valid
 for the real issue or PR being transitioned.
 
+If the smoke path reports `stale-host-cli`, refresh the host-local
+`.intent-cli/bin/intent-cli` wrapper from the parent host root using the
+current `submodules/intent-system` checkout. The supported refresh is:
+pack `src/IntentSystem.Cli/IntentSystem.Cli.csproj` into
+`$HOST_ROOT/.intent-cli/packages`, replace only
+`$HOST_ROOT/.intent-cli/bin/intent-cli` with a wrapper that executes
+`dotnet tool exec --yes --source "$HOST_ROOT/.intent-cli/packages"
+--version 0.1.0 intent-cli "$@"`, then rerun `automation doctor` and
+`automation host-review-preflight`. Do not continue with raw `gh`
+label mutation while the installed command surface is stale.
+
 ## 1. Issue Runner
 
 The issue runner owns the Issue-to-PR transition.


### PR DESCRIPTION
## Summary
- document the supported host-local .intent-cli/bin/intent-cli refresh procedure from submodules/intent-system
- add worktree-safe wrapper replacement guidance and post-refresh verification commands
- cross-link host review, next-slice, dry-run, and ops guidance while preserving abort-not-fallback semantics

Closes #573

## Verification
- rg -n 'stale-host-cli|refreshing-the-host-local-installed-cli|dotnet tool exec|\.intent-cli/bin/intent-cli|raw Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility`' docs/automation-templates ops/intent-automation-label-state-machine.md
- git diff --check