### PR TITLE
G244 Add intent-cli packet draft command

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -41,6 +41,7 @@ These templates assume:
 | G241  | `intent-cli intent status`              | Read-only domain status: latest completed, WIP, queued packets, open clarifications |
 | G242  | `intent-cli intent search` / `intent explain` | Read-only intent discovery: substring search across packets/intents and execution-unit explainer |
 | G243  | `intent-cli intent next-slice --dry-run` | Read-only next-slice planning facts: WIP, clarification blockers, candidate packets, missing contract fields, recommended outcome |
+| G244  | `intent-cli packet draft`               | Scaffold packet.yaml / implementation.md / review-context.md / github-body.md skeletons with required Child Issue Contract sections; never overwrites existing files |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -26,7 +26,8 @@ internal static class CommandRouter
         "worker",
         "metadata",
         "guide",
-        "intent"
+        "intent",
+        "packet"
     ];
 
     private static readonly IReadOnlyList<string> AutomationCommandHelp =
@@ -207,6 +208,10 @@ internal static class CommandRouter
                 ["search"] = IntentSearchCommand.Execute,
                 ["explain"] = IntentExplainCommand.Execute,
                 ["next-slice"] = IntentNextSliceCommand.Execute
+            },
+            ["packet"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["draft"] = PacketDraftCommand.Execute
             }
         };
 

--- a/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
@@ -1,0 +1,487 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G244: <c>intent-cli packet draft</c> command. Scaffolds and validates
+/// the canonical packet directory for a child execution unit
+/// (<c>.intent-cli/issues/&lt;id&gt;/</c>). Writes only skeleton files
+/// (<c>packet.yaml</c>, <c>implementation.md</c>, <c>review-context.md</c>,
+/// <c>github-body.md</c>) and never overwrites existing content. Produces
+/// deterministic output, supports a read-only <c>--dry-run</c> preview,
+/// and never launches an AI provider.
+/// </summary>
+internal static class PacketDraftCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string ModeWrite = "write";
+    private const string ModeDryRun = "dry-run";
+
+    private const string FileCreated = "created";
+    private const string FileSkipped = "skipped";
+    private const string FilePlanned = "planned";
+
+    private const string UsageLine =
+        "Usage: intent-cli packet draft --execution-unit <id> [--domain <name>] [--target-repo <owner/repo>] [--dry-run] [--format markdown|json]";
+
+    private static readonly Regex ExecutionUnitPattern = new(
+        @"^[A-Za-z][A-Za-z0-9-]*$",
+        RegexOptions.Compiled);
+
+    internal static readonly IReadOnlyList<string> RequiredContractSections =
+        new[]
+        {
+            "Goal",
+            "Why This Slice Exists Now",
+            "Current Observed State",
+            "Accepted Baseline You May Assume",
+            "Target Repo / Path / Part",
+            "In Scope",
+            "Out Of Scope",
+            "Acceptance Criteria",
+            "Verification",
+            "Related Links"
+        };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var executionUnit, out var domainOverride, out var targetRepo, out var dryRun, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (!ExecutionUnitPattern.IsMatch(executionUnit!))
+        {
+            writer.WriteLine($"Invalid execution-unit id '{executionUnit}'. Expected an alphanumeric token like 'G244'.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = Draft(context, executionUnit!, domainOverride, targetRepo, dryRun);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    internal static PacketDraftResult Draft(
+        CliContext context,
+        string executionUnit,
+        string? domainOverride,
+        string? targetRepo,
+        bool dryRun)
+    {
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride!;
+
+        var packetDirectory = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit);
+        var mode = dryRun ? ModeDryRun : ModeWrite;
+
+        if (!dryRun)
+        {
+            Directory.CreateDirectory(packetDirectory);
+        }
+
+        var planned = new[]
+        {
+            ("packet.yaml", BuildPacketYaml(executionUnit, domain, targetRepo)),
+            ("implementation.md", BuildImplementationMd(executionUnit)),
+            ("review-context.md", BuildReviewContextMd(executionUnit)),
+            ("github-body.md", BuildGithubBodyMd(executionUnit))
+        };
+
+        var files = new List<PacketDraftFile>();
+        foreach (var (name, content) in planned)
+        {
+            var path = Path.Combine(packetDirectory, name);
+            var alreadyExists = File.Exists(path);
+
+            string status;
+            if (dryRun)
+            {
+                status = alreadyExists ? FileSkipped : FilePlanned;
+            }
+            else if (alreadyExists)
+            {
+                status = FileSkipped;
+            }
+            else
+            {
+                File.WriteAllText(path, content);
+                status = FileCreated;
+            }
+
+            files.Add(new PacketDraftFile
+            {
+                Name = name,
+                Path = path,
+                Status = status
+            });
+        }
+
+        // Validate contract sections against whatever github-body.md ends up on disk
+        // (skeleton if newly written, existing content if previously authored).
+        var githubBodyPath = Path.Combine(packetDirectory, "github-body.md");
+        IReadOnlyList<string> missingSections = Array.Empty<string>();
+        if (File.Exists(githubBodyPath))
+        {
+            var content = File.ReadAllText(githubBodyPath);
+            missingSections = RequiredContractSections
+                .Where(section => !ContainsSectionHeading(content, section))
+                .ToArray();
+        }
+        else if (dryRun)
+        {
+            // Dry-run did not write the skeleton, but the planned content satisfies all
+            // required headings, so the validation result mirrors that intent.
+            missingSections = Array.Empty<string>();
+        }
+        else
+        {
+            missingSections = RequiredContractSections;
+        }
+
+        return new PacketDraftResult
+        {
+            ExecutionUnit = executionUnit,
+            Domain = domain,
+            TargetRepo = targetRepo,
+            PacketDirectory = packetDirectory,
+            Mode = mode,
+            Files = files,
+            MissingContractSections = missingSections
+        };
+    }
+
+    private static string BuildPacketYaml(string executionUnit, string domain, string? targetRepo)
+    {
+        var repoLine = targetRepo ?? "<owner/repo>";
+        return $"""
+            implementation_issue_packet:
+              issue_title: "{executionUnit} TODO short title"
+              issue_kind: feature
+              source_execution_unit: {executionUnit}
+              domain: {domain}
+              target_repo: {repoLine}
+              target_path: <comma- or space-separated paths>
+              target_part: "<one-line target description>"
+              dependencies: []
+              technical_baseline: []
+              intent_references: []
+              acceptance_criteria:
+                - "TODO: at least one acceptance criterion"
+            """;
+    }
+
+    private static string BuildImplementationMd(string executionUnit)
+    {
+        return $"""
+            # {executionUnit} Implementation Packet
+
+            ## Goal
+
+            TODO: one-paragraph statement of what this slice changes.
+
+            ## Why
+
+            TODO: why this slice exists now.
+
+            ## Scope
+
+            - TODO
+
+            ## Out of scope
+
+            - TODO
+
+            ## Verification
+
+            TODO: focused tests and `git diff --check`.
+            """;
+    }
+
+    private static string BuildReviewContextMd(string executionUnit)
+    {
+        return $"""
+            # {executionUnit} Review Context
+
+            Review that this slice moves operation toward the documented intent without widening scope.
+
+            Flag findings if the implementation:
+
+            - widens scope beyond the issue contract;
+            - launches AI providers from `intent-cli`;
+            - mutates GitHub or parent state when the issue is read-only;
+            - skips required contract sections.
+            """;
+    }
+
+    private static string BuildGithubBodyMd(string executionUnit)
+    {
+        return $"""
+            ## Goal
+
+            TODO: state what this slice will change.
+
+            ## Why This Slice Exists Now
+
+            TODO: explain why this is the next step.
+
+            ## Current Observed State
+
+            TODO: describe current behavior or repro.
+
+            ## Accepted Baseline You May Assume
+
+            - TODO
+
+            ## Target Repo / Path / Part
+
+            Repository: `<owner/repo>`
+
+            Target paths: `<comma- or space-separated paths>`
+
+            Target part: `<one-line target description>`
+
+            ## In Scope
+
+            - TODO
+
+            ## Out Of Scope
+
+            - TODO
+
+            ## Acceptance Criteria
+
+            - TODO
+
+            ## Verification
+
+            TODO: focused tests and `git diff --check`.
+
+            ## Related Links
+
+            - TODO
+            """;
+    }
+
+    private static bool ContainsSectionHeading(string content, string section)
+    {
+        var lines = content.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.Trim();
+            if (!line.StartsWith("##", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var heading = line.TrimStart('#').Trim();
+            if (string.Equals(heading, section, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void WriteMarkdown(TextWriter writer, PacketDraftResult result)
+    {
+        writer.WriteLine($"# Packet draft — {result.ExecutionUnit}");
+        writer.WriteLine();
+        writer.WriteLine($"- domain: {result.Domain}");
+        writer.WriteLine($"- target repo: {(result.TargetRepo ?? "(unspecified)")}");
+        writer.WriteLine($"- packet directory: {result.PacketDirectory}");
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Files");
+        foreach (var file in result.Files)
+        {
+            writer.WriteLine($"- {file.Name}: {file.Status}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Contract validation");
+        if (result.MissingContractSections.Count == 0)
+        {
+            writer.WriteLine("- missing sections: none");
+        }
+        else
+        {
+            writer.WriteLine("- missing sections:");
+            foreach (var section in result.MissingContractSections)
+            {
+                writer.WriteLine($"  - {section}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? executionUnit,
+        out string? domainOverride,
+        out string? targetRepo,
+        out bool dryRun,
+        out string format,
+        out string error)
+    {
+        executionUnit = null;
+        domainOverride = null;
+        targetRepo = null;
+        dryRun = false;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--execution-unit":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--execution-unit requires a value.";
+                        return false;
+                    }
+
+                    executionUnit = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--target-repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--target-repo requires a value.";
+                        return false;
+                    }
+
+                    targetRepo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--dry-run":
+                    dryRun = true;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            error = "--execution-unit is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("packet draft");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Scaffolds packet.yaml, implementation.md, review-context.md, github-body.md for an execution unit. Existing files are never overwritten.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record PacketDraftResult
+{
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("target_repo")]
+    public string? TargetRepo { get; init; }
+
+    [JsonPropertyName("packet_directory")]
+    public required string PacketDirectory { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("files")]
+    public required IReadOnlyList<PacketDraftFile> Files { get; init; }
+
+    [JsonPropertyName("missing_contract_sections")]
+    public required IReadOnlyList<string> MissingContractSections { get; init; }
+}
+
+internal sealed record PacketDraftFile
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("path")]
+    public required string Path { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
@@ -1,0 +1,216 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class PacketDraftCommandTests
+{
+    [Fact]
+    public void Execute_GivenWriteMode_CreatesAllFourPacketFilesWithRequiredHeadings()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G244", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Packet draft — G244", output, StringComparison.Ordinal);
+        Assert.Contains("mode: write", output, StringComparison.Ordinal);
+        Assert.Contains("packet.yaml: created", output, StringComparison.Ordinal);
+        Assert.Contains("implementation.md: created", output, StringComparison.Ordinal);
+        Assert.Contains("review-context.md: created", output, StringComparison.Ordinal);
+        Assert.Contains("github-body.md: created", output, StringComparison.Ordinal);
+        Assert.Contains("missing sections: none", output, StringComparison.Ordinal);
+
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G244");
+        Assert.True(File.Exists(Path.Combine(packetDir, "packet.yaml")));
+        Assert.True(File.Exists(Path.Combine(packetDir, "implementation.md")));
+        Assert.True(File.Exists(Path.Combine(packetDir, "review-context.md")));
+        var githubBody = File.ReadAllText(Path.Combine(packetDir, "github-body.md"));
+        foreach (var section in PacketDraftCommand.RequiredContractSections)
+        {
+            Assert.Contains($"## {section}", githubBody, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenExistingFiles_DoesNotOverwriteAndReportsSkipped()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G244");
+        Directory.CreateDirectory(packetDir);
+        File.WriteAllText(Path.Combine(packetDir, "packet.yaml"), "existing content");
+
+        using var writer = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G244"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("packet.yaml: skipped", output, StringComparison.Ordinal);
+        Assert.Equal("existing content", File.ReadAllText(Path.Combine(packetDir, "packet.yaml")));
+    }
+
+    [Fact]
+    public void Execute_GivenDryRun_DoesNotWriteFilesAndReportsPlanned()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G244", "--dry-run", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("dry-run", root.GetProperty("mode").GetString());
+        var files = root.GetProperty("files");
+        Assert.Equal(4, files.GetArrayLength());
+        foreach (var file in files.EnumerateArray())
+        {
+            Assert.Equal("planned", file.GetProperty("status").GetString());
+        }
+
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G244");
+        Assert.False(Directory.Exists(packetDir));
+    }
+
+    [Fact]
+    public void Execute_GivenJsonFormat_EmitsStructuredResult()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G244", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("G244", root.GetProperty("execution_unit").GetString());
+        Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("target_repo").GetString());
+        Assert.Equal("write", root.GetProperty("mode").GetString());
+        Assert.Equal(0, root.GetProperty("missing_contract_sections").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_MissingExecutionUnit_ReturnsUsageError()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--execution-unit is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_InvalidExecutionUnitId_ReturnsUsageError()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "bad/id"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Invalid execution-unit id", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedFormat_ReturnsUsageError()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G244", "--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ReturnsUsageError()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G244", "--surprise"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument '--surprise'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("packet draft", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--execution-unit", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private sealed class PacketDraftWorkspace : IDisposable
+    {
+        public PacketDraftWorkspace()
+        {
+            RepoRoot = Directory.CreateTempSubdirectory("packet-draft-tests-").FullName;
+            Context = new CliContext
+            {
+                RepoRoot = RepoRoot,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees"
+                    }
+                }
+            };
+        }
+
+        public string RepoRoot { get; }
+
+        public CliContext Context { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RepoRoot))
+            {
+                Directory.Delete(RepoRoot, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #591

## Summary

- Adds `intent-cli packet draft --execution-unit <id> [--domain <name>] [--target-repo <owner/repo>] [--dry-run] [--format markdown|json]`.
- Scaffolds the canonical packet directory `.intent-cli/issues/<id>/` with four files: `packet.yaml`, `implementation.md`, `review-context.md`, and `github-body.md`. The github-body skeleton includes all 10 required Child Issue Contract section headings.
- Never overwrites existing files. Each file is reported as `created`, `skipped` (already exists), or `planned` (dry-run).
- Validates the on-disk `github-body.md` for required section headings and reports missing ones.
- `--dry-run` previews without writing.
- Read on the AI provider boundary: never creates GitHub issues, never applies labels, never launches an AI provider.
- 9 focused tests cover write mode, skipped existing files, dry-run preview, JSON format, missing/invalid arg paths, unsupported format, unknown argument, and help.
- Lists the new G244 command in `docs/automation-templates/README.md`.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~PacketDraftCommandTests"` (9/9 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean