### PR TITLE
G242 Add intent-cli intent search and explain commands

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -39,6 +39,7 @@ These templates assume:
 | G239  | `intent-cli guide oneshot`              | Emit the current host or child one-shot prompt for manual single-wake operation |
 | G240  | `intent-cli guide automation`           | Emit the current recurring host-review or child implement/update automation setup prompt |
 | G241  | `intent-cli intent status`              | Read-only domain status: latest completed, WIP, queued packets, open clarifications |
+| G242  | `intent-cli intent search` / `intent explain` | Read-only intent discovery: substring search across packets/intents and execution-unit explainer |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -203,7 +203,9 @@ internal static class CommandRouter
             },
             ["intent"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
-                ["status"] = IntentStatusCommand.Execute
+                ["status"] = IntentStatusCommand.Execute,
+                ["search"] = IntentSearchCommand.Execute,
+                ["explain"] = IntentExplainCommand.Execute
             }
         };
 

--- a/src/IntentSystem.Cli/Commands/IntentExplainCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentExplainCommand.cs
@@ -1,0 +1,321 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G242: Read-only <c>intent-cli intent explain</c> command. Resolves an
+/// execution-unit identifier (e.g. <c>G241</c>) and emits a deterministic
+/// summary that includes the queue-state record, packet directory contents,
+/// and a head excerpt of the GitHub-body packet when present. Never
+/// mutates state and never launches an AI provider.
+/// </summary>
+internal static class IntentExplainCommand
+{
+    private const string FormatMarkdown = "markdown";
+    private const string FormatJson = "json";
+
+    private const int GithubBodyHeadLines = 12;
+
+    private const string UsageLine =
+        "Usage: intent-cli intent explain <execution-unit-id> [--domain <name>] [--format markdown|json]";
+
+    private static readonly Regex ExecutionUnitPattern = new(
+        @"^[A-Za-z][A-Za-z0-9-]*$",
+        RegexOptions.Compiled);
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var executionUnit, out var domainOverride, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (!ExecutionUnitPattern.IsMatch(executionUnit!))
+        {
+            writer.WriteLine($"Invalid execution-unit id '{executionUnit}'. Expected an alphanumeric token like 'G241'.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = Explain(context, executionUnit!, domainOverride);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return result.Found ? 0 : 1;
+    }
+
+    internal static IntentExplainResult Explain(CliContext context, string executionUnit, string? domainOverride)
+    {
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride!;
+
+        var packetDirectory = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit);
+        var packetExists = Directory.Exists(packetDirectory);
+
+        IReadOnlyList<string> packetFiles = packetExists
+            ? Directory.EnumerateFiles(packetDirectory)
+                .Select(file => Path.GetFileName(file))
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray()
+            : Array.Empty<string>();
+
+        var githubBodyPath = Path.Combine(packetDirectory, "github-body.md");
+        var githubBodyHead = File.Exists(githubBodyPath)
+            ? string.Join('\n', File.ReadAllLines(githubBodyPath).Take(GithubBodyHeadLines))
+            : null;
+
+        var queueStatePath = context.GetQueueStatePath();
+        QueueItem? queueItem = null;
+        if (File.Exists(queueStatePath))
+        {
+            try
+            {
+                var state = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+                queueItem = state.Items.FirstOrDefault(item =>
+                    string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+            }
+            catch (JsonException)
+            {
+                // Queue parse errors surface in the result via Found=false context.
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        return new IntentExplainResult
+        {
+            ExecutionUnit = executionUnit,
+            Domain = domain,
+            Found = packetExists || queueItem is not null,
+            PacketDirectory = packetDirectory,
+            PacketFiles = packetFiles,
+            QueueItem = queueItem is null ? null : IntentExplainQueueItem.From(queueItem),
+            GithubBodyHead = githubBodyHead
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, IntentExplainResult result)
+    {
+        writer.WriteLine($"# Intent explain — {result.ExecutionUnit}");
+        writer.WriteLine();
+        writer.WriteLine($"- domain: {result.Domain}");
+        writer.WriteLine($"- packet directory: {result.PacketDirectory}");
+        writer.WriteLine($"- found: {(result.Found ? "yes" : "no")}");
+        writer.WriteLine();
+
+        if (result.QueueItem is not null)
+        {
+            writer.WriteLine("## Queue item");
+            writer.WriteLine($"- title: {result.QueueItem.Title}");
+            writer.WriteLine($"- state: {result.QueueItem.State}");
+            writer.WriteLine($"- worker role: {result.QueueItem.WorkerRole}");
+            writer.WriteLine($"- review role: {result.QueueItem.ReviewRole}");
+            writer.WriteLine($"- priority: {result.QueueItem.Priority}");
+            if (!string.IsNullOrWhiteSpace(result.QueueItem.LinkedPr))
+            {
+                writer.WriteLine($"- linked PR: {result.QueueItem.LinkedPr}");
+            }
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Packet files");
+        if (result.PacketFiles.Count == 0)
+        {
+            writer.WriteLine("- none");
+        }
+        else
+        {
+            foreach (var file in result.PacketFiles)
+            {
+                writer.WriteLine($"- {file}");
+            }
+        }
+        writer.WriteLine();
+
+        if (!string.IsNullOrWhiteSpace(result.GithubBodyHead))
+        {
+            writer.WriteLine($"## github-body.md head ({GithubBodyHeadLines} lines)");
+            writer.WriteLine();
+            writer.WriteLine("```");
+            writer.WriteLine(result.GithubBodyHead);
+            writer.WriteLine("```");
+        }
+
+        if (!result.Found)
+        {
+            writer.WriteLine("No packet directory or queue-state record found for this execution unit.");
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? executionUnit,
+        out string? domainOverride,
+        out string format,
+        out string error)
+    {
+        executionUnit = null;
+        domainOverride = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    if (argument.StartsWith("--", StringComparison.Ordinal))
+                    {
+                        error = $"Unknown argument '{argument}'.";
+                        return false;
+                    }
+
+                    if (executionUnit is not null)
+                    {
+                        error = $"Only one execution-unit id is allowed (got '{executionUnit}' and '{argument}').";
+                        return false;
+                    }
+
+                    executionUnit = argument;
+                    break;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            error = "An execution-unit id is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("intent explain");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only execution-unit summary using packet directory and queue-state.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record IntentExplainResult
+{
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("found")]
+    public required bool Found { get; init; }
+
+    [JsonPropertyName("packet_directory")]
+    public required string PacketDirectory { get; init; }
+
+    [JsonPropertyName("packet_files")]
+    public required IReadOnlyList<string> PacketFiles { get; init; }
+
+    [JsonPropertyName("queue_item")]
+    public IntentExplainQueueItem? QueueItem { get; init; }
+
+    [JsonPropertyName("github_body_head")]
+    public string? GithubBodyHead { get; init; }
+}
+
+internal sealed record IntentExplainQueueItem
+{
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    [JsonPropertyName("state")]
+    public required string State { get; init; }
+
+    [JsonPropertyName("worker_role")]
+    public required string WorkerRole { get; init; }
+
+    [JsonPropertyName("review_role")]
+    public required string ReviewRole { get; init; }
+
+    [JsonPropertyName("priority")]
+    public required string Priority { get; init; }
+
+    [JsonPropertyName("linked_pr")]
+    public string? LinkedPr { get; init; }
+
+    public static IntentExplainQueueItem From(QueueItem item)
+    {
+        return new IntentExplainQueueItem
+        {
+            Title = item.Title,
+            State = item.State.ToString().ToLowerInvariant(),
+            WorkerRole = item.WorkerRole,
+            ReviewRole = item.ReviewRole,
+            Priority = item.Priority,
+            LinkedPr = item.LinkedPr
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntentSearchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentSearchCommand.cs
@@ -1,0 +1,287 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G242: Read-only <c>intent-cli intent search</c> command. Performs a
+/// case-insensitive substring search across the packet directory
+/// (<c>.intent-cli/issues/</c>) and the per-domain intent tree
+/// (<c>intents/&lt;domain&gt;/</c>) and emits the matching file paths,
+/// 1-based line numbers, and a trimmed snippet. Never mutates state and
+/// never launches an AI provider.
+/// </summary>
+internal static class IntentSearchCommand
+{
+    private const string FormatMarkdown = "markdown";
+    private const string FormatJson = "json";
+
+    private const int MatchesPerFile = 3;
+    private const int SnippetMaxLength = 240;
+
+    private const string UsageLine =
+        "Usage: intent-cli intent search --query <text> [--domain <name>] [--format markdown|json]";
+
+    private static readonly string[] SearchableExtensions =
+        new[] { ".md", ".yaml", ".yml", ".json", ".txt" };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var query, out var domainOverride, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = Search(context, query!, domainOverride);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    internal static IntentSearchResult Search(CliContext context, string query, string? domainOverride)
+    {
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride!;
+
+        var hits = new List<IntentSearchHit>();
+
+        var packetRoot = Path.Combine(context.RepoRoot, ".intent-cli", "issues");
+        if (Directory.Exists(packetRoot))
+        {
+            CollectMatches(packetRoot, query, hits);
+        }
+
+        var domainRoot = Path.Combine(context.RepoRoot, "intents", domain);
+        if (Directory.Exists(domainRoot))
+        {
+            CollectMatches(domainRoot, query, hits);
+        }
+
+        return new IntentSearchResult
+        {
+            Domain = domain,
+            Query = query,
+            PacketRoot = packetRoot,
+            DomainRoot = domainRoot,
+            Hits = hits
+        };
+    }
+
+    private static void CollectMatches(string root, string query, List<IntentSearchHit> hits)
+    {
+        var files = Directory
+            .EnumerateFiles(root, "*", SearchOption.AllDirectories)
+            .Where(file => SearchableExtensions.Contains(
+                Path.GetExtension(file),
+                StringComparer.OrdinalIgnoreCase))
+            .OrderBy(file => file, StringComparer.Ordinal);
+
+        foreach (var file in files)
+        {
+            string[] lines;
+            try
+            {
+                lines = File.ReadAllLines(file);
+            }
+            catch (IOException)
+            {
+                continue;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                continue;
+            }
+
+            var matchesInFile = 0;
+            for (var index = 0; index < lines.Length && matchesInFile < MatchesPerFile; index++)
+            {
+                var line = lines[index];
+                if (line.IndexOf(query, StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    continue;
+                }
+
+                hits.Add(new IntentSearchHit
+                {
+                    Path = file,
+                    Line = index + 1,
+                    Snippet = TrimSnippet(line)
+                });
+                matchesInFile++;
+            }
+        }
+    }
+
+    private static string TrimSnippet(string line)
+    {
+        var trimmed = line.Trim();
+        if (trimmed.Length <= SnippetMaxLength)
+        {
+            return trimmed;
+        }
+
+        return trimmed[..SnippetMaxLength] + "…";
+    }
+
+    private static void WriteMarkdown(TextWriter writer, IntentSearchResult result)
+    {
+        writer.WriteLine($"# Intent search — {result.Domain}");
+        writer.WriteLine();
+        writer.WriteLine($"- query: `{result.Query}`");
+        writer.WriteLine($"- packet root: {result.PacketRoot}");
+        writer.WriteLine($"- domain root: {result.DomainRoot}");
+        writer.WriteLine($"- matches: {result.Hits.Count}");
+        writer.WriteLine();
+
+        if (result.Hits.Count == 0)
+        {
+            writer.WriteLine("No matches.");
+            return;
+        }
+
+        writer.WriteLine("## Matches");
+        foreach (var hit in result.Hits)
+        {
+            writer.WriteLine($"- {hit.Path}:{hit.Line} — {hit.Snippet}");
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? query,
+        out string? domainOverride,
+        out string format,
+        out string error)
+    {
+        query = null;
+        domainOverride = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--query":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--query requires a value.";
+                        return false;
+                    }
+
+                    query = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            error = "--query is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("intent search");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only substring search across packets and the per-domain intent tree.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record IntentSearchResult
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("query")]
+    public required string Query { get; init; }
+
+    [JsonPropertyName("packet_root")]
+    public required string PacketRoot { get; init; }
+
+    [JsonPropertyName("domain_root")]
+    public required string DomainRoot { get; init; }
+
+    [JsonPropertyName("hits")]
+    public required IReadOnlyList<IntentSearchHit> Hits { get; init; }
+}
+
+internal sealed record IntentSearchHit
+{
+    [JsonPropertyName("path")]
+    public required string Path { get; init; }
+
+    [JsonPropertyName("line")]
+    public required int Line { get; init; }
+
+    [JsonPropertyName("snippet")]
+    public required string Snippet { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/IntentExplainCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentExplainCommandTests.cs
@@ -1,0 +1,225 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntentExplainCommandTests
+{
+    [Fact]
+    public void Execute_GivenPacketAndQueueItem_EmitsCombinedSummary()
+    {
+        using var workspace = new IntentExplainWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G241/packet.yaml",
+            "execution_unit: G241\ntitle: intent status\n");
+        workspace.WriteFile(
+            ".intent-cli/issues/G241/github-body.md",
+            """
+            ## Goal
+            Add read-only intent status command.
+
+            ## Why
+            Discoverable status replaces manual file inspection.
+            """);
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G241",
+                  "title": "intent status command",
+                  "state": "completed",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal",
+                  "linked_pr": "586"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentExplainCommand.Execute(workspace.Context, ["G241"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Intent explain — G241", output, StringComparison.Ordinal);
+        Assert.Contains("found: yes", output, StringComparison.Ordinal);
+        Assert.Contains("title: intent status command", output, StringComparison.Ordinal);
+        Assert.Contains("state: completed", output, StringComparison.Ordinal);
+        Assert.Contains("linked PR: 586", output, StringComparison.Ordinal);
+        Assert.Contains("- packet.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("- github-body.md", output, StringComparison.Ordinal);
+        Assert.Contains("github-body.md head", output, StringComparison.Ordinal);
+        Assert.Contains("Add read-only intent status command.", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_EmitsStructuredResult()
+    {
+        using var workspace = new IntentExplainWorkspace();
+        workspace.WriteFile(".intent-cli/issues/G242/packet.yaml", "x");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentExplainCommand.Execute(
+            workspace.Context,
+            ["G242", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("G242", root.GetProperty("execution_unit").GetString());
+        Assert.True(root.GetProperty("found").GetBoolean());
+        var packetFiles = root.GetProperty("packet_files");
+        Assert.Equal(1, packetFiles.GetArrayLength());
+        Assert.Equal("packet.yaml", packetFiles[0].GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenUnknownExecutionUnit_ReturnsNotFound()
+    {
+        using var workspace = new IntentExplainWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = IntentExplainCommand.Execute(
+            workspace.Context,
+            ["G999"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("found: no", output, StringComparison.Ordinal);
+        Assert.Contains("No packet directory or queue-state record found", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MissingExecutionUnitArg_ReturnsUsageError()
+    {
+        using var workspace = new IntentExplainWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = IntentExplainCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("execution-unit id is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MultipleExecutionUnitArgs_ReturnsUsageError()
+    {
+        using var workspace = new IntentExplainWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = IntentExplainCommand.Execute(
+            workspace.Context,
+            ["G241", "G242"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Only one execution-unit id is allowed", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_InvalidExecutionUnitId_ReturnsUsageError()
+    {
+        using var workspace = new IntentExplainWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = IntentExplainCommand.Execute(
+            workspace.Context,
+            ["bad/id"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Invalid execution-unit id", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedFormat_ReturnsUsageError()
+    {
+        using var workspace = new IntentExplainWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = IntentExplainCommand.Execute(
+            workspace.Context,
+            ["G241", "--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var workspace = new IntentExplainWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = IntentExplainCommand.Execute(
+            workspace.Context,
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("intent explain", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private sealed class IntentExplainWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("intent-explain-tests-")
+            .FullName;
+
+        public IntentExplainWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public void WriteFile(string relativePath, string content)
+        {
+            var full = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+            File.WriteAllText(full, content);
+        }
+
+        public void WriteQueueState(string content)
+        {
+            File.WriteAllText(Context.GetQueueStatePath(), content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntentSearchCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentSearchCommandTests.cs
@@ -1,0 +1,197 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntentSearchCommandTests
+{
+    [Fact]
+    public void Execute_GivenMatchInPacketAndDomainTree_EmitsBothHits()
+    {
+        using var workspace = new IntentSearchWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G241/github-body.md",
+            """
+            ## Goal
+            Add intent-cli intent status command.
+
+            ## Scope
+            Read-only domain status.
+            """);
+        workspace.WriteFile(
+            "intents/intent-cli/specs/05-intent-cli-surface.md",
+            """
+            # intent-cli surface
+            Includes: intent status, intent search, intent explain.
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentSearchCommand.Execute(
+            workspace.Context,
+            ["--query", "intent status"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Intent search — intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("query: `intent status`", output, StringComparison.Ordinal);
+        Assert.Contains("github-body.md:2", output, StringComparison.Ordinal);
+        Assert.Contains("05-intent-cli-surface.md:2", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNoMatch_EmitsZeroMatches()
+    {
+        using var workspace = new IntentSearchWorkspace();
+        workspace.WriteFile("intents/intent-cli/README.md", "Nothing relevant here.");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentSearchCommand.Execute(
+            workspace.Context,
+            ["--query", "absent-keyword"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("matches: 0", output, StringComparison.Ordinal);
+        Assert.Contains("No matches.", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_EmitsStructuredHits()
+    {
+        using var workspace = new IntentSearchWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G242/packet.yaml",
+            """
+            execution_unit: G242
+            title: intent search and explain
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentSearchCommand.Execute(
+            workspace.Context,
+            ["--query", "G242", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        Assert.Equal("G242", root.GetProperty("query").GetString());
+        var hits = root.GetProperty("hits");
+        Assert.True(hits.GetArrayLength() >= 1);
+        var first = hits[0];
+        Assert.Contains("G242", first.GetProperty("path").GetString()!, StringComparison.Ordinal);
+        Assert.True(first.GetProperty("line").GetInt32() >= 1);
+    }
+
+    [Fact]
+    public void Execute_GivenDomainOverride_SearchesThatDomainTreeOnly()
+    {
+        using var workspace = new IntentSearchWorkspace();
+        workspace.WriteFile("intents/intent-cli/README.md", "shared keyword");
+        workspace.WriteFile("intents/other-domain/README.md", "shared keyword in other-domain");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentSearchCommand.Execute(
+            workspace.Context,
+            ["--query", "shared keyword", "--domain", "other-domain"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Intent search — other-domain", output, StringComparison.Ordinal);
+        Assert.Contains("intents/other-domain/README.md", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("intents/intent-cli/README.md", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MissingQuery_ReturnsUsageError()
+    {
+        using var workspace = new IntentSearchWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentSearchCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--query is required.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedFormat_ReturnsUsageError()
+    {
+        using var workspace = new IntentSearchWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentSearchCommand.Execute(
+            workspace.Context,
+            ["--query", "x", "--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var workspace = new IntentSearchWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentSearchCommand.Execute(
+            workspace.Context,
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("intent search", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--query", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private sealed class IntentSearchWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("intent-search-tests-")
+            .FullName;
+
+        public IntentSearchWorkspace()
+        {
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public void WriteFile(string relativePath, string content)
+        {
+            var full = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+            File.WriteAllText(full, content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #587

## Summary

- Adds two read-only discovery commands under the `intent` group:
  - `intent search --query <text> [--domain <name>] [--format markdown|json]` — case-insensitive substring search across `.intent-cli/issues/` and `intents/<domain>/`. Searches `.md`, `.yaml`, `.yml`, `.json`, `.txt`. Caps at 3 matches per file. Each hit reports path, 1-based line, and a trimmed snippet.
  - `intent explain <execution-unit-id> [--domain <name>] [--format markdown|json]` — resolves an execution unit (e.g. `G241`), emits the queue-state record (title, state, worker/review role, priority, linked PR), packet directory listing, and head of `github-body.md` when present. Exits non-zero when no packet directory or queue-state record is found.
- Both commands are read-only, never launch an AI provider, and fail deterministically on unsupported inputs.
- Adds 7 search tests and 8 explain tests.
- Lists the new G242 surface in `docs/automation-templates/README.md`.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~IntentSearchCommandTests|FullyQualifiedName~IntentExplainCommandTests"` (15/15 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean