### PR TITLE
G247 Add intent-cli review closeout-plan command

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -44,6 +44,7 @@ These templates assume:
 | G244  | `intent-cli packet draft`               | Scaffold packet.yaml / implementation.md / review-context.md / github-body.md skeletons with required Child Issue Contract sections; never overwrites existing files |
 | G245  | `intent-cli issue publish-flow`         | Validate packet, create the GitHub issue without intent-target, and report the durable-state + intent-target publish boundary as next steps |
 | G246  | `intent-cli closeout pr`                | Resolve linked execution unit by `linked_pr`, transition the queue item to completed, append `pr-merged`/`closeout-recorded` runs events, and emit a continuation hint plus the manual submodule sync next-step |
+| G247  | `intent-cli review closeout-plan`       | Read-only review-pass closeout plan: execution unit, linked issue, packet refs, contract validation, expected submodule path, validation/closeout steps, and blocking gaps |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -73,7 +73,8 @@ internal static class CommandRouter
             {
                 ["run"] = ReviewRunCommand.Execute,
                 ["comment"] = ReviewCommentCommand.Execute,
-                ["accept"] = ReviewAcceptCommand.Execute
+                ["accept"] = ReviewAcceptCommand.Execute,
+                ["closeout-plan"] = ReviewCloseoutPlanCommand.Execute
             },
             ["interview"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
@@ -1,0 +1,493 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G247: Read-only <c>intent-cli review closeout-plan</c> command. Reports
+/// what a review-pass closeout would mutate before any merge or parent
+/// state write. Resolves the queue item via <c>linked_pr</c>, lists the
+/// packet directory contents, validates Child Issue Contract sections,
+/// derives the expected submodule path, and emits the deterministic
+/// validation/closeout steps the operator must run separately. Reports
+/// blocking ambiguities as actionable gaps. Never mutates state. Never
+/// launches an AI provider.
+/// </summary>
+internal static class ReviewCloseoutPlanCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli review closeout-plan --pr <n> --repo <owner/repo> [--domain <name>] [--format json|markdown]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var pr, out var repo, out var domainOverride, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride!;
+
+        var queueStatePath = context.GetQueueStatePath();
+        var gaps = new List<string>();
+
+        QueueState? queueState = null;
+        if (!File.Exists(queueStatePath))
+        {
+            gaps.Add($"queue-state file not found: {queueStatePath}");
+        }
+        else
+        {
+            try
+            {
+                queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            }
+            catch (JsonException jsonException)
+            {
+                gaps.Add($"queue-state JSON could not be parsed: {jsonException.Message}");
+            }
+            catch (InvalidOperationException invalidOperation)
+            {
+                gaps.Add($"queue-state payload was invalid: {invalidOperation.Message}");
+            }
+        }
+
+        QueueItem? matchedItem = null;
+        if (queueState is not null)
+        {
+            var prToken = pr!.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            matchedItem = queueState.Items.FirstOrDefault(item => MatchesLinkedPr(item.LinkedPr, prToken));
+            if (matchedItem is null)
+            {
+                gaps.Add($"no queue item found with linked_pr matching #{pr}.");
+            }
+        }
+
+        string? packetDirectory = null;
+        IReadOnlyList<string> packetFiles = Array.Empty<string>();
+        IReadOnlyList<string> missingSections = Array.Empty<string>();
+        ReviewCloseoutLinkedIssue? linkedIssue = null;
+        if (matchedItem is not null)
+        {
+            packetDirectory = Path.Combine(context.RepoRoot, ".intent-cli", "issues", matchedItem.ExecutionUnit);
+            if (Directory.Exists(packetDirectory))
+            {
+                packetFiles = Directory.EnumerateFiles(packetDirectory)
+                    .Select(file => Path.GetFileName(file))
+                    .OrderBy(name => name, StringComparer.Ordinal)
+                    .ToArray();
+
+                var githubBodyPath = Path.Combine(packetDirectory, "github-body.md");
+                if (!File.Exists(githubBodyPath))
+                {
+                    gaps.Add($"github-body.md not found in packet directory: {packetDirectory}");
+                    missingSections = PacketDraftCommand.RequiredContractSections;
+                }
+                else
+                {
+                    var content = File.ReadAllText(githubBodyPath);
+                    missingSections = PacketDraftCommand.RequiredContractSections
+                        .Where(section => !ContainsSectionHeading(content, section))
+                        .ToArray();
+                    if (missingSections.Count > 0)
+                    {
+                        gaps.Add("Child Issue Contract is incomplete; sections missing: " + string.Join(", ", missingSections));
+                    }
+                }
+            }
+            else
+            {
+                gaps.Add($"packet directory not found: {packetDirectory}");
+                missingSections = PacketDraftCommand.RequiredContractSections;
+            }
+
+            if (matchedItem.LinkedIssue is null)
+            {
+                gaps.Add("queue item has no linked_issue; closeout requires a linked issue to close.");
+            }
+            else
+            {
+                linkedIssue = new ReviewCloseoutLinkedIssue
+                {
+                    Repo = matchedItem.LinkedIssue.Repo,
+                    Number = matchedItem.LinkedIssue.Number,
+                    Url = matchedItem.LinkedIssue.Url
+                };
+            }
+        }
+
+        var expectedSubmodulePath = DeriveSubmodulePath(repo!);
+
+        var validationSteps = new List<string>
+        {
+            "Run focused tests for the touched packet area.",
+            "Run `git diff --check` against the merge result.",
+            "Confirm the PR head SHA before and after the review pass."
+        };
+
+        var closeoutSteps = new List<string>
+        {
+            $"Sync the parent submodule pointer for {repo} at `{expectedSubmodulePath}` to the merge commit.",
+            "Mark the queue item completed and append `pr-merged` + `closeout-recorded` runs events (see `intent-cli closeout pr --write`).",
+            "Close the linked child issue once the merge is durable.",
+            "Commit and push the parent durable state (queue-state, runs, submodule pointer)."
+        };
+
+        var result = new ReviewCloseoutPlanResult
+        {
+            Domain = domain,
+            Repo = repo!,
+            Pr = pr!.Value,
+            QueueStatePath = queueStatePath,
+            ExecutionUnit = matchedItem?.ExecutionUnit,
+            QueueItemState = matchedItem?.State.ToString().ToLowerInvariant(),
+            LinkedIssue = linkedIssue,
+            PacketDirectory = packetDirectory,
+            PacketFiles = packetFiles,
+            MissingContractSections = missingSections,
+            ExpectedSubmodulePath = expectedSubmodulePath,
+            ValidationSteps = validationSteps,
+            ClosingSteps = closeoutSteps,
+            Gaps = gaps,
+            Ready = gaps.Count == 0 && matchedItem is not null
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return result.Ready ? 0 : 1;
+    }
+
+    private static bool MatchesLinkedPr(string? linkedPr, string prToken)
+    {
+        if (string.IsNullOrWhiteSpace(linkedPr))
+        {
+            return false;
+        }
+
+        if (string.Equals(linkedPr, prToken, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return linkedPr!.EndsWith($"/{prToken}", StringComparison.Ordinal);
+    }
+
+    private static string DeriveSubmodulePath(string repo)
+    {
+        var segments = repo.Split('/', 2, StringSplitOptions.RemoveEmptyEntries);
+        var name = segments.Length == 2 ? segments[1] : repo;
+        return $"submodules/{name}";
+    }
+
+    private static bool ContainsSectionHeading(string content, string section)
+    {
+        var lines = content.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.Trim();
+            if (!line.StartsWith("##", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var heading = line.TrimStart('#').Trim();
+            if (string.Equals(heading, section, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void WriteMarkdown(TextWriter writer, ReviewCloseoutPlanResult result)
+    {
+        writer.WriteLine($"# Review closeout plan — {result.Repo}#{result.Pr}");
+        writer.WriteLine();
+        writer.WriteLine($"- domain: {result.Domain}");
+        writer.WriteLine($"- queue-state path: {result.QueueStatePath}");
+        writer.WriteLine($"- execution unit: {(result.ExecutionUnit ?? "(unresolved)")}");
+        if (!string.IsNullOrWhiteSpace(result.QueueItemState))
+        {
+            writer.WriteLine($"- queue item state: {result.QueueItemState}");
+        }
+        writer.WriteLine($"- expected submodule path: {result.ExpectedSubmodulePath}");
+        writer.WriteLine($"- ready: {(result.Ready ? "yes" : "no")}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Linked issue");
+        if (result.LinkedIssue is null)
+        {
+            writer.WriteLine("- (none recorded)");
+        }
+        else
+        {
+            writer.WriteLine($"- repo: {result.LinkedIssue.Repo}");
+            if (result.LinkedIssue.Number is not null)
+            {
+                writer.WriteLine($"- number: {result.LinkedIssue.Number}");
+            }
+            if (!string.IsNullOrWhiteSpace(result.LinkedIssue.Url))
+            {
+                writer.WriteLine($"- url: {result.LinkedIssue.Url}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Packet");
+        if (string.IsNullOrWhiteSpace(result.PacketDirectory))
+        {
+            writer.WriteLine("- packet directory: (unknown)");
+        }
+        else
+        {
+            writer.WriteLine($"- packet directory: {result.PacketDirectory}");
+            if (result.PacketFiles.Count == 0)
+            {
+                writer.WriteLine("- files: (none)");
+            }
+            else
+            {
+                writer.WriteLine("- files:");
+                foreach (var file in result.PacketFiles)
+                {
+                    writer.WriteLine($"  - {file}");
+                }
+            }
+            if (result.MissingContractSections.Count == 0)
+            {
+                writer.WriteLine("- missing contract sections: none");
+            }
+            else
+            {
+                writer.WriteLine("- missing contract sections:");
+                foreach (var section in result.MissingContractSections)
+                {
+                    writer.WriteLine($"  - {section}");
+                }
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Validation steps");
+        foreach (var step in result.ValidationSteps)
+        {
+            writer.WriteLine($"- {step}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Closeout steps");
+        foreach (var step in result.ClosingSteps)
+        {
+            writer.WriteLine($"- {step}");
+        }
+        writer.WriteLine();
+
+        if (result.Gaps.Count > 0)
+        {
+            writer.WriteLine("## Gaps");
+            foreach (var gap in result.Gaps)
+            {
+                writer.WriteLine($"- {gap}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out int? pr,
+        out string? repo,
+        out string? domainOverride,
+        out string format,
+        out string error)
+    {
+        pr = null;
+        repo = null;
+        domainOverride = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--pr":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--pr requires a value.";
+                        return false;
+                    }
+
+                    if (!int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var prValue) || prValue <= 0)
+                    {
+                        error = $"--pr must be a positive integer (got '{args[index + 1]}').";
+                        return false;
+                    }
+
+                    pr = prValue;
+                    index++;
+                    break;
+
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value.";
+                        return false;
+                    }
+
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (json or markdown).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatJson, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatMarkdown, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'json' or 'markdown' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (pr is null)
+        {
+            error = "--pr is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "--repo is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("review closeout-plan");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only review-pass closeout planning facts. Reports execution unit, linked issue, packet refs, expected submodule path, validation steps, and any blocking gaps without mutating state.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record ReviewCloseoutPlanResult
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("pr")]
+    public required int Pr { get; init; }
+
+    [JsonPropertyName("queue_state_path")]
+    public required string QueueStatePath { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public string? ExecutionUnit { get; init; }
+
+    [JsonPropertyName("queue_item_state")]
+    public string? QueueItemState { get; init; }
+
+    [JsonPropertyName("linked_issue")]
+    public ReviewCloseoutLinkedIssue? LinkedIssue { get; init; }
+
+    [JsonPropertyName("packet_directory")]
+    public string? PacketDirectory { get; init; }
+
+    [JsonPropertyName("packet_files")]
+    public required IReadOnlyList<string> PacketFiles { get; init; }
+
+    [JsonPropertyName("missing_contract_sections")]
+    public required IReadOnlyList<string> MissingContractSections { get; init; }
+
+    [JsonPropertyName("expected_submodule_path")]
+    public required string ExpectedSubmodulePath { get; init; }
+
+    [JsonPropertyName("validation_steps")]
+    public required IReadOnlyList<string> ValidationSteps { get; init; }
+
+    [JsonPropertyName("closeout_steps")]
+    public required IReadOnlyList<string> ClosingSteps { get; init; }
+
+    [JsonPropertyName("gaps")]
+    public required IReadOnlyList<string> Gaps { get; init; }
+
+    [JsonPropertyName("ready")]
+    public required bool Ready { get; init; }
+}
+
+internal sealed record ReviewCloseoutLinkedIssue
+{
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("number")]
+    public int? Number { get; init; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
@@ -1,0 +1,313 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ReviewCloseoutPlanCommandTests
+{
+    [Fact]
+    public void Execute_GivenCompletePacketAndQueueMatch_ReportsReadyTrue()
+    {
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review", linkedPr: "596", linkedIssue: ("J-Tech-Japan/intent-system", 595, "https://github.com/J-Tech-Japan/intent-system/issues/595")));
+        workspace.WriteFile(".intent-cli/issues/G247/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(".intent-cli/issues/G247/packet.yaml", "x");
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("ready").GetBoolean());
+        Assert.Equal("G247", root.GetProperty("execution_unit").GetString());
+        Assert.Equal("review", root.GetProperty("queue_item_state").GetString());
+        Assert.Equal("submodules/intent-system", root.GetProperty("expected_submodule_path").GetString());
+        Assert.Equal(0, root.GetProperty("missing_contract_sections").GetArrayLength());
+        Assert.Equal(0, root.GetProperty("gaps").GetArrayLength());
+        var linked = root.GetProperty("linked_issue");
+        Assert.Equal("J-Tech-Japan/intent-system", linked.GetProperty("repo").GetString());
+        Assert.Equal(595, linked.GetProperty("number").GetInt32());
+        Assert.True(root.GetProperty("packet_files").GetArrayLength() >= 2);
+        Assert.True(root.GetProperty("validation_steps").GetArrayLength() >= 2);
+        Assert.True(root.GetProperty("closeout_steps").GetArrayLength() >= 2);
+    }
+
+    [Fact]
+    public void Execute_GivenMissingContractSections_ReportsGapAndExitsNonZero()
+    {
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review", linkedPr: "596", linkedIssue: ("J-Tech-Japan/intent-system", 595, null)));
+        workspace.WriteFile(".intent-cli/issues/G247/github-body.md", "## Goal\nx\n");
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("ready").GetBoolean());
+        Assert.True(root.GetProperty("gaps").GetArrayLength() > 0);
+        var missingNames = root.GetProperty("missing_contract_sections").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains("Verification", missingNames);
+    }
+
+    [Fact]
+    public void Execute_GivenNoLinkedIssue_ReportsLinkedIssueGap()
+    {
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review", linkedPr: "596", linkedIssue: null));
+        workspace.WriteFile(".intent-cli/issues/G247/github-body.md", BuildCompleteContractBody());
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var gaps = document.RootElement.GetProperty("gaps").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(gaps, gap => gap!.Contains("linked_issue", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingPacketDirectory_ReportsPacketGap()
+    {
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review", linkedPr: "596", linkedIssue: ("J-Tech-Japan/intent-system", 595, null)));
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var gaps = document.RootElement.GetProperty("gaps").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(gaps, gap => gap!.Contains("packet directory not found", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenNoMatchingLinkedPr_ReportsQueueGap()
+    {
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review", linkedPr: "999", linkedIssue: null));
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var gaps = document.RootElement.GetProperty("gaps").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(gaps, gap => gap!.Contains("no queue item found with linked_pr", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_MissingPr_ReturnsUsageError()
+    {
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--pr is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MissingRepo_ReturnsUsageError()
+    {
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--pr", "596"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--repo is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedFormat_ReturnsUsageError()
+    {
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'json' or 'markdown'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MarkdownFormat_EmitsHumanReadableOutput()
+    {
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review", linkedPr: "596", linkedIssue: ("J-Tech-Japan/intent-system", 595, null)));
+        workspace.WriteFile(".intent-cli/issues/G247/github-body.md", BuildCompleteContractBody());
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Review closeout plan — J-Tech-Japan/intent-system#596", output, StringComparison.Ordinal);
+        Assert.Contains("expected submodule path: submodules/intent-system", output, StringComparison.Ordinal);
+        Assert.Contains("ready: yes", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("review closeout-plan", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static string BuildCompleteContractBody()
+    {
+        return """
+            ## Goal
+            x
+
+            ## Why This Slice Exists Now
+            x
+
+            ## Current Observed State
+            x
+
+            ## Accepted Baseline You May Assume
+            x
+
+            ## Target Repo / Path / Part
+            x
+
+            ## In Scope
+            - x
+
+            ## Out Of Scope
+            - x
+
+            ## Acceptance Criteria
+            - x
+
+            ## Verification
+            x
+
+            ## Related Links
+            - x
+            """;
+    }
+
+    private static string BuildQueueState(string executionUnit, string state, string? linkedPr, (string Repo, int Number, string? Url)? linkedIssue)
+    {
+        var linkedPrToken = linkedPr is null ? "null" : $"\"{linkedPr}\"";
+        var linkedIssueBlock = linkedIssue is null
+            ? ""
+            : $@",
+                  ""linked_issue"": {{
+                    ""repo"": ""{linkedIssue.Value.Repo}"",
+                    ""number"": {linkedIssue.Value.Number},
+                    ""url"": {(linkedIssue.Value.Url is null ? "null" : $"\"{linkedIssue.Value.Url}\"")}
+                  }}";
+        return $$"""
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "{{executionUnit}}",
+                  "title": "title",
+                  "state": "{{state}}",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_pr": {{linkedPrToken}}{{linkedIssueBlock}},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """;
+    }
+
+    private sealed class ReviewCloseoutPlanWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("review-closeout-plan-tests-")
+            .FullName;
+
+        public ReviewCloseoutPlanWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public void WriteQueueState(string content)
+        {
+            File.WriteAllText(Context.GetQueueStatePath(), content);
+        }
+
+        public void WriteFile(string relativePath, string content)
+        {
+            var full = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+            File.WriteAllText(full, content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #597

## Summary

- Adds read-only `intent-cli review closeout-plan --pr <n> --repo <owner/repo> [--domain <name>] [--format json|markdown]`.
- Resolves the execution unit via the queue item's `linked_pr` field, lists the packet directory contents, validates Child Issue Contract sections in `github-body.md`, derives the expected submodule path (`submodules/<repo-name>`), and emits both the validation steps and the closeout steps the operator must run separately.
- Reports blocking ambiguities in a `gaps` array. Exits non-zero when any gap is present (no queue match, missing linked_issue, missing packet directory, missing required contract sections) so review agents can detect contract issues before mutating GitHub or parent state.
- Read-only: never mutates queue-state, runs, GitHub, or source files. Never launches an AI provider.
- 10 focused tests cover ready-true happy path, missing contract sections, missing linked_issue, missing packet directory, no queue match, markdown format, missing args, unsupported format, and help.
- Lists the new G247 command in `docs/automation-templates/README.md`.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~ReviewCloseoutPlanCommandTests"` (10/10 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean