### PR TITLE
G250 Add interview next-question and record-answer commands

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -47,6 +47,7 @@ These templates assume:
 | G247  | `intent-cli review closeout-plan`       | Read-only review-pass closeout plan: execution unit, linked issue, packet refs, contract validation, expected submodule path, validation/closeout steps, and blocking gaps |
 | G248  | `intent-cli guide review`               | Read-only PR review guidance: execution unit + packet refs, review-context excerpt, deterministic checklist, boundaries, and validation suggestions |
 | G249  | `intent-cli guide collaborate`          | Read-only operator-facing collaboration guide for early product-owner feature intake (responsibility boundaries + suggested command sequence + interview/draft rules) |
+| G250  | `intent-cli interview next-question` / `interview record-answer` | Durable per-domain interview session store: returns first pending question and records (or appends new) answers under `intents/<domain>/interviews/<session>.json` |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -80,7 +80,9 @@ internal static class CommandRouter
             {
                 ["start"] = InterviewStartCommand.Execute,
                 ["answer"] = InterviewAnswerCommand.Execute,
-                ["resume"] = InterviewResumeCommand.Execute
+                ["resume"] = InterviewResumeCommand.Execute,
+                ["next-question"] = InterviewNextQuestionCommand.Execute,
+                ["record-answer"] = InterviewRecordAnswerCommand.Execute
             },
             ["clarify"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/InterviewNextQuestionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/InterviewNextQuestionCommand.cs
@@ -1,0 +1,229 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G250: Read-only <c>intent-cli interview next-question</c>. Returns the
+/// first pending question (one whose answer is empty) for a given
+/// <c>--session</c> in a per-domain interview store. Never launches an AI
+/// provider, never mutates state.
+/// </summary>
+internal static class InterviewNextQuestionCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli interview next-question --session <id> [--domain <name>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var session, out var domainOverride, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride!;
+
+        var sessionPath = InterviewSessionStore.ResolvePath(context.RepoRoot, domain, session!);
+        var stored = InterviewSessionStore.Read(sessionPath);
+
+        InterviewQuestion? pending = null;
+        var totalQuestions = 0;
+        var pendingCount = 0;
+        var sessionExists = stored is not null;
+
+        if (stored is not null)
+        {
+            totalQuestions = stored.Questions.Count;
+            pending = stored.Questions.FirstOrDefault(q => string.IsNullOrEmpty(q.Answer));
+            pendingCount = stored.Questions.Count(q => string.IsNullOrEmpty(q.Answer));
+        }
+
+        var result = new InterviewNextQuestionResult
+        {
+            Domain = domain,
+            Session = session!,
+            SessionPath = sessionPath,
+            SessionExists = sessionExists,
+            TotalQuestions = totalQuestions,
+            PendingCount = pendingCount,
+            HasPending = pending is not null,
+            Pending = pending is null
+                ? null
+                : new InterviewNextQuestionPending
+                {
+                    Id = pending.Id,
+                    Prompt = pending.Prompt
+                }
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static void WriteMarkdown(TextWriter writer, InterviewNextQuestionResult result)
+    {
+        writer.WriteLine($"# Interview next question — {result.Domain} / {result.Session}");
+        writer.WriteLine();
+        writer.WriteLine($"- session path: {result.SessionPath}");
+        writer.WriteLine($"- session exists: {(result.SessionExists ? "yes" : "no")}");
+        writer.WriteLine($"- total questions: {result.TotalQuestions}");
+        writer.WriteLine($"- pending count: {result.PendingCount}");
+        writer.WriteLine();
+
+        if (result.Pending is null)
+        {
+            writer.WriteLine("No pending question.");
+            return;
+        }
+
+        writer.WriteLine("## Next pending");
+        writer.WriteLine($"- id: {result.Pending.Id}");
+        writer.WriteLine($"- prompt:");
+        writer.WriteLine();
+        writer.WriteLine(result.Pending.Prompt);
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? session,
+        out string? domainOverride,
+        out string format,
+        out string error)
+    {
+        session = null;
+        domainOverride = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--session":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--session requires a value.";
+                        return false;
+                    }
+
+                    session = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(session))
+        {
+            error = "--session is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("interview next-question");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only first-pending-question lookup for the per-domain interview session.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = InterviewSessionStore.JsonOptions;
+}
+
+internal sealed record InterviewNextQuestionResult
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("session")]
+    public required string Session { get; init; }
+
+    [JsonPropertyName("session_path")]
+    public required string SessionPath { get; init; }
+
+    [JsonPropertyName("session_exists")]
+    public required bool SessionExists { get; init; }
+
+    [JsonPropertyName("total_questions")]
+    public required int TotalQuestions { get; init; }
+
+    [JsonPropertyName("pending_count")]
+    public required int PendingCount { get; init; }
+
+    [JsonPropertyName("has_pending")]
+    public required bool HasPending { get; init; }
+
+    [JsonPropertyName("pending")]
+    public InterviewNextQuestionPending? Pending { get; init; }
+}
+
+internal sealed record InterviewNextQuestionPending
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/InterviewRecordAnswerCommand.cs
+++ b/src/IntentSystem.Cli/Commands/InterviewRecordAnswerCommand.cs
@@ -1,0 +1,345 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G250: <c>intent-cli interview record-answer</c>. Writes the operator's
+/// answer for a question to the per-domain interview session store.
+/// Supports a dry-run preview without <c>--write</c>; with <c>--write</c>
+/// the answer is persisted. If the question id is new and <c>--prompt</c>
+/// is provided, a new question entry is appended; otherwise an unknown
+/// id is rejected. Never launches an AI provider.
+/// </summary>
+internal static class InterviewRecordAnswerCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string ModeWrite = "write";
+    private const string ModeDryRun = "dry-run";
+
+    private const string UsageLine =
+        "Usage: intent-cli interview record-answer --session <id> --question <q> --from-file <path> "
+        + "[--domain <name>] [--prompt <text>] [--write] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var session, out var question, out var fromFile, out var domainOverride, out var prompt, out var write, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (!File.Exists(fromFile))
+        {
+            EmitError(writer, format, NewError(domainOverride ?? context.Config.Project.Domain, session!, question!, write,
+                $"answer file not found: {fromFile}"));
+            return 1;
+        }
+
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride!;
+
+        var sessionPath = InterviewSessionStore.ResolvePath(context.RepoRoot, domain, session!);
+        var stored = InterviewSessionStore.Read(sessionPath) ?? new InterviewSession
+        {
+            Session = session!,
+            Domain = domain,
+            Questions = new List<InterviewQuestion>()
+        };
+
+        var existing = stored.Questions.FirstOrDefault(q => string.Equals(q.Id, question, StringComparison.Ordinal));
+        var newlyAdded = false;
+        var answerText = File.ReadAllText(fromFile);
+
+        if (existing is null)
+        {
+            if (string.IsNullOrWhiteSpace(prompt))
+            {
+                EmitError(writer, format, NewError(domain, session!, question!, write,
+                    $"no question with id '{question}' in session '{session}'; pass --prompt <text> to add a new question."));
+                return 1;
+            }
+
+            var newQuestion = new InterviewQuestion
+            {
+                Id = question!,
+                Prompt = prompt!,
+                Answer = answerText
+            };
+            stored.Questions.Add(newQuestion);
+            existing = newQuestion;
+            newlyAdded = true;
+        }
+        else
+        {
+            existing.Answer = answerText;
+        }
+
+        if (write)
+        {
+            InterviewSessionStore.Write(sessionPath, stored);
+        }
+
+        var result = new InterviewRecordAnswerResult
+        {
+            Domain = domain,
+            Session = session!,
+            QuestionId = question!,
+            SessionPath = sessionPath,
+            Mode = write ? ModeWrite : ModeDryRun,
+            NewlyAdded = newlyAdded,
+            AnswerLength = answerText.Length,
+            TotalQuestions = stored.Questions.Count,
+            PendingCount = stored.Questions.Count(q => string.IsNullOrEmpty(q.Answer)),
+            Error = null
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static void EmitError(TextWriter writer, string format, InterviewRecordAnswerResult error)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(error, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            writer.WriteLine($"# Interview record-answer — {error.Domain} / {error.Session}");
+            writer.WriteLine();
+            writer.WriteLine($"## Error");
+            writer.WriteLine($"- {error.Error}");
+        }
+    }
+
+    private static InterviewRecordAnswerResult NewError(string domain, string session, string question, bool write, string message)
+    {
+        return new InterviewRecordAnswerResult
+        {
+            Domain = domain,
+            Session = session,
+            QuestionId = question,
+            SessionPath = "(unresolved)",
+            Mode = write ? ModeWrite : ModeDryRun,
+            NewlyAdded = false,
+            AnswerLength = 0,
+            TotalQuestions = 0,
+            PendingCount = 0,
+            Error = message
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, InterviewRecordAnswerResult result)
+    {
+        writer.WriteLine($"# Interview record-answer — {result.Domain} / {result.Session}");
+        writer.WriteLine();
+        writer.WriteLine($"- session path: {result.SessionPath}");
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- question id: {result.QuestionId}");
+        writer.WriteLine($"- newly added: {(result.NewlyAdded ? "yes" : "no")}");
+        writer.WriteLine($"- answer length: {result.AnswerLength}");
+        writer.WriteLine($"- total questions: {result.TotalQuestions}");
+        writer.WriteLine($"- pending count: {result.PendingCount}");
+        if (!string.IsNullOrWhiteSpace(result.Error))
+        {
+            writer.WriteLine($"- error: {result.Error}");
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? session,
+        out string? question,
+        out string? fromFile,
+        out string? domainOverride,
+        out string? prompt,
+        out bool write,
+        out string format,
+        out string error)
+    {
+        session = null;
+        question = null;
+        fromFile = null;
+        domainOverride = null;
+        prompt = null;
+        write = false;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--session":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--session requires a value.";
+                        return false;
+                    }
+
+                    session = args[index + 1];
+                    index++;
+                    break;
+
+                case "--question":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--question requires a value.";
+                        return false;
+                    }
+
+                    question = args[index + 1];
+                    index++;
+                    break;
+
+                case "--from-file":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-file requires a path.";
+                        return false;
+                    }
+
+                    fromFile = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--prompt":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--prompt requires a value.";
+                        return false;
+                    }
+
+                    prompt = args[index + 1];
+                    index++;
+                    break;
+
+                case "--write":
+                    write = true;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(session))
+        {
+            error = "--session is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(question))
+        {
+            error = "--question is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(fromFile))
+        {
+            error = "--from-file is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("interview record-answer");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Records an operator answer for a question id. Without --write the call is a dry-run.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = InterviewSessionStore.JsonOptions;
+}
+
+internal sealed record InterviewRecordAnswerResult
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("session")]
+    public required string Session { get; init; }
+
+    [JsonPropertyName("question_id")]
+    public required string QuestionId { get; init; }
+
+    [JsonPropertyName("session_path")]
+    public required string SessionPath { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("newly_added")]
+    public required bool NewlyAdded { get; init; }
+
+    [JsonPropertyName("answer_length")]
+    public required int AnswerLength { get; init; }
+
+    [JsonPropertyName("total_questions")]
+    public required int TotalQuestions { get; init; }
+
+    [JsonPropertyName("pending_count")]
+    public required int PendingCount { get; init; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/InterviewSessionStore.cs
+++ b/src/IntentSystem.Cli/Commands/InterviewSessionStore.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G250: Durable JSON-backed interview session store. Questions are
+/// addressed by stable id. Answers may be empty (pending) or recorded.
+/// File path: <c>&lt;root&gt;/intents/&lt;domain&gt;/interviews/&lt;session&gt;.json</c>.
+/// The store never launches an AI provider and only mutates the file
+/// when explicitly asked to.
+/// </summary>
+internal static class InterviewSessionStore
+{
+    public static string ResolvePath(string repoRoot, string domain, string session)
+    {
+        return Path.Combine(repoRoot, "intents", domain, "interviews", $"{session}.json");
+    }
+
+    public static InterviewSession? Read(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize<InterviewSession>(json, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    public static void Write(string path, InterviewSession session)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, JsonSerializer.Serialize(session, JsonOptions));
+    }
+
+    internal static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record InterviewSession
+{
+    [JsonPropertyName("session")]
+    public required string Session { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("questions")]
+    public required List<InterviewQuestion> Questions { get; init; }
+}
+
+internal sealed record InterviewQuestion
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+
+    [JsonPropertyName("answer")]
+    public string? Answer { get; set; }
+}

--- a/tests/IntentSystem.Cli.Tests/InterviewSessionCommandsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/InterviewSessionCommandsTests.cs
@@ -1,0 +1,292 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class InterviewSessionCommandsTests
+{
+    [Fact]
+    public void NextQuestion_GivenSeededPending_ReturnsFirstPendingId()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        workspace.SeedSession("intent-cli", "alpha", new[]
+        {
+            (Id: "q1", Prompt: "Goal scope?", Answer: "scoped"),
+            (Id: "q2", Prompt: "Verification approach?", Answer: (string?)null),
+            (Id: "q3", Prompt: "Out of scope?", Answer: (string?)null)
+        });
+
+        using var writer = new StringWriter();
+        var exitCode = InterviewNextQuestionCommand.Execute(
+            workspace.Context,
+            ["--session", "alpha", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("session_exists").GetBoolean());
+        Assert.Equal(3, root.GetProperty("total_questions").GetInt32());
+        Assert.Equal(2, root.GetProperty("pending_count").GetInt32());
+        Assert.True(root.GetProperty("has_pending").GetBoolean());
+        Assert.Equal("q2", root.GetProperty("pending").GetProperty("id").GetString());
+    }
+
+    [Fact]
+    public void NextQuestion_GivenAllAnswered_ReportsHasPendingFalse()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        workspace.SeedSession("intent-cli", "alpha", new[]
+        {
+            (Id: "q1", Prompt: "Done?", Answer: "yes")
+        });
+
+        using var writer = new StringWriter();
+        var exitCode = InterviewNextQuestionCommand.Execute(
+            workspace.Context,
+            ["--session", "alpha", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("has_pending").GetBoolean());
+        Assert.Equal(0, root.GetProperty("pending_count").GetInt32());
+    }
+
+    [Fact]
+    public void NextQuestion_GivenMissingSession_ReportsSessionDoesNotExist()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewNextQuestionCommand.Execute(
+            workspace.Context,
+            ["--session", "missing", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("session_exists").GetBoolean());
+        Assert.Equal(0, root.GetProperty("total_questions").GetInt32());
+        Assert.False(root.GetProperty("has_pending").GetBoolean());
+    }
+
+    [Fact]
+    public void NextQuestion_MissingSession_ReturnsUsageError()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewNextQuestionCommand.Execute(
+            workspace.Context,
+            [],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--session is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RecordAnswer_GivenWriteOnExistingPendingQuestion_PersistsAnswer()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        workspace.SeedSession("intent-cli", "alpha", new[]
+        {
+            (Id: "q1", Prompt: "Goal?", Answer: (string?)null)
+        });
+        var answerFile = workspace.WriteAnswerFile("alpha-q1.txt", "Add deterministic CLI surfaces.");
+
+        using var writer = new StringWriter();
+        var exitCode = InterviewRecordAnswerCommand.Execute(
+            workspace.Context,
+            ["--session", "alpha", "--question", "q1", "--from-file", answerFile, "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("write", root.GetProperty("mode").GetString());
+        Assert.False(root.GetProperty("newly_added").GetBoolean());
+        Assert.Equal(0, root.GetProperty("pending_count").GetInt32());
+
+        var stored = workspace.ReadSession("intent-cli", "alpha");
+        Assert.Single(stored.Questions);
+        Assert.Equal("Add deterministic CLI surfaces.", stored.Questions[0].Answer);
+    }
+
+    [Fact]
+    public void RecordAnswer_DryRun_DoesNotWriteFile()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        workspace.SeedSession("intent-cli", "alpha", new[]
+        {
+            (Id: "q1", Prompt: "Goal?", Answer: (string?)null)
+        });
+        var answerFile = workspace.WriteAnswerFile("answer.txt", "draft");
+
+        using var writer = new StringWriter();
+        var exitCode = InterviewRecordAnswerCommand.Execute(
+            workspace.Context,
+            ["--session", "alpha", "--question", "q1", "--from-file", answerFile, "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("dry-run", document.RootElement.GetProperty("mode").GetString());
+
+        var stored = workspace.ReadSession("intent-cli", "alpha");
+        Assert.Null(stored.Questions[0].Answer);
+    }
+
+    [Fact]
+    public void RecordAnswer_WithPromptOnNewQuestion_AppendsEntry()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        var answerFile = workspace.WriteAnswerFile("first.txt", "yes");
+
+        using var writer = new StringWriter();
+        var exitCode = InterviewRecordAnswerCommand.Execute(
+            workspace.Context,
+            ["--session", "alpha", "--question", "q1", "--from-file", answerFile, "--prompt", "Is in scope?", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.True(document.RootElement.GetProperty("newly_added").GetBoolean());
+        var stored = workspace.ReadSession("intent-cli", "alpha");
+        Assert.Single(stored.Questions);
+        Assert.Equal("q1", stored.Questions[0].Id);
+        Assert.Equal("Is in scope?", stored.Questions[0].Prompt);
+        Assert.Equal("yes", stored.Questions[0].Answer);
+    }
+
+    [Fact]
+    public void RecordAnswer_NewQuestionWithoutPrompt_ReturnsError()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        var answerFile = workspace.WriteAnswerFile("a.txt", "yes");
+
+        using var writer = new StringWriter();
+        var exitCode = InterviewRecordAnswerCommand.Execute(
+            workspace.Context,
+            ["--session", "alpha", "--question", "q-new", "--from-file", answerFile, "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Contains("no question with id 'q-new'", document.RootElement.GetProperty("error").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RecordAnswer_MissingAnswerFile_ReturnsError()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = InterviewRecordAnswerCommand.Execute(
+            workspace.Context,
+            ["--session", "alpha", "--question", "q1", "--from-file", "/tmp/does-not-exist", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Contains("answer file not found", document.RootElement.GetProperty("error").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RecordAnswer_MissingFlags_ReturnUsageErrors()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = InterviewRecordAnswerCommand.Execute(
+            workspace.Context,
+            ["--question", "q1"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--session is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RecordAnswer_HelpFlag_PrintsUsage()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = InterviewRecordAnswerCommand.Execute(
+            workspace.Context,
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("interview record-answer", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private sealed class InterviewSessionWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("interview-session-tests-")
+            .FullName;
+
+        public InterviewSessionWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public void SeedSession(string domain, string session, IEnumerable<(string Id, string Prompt, string? Answer)> questions)
+        {
+            var path = InterviewSessionStore.ResolvePath(rootPath, domain, session);
+            var stored = new InterviewSession
+            {
+                Session = session,
+                Domain = domain,
+                Questions = questions
+                    .Select(q => new InterviewQuestion { Id = q.Id, Prompt = q.Prompt, Answer = q.Answer })
+                    .ToList()
+            };
+            InterviewSessionStore.Write(path, stored);
+        }
+
+        public string WriteAnswerFile(string name, string content)
+        {
+            var path = Path.Combine(rootPath, name);
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        public InterviewSession ReadSession(string domain, string session)
+        {
+            var path = InterviewSessionStore.ResolvePath(rootPath, domain, session);
+            return InterviewSessionStore.Read(path)
+                ?? throw new InvalidOperationException($"Session not found at {path}");
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #603

## Summary

- Adds two durable-state interview commands plus the JSON-backed session store they share. The session file lives at `intents/<domain>/interviews/<session>.json` and stores `{ session, domain, questions: [{id, prompt, answer?}] }`.
- `interview next-question --session <id> [--domain <name>] [--format markdown|json]` reads the session file and reports the first question with no recorded answer, plus total/pending counts. Read-only.
- `interview record-answer --session <id> --question <q> --from-file <path> [--domain <name>] [--prompt <text>] [--write] [--format markdown|json]` reads the answer text from a file. Without `--write` the call is a dry-run and does not mutate the file. With `--write`:
  - Existing question id → answer field is updated.
  - Unknown question id → rejected unless `--prompt <text>` is provided, in which case a new question entry is appended (this is the only path through which questions enter the store in this slice).
- Resume-safe: the session file is created on first write and updated on subsequent answers.
- Both commands fail deterministically on missing required flags, unknown arguments, unsupported formats, and missing answer files.
- Never launches an AI provider. Never mutates other state.
- 11 focused tests cover next-question (seeded pending, all answered, missing session, usage error) and record-answer (write, dry-run, append-with-prompt, unknown-id-without-prompt, missing answer file, missing flags, help).
- Lists the new G250 surface in `docs/automation-templates/README.md`.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~InterviewSessionCommandsTests"` (11/11 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean