### PR TITLE
G236 Make host-local CLI refresh install current automation surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,23 @@ The CLI is packaged as a .NET tool with:
 Local package smoke path:
 
 ```bash
-dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -o .artifacts/packages
+export INTENT_CLI_LOCAL_VERSION="0.1.0-local.$(date -u +%Y%m%d%H%M%S)"
+dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
+  -p:Version="$INTENT_CLI_LOCAL_VERSION" \
+  -o .artifacts/packages
 mkdir -p .artifacts/smoke-repo/.intent-cli
 cat > .artifacts/smoke-repo/.intent-cli/config.toml <<'EOF'
 default_domain = "intent-cli"
 artifact_root = ".intent-cli"
 worktree_root = ".intent-cli/worktrees"
 EOF
-(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version 0.1.0 intent-cli project status)
+(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version "$INTENT_CLI_LOCAL_VERSION" intent-cli project status)
 ```
 
 Equivalent `dnx` path:
 
 ```bash
-(cd .artifacts/smoke-repo && dnx --yes --source ../packages --version 0.1.0 intent-cli project status)
+(cd .artifacts/smoke-repo && dnx --yes --source ../packages --version "$INTENT_CLI_LOCAL_VERSION" intent-cli project status)
 ```
 
 ## CLI command roles

--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -89,23 +89,7 @@ cd "$HOST_ROOT"
 export CHILD_INTENT_SYSTEM="$HOST_ROOT/submodules/intent-system"
 
 git -C "$CHILD_INTENT_SYSTEM" rev-parse --show-toplevel
-dotnet pack "$CHILD_INTENT_SYSTEM/src/IntentSystem.Cli/IntentSystem.Cli.csproj" \
-  -o "$HOST_ROOT/.intent-cli/packages"
-
-mkdir -p "$HOST_ROOT/.intent-cli/bin"
-cat > "$HOST_ROOT/.intent-cli/bin/intent-cli.tmp" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-HOST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-exec dotnet tool exec \
-  --yes \
-  --source "$HOST_ROOT/.intent-cli/packages" \
-  --version 0.1.0 \
-  intent-cli \
-  "$@"
-EOF
-chmod +x "$HOST_ROOT/.intent-cli/bin/intent-cli.tmp"
-mv "$HOST_ROOT/.intent-cli/bin/intent-cli.tmp" "$HOST_ROOT/.intent-cli/bin/intent-cli"
+"$CHILD_INTENT_SYSTEM/ops/refresh-host-local-intent-cli.sh" "$HOST_ROOT"
 ```
 
 Run the refresh from the parent host root, not from an arbitrary child
@@ -115,12 +99,23 @@ worktree. The package source is the host's checked-out
 implementation worktrees, and do not commit generated packages or other
 local install artifacts from `.intent-cli/packages`.
 
+The refresh script packs the current child checkout with a unique local
+version such as `0.1.0-local.<utc-stamp>.<pid>.g<child-sha>`, removes
+older host-local `intent-cli.*.nupkg` files from `.intent-cli/packages`,
+and writes a wrapper pinned to that exact local version. Do not use a
+fixed `--version 0.1.0` wrapper for host-local automation refreshes; it
+can resolve a stale .NET tool package cache that does not contain the
+current `automation` command group.
+
 After refreshing, verify the installed command surfaces before any label
 transition:
 
 ```bash
 "$HOST_ROOT/.intent-cli/bin/intent-cli" automation doctor --format json \
-  | jq '{status, installedCliPath, unavailable: [.requiredCommands[] | select(.available == false)]}'
+  | jq '{status, installedCliPath, surface: .automationCommandSurfaceVersion, unavailable: [.requiredCommands[] | select(.available == false)]}'
+
+"$HOST_ROOT/.intent-cli/bin/intent-cli" automation summary --format json \
+  | jq '{surface: .automationCommandSurfaceVersion, capabilities: [.automationCommandCapabilities[] | .name]}'
 
 "$HOST_ROOT/.intent-cli/bin/intent-cli" automation host-review-preflight \
   --repo "$CHILD_REPO" \
@@ -129,8 +124,10 @@ transition:
 ```
 
 Both commands must succeed without unavailable command surfaces. If they
-still report `stale-host-cli`, stop and repair the local install; do not
-fall back to raw GitHub label mutation.
+still report `stale-host-cli`, if `automationCommandSurfaceVersion` is
+missing, or if `automation pr-transition --help` is not recognized, stop
+and repair the local install; do not fall back to raw GitHub label
+mutation.
 
 Supported installed transitions:
 

--- a/docs/automation-templates/dry-run-checklist.md
+++ b/docs/automation-templates/dry-run-checklist.md
@@ -203,34 +203,22 @@ cd "$HOST_ROOT"
 export CHILD_INTENT_SYSTEM="$HOST_ROOT/submodules/intent-system"
 
 git -C "$CHILD_INTENT_SYSTEM" rev-parse --show-toplevel
-dotnet pack "$CHILD_INTENT_SYSTEM/src/IntentSystem.Cli/IntentSystem.Cli.csproj" \
-  -o "$HOST_ROOT/.intent-cli/packages"
-
-mkdir -p "$HOST_ROOT/.intent-cli/bin"
-cat > "$HOST_ROOT/.intent-cli/bin/intent-cli.tmp" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-HOST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-exec dotnet tool exec \
-  --yes \
-  --source "$HOST_ROOT/.intent-cli/packages" \
-  --version 0.1.0 \
-  intent-cli \
-  "$@"
-EOF
-chmod +x "$HOST_ROOT/.intent-cli/bin/intent-cli.tmp"
-mv "$HOST_ROOT/.intent-cli/bin/intent-cli.tmp" "$HOST_ROOT/.intent-cli/bin/intent-cli"
+"$CHILD_INTENT_SYSTEM/ops/refresh-host-local-intent-cli.sh" "$HOST_ROOT"
 ```
 
 This refresh is worktree-safe when run from the parent host root: it
 packs the host's `submodules/intent-system` source and replaces only the
 host-local wrapper. It must not write into child implementation
 worktrees. Keep generated packages and wrapper artifacts out of child
-repo commits.
+repo commits. The script uses a unique local package version derived
+from the current child checkout and pins the wrapper to that version, so
+`dotnet tool exec` does not resolve a stale fixed `0.1.0` tool package.
 
 Re-run the availability check immediately after refresh. If it still
-reports `stale-host-cli`, stop and repair the local install; do not
-continue to transition labels by hand.
+reports `stale-host-cli`, if `automationCommandSurfaceVersion` is
+missing from `automation summary --format json`, or if
+`automation pr-transition --help` is not recognized, stop and repair the
+local install; do not continue to transition labels by hand.
 
 ### Host review target preflight
 

--- a/ops/intent-automation-label-state-machine.md
+++ b/ops/intent-automation-label-state-machine.md
@@ -106,13 +106,14 @@ for the real issue or PR being transitioned.
 If the smoke path reports `stale-host-cli`, refresh the host-local
 `.intent-cli/bin/intent-cli` wrapper from the parent host root using the
 current `submodules/intent-system` checkout. The supported refresh is:
-pack `src/IntentSystem.Cli/IntentSystem.Cli.csproj` into
-`$HOST_ROOT/.intent-cli/packages`, replace only
-`$HOST_ROOT/.intent-cli/bin/intent-cli` with a wrapper that executes
-`dotnet tool exec --yes --source "$HOST_ROOT/.intent-cli/packages"
---version 0.1.0 intent-cli "$@"`, then rerun `automation doctor` and
-`automation host-review-preflight`. Do not continue with raw `gh`
-label mutation while the installed command surface is stale.
+run
+`$HOST_ROOT/submodules/intent-system/ops/refresh-host-local-intent-cli.sh "$HOST_ROOT"`.
+The script packs the current child checkout with a unique local version,
+replaces only `$HOST_ROOT/.intent-cli/bin/intent-cli`, verifies
+`automationCommandSurfaceVersion`, and verifies `automation
+pr-transition --help`. Then rerun `automation doctor` and `automation
+host-review-preflight`. Do not continue with raw `gh` label mutation
+while the installed command surface is stale.
 
 ## 1. Issue Runner
 

--- a/ops/refresh-host-local-intent-cli.sh
+++ b/ops/refresh-host-local-intent-cli.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: refresh-host-local-intent-cli.sh [HOST_ROOT]
+
+Refresh HOST_ROOT/.intent-cli/bin/intent-cli from the current intent-system
+checkout. HOST_ROOT defaults to $HOST_ROOT when set, otherwise the current
+directory. CHILD_INTENT_SYSTEM may override the child checkout path.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+HOST_ROOT_INPUT="${1:-${HOST_ROOT:-$(pwd)}}"
+HOST_ROOT="$(cd "$HOST_ROOT_INPUT" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHILD_INTENT_SYSTEM="${CHILD_INTENT_SYSTEM:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+CHILD_INTENT_SYSTEM="$(cd "$CHILD_INTENT_SYSTEM" && pwd)"
+
+PROJECT_PATH="$CHILD_INTENT_SYSTEM/src/IntentSystem.Cli/IntentSystem.Cli.csproj"
+PACKAGES_DIR="$HOST_ROOT/.intent-cli/packages"
+BIN_DIR="$HOST_ROOT/.intent-cli/bin"
+WRAPPER_PATH="$BIN_DIR/intent-cli"
+
+if [[ ! -f "$PROJECT_PATH" ]]; then
+  echo "intent-cli project not found: $PROJECT_PATH" >&2
+  exit 1
+fi
+
+CHILD_SHA="$(git -C "$CHILD_INTENT_SYSTEM" rev-parse --short=12 HEAD)"
+LOCAL_STAMP="$(date -u +%Y%m%d%H%M%S)"
+INTENT_CLI_LOCAL_VERSION="${INTENT_CLI_LOCAL_VERSION:-0.1.0-local.$LOCAL_STAMP.$$.g$CHILD_SHA}"
+
+if [[ "$INTENT_CLI_LOCAL_VERSION" == "0.1.0" ]]; then
+  echo "INTENT_CLI_LOCAL_VERSION must not be the fixed package version 0.1.0." >&2
+  exit 1
+fi
+
+mkdir -p "$PACKAGES_DIR" "$BIN_DIR"
+find "$PACKAGES_DIR" -maxdepth 1 -type f -name 'intent-cli.*.nupkg' -delete
+
+dotnet pack "$PROJECT_PATH" \
+  -p:Version="$INTENT_CLI_LOCAL_VERSION" \
+  -o "$PACKAGES_DIR"
+
+cat > "$WRAPPER_PATH.tmp" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+HOST_ROOT="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")/../.." && pwd)"
+INTENT_CLI_LOCAL_VERSION="$INTENT_CLI_LOCAL_VERSION"
+exec dotnet tool exec \\
+  --yes \\
+  --source "\$HOST_ROOT/.intent-cli/packages" \\
+  --version "\$INTENT_CLI_LOCAL_VERSION" \\
+  intent-cli \\
+  "\$@"
+EOF
+
+chmod +x "$WRAPPER_PATH.tmp"
+mv "$WRAPPER_PATH.tmp" "$WRAPPER_PATH"
+
+SUMMARY_OUTPUT="$("$WRAPPER_PATH" automation summary --format json)"
+if [[ "$SUMMARY_OUTPUT" != *'"automationCommandSurfaceVersion"'* ]]; then
+  echo "refreshed wrapper did not emit automationCommandSurfaceVersion." >&2
+  exit 1
+fi
+
+"$WRAPPER_PATH" automation pr-transition --help >/dev/null
+
+echo "Refreshed $WRAPPER_PATH"
+echo "Package version: $INTENT_CLI_LOCAL_VERSION"
+echo "Child checkout: $CHILD_INTENT_SYSTEM@$CHILD_SHA"

--- a/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
@@ -44,8 +44,9 @@ public sealed class PackagedInvocationSmokeTests
 
             var packOutputPath = tempDirectory.GetPath("pack.stdout.txt");
             var packErrorPath = tempDirectory.GetPath("pack.stderr.txt");
+            var packageVersion = CreateLocalPackageVersion();
             var packResult = RunShellCommand(
-                $"dotnet pack {QuoteForShell(Path.Combine(GetSolutionRoot(), "src", "IntentSystem.Cli", "IntentSystem.Cli.csproj"))} -o {QuoteForShell(packageOutputDirectory)} > {QuoteForShell(packOutputPath)} 2> {QuoteForShell(packErrorPath)}",
+                $"dotnet pack {QuoteForShell(Path.Combine(GetSolutionRoot(), "src", "IntentSystem.Cli", "IntentSystem.Cli.csproj"))} -p:Version={QuoteForShell(packageVersion)} -o {QuoteForShell(packageOutputDirectory)} > {QuoteForShell(packOutputPath)} 2> {QuoteForShell(packErrorPath)}",
                 GetSolutionRoot());
 
             var packLog = File.ReadAllText(packOutputPath) + File.ReadAllText(packErrorPath);
@@ -56,7 +57,7 @@ public sealed class PackagedInvocationSmokeTests
             var invokeOutputPath = tempDirectory.GetPath("invoke.stdout.txt");
             var invokeErrorPath = tempDirectory.GetPath("invoke.stderr.txt");
             var invokeResult = RunShellCommand(
-                $"dotnet tool exec --yes --source {QuoteForShell(packageOutputDirectory)} --version 0.1.0 intent-cli project status > {QuoteForShell(invokeOutputPath)} 2> {QuoteForShell(invokeErrorPath)}",
+                $"dotnet tool exec --yes --source {QuoteForShell(packageOutputDirectory)} --version {QuoteForShell(packageVersion)} intent-cli project status > {QuoteForShell(invokeOutputPath)} 2> {QuoteForShell(invokeErrorPath)}",
                 fixtureRoot);
 
             var invokeOutput = File.ReadAllText(invokeOutputPath);
@@ -70,14 +71,80 @@ public sealed class PackagedInvocationSmokeTests
     }
 
     [Fact]
+    public void DotnetToolExec_RunsPackagedAutomationSurfaceWithUniqueLocalVersion()
+    {
+        lock (ProcessStateLock)
+        {
+            using var tempDirectory = new TemporaryDirectory();
+            var packageOutputDirectory = tempDirectory.CreateDirectory("packages");
+            var fixtureRoot = tempDirectory.CreateDirectory(Path.Combine("smoke-repo"));
+            tempDirectory.CreateDirectory(Path.Combine("smoke-repo", ".intent-cli"));
+            tempDirectory.CreateFile(
+                Path.Combine("smoke-repo", ".intent-cli", "config.toml"),
+                """
+                default_domain = "intent-cli"
+                artifact_root = ".intent-cli"
+                worktree_root = ".intent-cli/worktrees"
+                """);
+
+            var packageVersion = CreateLocalPackageVersion();
+            var packResult = RunShellCommand(
+                $"dotnet pack {QuoteForShell(Path.Combine(GetSolutionRoot(), "src", "IntentSystem.Cli", "IntentSystem.Cli.csproj"))} -p:Version={QuoteForShell(packageVersion)} -o {QuoteForShell(packageOutputDirectory)} > {QuoteForShell(tempDirectory.GetPath("pack.stdout.txt"))} 2> {QuoteForShell(tempDirectory.GetPath("pack.stderr.txt"))}",
+                GetSolutionRoot());
+
+            Assert.Equal(0, packResult.ExitCode);
+
+            var summaryOutputPath = tempDirectory.GetPath("summary.stdout.txt");
+            var summaryErrorPath = tempDirectory.GetPath("summary.stderr.txt");
+            var summaryResult = RunShellCommand(
+                $"dotnet tool exec --yes --source {QuoteForShell(packageOutputDirectory)} --version {QuoteForShell(packageVersion)} intent-cli automation summary --format json > {QuoteForShell(summaryOutputPath)} 2> {QuoteForShell(summaryErrorPath)}",
+                fixtureRoot);
+
+            var summaryOutput = File.ReadAllText(summaryOutputPath);
+            var summaryError = File.ReadAllText(summaryErrorPath);
+
+            Assert.Equal(0, summaryResult.ExitCode);
+            Assert.Contains("\"automationCommandSurfaceVersion\"", summaryOutput, StringComparison.Ordinal);
+            Assert.Contains("\"automationCommandCapabilities\"", summaryOutput, StringComparison.Ordinal);
+            Assert.Equal(string.Empty, summaryError.Trim(), ignoreCase: false);
+
+            var prTransitionHelpErrorPath = tempDirectory.GetPath("pr-transition.stderr.txt");
+            var prTransitionHelpResult = RunShellCommand(
+                $"dotnet tool exec --yes --source {QuoteForShell(packageOutputDirectory)} --version {QuoteForShell(packageVersion)} intent-cli automation pr-transition --help > {QuoteForShell(tempDirectory.GetPath("pr-transition.stdout.txt"))} 2> {QuoteForShell(prTransitionHelpErrorPath)}",
+                fixtureRoot);
+
+            var prTransitionHelpError = File.ReadAllText(prTransitionHelpErrorPath);
+
+            Assert.Equal(0, prTransitionHelpResult.ExitCode);
+            Assert.Equal(string.Empty, prTransitionHelpError.Trim(), ignoreCase: false);
+        }
+    }
+
+    [Fact]
     public void Readme_DocumentsHermeticPackagedInvocationPaths()
     {
         var readme = File.ReadAllText(Path.Combine(GetSolutionRoot(), "README.md"));
 
         Assert.Contains("mkdir -p .artifacts/smoke-repo/.intent-cli", readme, StringComparison.Ordinal);
         Assert.Contains("cat > .artifacts/smoke-repo/.intent-cli/config.toml <<'EOF'", readme, StringComparison.Ordinal);
-        Assert.Contains("(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version 0.1.0 intent-cli project status)", readme, StringComparison.Ordinal);
-        Assert.Contains("(cd .artifacts/smoke-repo && dnx --yes --source ../packages --version 0.1.0 intent-cli project status)", readme, StringComparison.Ordinal);
+        Assert.Contains("export INTENT_CLI_LOCAL_VERSION=\"0.1.0-local.$(date -u +%Y%m%d%H%M%S)\"", readme, StringComparison.Ordinal);
+        Assert.Contains("(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version \"$INTENT_CLI_LOCAL_VERSION\" intent-cli project status)", readme, StringComparison.Ordinal);
+        Assert.Contains("(cd .artifacts/smoke-repo && dnx --yes --source ../packages --version \"$INTENT_CLI_LOCAL_VERSION\" intent-cli project status)", readme, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HostRefreshScript_UsesUniqueLocalVersionAndVerifiesAutomationSurface()
+    {
+        var script = File.ReadAllText(Path.Combine(GetSolutionRoot(), "ops", "refresh-host-local-intent-cli.sh"));
+
+        Assert.Contains("0.1.0-local.$LOCAL_STAMP.$$.g$CHILD_SHA", script, StringComparison.Ordinal);
+        Assert.Contains("-p:Version=\"$INTENT_CLI_LOCAL_VERSION\"", script, StringComparison.Ordinal);
+        Assert.Contains("--version \"\\$INTENT_CLI_LOCAL_VERSION\"", script, StringComparison.Ordinal);
+        Assert.Contains("find \"$PACKAGES_DIR\" -maxdepth 1 -type f -name 'intent-cli.*.nupkg' -delete", script, StringComparison.Ordinal);
+        Assert.Contains("automation summary --format json", script, StringComparison.Ordinal);
+        Assert.Contains("\"automationCommandSurfaceVersion\"", script, StringComparison.Ordinal);
+        Assert.Contains("automation pr-transition --help", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("--version 0.1.0", script, StringComparison.Ordinal);
     }
 
     private static ProcessResult RunShellCommand(string script, string workingDirectory)
@@ -118,6 +185,11 @@ public sealed class PackagedInvocationSmokeTests
     private static string QuoteForShell(string value)
     {
         return $"'{value.Replace("'", "'\"'\"'")}'";
+    }
+
+    private static string CreateLocalPackageVersion()
+    {
+        return $"0.1.0-local.{Guid.NewGuid():N}";
     }
 
     private sealed record ProcessResult(int ExitCode);


### PR DESCRIPTION
## Summary
- Add `ops/refresh-host-local-intent-cli.sh` to pack the current child checkout with a unique local version and pin the host wrapper to it
- Remove the stale fixed `--version 0.1.0` host refresh path from automation docs/templates
- Extend package smoke coverage to verify packaged automation summary capability JSON and `automation pr-transition` availability with unique local versions

Closes #577

## Verification
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~PackagedInvocationSmokeTests"
- git diff --check
- bash -n ops/refresh-host-local-intent-cli.sh
- HOST_TMP="$(mktemp -d)" && ops/refresh-host-local-intent-cli.sh "$HOST_TMP" && "$HOST_TMP/.intent-cli/bin/intent-cli" automation summary --format json | rg "\"automationCommandSurfaceVersion\"" && "$HOST_TMP/.intent-cli/bin/intent-cli" automation pr-transition --help >/dev/null