### PR TITLE
G241 Add intent-cli intent status command

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -38,6 +38,7 @@ These templates assume:
 | G232  | host transition smoke examples | Read-only local verification before command-only host runbooks |
 | G239  | `intent-cli guide oneshot`              | Emit the current host or child one-shot prompt for manual single-wake operation |
 | G240  | `intent-cli guide automation`           | Emit the current recurring host-review or child implement/update automation setup prompt |
+| G241  | `intent-cli intent status`              | Read-only domain status: latest completed, WIP, queued packets, open clarifications |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -25,7 +25,8 @@ internal static class CommandRouter
         "tasking",
         "worker",
         "metadata",
-        "guide"
+        "guide",
+        "intent"
     ];
 
     private static readonly IReadOnlyList<string> AutomationCommandHelp =
@@ -199,6 +200,10 @@ internal static class CommandRouter
             {
                 ["oneshot"] = GuideOneshotCommand.Execute,
                 ["automation"] = GuideAutomationCommand.Execute
+            },
+            ["intent"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["status"] = IntentStatusCommand.Execute
             }
         };
 

--- a/src/IntentSystem.Cli/Commands/IntentStatusCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentStatusCommand.cs
@@ -1,0 +1,345 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G241: Read-only <c>intent-cli intent status</c> command. Summarizes a
+/// domain's current baseline (latest completed execution units), in-flight
+/// WIP, queued/preloaded packets, and open clarification state. Reads queue
+/// state, runs log, and clarification file only — never mutates them and
+/// never launches an AI provider.
+/// </summary>
+internal static class IntentStatusCommand
+{
+    private const string FormatMarkdown = "markdown";
+    private const string FormatJson = "json";
+
+    private const int LatestCompletedLimit = 5;
+
+    private const string UsageLine =
+        "Usage: intent-cli intent status [--domain <name>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var domainOverride, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = Analyze(context, domainOverride);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    internal static IntentStatusResult Analyze(CliContext context, string? domainOverride)
+    {
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride!;
+
+        var notes = new List<string>();
+        var queueStatePath = context.GetQueueStatePath();
+        QueueState? queueState = null;
+
+        if (File.Exists(queueStatePath))
+        {
+            try
+            {
+                queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            }
+            catch (JsonException jsonException)
+            {
+                notes.Add($"queue-state JSON could not be parsed: {jsonException.Message}");
+            }
+            catch (InvalidOperationException invalidOperation)
+            {
+                notes.Add($"queue-state payload was invalid: {invalidOperation.Message}");
+            }
+        }
+        else
+        {
+            notes.Add($"no queue-state file at {queueStatePath}");
+        }
+
+        var latestCompleted = new List<IntentStatusItem>();
+        var wip = new List<IntentStatusItem>();
+        var queued = new List<IntentStatusItem>();
+
+        if (queueState is not null)
+        {
+            foreach (var item in queueState.Items.Reverse().Where(item => item.State == QueueItemState.Completed))
+            {
+                if (latestCompleted.Count >= LatestCompletedLimit)
+                {
+                    break;
+                }
+
+                latestCompleted.Add(IntentStatusItem.From(item));
+            }
+
+            foreach (var item in queueState.Items)
+            {
+                switch (item.State)
+                {
+                    case QueueItemState.Active:
+                    case QueueItemState.Review:
+                    case QueueItemState.Fixing:
+                        wip.Add(IntentStatusItem.From(item));
+                        break;
+
+                    case QueueItemState.Queued:
+                    case QueueItemState.Blocked:
+                    case QueueItemState.ClarifyBlocked:
+                        queued.Add(IntentStatusItem.From(item));
+                        break;
+                }
+            }
+        }
+
+        var clarificationPath = ResolveClarificationPath(context, domain);
+        var clarificationFilePresent = clarificationPath is not null && File.Exists(clarificationPath);
+        var clarificationOpen = false;
+        if (clarificationFilePresent)
+        {
+            clarificationOpen = ClarificationOpenDetector.HasOpenBlocker(File.ReadAllText(clarificationPath!));
+        }
+
+        return new IntentStatusResult
+        {
+            Domain = domain,
+            QueueStatePath = queueStatePath,
+            QueueStatePresent = queueState is not null,
+            LatestCompleted = latestCompleted,
+            Wip = wip,
+            Queued = queued,
+            ClarificationPath = clarificationPath,
+            ClarificationFilePresent = clarificationFilePresent,
+            ClarificationOpen = clarificationOpen,
+            Notes = notes
+        };
+    }
+
+    private static string? ResolveClarificationPath(CliContext context, string domain)
+    {
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            return null;
+        }
+
+        return Path.Combine(context.RepoRoot, "intents", domain, "clarifications", "open.md");
+    }
+
+    private static void WriteMarkdown(TextWriter writer, IntentStatusResult result)
+    {
+        writer.WriteLine($"# Intent status — {result.Domain}");
+        writer.WriteLine();
+        writer.WriteLine($"- queue-state path: {result.QueueStatePath}");
+        writer.WriteLine($"- queue-state present: {(result.QueueStatePresent ? "yes" : "no")}");
+        writer.WriteLine();
+
+        writer.WriteLine($"## Latest completed (up to {LatestCompletedLimit})");
+        if (result.LatestCompleted.Count == 0)
+        {
+            writer.WriteLine("- none");
+        }
+        else
+        {
+            foreach (var item in result.LatestCompleted)
+            {
+                writer.WriteLine($"- {item.ExecutionUnit} — {item.Title}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## WIP (in-flight)");
+        if (result.Wip.Count == 0)
+        {
+            writer.WriteLine("- none");
+        }
+        else
+        {
+            foreach (var item in result.Wip)
+            {
+                writer.WriteLine($"- {item.ExecutionUnit} ({item.State}) — {item.Title}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Queued / preloaded packets");
+        if (result.Queued.Count == 0)
+        {
+            writer.WriteLine("- none");
+        }
+        else
+        {
+            foreach (var item in result.Queued)
+            {
+                writer.WriteLine($"- {item.ExecutionUnit} ({item.State}) — {item.Title}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Open clarifications");
+        writer.WriteLine($"- file: {(result.ClarificationPath ?? "(none)")}");
+        writer.WriteLine($"- file present: {(result.ClarificationFilePresent ? "yes" : "no")}");
+        writer.WriteLine($"- has open blocker: {(result.ClarificationOpen ? "yes" : "no")}");
+        writer.WriteLine();
+
+        if (result.Notes.Count > 0)
+        {
+            writer.WriteLine("## Notes");
+            foreach (var note in result.Notes)
+            {
+                writer.WriteLine($"- {note}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? domainOverride,
+        out string format,
+        out string error)
+    {
+        domainOverride = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("intent status");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only domain status: latest completed, WIP, queued packets, open clarifications.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record IntentStatusResult
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("queue_state_path")]
+    public required string QueueStatePath { get; init; }
+
+    [JsonPropertyName("queue_state_present")]
+    public required bool QueueStatePresent { get; init; }
+
+    [JsonPropertyName("latest_completed")]
+    public required IReadOnlyList<IntentStatusItem> LatestCompleted { get; init; }
+
+    [JsonPropertyName("wip")]
+    public required IReadOnlyList<IntentStatusItem> Wip { get; init; }
+
+    [JsonPropertyName("queued")]
+    public required IReadOnlyList<IntentStatusItem> Queued { get; init; }
+
+    [JsonPropertyName("clarification_path")]
+    public string? ClarificationPath { get; init; }
+
+    [JsonPropertyName("clarification_file_present")]
+    public required bool ClarificationFilePresent { get; init; }
+
+    [JsonPropertyName("clarification_open")]
+    public required bool ClarificationOpen { get; init; }
+
+    [JsonPropertyName("notes")]
+    public required IReadOnlyList<string> Notes { get; init; }
+}
+
+internal sealed record IntentStatusItem
+{
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    [JsonPropertyName("state")]
+    public required string State { get; init; }
+
+    public static IntentStatusItem From(QueueItem item)
+    {
+        return new IntentStatusItem
+        {
+            ExecutionUnit = item.ExecutionUnit,
+            Title = item.Title,
+            State = item.State.ToString().ToLowerInvariant()
+        };
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntentStatusCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentStatusCommandTests.cs
@@ -1,0 +1,322 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntentStatusCommandTests
+{
+    [Fact]
+    public void Execute_GivenNoQueueState_EmitsEmptySectionsAndNote()
+    {
+        using var workspace = new IntentStatusWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentStatusCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Intent status — intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("queue-state present: no", output, StringComparison.Ordinal);
+        Assert.Contains("## Latest completed", output, StringComparison.Ordinal);
+        Assert.Contains("## WIP (in-flight)", output, StringComparison.Ordinal);
+        Assert.Contains("## Queued / preloaded packets", output, StringComparison.Ordinal);
+        Assert.Contains("## Open clarifications", output, StringComparison.Ordinal);
+        Assert.Contains("no queue-state file at", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMixedQueueItems_BucketsCompletedWipAndQueued()
+    {
+        using var workspace = new IntentStatusWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G237",
+                  "title": "old completed",
+                  "state": "completed",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                },
+                {
+                  "execution_unit": "G238",
+                  "title": "newer completed",
+                  "state": "completed",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                },
+                {
+                  "execution_unit": "G239",
+                  "title": "in flight",
+                  "state": "active",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                },
+                {
+                  "execution_unit": "G240",
+                  "title": "preloaded",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentStatusCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("queue-state present: yes", output, StringComparison.Ordinal);
+        Assert.Contains("- G238 — newer completed", output, StringComparison.Ordinal);
+        Assert.Contains("- G237 — old completed", output, StringComparison.Ordinal);
+        Assert.Contains("- G239 (active) — in flight", output, StringComparison.Ordinal);
+        Assert.Contains("- G240 (queued) — preloaded", output, StringComparison.Ordinal);
+        // Latest completed should be ordered newest first (reverse order in queue array).
+        var newerIndex = output.IndexOf("G238 — newer completed", StringComparison.Ordinal);
+        var olderIndex = output.IndexOf("G237 — old completed", StringComparison.Ordinal);
+        Assert.True(newerIndex >= 0 && olderIndex >= 0 && newerIndex < olderIndex);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_EmitsStructuredSnakeCase()
+    {
+        using var workspace = new IntentStatusWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G241",
+                  "title": "queued slice",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentStatusCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        Assert.True(root.GetProperty("queue_state_present").GetBoolean());
+        Assert.Equal(0, root.GetProperty("latest_completed").GetArrayLength());
+        Assert.Equal(0, root.GetProperty("wip").GetArrayLength());
+        Assert.Equal(1, root.GetProperty("queued").GetArrayLength());
+        var queuedFirst = root.GetProperty("queued")[0];
+        Assert.Equal("G241", queuedFirst.GetProperty("execution_unit").GetString());
+        Assert.Equal("queued slice", queuedFirst.GetProperty("title").GetString());
+        Assert.Equal("queued", queuedFirst.GetProperty("state").GetString());
+        Assert.False(root.GetProperty("clarification_open").GetBoolean());
+    }
+
+    [Fact]
+    public void Execute_GivenOpenClarification_FlagsOpenBlocker()
+    {
+        using var workspace = new IntentStatusWorkspace();
+        workspace.WriteClarificationOpen(
+            """
+            # Open clarifications
+
+            ## Current Open Blockers
+            - Need answer on storage strategy
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentStatusCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("file present: yes", output, StringComparison.Ordinal);
+        Assert.Contains("has open blocker: yes", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenDomainOverride_ResolvesClarificationPathPerDomain()
+    {
+        using var workspace = new IntentStatusWorkspace();
+        workspace.WriteClarificationOpen(
+            """
+            ## Current Open Blockers
+            - none
+            """,
+            "other-domain");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentStatusCommand.Execute(
+            workspace.Context,
+            ["--domain", "other-domain"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Intent status — other-domain", output, StringComparison.Ordinal);
+        Assert.Contains("intents/other-domain/clarifications/open.md", output, StringComparison.Ordinal);
+        Assert.Contains("file present: yes", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenInvalidQueueStateJson_RecordsParseNote()
+    {
+        using var workspace = new IntentStatusWorkspace();
+        workspace.WriteQueueState("{ this is not json");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentStatusCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("queue-state JSON could not be parsed", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnsupportedFormat_ReturnsUsageError()
+    {
+        using var workspace = new IntentStatusWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentStatusCommand.Execute(
+            workspace.Context,
+            ["--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownArgument_ReturnsUsageError()
+    {
+        using var workspace = new IntentStatusWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentStatusCommand.Execute(
+            workspace.Context,
+            ["--unknown"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument '--unknown'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingDomainValue_ReturnsUsageError()
+    {
+        using var workspace = new IntentStatusWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentStatusCommand.Execute(
+            workspace.Context,
+            ["--domain"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--domain requires a value", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenHelpFlag_PrintsUsageAndExitsZero()
+    {
+        using var workspace = new IntentStatusWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentStatusCommand.Execute(
+            workspace.Context,
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("intent status", output, StringComparison.Ordinal);
+        Assert.Contains("--domain", output, StringComparison.Ordinal);
+        Assert.Contains("--format markdown|json", output, StringComparison.Ordinal);
+    }
+
+    private sealed class IntentStatusWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("intent-status-tests-")
+            .FullName;
+
+        public IntentStatusWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public void WriteQueueState(string content)
+        {
+            File.WriteAllText(Context.GetQueueStatePath(), content);
+        }
+
+        public void WriteClarificationOpen(string content, string domain = "intent-cli")
+        {
+            var path = Path.Combine(rootPath, "intents", domain, "clarifications");
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "open.md"), content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #585

## Summary

- Adds read-only `intent-cli intent status [--domain <name>] [--format markdown|json]`.
- Reads `.intent-cli/queue-state.json` and `intents/<domain>/clarifications/open.md`. Never mutates state and never launches an AI provider.
- Emits four sections: latest completed (up to 5, newest first), WIP (Active/Review/Fixing), queued/preloaded packets (Queued/Blocked/ClarifyBlocked), and open clarification status.
- JSON output uses snake_case keys (`domain`, `queue_state_path`, `latest_completed`, `wip`, `queued`, `clarification_open`, `clarification_path`, `notes`) for stable consumption.
- Unsupported `--format` values and unknown arguments fail deterministically with usage guidance and exit code 1.
- Adds 10 focused tests in `IntentStatusCommandTests` covering the markdown and JSON paths, mixed queue items, open-blocker detection, domain override, malformed JSON, and each error path.
- Lists the new G241 command in `docs/automation-templates/README.md`.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~IntentStatusCommandTests"` (10/10 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean