### PR TITLE
G238 Make host automation runbook consume capability JSON before transitions

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -108,14 +108,14 @@ can resolve a stale .NET tool package cache that does not contain the
 current `automation` command group.
 
 After refreshing, verify the installed command surfaces before any label
-transition:
+transition by reading the capability JSON:
 
 ```bash
 "$HOST_ROOT/.intent-cli/bin/intent-cli" automation doctor --format json \
   | jq '{status, installedCliPath, surface: .automationCommandSurfaceVersion, unavailable: [.requiredCommands[] | select(.available == false)]}'
 
 "$HOST_ROOT/.intent-cli/bin/intent-cli" automation summary --format json \
-  | jq '{surface: .automationCommandSurfaceVersion, capabilities: [.automationCommandCapabilities[] | .name]}'
+  | jq '{surface: .automationCommandSurfaceVersion, capabilities: [.automationCommandCapabilities[] | .capability]}'
 
 "$HOST_ROOT/.intent-cli/bin/intent-cli" automation host-review-preflight \
   --repo "$CHILD_REPO" \
@@ -123,11 +123,21 @@ transition:
   | jq '{action, installedCliPath, warnings}'
 ```
 
-Both commands must succeed without unavailable command surfaces. If they
-still report `stale-host-cli`, if `automationCommandSurfaceVersion` is
-missing, or if `automation pr-transition --help` is not recognized, stop
-and repair the local install; do not fall back to raw GitHub label
-mutation.
+Required capability set (consume from `automationCommandCapabilities[]`):
+
+- `issue-publish`
+- `pr-transition.review-start`
+- `pr-transition.request-update`
+- `pr-transition.approved`
+
+Host runbooks MUST mechanically check that every required capability name
+is present in the JSON before any installed transition. If `doctor`
+reports `stale-host-cli`, if `automationCommandSurfaceVersion` is
+missing, or if any required capability is absent from
+`automationCommandCapabilities[]`, abort the runbook and refresh the
+installed CLI; do not fall back to raw GitHub label mutation, and do not
+infer command availability by reading `--help` text or other prose
+output.
 
 Supported installed transitions:
 

--- a/docs/automation-templates/dry-run-checklist.md
+++ b/docs/automation-templates/dry-run-checklist.md
@@ -192,6 +192,14 @@ the runbook and refresh the wrapper/tool before using host runbooks; do
 not fall back to raw `gh issue edit` or `gh pr edit` label mutation for
 installed transitions.
 
+The runbook MUST also abort when `automationCommandCapabilities[]` is
+missing any of the required capability names — `issue-publish`,
+`pr-transition.review-start`, `pr-transition.request-update`,
+`pr-transition.approved` — even if `status` is `ok`. Capability presence
+is checked mechanically by name against the JSON; do not infer
+availability from `--help` output, prose summaries, or runbook
+paragraphs.
+
 ### Refresh stale host-local CLI
 
 If the availability check fails because the host-local
@@ -216,9 +224,12 @@ from the current child checkout and pins the wrapper to that version, so
 
 Re-run the availability check immediately after refresh. If it still
 reports `stale-host-cli`, if `automationCommandSurfaceVersion` is
-missing from `automation summary --format json`, or if
-`automation pr-transition --help` is not recognized, stop and repair the
-local install; do not continue to transition labels by hand.
+missing from `automation summary --format json`, or if any required
+capability name (`issue-publish`, `pr-transition.review-start`,
+`pr-transition.request-update`, `pr-transition.approved`) is absent from
+`automationCommandCapabilities[]`, stop and repair the local install; do
+not continue to transition labels by hand, and do not infer command
+availability from `--help` text.
 
 ### Host review target preflight
 

--- a/docs/automation-templates/host-next-slice-loop.md
+++ b/docs/automation-templates/host-next-slice-loop.md
@@ -143,13 +143,21 @@ intent-cli automation issue-publish \
   --format json
 ```
 
+Before invoking `--write`, mechanically check the capability JSON from
+`automation doctor --format json` (or `automation summary --format
+json`) and confirm `automationCommandCapabilities[]` contains
+`issue-publish`. If that capability is absent, if
+`automationCommandSurfaceVersion` is missing, or if `doctor` reports
+`stale-host-cli`, abort the publish step and refresh the installed CLI
+using
+[`README.md`](./README.md#refreshing-the-host-local-installed-cli)
+before mutating labels; do not fall back to raw `gh issue edit` label
+mutation, and do not infer command availability from `--help` output.
+
 Dry-run the same command without `--write` to capture the planned
 `intent-target` label action and JSON publish metadata before mutation.
 Raw `gh issue edit` label mutation is not the normal path for this
-installed transition. If the command is missing or stale, refresh the
-installed CLI using
-[`README.md`](./README.md#refreshing-the-host-local-installed-cli)
-before mutating labels.
+installed transition.
 
 ## What this template forbids
 

--- a/docs/automation-templates/host-review-loop.md
+++ b/docs/automation-templates/host-review-loop.md
@@ -127,15 +127,23 @@ intent-cli automation host-review-preflight \
   --format json
 ```
 
-The preflight is read-only. It must report the required
-`intent-cli automation pr-transition` command surface, including
-`review-start`, `request-update`, and `approved`, before the host loop
-attempts a GitHub label mutation. If either preflight reports a stale or
-missing command surface, stop and refresh the installed CLI using the
-host-local procedure in
+The preflight is read-only. Before the host loop attempts a GitHub
+label mutation it MUST mechanically check the capability JSON emitted by
+`automation doctor --format json` (or `automation summary --format json`)
+and confirm that `automationCommandCapabilities[]` contains every
+required capability name for this loop:
+
+- `pr-transition.review-start`
+- `pr-transition.request-update`
+- `pr-transition.approved`
+
+If `automationCommandSurfaceVersion` is missing, if either preflight
+reports `stale-host-cli`, or if any required capability above is absent
+from the JSON, stop and refresh the installed CLI using the host-local
+procedure in
 [`README.md`](./README.md#refreshing-the-host-local-installed-cli);
 do not fall back to raw `gh pr edit` label mutation for installed
-transitions.
+transitions, and do not infer command availability from `--help` text.
 
 Choose ONE of the following review verdicts. Each has an explicit
 label transition. For host-owned review-start, request-update, and

--- a/ops/intent-automation-label-state-machine.md
+++ b/ops/intent-automation-label-state-machine.md
@@ -92,8 +92,15 @@ transition mutation. These checks must name the host-local installed CLI
 path and fail with stale/missing surface detail before mutation when
 `automation summary`, `automation host-review-preflight`,
 `automation issue-publish`, or any `automation pr-transition`
-transition is unavailable. `intent-pr-created` remains issue-only and
-must not be applied to PRs by installed commands or fallback paths.
+transition is unavailable. Host runbooks consume the capability JSON
+emitted by `automation summary --format json` (or the same fields under
+`automation doctor --format json`) and abort before mutation when
+`automationCommandCapabilities[]` is missing any of `issue-publish`,
+`pr-transition.review-start`, `pr-transition.request-update`, or
+`pr-transition.approved`. Do not infer command availability by parsing
+`--help` text or other prose output. `intent-pr-created` remains
+issue-only and must not be applied to PRs by installed commands or
+fallback paths.
 
 For local smoke testing, run the dry-run examples in
 `docs/automation-templates/dry-run-checklist.md` before enabling
@@ -109,11 +116,14 @@ current `submodules/intent-system` checkout. The supported refresh is:
 run
 `$HOST_ROOT/submodules/intent-system/ops/refresh-host-local-intent-cli.sh "$HOST_ROOT"`.
 The script packs the current child checkout with a unique local version,
-replaces only `$HOST_ROOT/.intent-cli/bin/intent-cli`, verifies
-`automationCommandSurfaceVersion`, and verifies `automation
-pr-transition --help`. Then rerun `automation doctor` and `automation
-host-review-preflight`. Do not continue with raw `gh` label mutation
-while the installed command surface is stale.
+replaces only `$HOST_ROOT/.intent-cli/bin/intent-cli`, and verifies the
+expected `automationCommandSurfaceVersion` together with the required
+`automationCommandCapabilities[]` entries (`issue-publish`,
+`pr-transition.review-start`, `pr-transition.request-update`,
+`pr-transition.approved`). Then rerun `automation doctor` and
+`automation host-review-preflight`. Do not continue with raw `gh` label
+mutation while the installed command surface is stale, and do not
+substitute `--help` or other prose checks for the capability JSON.
 
 ## 1. Issue Runner
 

--- a/ops/refresh-host-local-intent-cli.sh
+++ b/ops/refresh-host-local-intent-cli.sh
@@ -70,7 +70,18 @@ if [[ "$SUMMARY_OUTPUT" != *'"automationCommandSurfaceVersion"'* ]]; then
   exit 1
 fi
 
-"$WRAPPER_PATH" automation pr-transition --help >/dev/null
+REQUIRED_CAPABILITIES=(
+  "issue-publish"
+  "pr-transition.review-start"
+  "pr-transition.request-update"
+  "pr-transition.approved"
+)
+for capability in "${REQUIRED_CAPABILITIES[@]}"; do
+  if [[ "$SUMMARY_OUTPUT" != *"\"$capability\""* ]]; then
+    echo "refreshed wrapper missing required automation capability: $capability" >&2
+    exit 1
+  fi
+done
 
 echo "Refreshed $WRAPPER_PATH"
 echo "Package version: $INTENT_CLI_LOCAL_VERSION"

--- a/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
@@ -143,7 +143,11 @@ public sealed class PackagedInvocationSmokeTests
         Assert.Contains("find \"$PACKAGES_DIR\" -maxdepth 1 -type f -name 'intent-cli.*.nupkg' -delete", script, StringComparison.Ordinal);
         Assert.Contains("automation summary --format json", script, StringComparison.Ordinal);
         Assert.Contains("\"automationCommandSurfaceVersion\"", script, StringComparison.Ordinal);
-        Assert.Contains("automation pr-transition --help", script, StringComparison.Ordinal);
+        Assert.Contains("\"issue-publish\"", script, StringComparison.Ordinal);
+        Assert.Contains("\"pr-transition.review-start\"", script, StringComparison.Ordinal);
+        Assert.Contains("\"pr-transition.request-update\"", script, StringComparison.Ordinal);
+        Assert.Contains("\"pr-transition.approved\"", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("automation pr-transition --help", script, StringComparison.Ordinal);
         Assert.DoesNotContain("--version 0.1.0", script, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
Closes #579

## Summary

- Host automation runbooks and `ops/refresh-host-local-intent-cli.sh` now mechanically check `automationCommandCapabilities[]` against the required capability set (`issue-publish`, `pr-transition.review-start`, `pr-transition.request-update`, `pr-transition.approved`) before any installed transition, and abort when any required capability name is missing from the JSON.
- `automation pr-transition --help` is no longer used as a command-availability smoke. The refresh script now asserts each required capability name is present in `automation summary --format json` output, and the docs explicitly forbid inferring command availability from `--help` text or other prose.
- Templates retain the fallback-free policy: stale or missing capability surface aborts the runbook; raw `gh issue edit` / `gh pr edit` label mutation is still not a fallback.

Files touched:
- `docs/automation-templates/README.md`
- `docs/automation-templates/dry-run-checklist.md`
- `docs/automation-templates/host-review-loop.md`
- `docs/automation-templates/host-next-slice-loop.md`
- `ops/intent-automation-label-state-machine.md`
- `ops/refresh-host-local-intent-cli.sh`
- `tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs`

## Test plan

- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~PackagedInvocationSmokeTests.HostRefreshScript_UsesUniqueLocalVersionAndVerifiesAutomationSurface"` — passed.
- [x] `bash -n ops/refresh-host-local-intent-cli.sh` — syntax OK.
- [x] `git diff --check` — clean.