### PR TITLE
G246 Add intent-cli closeout pr command

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -43,6 +43,7 @@ These templates assume:
 | G243  | `intent-cli intent next-slice --dry-run` | Read-only next-slice planning facts: WIP, clarification blockers, candidate packets, missing contract fields, recommended outcome |
 | G244  | `intent-cli packet draft`               | Scaffold packet.yaml / implementation.md / review-context.md / github-body.md skeletons with required Child Issue Contract sections; never overwrites existing files |
 | G245  | `intent-cli issue publish-flow`         | Validate packet, create the GitHub issue without intent-target, and report the durable-state + intent-target publish boundary as next steps |
+| G246  | `intent-cli closeout pr`                | Resolve linked execution unit by `linked_pr`, transition the queue item to completed, append `pr-merged`/`closeout-recorded` runs events, and emit a continuation hint plus the manual submodule sync next-step |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
@@ -1,0 +1,527 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G246: <c>intent-cli closeout pr</c> command. Records and applies parent
+/// state updates for an already-accepted child PR without depending on
+/// environment-specific closeout skills. Resolves the queue item via the
+/// PR's <c>linked_pr</c> reference, plans (or applies) the
+/// queue-completion transition, appends <c>runs.jsonl</c> events, and
+/// emits a continuation classification hint plus the submodule sync
+/// step the operator must run separately. Never merges a PR. Never
+/// launches an AI provider.
+/// </summary>
+internal static class CloseoutPrCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string ModeWrite = "write";
+    private const string ModeDryRun = "dry-run";
+
+    private const string ContinuationNextSliceReady = "next-slice-ready";
+    private const string ContinuationNoActionableItem = "no-actionable-item";
+    private const string ContinuationClarificationRequired = "clarification-required";
+
+    private const string UsageLine =
+        "Usage: intent-cli closeout pr --pr <n> --repo <owner/repo> [--domain <name>] [--dry-run|--write] [--format json|markdown]";
+
+    /// <summary>
+    /// Test seam — replaces the default UTC timestamp source for runs events.
+    /// </summary>
+    public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var pr, out var repo, out var domainOverride, out var write, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride!;
+
+        var queueStatePath = context.GetQueueStatePath();
+        var runsLogPath = context.GetRunLogPath();
+
+        if (!File.Exists(queueStatePath))
+        {
+            EmitErrorResult(writer, format, NewFailureResult(domain, repo!, pr!.Value, queueStatePath, runsLogPath, write,
+                $"queue-state file not found: {queueStatePath}"));
+            return 1;
+        }
+
+        QueueState queueState;
+        try
+        {
+            queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        }
+        catch (JsonException jsonException)
+        {
+            EmitErrorResult(writer, format, NewFailureResult(domain, repo!, pr!.Value, queueStatePath, runsLogPath, write,
+                $"queue-state JSON could not be parsed: {jsonException.Message}"));
+            return 1;
+        }
+        catch (InvalidOperationException invalidOperation)
+        {
+            EmitErrorResult(writer, format, NewFailureResult(domain, repo!, pr!.Value, queueStatePath, runsLogPath, write,
+                $"queue-state payload was invalid: {invalidOperation.Message}"));
+            return 1;
+        }
+
+        var prToken = pr!.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var matchedItem = queueState.Items.FirstOrDefault(item => MatchesLinkedPr(item.LinkedPr, prToken));
+        if (matchedItem is null)
+        {
+            EmitErrorResult(writer, format, NewFailureResult(domain, repo!, pr.Value, queueStatePath, runsLogPath, write,
+                $"no queue item found with linked_pr matching #{pr}."));
+            return 1;
+        }
+
+        var alreadyCompleted = matchedItem.State == QueueItemState.Completed;
+        var beforeState = matchedItem.State.ToString().ToLowerInvariant();
+        var mode = write ? ModeWrite : ModeDryRun;
+
+        // Plan the queue transition. Only Active/Review/Fixing → Completed is supported here.
+        if (!alreadyCompleted
+            && matchedItem.State != QueueItemState.Active
+            && matchedItem.State != QueueItemState.Review
+            && matchedItem.State != QueueItemState.Fixing)
+        {
+            EmitErrorResult(writer, format, NewFailureResult(domain, repo!, pr.Value, queueStatePath, runsLogPath, write,
+                $"queue item '{matchedItem.ExecutionUnit}' is in state '{beforeState}'; closeout supports active/review/fixing → completed only."));
+            return 1;
+        }
+
+        var executionUnit = matchedItem.ExecutionUnit;
+        var nowIso = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow)
+            .ToUniversalTime()
+            .ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", System.Globalization.CultureInfo.InvariantCulture);
+
+        var runsEvents = new List<string>
+        {
+            BuildRunsEvent(executionUnit, "pr-merged", repo!, pr.Value, nowIso),
+            BuildRunsEvent(executionUnit, "closeout-recorded", repo!, pr.Value, nowIso)
+        };
+
+        if (write && !alreadyCompleted)
+        {
+            var updatedItems = queueState.Items
+                .Select(item => item.ExecutionUnit == matchedItem.ExecutionUnit
+                    ? UpdateItemState(item, QueueItemState.Completed)
+                    : item)
+                .ToArray();
+            var updatedState = new QueueState
+            {
+                SchemaVersion = queueState.SchemaVersion,
+                UpdatedAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime(),
+                Items = updatedItems
+            };
+            File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+
+            using var stream = new FileStream(runsLogPath, FileMode.Append, FileAccess.Write);
+            using var streamWriter = new StreamWriter(stream);
+            foreach (var line in runsEvents)
+            {
+                streamWriter.WriteLine(line);
+            }
+        }
+
+        var continuation = ClassifyContinuation(queueState, matchedItem.ExecutionUnit);
+
+        var nextSteps = new List<string>
+        {
+            $"Sync the parent submodule pointer for {repo} to the merge commit (manual step: git -C submodules/<child> fetch && git -C submodules/<child> reset --hard <merge-sha>; git add submodules/<child>).",
+            "Commit and push the parent durable state (queue-state, runs, submodule pointer)."
+        };
+
+        var result = new CloseoutPrResult
+        {
+            Domain = domain,
+            Repo = repo!,
+            Pr = pr.Value,
+            ExecutionUnit = executionUnit,
+            Mode = mode,
+            QueueStatePath = queueStatePath,
+            RunsLogPath = runsLogPath,
+            QueueStateBeforeState = beforeState,
+            QueueStateAfterState = "completed",
+            QueueAlreadyCompleted = alreadyCompleted,
+            RunsEvents = runsEvents,
+            ContinuationHint = continuation,
+            NextSteps = nextSteps,
+            Error = null
+        };
+
+        EmitResult(writer, result, format);
+        return 0;
+    }
+
+    private static bool MatchesLinkedPr(string? linkedPr, string prToken)
+    {
+        if (string.IsNullOrWhiteSpace(linkedPr))
+        {
+            return false;
+        }
+
+        if (string.Equals(linkedPr, prToken, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return linkedPr!.EndsWith($"/{prToken}", StringComparison.Ordinal);
+    }
+
+    private static QueueItem UpdateItemState(QueueItem item, QueueItemState state)
+    {
+        return new QueueItem
+        {
+            ExecutionUnit = item.ExecutionUnit,
+            Title = item.Title,
+            State = state,
+            Dependencies = item.Dependencies,
+            BlockedBy = item.BlockedBy,
+            ClarificationReturnPath = item.ClarificationReturnPath,
+            PacketPaths = item.PacketPaths,
+            LinkedIssue = item.LinkedIssue,
+            LinkedPr = item.LinkedPr,
+            WorkerRole = item.WorkerRole,
+            ReviewRole = item.ReviewRole,
+            Priority = item.Priority
+        };
+    }
+
+    private static string BuildRunsEvent(string executionUnit, string kind, string repo, int pr, string timestampIso)
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["timestamp"] = timestampIso,
+            ["execution_unit"] = executionUnit,
+            ["kind"] = kind,
+            ["repo"] = repo,
+            ["pr"] = pr
+        };
+        return JsonSerializer.Serialize(payload, RunsEventJsonOptions);
+    }
+
+    private static string ClassifyContinuation(QueueState state, string completingUnit)
+    {
+        var openClarification = state.Items.Any(item => item.State == QueueItemState.ClarifyBlocked);
+        if (openClarification)
+        {
+            return ContinuationClarificationRequired;
+        }
+
+        var queuedRemaining = state.Items.Any(item =>
+            item.State == QueueItemState.Queued
+            && !string.Equals(item.ExecutionUnit, completingUnit, StringComparison.Ordinal));
+        if (queuedRemaining)
+        {
+            return ContinuationNextSliceReady;
+        }
+
+        return ContinuationNoActionableItem;
+    }
+
+    private static CloseoutPrResult NewFailureResult(
+        string domain,
+        string repo,
+        int pr,
+        string queueStatePath,
+        string runsLogPath,
+        bool write,
+        string error)
+    {
+        return new CloseoutPrResult
+        {
+            Domain = domain,
+            Repo = repo,
+            Pr = pr,
+            ExecutionUnit = null,
+            Mode = write ? ModeWrite : ModeDryRun,
+            QueueStatePath = queueStatePath,
+            RunsLogPath = runsLogPath,
+            QueueStateBeforeState = null,
+            QueueStateAfterState = null,
+            QueueAlreadyCompleted = false,
+            RunsEvents = Array.Empty<string>(),
+            ContinuationHint = null,
+            NextSteps = Array.Empty<string>(),
+            Error = error
+        };
+    }
+
+    private static void EmitErrorResult(TextWriter writer, string format, CloseoutPrResult result)
+    {
+        EmitResult(writer, result, format);
+    }
+
+    private static void EmitResult(TextWriter writer, CloseoutPrResult result, string format)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+    }
+
+    private static void WriteMarkdown(TextWriter writer, CloseoutPrResult result)
+    {
+        writer.WriteLine($"# Closeout PR — {result.Repo}#{result.Pr}");
+        writer.WriteLine();
+        writer.WriteLine($"- domain: {result.Domain}");
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- queue-state path: {result.QueueStatePath}");
+        writer.WriteLine($"- runs-log path: {result.RunsLogPath}");
+        if (!string.IsNullOrWhiteSpace(result.ExecutionUnit))
+        {
+            writer.WriteLine($"- execution unit: {result.ExecutionUnit}");
+        }
+        writer.WriteLine();
+
+        if (!string.IsNullOrWhiteSpace(result.Error))
+        {
+            writer.WriteLine("## Error");
+            writer.WriteLine($"- {result.Error}");
+            return;
+        }
+
+        writer.WriteLine("## Queue transition");
+        writer.WriteLine($"- before: {result.QueueStateBeforeState}");
+        writer.WriteLine($"- after: {result.QueueStateAfterState}");
+        writer.WriteLine($"- already completed: {(result.QueueAlreadyCompleted ? "yes" : "no")}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Runs events");
+        if (result.RunsEvents.Count == 0)
+        {
+            writer.WriteLine("- none");
+        }
+        else
+        {
+            foreach (var line in result.RunsEvents)
+            {
+                writer.WriteLine($"- {line}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine($"## Continuation hint: {result.ContinuationHint}");
+        writer.WriteLine();
+
+        if (result.NextSteps.Count > 0)
+        {
+            writer.WriteLine("## Next steps");
+            foreach (var step in result.NextSteps)
+            {
+                writer.WriteLine($"- {step}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out int? pr,
+        out string? repo,
+        out string? domainOverride,
+        out bool write,
+        out string format,
+        out string error)
+    {
+        pr = null;
+        repo = null;
+        domainOverride = null;
+        write = false;
+        var dryRun = false;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--pr":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--pr requires a value.";
+                        return false;
+                    }
+
+                    if (!int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var prValue) || prValue <= 0)
+                    {
+                        error = $"--pr must be a positive integer (got '{args[index + 1]}').";
+                        return false;
+                    }
+
+                    pr = prValue;
+                    index++;
+                    break;
+
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value.";
+                        return false;
+                    }
+
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--write":
+                    if (dryRun)
+                    {
+                        error = "--write and --dry-run are mutually exclusive.";
+                        return false;
+                    }
+
+                    write = true;
+                    break;
+
+                case "--dry-run":
+                    if (write)
+                    {
+                        error = "--write and --dry-run are mutually exclusive.";
+                        return false;
+                    }
+
+                    dryRun = true;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (pr is null)
+        {
+            error = "--pr is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "--repo is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("closeout pr");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Records the queue/runs closeout for an accepted child PR. --dry-run plans only; --write applies queue + runs updates. Submodule sync remains a manual next step.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private static readonly JsonSerializerOptions RunsEventJsonOptions = new()
+    {
+        WriteIndented = false
+    };
+}
+
+internal sealed record CloseoutPrResult
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("pr")]
+    public required int Pr { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public string? ExecutionUnit { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("queue_state_path")]
+    public required string QueueStatePath { get; init; }
+
+    [JsonPropertyName("runs_log_path")]
+    public required string RunsLogPath { get; init; }
+
+    [JsonPropertyName("queue_state_before")]
+    public string? QueueStateBeforeState { get; init; }
+
+    [JsonPropertyName("queue_state_after")]
+    public string? QueueStateAfterState { get; init; }
+
+    [JsonPropertyName("queue_already_completed")]
+    public required bool QueueAlreadyCompleted { get; init; }
+
+    [JsonPropertyName("runs_events")]
+    public required IReadOnlyList<string> RunsEvents { get; init; }
+
+    [JsonPropertyName("continuation_hint")]
+    public string? ContinuationHint { get; init; }
+
+    [JsonPropertyName("next_steps")]
+    public required IReadOnlyList<string> NextSteps { get; init; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -27,7 +27,8 @@ internal static class CommandRouter
         "metadata",
         "guide",
         "intent",
-        "packet"
+        "packet",
+        "closeout"
     ];
 
     private static readonly IReadOnlyList<string> AutomationCommandHelp =
@@ -213,6 +214,10 @@ internal static class CommandRouter
             ["packet"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
                 ["draft"] = PacketDraftCommand.Execute
+            },
+            ["closeout"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["pr"] = CloseoutPrCommand.Execute
             }
         };
 

--- a/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
@@ -1,0 +1,365 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class CloseoutPrCommandTests : IDisposable
+{
+    public CloseoutPrCommandTests()
+    {
+        CloseoutPrCommand.UtcNowFactory = () => new DateTimeOffset(2026, 5, 4, 12, 0, 0, TimeSpan.Zero);
+    }
+
+    public void Dispose()
+    {
+        CloseoutPrCommand.UtcNowFactory = null;
+    }
+
+    [Fact]
+    public void Execute_GivenWriteWithReviewItem_TransitionsToCompletedAndAppendsRunsEvents()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G246", "review", linkedPr: "594"));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "594", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("write", root.GetProperty("mode").GetString());
+        Assert.Equal("G246", root.GetProperty("execution_unit").GetString());
+        Assert.Equal("review", root.GetProperty("queue_state_before").GetString());
+        Assert.Equal("completed", root.GetProperty("queue_state_after").GetString());
+        Assert.Equal(2, root.GetProperty("runs_events").GetArrayLength());
+
+        var queueOnDisk = File.ReadAllText(workspace.Context.GetQueueStatePath());
+        Assert.Contains("\"state\": \"completed\"", queueOnDisk, StringComparison.Ordinal);
+
+        var runsLines = File.ReadAllLines(workspace.Context.GetRunLogPath());
+        Assert.Equal(2, runsLines.Length);
+        Assert.Contains("pr-merged", runsLines[0], StringComparison.Ordinal);
+        Assert.Contains("closeout-recorded", runsLines[1], StringComparison.Ordinal);
+        Assert.Contains("\"pr\":594", runsLines[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenDryRun_DoesNotMutateAnyFile()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        var queueBefore = BuildQueueState("G246", "review", linkedPr: "594");
+        workspace.WriteQueueState(queueBefore);
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "594", "--dry-run", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("dry-run", document.RootElement.GetProperty("mode").GetString());
+
+        Assert.Equal(queueBefore, File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        Assert.False(File.Exists(workspace.Context.GetRunLogPath()));
+    }
+
+    [Fact]
+    public void Execute_GivenAlreadyCompletedItem_ReportsAlreadyCompletedAndDoesNotAppend()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        var queue = BuildQueueState("G246", "completed", linkedPr: "594");
+        workspace.WriteQueueState(queue);
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "594", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("queue_already_completed").GetBoolean());
+
+        Assert.Equal(queue, File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        Assert.False(File.Exists(workspace.Context.GetRunLogPath()));
+    }
+
+    [Fact]
+    public void Execute_GivenQueuedItem_FailsWithUnsupportedTransition()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G246", "queued", linkedPr: "594"));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "594", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Contains("active/review/fixing → completed only", document.RootElement.GetProperty("error").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNoMatchingLinkedPr_FailsWithLinkedPrError()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G246", "review", linkedPr: "999"));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "594", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Contains("no queue item found with linked_pr matching #594", document.RootElement.GetProperty("error").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenAnotherQueuedSlice_RecommendsNextSliceReady()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueWithTwoItems(
+            completing: ("G246", "review", "594"),
+            waiting: ("G247", "queued", null)));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "594", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("next-slice-ready", document.RootElement.GetProperty("continuation_hint").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenNoOtherSlice_RecommendsNoActionableItem()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G246", "review", linkedPr: "594"));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "594", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("no-actionable-item", document.RootElement.GetProperty("continuation_hint").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenClarifyBlockedSibling_RecommendsClarificationRequired()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueWithTwoItems(
+            completing: ("G246", "review", "594"),
+            waiting: ("G247", "clarify-blocked", null)));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "594", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("clarification-required", document.RootElement.GetProperty("continuation_hint").GetString());
+    }
+
+    [Fact]
+    public void Execute_MissingPr_ReturnsUsageError()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--pr is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MissingRepo_ReturnsUsageError()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--pr", "594"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--repo is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NonPositivePr_ReturnsUsageError()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "0"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--pr must be a positive integer", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_BothWriteAndDryRun_ReturnsUsageError()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "594", "--write", "--dry-run"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--write and --dry-run are mutually exclusive", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("closeout pr", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static string BuildQueueState(string executionUnit, string state, string? linkedPr)
+    {
+        var linked = linkedPr is null ? "null" : $"\"{linkedPr}\"";
+        return $$"""
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "{{executionUnit}}",
+                  "title": "title",
+                  "state": "{{state}}",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_pr": {{linked}},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """;
+    }
+
+    private static string BuildQueueWithTwoItems(
+        (string ExecutionUnit, string State, string? LinkedPr) completing,
+        (string ExecutionUnit, string State, string? LinkedPr) waiting)
+    {
+        var completingLinked = completing.LinkedPr is null ? "null" : $"\"{completing.LinkedPr}\"";
+        var waitingLinked = waiting.LinkedPr is null ? "null" : $"\"{waiting.LinkedPr}\"";
+        return $$"""
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "{{completing.ExecutionUnit}}",
+                  "title": "completing",
+                  "state": "{{completing.State}}",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_pr": {{completingLinked}},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                },
+                {
+                  "execution_unit": "{{waiting.ExecutionUnit}}",
+                  "title": "waiting",
+                  "state": "{{waiting.State}}",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_pr": {{waitingLinked}},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """;
+    }
+
+    private sealed class CloseoutPrWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("closeout-pr-tests-")
+            .FullName;
+
+        public CloseoutPrWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public void WriteQueueState(string content)
+        {
+            File.WriteAllText(Context.GetQueueStatePath(), content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #595

## Summary

- Adds `intent-cli closeout pr --pr <n> --repo <owner/repo> [--domain <name>] [--dry-run|--write] [--format json|markdown]`.
- Resolves the queue item via the PR's `linked_pr` reference and plans the queue-completion transition.
- Supported transitions are active/review/fixing → completed only. Already-completed items short-circuit without re-appending events. Other states fail deterministically with an actionable error.
- Appends two runs events (`pr-merged`, `closeout-recorded`) to `runs.jsonl` with a deterministic timestamp source (test-injectable).
- Emits a continuation classification hint based on remaining queue state: `next-slice-ready`, `no-actionable-item`, or `clarification-required` (when any sibling is `clarify-blocked`).
- Submodule pointer update is intentionally out of scope for this slice; the command instead reports it as a manual next step in the output.
- `--dry-run` plans only and never mutates files. `--write` rewrites queue-state and appends runs events.
- Never merges a PR. Never launches an AI provider.
- 13 focused tests cover write/dry-run/already-completed paths, unsupported state, no-match, all three continuation hints, and each usage error.
- Lists the new G246 command in `docs/automation-templates/README.md`.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~CloseoutPrCommandTests"` (13/13 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean