### PR TITLE
G240 Add intent-cli guide automation command

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -37,6 +37,7 @@ These templates assume:
 | G230  | `intent-cli automation pr-transition --transition review-start` | Robust absent-rereview-label cleanup |
 | G232  | host transition smoke examples | Read-only local verification before command-only host runbooks |
 | G239  | `intent-cli guide oneshot`              | Emit the current host or child one-shot prompt for manual single-wake operation |
+| G240  | `intent-cli guide automation`           | Emit the current recurring host-review or child implement/update automation setup prompt |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -197,7 +197,8 @@ internal static class CommandRouter
             },
             ["guide"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
-                ["oneshot"] = GuideOneshotCommand.Execute
+                ["oneshot"] = GuideOneshotCommand.Execute,
+                ["automation"] = GuideAutomationCommand.Execute
             }
         };
 

--- a/src/IntentSystem.Cli/Commands/GuideAutomationCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationCommand.cs
@@ -1,0 +1,392 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G240: Read-only <c>intent-cli guide automation</c> command. Emits the
+/// current recurring host review/next-slice or child implement/update
+/// automation setup prompt so operators do not need to manually open files
+/// under <c>intents/rules/automations</c>. The command never launches an AI
+/// provider and does not mutate queue state, runs, GitHub, packet files, or
+/// other on-disk state.
+/// </summary>
+internal static class GuideAutomationCommand
+{
+    private const string KindHostReview = "host-review";
+    private const string KindChildImplementUpdate = "child-implement-update";
+
+    private const string DomainIntentCli = "intent-cli";
+    private const string DomainSekibanAsAService = "sekiban-as-a-service";
+
+    private const string RepoIntentSystem = "J-Tech-Japan/intent-system";
+    private const string RepoSekibanAsAService = "J-Tech-Japan/SekibanAsAService";
+
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide automation --kind <host-review|child-implement-update> "
+        + "[--domain <intent-cli|sekiban-as-a-service>] [--repo <owner/repo>] [--format markdown]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var kind, out var domain, out var repo, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (!string.Equals(format, FormatMarkdown, StringComparison.Ordinal))
+        {
+            writer.WriteLine($"--format must be 'markdown' (got '{format}').");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        switch (kind)
+        {
+            case KindHostReview:
+                return EmitHostReviewPrompt(domain, writer);
+
+            case KindChildImplementUpdate:
+                return EmitChildImplementUpdatePrompt(repo, writer);
+
+            default:
+                writer.WriteLine(
+                    $"--kind must be '{KindHostReview}' or '{KindChildImplementUpdate}' (got '{kind}').");
+                writer.WriteLine(UsageLine);
+                return 1;
+        }
+    }
+
+    private static int EmitHostReviewPrompt(string? domain, TextWriter writer)
+    {
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            writer.WriteLine($"--domain is required for --kind {KindHostReview}.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var prompt = domain switch
+        {
+            DomainIntentCli => HostReviewIntentCliPrompt,
+            DomainSekibanAsAService => HostReviewSekibanAsAServicePrompt,
+            _ => null
+        };
+
+        if (prompt is null)
+        {
+            writer.WriteLine(
+                $"Unsupported --domain '{domain}'. Supported: {DomainIntentCli}, {DomainSekibanAsAService}.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        writer.WriteLine(prompt);
+        return 0;
+    }
+
+    private static int EmitChildImplementUpdatePrompt(string? repo, TextWriter writer)
+    {
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            writer.WriteLine($"--repo is required for --kind {KindChildImplementUpdate}.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (!string.Equals(repo, RepoIntentSystem, StringComparison.Ordinal)
+            && !string.Equals(repo, RepoSekibanAsAService, StringComparison.Ordinal))
+        {
+            writer.WriteLine(
+                $"Unsupported --repo '{repo}'. Supported: {RepoIntentSystem}, {RepoSekibanAsAService}.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        writer.WriteLine(ChildImplementUpdateHeader);
+        writer.WriteLine();
+        writer.WriteLine(ChildImplementUpdateBody);
+        writer.WriteLine();
+        writer.WriteLine($"## Notes for `{repo}`");
+        writer.WriteLine();
+        writer.WriteLine($"Run this loop from a `{repo}` child worktree root.");
+        return 0;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? kind,
+        out string? domain,
+        out string? repo,
+        out string format,
+        out string error)
+    {
+        kind = null;
+        domain = null;
+        repo = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--kind":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--kind requires a value.";
+                        return false;
+                    }
+
+                    kind = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domain = args[index + 1];
+                    index++;
+                    break;
+
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value.";
+                        return false;
+                    }
+
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown).";
+                        return false;
+                    }
+
+                    format = args[index + 1];
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(kind))
+        {
+            error = "--kind is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide automation");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Emits the current checked-in recurring automation setup prompt for the requested kind.");
+        writer.WriteLine();
+        writer.WriteLine("Supported kinds:");
+        writer.WriteLine($"- {KindHostReview} (requires --domain)");
+        writer.WriteLine($"- {KindChildImplementUpdate} (requires --repo)");
+        writer.WriteLine();
+        writer.WriteLine("Supported host domains:");
+        writer.WriteLine($"- {DomainIntentCli}");
+        writer.WriteLine($"- {DomainSekibanAsAService}");
+        writer.WriteLine();
+        writer.WriteLine("Supported child repos:");
+        writer.WriteLine($"- {RepoIntentSystem}");
+        writer.WriteLine($"- {RepoSekibanAsAService}");
+    }
+
+    internal const string HostReviewIntentCliPrompt =
+"""
+# Automation: Host Review & Next Slice — intent-cli
+
+Run MyIntentHost host-side review and next-slice on a recurring schedule. Each wake performs Stage 1 (review/closeout) then Stage 2 (next-slice). At most one PR review and at most one new child issue per wake.
+
+Cwd / repo:
+- host repo root: `/Users/tomohisa/dev/GitHub/MyIntentHost`
+- domain: `intent-cli`
+- child repo: `J-Tech-Japan/intent-system`
+- child submodule: `submodules/intent-system`
+
+Current baseline:
+- Use the host-local installed `intent-cli` on PATH or at `$HOST_ROOT/.intent-cli/bin/intent-cli`.
+- First run `intent-cli automation summary --format text` and use it as the label-contract source.
+- Use installed `intent-cli` commands for command surfaces that exist and work; do not invent raw `gh` fallback for intent-cli-owned transitions.
+- For steps not yet owned by installed `intent-cli`, follow `intents/rules/automations/host-review-loop.md` and existing checked-in rule docs.
+- `intent-cli` must not launch Claude, Codex, or any AI provider.
+
+Wake contract:
+1. `cd /Users/tomohisa/dev/GitHub/MyIntentHost`.
+2. Run `git pull --ff-only origin main`.
+3. Run `git submodule update --init submodules/intent-system`.
+4. Read `intents/intent-cli/automation/bindings.md` and `intents/rules/automations/host-review-loop.md`.
+5. Stage 1: review at most one open `intent-target` PR. Use `intent-cli automation host-review-preflight` and `intent-cli automation pr-transition` for supported transitions.
+6. If review passes: merge the PR, close the linked issue, sync the child submodule, update parent queue/runs.
+7. If review requires repair: leave an actionable PR comment and move the PR to `intent-pr-request-update` via the installed transition.
+8. Stage 2: run `intent-next-slice` planning. Honor the WIP cap — do not cut a new child issue while any open child issue/PR carries `intent-target`.
+9. If next-slice is clear and the WIP cap is empty, publish exactly one new child issue and apply `intent-target` only after parent state is durable.
+10. If clarification is required, stop and report: background, question, options, pros/cons, and recommendation.
+11. Commit and push parent host changes directly to `main` per `AGENTS.md`. Do not create a PR.
+
+Hard rules:
+- At most one PR review per wake; at most one issue cut per wake.
+- `intent-pr-created` is issue-only; never apply it to a PR.
+- `intent-target` is host-owned; the child loop never adds or removes it.
+- Stop on Hard Clarification rather than guessing when source-of-truth is ambiguous.
+
+Final report must include:
+- selected issue / PR or none
+- label transitions applied
+- review result
+- merge / closeout result
+- next issue created/published or not
+- clarification status
+- validation performed
+- commits pushed
+""";
+
+    internal const string HostReviewSekibanAsAServicePrompt =
+"""
+# Automation: Host Review & Next Slice — sekiban-as-a-service
+
+Run MyIntentHost host-side review and next-slice on a recurring schedule. Each wake performs Stage 1 (review/closeout) then Stage 2 (next-slice). At most one PR review and at most one new child issue per wake.
+
+Cwd / repo:
+- host repo root: `/Users/tomohisa/dev/GitHub/MyIntentHost`
+- domain: `sekiban-as-a-service`
+- child repo: `J-Tech-Japan/SekibanAsAService`
+- child submodule: `submodules/SekibanAsAService`
+
+Current baseline:
+- Use the host-local installed `intent-cli` on PATH or at `$HOST_ROOT/.intent-cli/bin/intent-cli`.
+- First run `intent-cli automation summary --format text` and use it as the label-contract source.
+- Use installed `intent-cli` commands for command surfaces that exist and work; do not invent raw `gh` fallback for intent-cli-owned transitions.
+- For steps not yet owned by installed `intent-cli`, follow `intents/rules/automations/host-review-loop.md` and existing checked-in rule docs.
+- `intent-cli` must not launch Claude, Codex, or any AI provider.
+
+Wake contract:
+1. `cd /Users/tomohisa/dev/GitHub/MyIntentHost`.
+2. Run `git pull --ff-only origin main`.
+3. Run `git submodule update --init submodules/SekibanAsAService`.
+4. Read `intents/sekiban-as-a-service/automation/bindings.md` and `intents/rules/automations/host-review-loop.md`.
+5. Stage 1: review at most one open `intent-target` PR. Use `intent-cli automation host-review-preflight` and `intent-cli automation pr-transition` for supported transitions.
+6. If review passes: merge the PR, close the linked issue, sync the child submodule, update parent queue/runs.
+7. If review requires repair: leave an actionable PR comment and move the PR to `intent-pr-request-update` via the installed transition.
+8. Stage 2: run `intent-next-slice` planning. Honor the WIP cap — do not cut a new child issue while any open child issue/PR carries `intent-target`.
+9. If next-slice is clear and the WIP cap is empty, publish exactly one new child issue and apply `intent-target` only after parent state is durable.
+10. If clarification is required, stop and report: background, question, options, pros/cons, and recommendation.
+11. Commit and push parent host changes directly to `main` per `AGENTS.md`. Do not create a PR.
+
+Hard rules:
+- At most one PR review per wake; at most one issue cut per wake.
+- `intent-pr-created` is issue-only; never apply it to a PR.
+- `intent-target` is host-owned; the child loop never adds or removes it.
+- Stop on Hard Clarification rather than guessing when source-of-truth is ambiguous.
+
+Final report must include:
+- selected issue / PR or none
+- label transitions applied
+- review result
+- merge / closeout result
+- next issue created/published or not
+- clarification status
+- validation performed
+- commits pushed
+""";
+
+    internal const string ChildImplementUpdateHeader = "# Automation: Child Implement & Update Loop";
+
+    internal const string ChildImplementUpdateBody =
+"""
+Run one wake of the child coding automation loop on a recurring schedule. Each wake handles at most one action.
+
+Assumptions:
+- Current working directory is the target repository worktree root.
+- `intent-cli` must be available on PATH.
+- The parent host root is `/Users/tomohisa/dev/GitHub/MyIntentHost`.
+- Use `gh` CLI for GitHub operations.
+- You may use implementation skills such as `gh-issue-to-pr` and `gh-fix-pr-comment`.
+- Do not use GitHub MCP.
+- Do not call `intent-cli run`.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude, Codex, or any AI provider.
+- Handle at most one action per wake.
+- Do not manually select issues or PRs by reading labels.
+- Label state is owned by `intent-cli`; implementation skills must not add/remove/propagate workflow labels unless `intent-cli` explicitly recommends it.
+- The current worktree is a dedicated automation worktree. Unsaved local changes in this child worktree and its submodules may be discarded before selection.
+
+Wake steps:
+1. Confirm the current directory is a git worktree root. If not, stop with status `wrong-worktree`.
+2. Save the child worktree path: `CHILD_WORKDIR="$PWD"`.
+3. Confirm `intent-cli` is available with `command -v intent-cli`. If not found, stop with status `intent-cli-not-found`. Do not fall back to `dotnet run`.
+4. Resolve the target GitHub repo from the child worktree using `gh repo view --json nameWithOwner --jq .nameWithOwner` (with a `git remote get-url origin` fallback).
+5. In the child worktree, run `git fetch --all --prune` and `git status --short`. If dirty, treat the diff as previous wake residue and clean before selector / claim / complete / push / label mutation:
+
+   ```bash
+   DIRTY_BEFORE="$(git status --short)"
+   if [ -n "$DIRTY_BEFORE" ]; then
+     git reset --hard
+     git clean -fd
+     git submodule foreach --recursive 'git reset --hard && git clean -fd'
+     git submodule update --init --recursive
+   fi
+   ```
+
+   Never use `git clean -fdx`. Never run this cleanup in a non-dedicated personal checkout.
+6. From the parent host root, run `intent-cli worker next-action --repo "$REPO" --workdir "$CHILD_WORKDIR" --format json`.
+7. Dispatch on `action`.
+8. If `action` is `none`: stop with status `idle`. Do not push. Do not mutate labels.
+9. If `action` is `issue-to-pr`:
+   - Claim with `intent-cli worker claim --kind issue --number <n> --write --format json`.
+   - Run the `gh-issue-to-pr` workflow on the returned issue URL only.
+   - Use the issue body as the standalone contract; do not read parent host packet files to fill gaps.
+   - Create at most one draft PR. Do not add `intent-target` or `intent-pr-created` to the PR.
+   - Classify the outcome as one of: `pr-created`, `declined-contract-incomplete`, `clarification-required`, `already-resolved`, `failed`, `label-cleanup-required`.
+   - From the parent host root run `intent-cli worker result-summary --kind issue-to-pr ...` then `intent-cli worker complete --kind issue --number <n> --outcome <outcome> --write --format json`.
+10. If `action` is `pr-comment-fix`:
+    - Claim with `intent-cli worker claim --kind pr --number <n> --write --format json`.
+    - Run the `gh-fix-pr-comment` workflow on the returned PR URL only.
+    - Repair only the narrow requested change. Push only the PR branch.
+    - Classify the outcome as one of: `repair-pushed`, `no-actionable-comments`, `already-resolved`, `clarification-required`, `failed`, `label-cleanup-required`.
+    - From the parent host root run `intent-cli worker result-summary --kind pr-comment-fix ...` then `intent-cli worker complete --kind pr --number <n> --outcome <outcome> --write --format json`.
+
+Hard label rules:
+- Never put `intent-pr-created` on a PR.
+- Never add `intent-target` from this implementation loop unless `intent-cli` explicitly owns that transition.
+- Do not manually invent label transitions. Use `intent-cli` claim/complete recommendations only.
+
+Final report must include:
+- selected action
+- selected URL
+- outcome
+- branch / PR updated or created
+- validation run
+- `intent-cli` warnings
+- claim/complete result
+- label actions applied, if any
+""";
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -73,7 +73,8 @@ internal static class Program
     {
         return args.Length >= 2
             && string.Equals(args[0], "guide", StringComparison.Ordinal)
-            && string.Equals(args[1], "oneshot", StringComparison.Ordinal);
+            && (string.Equals(args[1], "oneshot", StringComparison.Ordinal)
+                || string.Equals(args[1], "automation", StringComparison.Ordinal));
     }
 
     private static CliContext CreateBootstrapContext(string currentDirectory, string[] args)

--- a/tests/IntentSystem.Cli.Tests/GuideAutomationCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideAutomationCommandTests.cs
@@ -1,0 +1,198 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideAutomationCommandTests
+{
+    [Fact]
+    public void Execute_HostReview_IntentCli_EmitsRecurringPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review", "--domain", "intent-cli", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Automation: Host Review & Next Slice — intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("recurring schedule", output, StringComparison.Ordinal);
+        Assert.Contains("domain: `intent-cli`", output, StringComparison.Ordinal);
+        Assert.Contains("child repo: `J-Tech-Japan/intent-system`", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli automation summary --format text", output, StringComparison.Ordinal);
+        Assert.Contains("Stage 1", output, StringComparison.Ordinal);
+        Assert.Contains("Stage 2", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostReview_SekibanAsAService_EmitsDomainSpecificPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review", "--domain", "sekiban-as-a-service"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("domain: `sekiban-as-a-service`", output, StringComparison.Ordinal);
+        Assert.Contains("submodules/SekibanAsAService", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementUpdate_IntentSystem_EmitsRecurringWakePrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement-update", "--repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Automation: Child Implement & Update Loop", output, StringComparison.Ordinal);
+        Assert.Contains("recurring schedule", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli worker next-action", output, StringComparison.Ordinal);
+        Assert.Contains("Run this loop from a `J-Tech-Japan/intent-system` child worktree root.", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementUpdate_SekibanAsAService_EmbedsRepoNote()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement-update", "--repo", "J-Tech-Japan/SekibanAsAService"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Run this loop from a `J-Tech-Japan/SekibanAsAService` child worktree root.", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MissingKind_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--kind is required.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedKind_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["--kind", "host", "--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--kind must be", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostReview_MissingDomain_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--domain is required for --kind host-review.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostReview_UnsupportedDomain_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review", "--domain", "unknown"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unsupported --domain 'unknown'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementUpdate_MissingRepo_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement-update"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--repo is required for --kind child-implement-update.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementUpdate_UnsupportedRepo_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement-update", "--repo", "other/repo"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unsupported --repo 'other/repo'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedFormat_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review", "--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsageAndExitsZero()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("guide automation", output, StringComparison.Ordinal);
+        Assert.Contains("host-review", output, StringComparison.Ordinal);
+        Assert.Contains("child-implement-update", output, StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #583

## Summary

- Adds `intent-cli guide automation` command. Two kinds:
  - `--kind host-review --domain <intent-cli|sekiban-as-a-service>` emits the recurring host review/next-slice automation setup prompt for the requested domain.
  - `--kind child-implement-update --repo <J-Tech-Japan/intent-system|J-Tech-Japan/SekibanAsAService>` emits the recurring child implement/update wake prompt with a per-repo note.
- Embeds the recurring automation prompts as the source of truth in the child CLI so operators no longer need to open files under `intents/rules/automations` to set up a loop.
- Unsupported `--kind`, `--domain`, `--repo`, or non-markdown `--format` inputs fail deterministically with usage guidance and exit code 1.
- The command is routed via the bootstrap path so it works outside a child-repo worktree.
- 12 focused tests in `GuideAutomationCommandTests` cover both supported kinds, both supported domains/repos, and each error path.
- Lists the new G240 command in `docs/automation-templates/README.md`.

The command does not launch any AI provider, does not mutate state, and does not change label semantics.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~GuideAutomationCommandTests"` (12/12 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean