### PR TITLE
G245 Add intent-cli issue publish-flow command

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -42,6 +42,7 @@ These templates assume:
 | G242  | `intent-cli intent search` / `intent explain` | Read-only intent discovery: substring search across packets/intents and execution-unit explainer |
 | G243  | `intent-cli intent next-slice --dry-run` | Read-only next-slice planning facts: WIP, clarification blockers, candidate packets, missing contract fields, recommended outcome |
 | G244  | `intent-cli packet draft`               | Scaffold packet.yaml / implementation.md / review-context.md / github-body.md skeletons with required Child Issue Contract sections; never overwrites existing files |
+| G245  | `intent-cli issue publish-flow`         | Validate packet, create the GitHub issue without intent-target, and report the durable-state + intent-target publish boundary as next steps |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -106,7 +106,8 @@ internal static class CommandRouter
                 ["validate-body"] = IssueValidateBodyCommand.Execute,
                 ["prepare"] = IssuePrepareCommand.Execute,
                 ["publish-reviewed"] = IssuePublishReviewedCommand.Execute,
-                ["plan-candidate"] = IssuePlanCandidateCommand.Execute
+                ["plan-candidate"] = IssuePlanCandidateCommand.Execute,
+                ["publish-flow"] = IssuePublishFlowCommand.Execute
             },
             ["bug"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -1,0 +1,538 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G245: <c>intent-cli issue publish-flow</c> command. Performs the
+/// deterministic issue create / durable-publish-boundary handoff for an
+/// existing packet without prompt-specific label mutation knowledge.
+///
+/// Validates the packet's <c>github-body.md</c> for required Child Issue
+/// Contract sections before any GitHub mutation. With <c>--write</c>,
+/// creates the GitHub issue WITHOUT <c>intent-target</c> and reports the
+/// required parent durable-state step (commit/push) plus the next
+/// command to run for the actual publish boundary
+/// (<c>automation issue-publish --write</c>). The command never applies
+/// <c>intent-target</c> directly. Never launches an AI provider.
+/// </summary>
+internal static class IssuePublishFlowCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string ModeWrite = "write";
+    private const string ModeDryRun = "dry-run";
+
+    private const string UsageLine =
+        "Usage: intent-cli issue publish-flow <execution-unit> --repo <owner/repo> [--domain <name>] [--write] [--format json|markdown]";
+
+    private static readonly Regex ExecutionUnitPattern = new(
+        @"^[A-Za-z][A-Za-z0-9-]*$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Test seam — replaces the default <c>gh issue create</c> shell out.
+    /// </summary>
+    public static Func<IIssueCreator>? CreatorFactory { get; set; }
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var executionUnit, out var repo, out var domainOverride, out var write, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (!ExecutionUnitPattern.IsMatch(executionUnit!))
+        {
+            writer.WriteLine($"Invalid execution-unit id '{executionUnit}'. Expected an alphanumeric token like 'G245'.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride!;
+
+        var packetDirectory = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit!);
+        var githubBodyPath = Path.Combine(packetDirectory, "github-body.md");
+
+        if (!Directory.Exists(packetDirectory))
+        {
+            var earlyResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, write,
+                packetExists: false,
+                githubBodyPresent: false,
+                missingSections: PacketDraftCommand.RequiredContractSections,
+                title: null,
+                created: false,
+                issueUrl: null,
+                error: $"packet directory not found: {packetDirectory}");
+            EmitResult(writer, earlyResult, format);
+            return 1;
+        }
+
+        var githubBodyPresent = File.Exists(githubBodyPath);
+        IReadOnlyList<string> missing = githubBodyPresent
+            ? PacketDraftCommand.RequiredContractSections
+                .Where(section => !ContainsSectionHeading(File.ReadAllText(githubBodyPath), section))
+                .ToArray()
+            : PacketDraftCommand.RequiredContractSections;
+
+        var title = githubBodyPresent
+            ? ResolveTitle(executionUnit!, githubBodyPath)
+            : null;
+
+        if (!githubBodyPresent || missing.Count > 0)
+        {
+            var validationResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, write,
+                packetExists: true,
+                githubBodyPresent: githubBodyPresent,
+                missingSections: missing,
+                title: title,
+                created: false,
+                issueUrl: null,
+                error: githubBodyPresent
+                    ? "Child Issue Contract is incomplete; required sections are missing."
+                    : "github-body.md is missing in the packet directory.");
+            EmitResult(writer, validationResult, format);
+            return 1;
+        }
+
+        if (!write)
+        {
+            var dryRunResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, write,
+                packetExists: true,
+                githubBodyPresent: true,
+                missingSections: Array.Empty<string>(),
+                title: title,
+                created: false,
+                issueUrl: null,
+                error: null);
+            EmitResult(writer, dryRunResult, format);
+            return 0;
+        }
+
+        IIssueCreator creator;
+        try
+        {
+            creator = CreatorFactory?.Invoke() ?? new GhCliIssueCreator();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            var creatorErrorResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, write,
+                packetExists: true,
+                githubBodyPresent: true,
+                missingSections: Array.Empty<string>(),
+                title: title,
+                created: false,
+                issueUrl: null,
+                error: $"failed to initialize GitHub issue creator: {exception.Message}");
+            EmitResult(writer, creatorErrorResult, format);
+            return 1;
+        }
+
+        IssueCreateOutcome outcome;
+        try
+        {
+            outcome = creator.CreateIssue(repo!, title!, githubBodyPath);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            var createErrorResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, write,
+                packetExists: true,
+                githubBodyPresent: true,
+                missingSections: Array.Empty<string>(),
+                title: title,
+                created: false,
+                issueUrl: null,
+                error: $"gh issue create failed: {exception.Message}");
+            EmitResult(writer, createErrorResult, format);
+            return 1;
+        }
+
+        var successResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, write,
+            packetExists: true,
+            githubBodyPresent: true,
+            missingSections: Array.Empty<string>(),
+            title: title,
+            created: true,
+            issueUrl: outcome.IssueUrl,
+            error: null);
+        EmitResult(writer, successResult, format);
+        return 0;
+    }
+
+    private static IssuePublishFlowResult NewResult(
+        string executionUnit,
+        string domain,
+        string repo,
+        string packetDirectory,
+        string githubBodyPath,
+        bool write,
+        bool packetExists,
+        bool githubBodyPresent,
+        IReadOnlyList<string> missingSections,
+        string? title,
+        bool created,
+        string? issueUrl,
+        string? error)
+    {
+        var nextSteps = new List<string>();
+        if (created)
+        {
+            nextSteps.Add("Commit and push the parent durable state for this execution unit (queue-state, runs, packet files).");
+            nextSteps.Add($"Then apply the publish boundary with: intent-cli automation issue-publish --repo {repo} --issue <issue-number> --write --format json");
+        }
+
+        return new IssuePublishFlowResult
+        {
+            ExecutionUnit = executionUnit,
+            Domain = domain,
+            Repo = repo,
+            PacketDirectory = packetDirectory,
+            GithubBodyPath = githubBodyPath,
+            PacketExists = packetExists,
+            GithubBodyPresent = githubBodyPresent,
+            MissingContractSections = missingSections,
+            Mode = write ? ModeWrite : ModeDryRun,
+            Title = title,
+            Created = created,
+            IssueUrl = issueUrl,
+            IntentTargetApplied = false,
+            NextSteps = nextSteps,
+            Error = error
+        };
+    }
+
+    private static void EmitResult(TextWriter writer, IssuePublishFlowResult result, string format)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+    }
+
+    private static void WriteMarkdown(TextWriter writer, IssuePublishFlowResult result)
+    {
+        writer.WriteLine($"# Issue publish-flow — {result.ExecutionUnit}");
+        writer.WriteLine();
+        writer.WriteLine($"- domain: {result.Domain}");
+        writer.WriteLine($"- repo: {result.Repo}");
+        writer.WriteLine($"- packet directory: {result.PacketDirectory}");
+        writer.WriteLine($"- packet exists: {(result.PacketExists ? "yes" : "no")}");
+        writer.WriteLine($"- github-body.md present: {(result.GithubBodyPresent ? "yes" : "no")}");
+        writer.WriteLine($"- mode: {result.Mode}");
+        if (!string.IsNullOrWhiteSpace(result.Title))
+        {
+            writer.WriteLine($"- title: {result.Title}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Contract validation");
+        if (result.MissingContractSections.Count == 0)
+        {
+            writer.WriteLine("- missing sections: none");
+        }
+        else
+        {
+            writer.WriteLine("- missing sections:");
+            foreach (var section in result.MissingContractSections)
+            {
+                writer.WriteLine($"  - {section}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Outcome");
+        writer.WriteLine($"- created: {(result.Created ? "yes" : "no")}");
+        if (!string.IsNullOrWhiteSpace(result.IssueUrl))
+        {
+            writer.WriteLine($"- issue URL: {result.IssueUrl}");
+        }
+        writer.WriteLine($"- intent-target applied: {(result.IntentTargetApplied ? "yes" : "no — apply only at the explicit publish boundary after parent durable state is pushed")}");
+        if (!string.IsNullOrWhiteSpace(result.Error))
+        {
+            writer.WriteLine($"- error: {result.Error}");
+        }
+        writer.WriteLine();
+
+        if (result.NextSteps.Count > 0)
+        {
+            writer.WriteLine("## Next steps");
+            foreach (var step in result.NextSteps)
+            {
+                writer.WriteLine($"- {step}");
+            }
+        }
+    }
+
+    private static bool ContainsSectionHeading(string content, string section)
+    {
+        var lines = content.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.Trim();
+            if (!line.StartsWith("##", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var heading = line.TrimStart('#').Trim();
+            if (string.Equals(heading, section, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string ResolveTitle(string executionUnit, string githubBodyPath)
+    {
+        // Look for the first non-empty top-of-file line. If the body starts with
+        // "## Goal" (canonical packet shape), fall back to the executionUnit + "TODO".
+        var lines = File.ReadAllLines(githubBodyPath);
+        foreach (var raw in lines)
+        {
+            var line = raw.Trim();
+            if (string.IsNullOrEmpty(line))
+            {
+                continue;
+            }
+
+            if (line.StartsWith("# ", StringComparison.Ordinal))
+            {
+                return line[2..].Trim();
+            }
+
+            break;
+        }
+
+        return $"{executionUnit} (untitled)";
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? executionUnit,
+        out string? repo,
+        out string? domainOverride,
+        out bool write,
+        out string format,
+        out string error)
+    {
+        executionUnit = null;
+        repo = null;
+        domainOverride = null;
+        write = false;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value.";
+                        return false;
+                    }
+
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--write":
+                    write = true;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    if (argument.StartsWith("--", StringComparison.Ordinal))
+                    {
+                        error = $"Unknown argument '{argument}'.";
+                        return false;
+                    }
+
+                    if (executionUnit is not null)
+                    {
+                        error = $"Only one execution-unit id is allowed (got '{executionUnit}' and '{argument}').";
+                        return false;
+                    }
+
+                    executionUnit = argument;
+                    break;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            error = "An execution-unit id is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "--repo is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("issue publish-flow");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Validates the packet, creates the GitHub issue without intent-target, and reports the durable-state + intent-target publish boundary as a next step.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal interface IIssueCreator
+{
+    IssueCreateOutcome CreateIssue(string repo, string title, string bodyFilePath);
+}
+
+internal sealed record IssueCreateOutcome(string IssueUrl);
+
+internal sealed class GhCliIssueCreator : IIssueCreator
+{
+    public IssueCreateOutcome CreateIssue(string repo, string title, string bodyFilePath)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("issue");
+        startInfo.ArgumentList.Add("create");
+        startInfo.ArgumentList.Add("--repo");
+        startInfo.ArgumentList.Add(repo);
+        startInfo.ArgumentList.Add("--title");
+        startInfo.ArgumentList.Add(title);
+        startInfo.ArgumentList.Add("--body-file");
+        startInfo.ArgumentList.Add(bodyFilePath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start gh process.");
+
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"gh issue create exit {process.ExitCode}: {stderr.Trim()}");
+        }
+
+        var url = stdout.Trim().Split('\n').LastOrDefault(line => line.StartsWith("https://", StringComparison.Ordinal))
+            ?? stdout.Trim();
+        return new IssueCreateOutcome(url);
+    }
+}
+
+internal sealed record IssuePublishFlowResult
+{
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("packet_directory")]
+    public required string PacketDirectory { get; init; }
+
+    [JsonPropertyName("github_body_path")]
+    public required string GithubBodyPath { get; init; }
+
+    [JsonPropertyName("packet_exists")]
+    public required bool PacketExists { get; init; }
+
+    [JsonPropertyName("github_body_present")]
+    public required bool GithubBodyPresent { get; init; }
+
+    [JsonPropertyName("missing_contract_sections")]
+    public required IReadOnlyList<string> MissingContractSections { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("created")]
+    public required bool Created { get; init; }
+
+    [JsonPropertyName("issue_url")]
+    public string? IssueUrl { get; init; }
+
+    [JsonPropertyName("intent_target_applied")]
+    public required bool IntentTargetApplied { get; init; }
+
+    [JsonPropertyName("next_steps")]
+    public required IReadOnlyList<string> NextSteps { get; init; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
@@ -1,0 +1,314 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IssuePublishFlowCommandTests : IDisposable
+{
+    public IssuePublishFlowCommandTests()
+    {
+        IssuePublishFlowCommand.CreatorFactory = null;
+    }
+
+    public void Dispose()
+    {
+        IssuePublishFlowCommand.CreatorFactory = null;
+    }
+
+    [Fact]
+    public void Execute_GivenCompletePacketDryRun_ReportsValidationOk()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G245", BuildCompleteContractBody("G245 Add intent-cli issue publish-flow command"));
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G245", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("dry-run", root.GetProperty("mode").GetString());
+        Assert.True(root.GetProperty("github_body_present").GetBoolean());
+        Assert.Equal(0, root.GetProperty("missing_contract_sections").GetArrayLength());
+        Assert.False(root.GetProperty("created").GetBoolean());
+        Assert.False(root.GetProperty("intent_target_applied").GetBoolean());
+        Assert.Equal("G245 Add intent-cli issue publish-flow command", root.GetProperty("title").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenIncompleteContract_ReportsMissingSectionsAndExitsNonZero()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G245",
+            """
+            # G245 short body
+
+            ## Goal
+            x
+
+            ## In Scope
+            - x
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G245", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        var missing = root.GetProperty("missing_contract_sections");
+        Assert.True(missing.GetArrayLength() > 0);
+        var names = missing.EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains("Verification", names);
+        Assert.Contains("Acceptance Criteria", names);
+        Assert.False(root.GetProperty("created").GetBoolean());
+        Assert.Contains("incomplete", root.GetProperty("error").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketDirectory_ReportsErrorAndExitsNonZero()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G999", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Contains("packet directory not found", document.RootElement.GetProperty("error").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenWriteWithCompletePacket_CreatesIssueAndReportsNextSteps()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G245", BuildCompleteContractBody("G245 Add intent-cli issue publish-flow command"));
+
+        var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/593");
+        IssuePublishFlowCommand.CreatorFactory = () => stub;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G245", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("write", root.GetProperty("mode").GetString());
+        Assert.True(root.GetProperty("created").GetBoolean());
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/593", root.GetProperty("issue_url").GetString());
+        Assert.False(root.GetProperty("intent_target_applied").GetBoolean());
+
+        var nextSteps = root.GetProperty("next_steps");
+        Assert.True(nextSteps.GetArrayLength() >= 2);
+        var stepText = string.Join('|', nextSteps.EnumerateArray().Select(e => e.GetString()));
+        Assert.Contains("automation issue-publish", stepText, StringComparison.Ordinal);
+
+        Assert.Equal("J-Tech-Japan/intent-system", stub.LastRepo);
+        Assert.Equal("G245 Add intent-cli issue publish-flow command", stub.LastTitle);
+        Assert.EndsWith("github-body.md", stub.LastBodyFile!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenCreatorFailure_ReportsErrorAndExitsNonZero()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G245", BuildCompleteContractBody("G245 Add intent-cli issue publish-flow command"));
+
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G245", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Contains("gh issue create failed", document.RootElement.GetProperty("error").GetString()!, StringComparison.Ordinal);
+        Assert.False(document.RootElement.GetProperty("created").GetBoolean());
+    }
+
+    [Fact]
+    public void Execute_MissingExecutionUnit_ReturnsUsageError()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("execution-unit id is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MissingRepo_ReturnsUsageError()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G245"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--repo is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_InvalidExecutionUnitId_ReturnsUsageError()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["bad/id", "--repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Invalid execution-unit id", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("issue publish-flow", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static string BuildCompleteContractBody(string title)
+    {
+        return $"""
+            # {title}
+
+            ## Goal
+            x
+
+            ## Why This Slice Exists Now
+            x
+
+            ## Current Observed State
+            x
+
+            ## Accepted Baseline You May Assume
+            x
+
+            ## Target Repo / Path / Part
+            x
+
+            ## In Scope
+            - x
+
+            ## Out Of Scope
+            - x
+
+            ## Acceptance Criteria
+            - x
+
+            ## Verification
+            x
+
+            ## Related Links
+            - x
+            """;
+    }
+
+    private sealed class StubIssueCreator : IIssueCreator
+    {
+        private readonly string url;
+
+        public StubIssueCreator(string url)
+        {
+            this.url = url;
+        }
+
+        public string? LastRepo { get; private set; }
+
+        public string? LastTitle { get; private set; }
+
+        public string? LastBodyFile { get; private set; }
+
+        public IssueCreateOutcome CreateIssue(string repo, string title, string bodyFilePath)
+        {
+            LastRepo = repo;
+            LastTitle = title;
+            LastBodyFile = bodyFilePath;
+            return new IssueCreateOutcome(url);
+        }
+    }
+
+    private sealed class ThrowingIssueCreator : IIssueCreator
+    {
+        public IssueCreateOutcome CreateIssue(string repo, string title, string bodyFilePath)
+        {
+            throw new InvalidOperationException("simulated gh failure");
+        }
+    }
+
+    private sealed class IssuePublishFlowWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("issue-publish-flow-tests-")
+            .FullName;
+
+        public IssuePublishFlowWorkspace()
+        {
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public void WriteGithubBody(string executionUnit, string content)
+        {
+            var directory = Path.Combine(rootPath, ".intent-cli", "issues", executionUnit);
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(Path.Combine(directory, "github-body.md"), content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #593

## Summary

- Adds `intent-cli issue publish-flow <execution-unit> --repo <owner/repo> [--domain <name>] [--write] [--format markdown|json]`.
- Validates the packet's `github-body.md` for all 10 required Child Issue Contract sections before any GitHub mutation. Failure to find the packet directory, the github-body file, or any required section exits non-zero with structured error output.
- Without `--write`: dry-run that reports validation only.
- With `--write`: shells out to `gh issue create --title ... --body-file ...` and emits explicit next-step instructions — commit/push parent durable state, then run `intent-cli automation issue-publish --write` for the publish boundary. The issue is created WITHOUT `intent-target`; the publish boundary remains owned by the existing `automation issue-publish` command.
- Uses an injectable `IIssueCreator` (`CreatorFactory` test seam) so tests run without spawning `gh`.
- 9 focused tests cover dry-run with complete contract, missing-section detection, missing packet directory, write-mode happy path with stub creator, creator failure, and each usage error.
- Lists the new G245 command in `docs/automation-templates/README.md`.

The command never applies labels itself, never mutates parent state, and never launches an AI provider.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~IssuePublishFlowCommandTests"` (9/9 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean