### PR TITLE
G251 Add interview compile and intent draft-from-interview commands

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -48,6 +48,7 @@ These templates assume:
 | G248  | `intent-cli guide review`               | Read-only PR review guidance: execution unit + packet refs, review-context excerpt, deterministic checklist, boundaries, and validation suggestions |
 | G249  | `intent-cli guide collaborate`          | Read-only operator-facing collaboration guide for early product-owner feature intake (responsibility boundaries + suggested command sequence + interview/draft rules) |
 | G250  | `intent-cli interview next-question` / `interview record-answer` | Durable per-domain interview session store: returns first pending question and records (or appends new) answers under `intents/<domain>/interviews/<session>.json` |
+| G251  | `intent-cli interview compile` / `intent draft-from-interview` | Compile accepted interview answers into a draft intent under `intents/<domain>/drafts/<session>.md`; both commands are read-only by default (`--write` for the draft writer). |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -82,7 +82,8 @@ internal static class CommandRouter
                 ["answer"] = InterviewAnswerCommand.Execute,
                 ["resume"] = InterviewResumeCommand.Execute,
                 ["next-question"] = InterviewNextQuestionCommand.Execute,
-                ["record-answer"] = InterviewRecordAnswerCommand.Execute
+                ["record-answer"] = InterviewRecordAnswerCommand.Execute,
+                ["compile"] = InterviewCompileCommand.Execute
             },
             ["clarify"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
@@ -214,7 +215,8 @@ internal static class CommandRouter
                 ["status"] = IntentStatusCommand.Execute,
                 ["search"] = IntentSearchCommand.Execute,
                 ["explain"] = IntentExplainCommand.Execute,
-                ["next-slice"] = IntentNextSliceCommand.Execute
+                ["next-slice"] = IntentNextSliceCommand.Execute,
+                ["draft-from-interview"] = IntentDraftFromInterviewCommand.Execute
             },
             ["packet"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/IntentDraftFromInterviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentDraftFromInterviewCommand.cs
@@ -1,0 +1,311 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G251: <c>intent-cli intent draft-from-interview</c>. Compiles accepted
+/// interview answers into a draft intent/packet candidate at
+/// <c>intents/&lt;domain&gt;/drafts/&lt;session&gt;.md</c>. Without
+/// <c>--write</c> the draft is emitted but not written. Never publishes
+/// a GitHub issue and never launches an AI provider.
+/// </summary>
+internal static class IntentDraftFromInterviewCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string ModeWrite = "write";
+    private const string ModeDryRun = "dry-run";
+
+    private const string UsageLine =
+        "Usage: intent-cli intent draft-from-interview --session <id> [--domain <name>] [--write] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var session, out var domainOverride, out var write, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride!;
+
+        var sessionPath = InterviewSessionStore.ResolvePath(context.RepoRoot, domain, session!);
+        var stored = InterviewSessionStore.Read(sessionPath);
+
+        if (stored is null)
+        {
+            EmitFailure(writer, format, NewFailureResult(domain, session!, sessionPath, write,
+                $"interview session not found: {sessionPath}"));
+            return 1;
+        }
+
+        var accepted = stored.Questions.Where(q => !string.IsNullOrEmpty(q.Answer)).ToArray();
+        var open = stored.Questions.Where(q => string.IsNullOrEmpty(q.Answer)).ToArray();
+        if (accepted.Length == 0)
+        {
+            EmitFailure(writer, format, NewFailureResult(domain, session!, sessionPath, write,
+                "interview session has no accepted answers; record at least one with `interview record-answer --write`."));
+            return 1;
+        }
+
+        var draft = BuildDraftMarkdown(domain, session!, accepted, open);
+        var draftPath = ResolveDraftPath(context.RepoRoot, domain, session!);
+
+        if (write)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(draftPath)!);
+            File.WriteAllText(draftPath, draft);
+        }
+
+        var result = new IntentDraftFromInterviewResult
+        {
+            Domain = domain,
+            Session = session!,
+            SessionPath = sessionPath,
+            DraftPath = draftPath,
+            Mode = write ? ModeWrite : ModeDryRun,
+            AcceptedCount = accepted.Length,
+            OpenCount = open.Length,
+            DraftMarkdown = draft,
+            Error = null
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static string ResolveDraftPath(string repoRoot, string domain, string session)
+    {
+        return Path.Combine(repoRoot, "intents", domain, "drafts", $"{session}.md");
+    }
+
+    private static string BuildDraftMarkdown(string domain, string session, IReadOnlyList<InterviewQuestion> accepted, IReadOnlyList<InterviewQuestion> open)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"# Draft intent — {domain} / session {session}");
+        builder.AppendLine();
+        builder.AppendLine("> Compiled from accepted interview answers. Operator must accept this draft before any source-of-truth mutation.");
+        builder.AppendLine();
+
+        builder.AppendLine("## Accepted baseline");
+        foreach (var question in accepted)
+        {
+            builder.AppendLine();
+            builder.AppendLine($"### {question.Id} — {question.Prompt}");
+            builder.AppendLine();
+            builder.AppendLine(question.Answer);
+        }
+        builder.AppendLine();
+
+        builder.AppendLine("## Open questions");
+        if (open.Count == 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("- none");
+        }
+        else
+        {
+            foreach (var question in open)
+            {
+                builder.AppendLine($"- **{question.Id}** — {question.Prompt}");
+            }
+        }
+
+        builder.AppendLine();
+        builder.AppendLine("## Candidate execution units");
+        builder.AppendLine();
+        builder.AppendLine("- TODO — operator decides whether to promote this draft into a published child issue.");
+
+        return builder.ToString();
+    }
+
+    private static IntentDraftFromInterviewResult NewFailureResult(string domain, string session, string sessionPath, bool write, string message)
+    {
+        return new IntentDraftFromInterviewResult
+        {
+            Domain = domain,
+            Session = session,
+            SessionPath = sessionPath,
+            DraftPath = "(unresolved)",
+            Mode = write ? ModeWrite : ModeDryRun,
+            AcceptedCount = 0,
+            OpenCount = 0,
+            DraftMarkdown = string.Empty,
+            Error = message
+        };
+    }
+
+    private static void EmitFailure(TextWriter writer, string format, IntentDraftFromInterviewResult error)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(error, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            writer.WriteLine($"# Intent draft-from-interview — {error.Domain} / {error.Session}");
+            writer.WriteLine();
+            writer.WriteLine($"## Error");
+            writer.WriteLine($"- {error.Error}");
+        }
+    }
+
+    private static void WriteMarkdown(TextWriter writer, IntentDraftFromInterviewResult result)
+    {
+        writer.WriteLine($"# Intent draft-from-interview — {result.Domain} / {result.Session}");
+        writer.WriteLine();
+        writer.WriteLine($"- session path: {result.SessionPath}");
+        writer.WriteLine($"- draft path: {result.DraftPath}");
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- accepted count: {result.AcceptedCount}");
+        writer.WriteLine($"- open count: {result.OpenCount}");
+        writer.WriteLine();
+        writer.WriteLine("## Draft");
+        writer.WriteLine();
+        writer.WriteLine(result.DraftMarkdown);
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? session,
+        out string? domainOverride,
+        out bool write,
+        out string format,
+        out string error)
+    {
+        session = null;
+        domainOverride = null;
+        write = false;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--session":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--session requires a value.";
+                        return false;
+                    }
+
+                    session = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--write":
+                    write = true;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(session))
+        {
+            error = "--session is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("intent draft-from-interview");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Compiles accepted interview answers into a draft intent at intents/<domain>/drafts/<session>.md (write requires --write).");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = InterviewSessionStore.JsonOptions;
+}
+
+internal sealed record IntentDraftFromInterviewResult
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("session")]
+    public required string Session { get; init; }
+
+    [JsonPropertyName("session_path")]
+    public required string SessionPath { get; init; }
+
+    [JsonPropertyName("draft_path")]
+    public required string DraftPath { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("accepted_count")]
+    public required int AcceptedCount { get; init; }
+
+    [JsonPropertyName("open_count")]
+    public required int OpenCount { get; init; }
+
+    [JsonPropertyName("draft_markdown")]
+    public required string DraftMarkdown { get; init; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/InterviewCompileCommand.cs
+++ b/src/IntentSystem.Cli/Commands/InterviewCompileCommand.cs
@@ -1,0 +1,284 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G251: Read-only <c>intent-cli interview compile</c>. Summarizes the
+/// per-domain interview session into accepted baseline (answered Qs),
+/// open questions (pending Qs), and a placeholder for candidate
+/// execution units. Read-only. Never launches an AI provider.
+/// </summary>
+internal static class InterviewCompileCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli interview compile --session <id> [--domain <name>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var session, out var domainOverride, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride!;
+
+        var sessionPath = InterviewSessionStore.ResolvePath(context.RepoRoot, domain, session!);
+        var stored = InterviewSessionStore.Read(sessionPath);
+
+        var accepted = new List<InterviewCompileAccepted>();
+        var open = new List<InterviewCompileOpen>();
+        if (stored is not null)
+        {
+            foreach (var question in stored.Questions)
+            {
+                if (string.IsNullOrEmpty(question.Answer))
+                {
+                    open.Add(new InterviewCompileOpen { Id = question.Id, Prompt = question.Prompt });
+                }
+                else
+                {
+                    accepted.Add(new InterviewCompileAccepted
+                    {
+                        Id = question.Id,
+                        Prompt = question.Prompt,
+                        Answer = question.Answer!
+                    });
+                }
+            }
+        }
+
+        var result = new InterviewCompileResult
+        {
+            Domain = domain,
+            Session = session!,
+            SessionPath = sessionPath,
+            SessionExists = stored is not null,
+            TotalQuestions = stored?.Questions.Count ?? 0,
+            AcceptedCount = accepted.Count,
+            OpenCount = open.Count,
+            AcceptedBaseline = accepted,
+            OpenQuestions = open,
+            CandidateExecutionUnits = Array.Empty<string>(),
+            Ready = stored is not null && accepted.Count > 0
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static void WriteMarkdown(TextWriter writer, InterviewCompileResult result)
+    {
+        writer.WriteLine($"# Interview compile — {result.Domain} / {result.Session}");
+        writer.WriteLine();
+        writer.WriteLine($"- session path: {result.SessionPath}");
+        writer.WriteLine($"- session exists: {(result.SessionExists ? "yes" : "no")}");
+        writer.WriteLine($"- total questions: {result.TotalQuestions}");
+        writer.WriteLine($"- accepted count: {result.AcceptedCount}");
+        writer.WriteLine($"- open count: {result.OpenCount}");
+        writer.WriteLine($"- ready for draft: {(result.Ready ? "yes" : "no")}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Accepted baseline");
+        if (result.AcceptedBaseline.Count == 0)
+        {
+            writer.WriteLine("- none");
+        }
+        else
+        {
+            foreach (var accepted in result.AcceptedBaseline)
+            {
+                writer.WriteLine($"- **{accepted.Id}** — {accepted.Prompt}");
+                writer.WriteLine($"  - answer: {accepted.Answer}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Open questions");
+        if (result.OpenQuestions.Count == 0)
+        {
+            writer.WriteLine("- none");
+        }
+        else
+        {
+            foreach (var open in result.OpenQuestions)
+            {
+                writer.WriteLine($"- **{open.Id}** — {open.Prompt}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Candidate execution units");
+        if (result.CandidateExecutionUnits.Count == 0)
+        {
+            writer.WriteLine("- none yet — promote with `intent draft-from-interview`");
+        }
+        else
+        {
+            foreach (var unit in result.CandidateExecutionUnits)
+            {
+                writer.WriteLine($"- {unit}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string? session, out string? domainOverride, out string format, out string error)
+    {
+        session = null;
+        domainOverride = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--session":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--session requires a value.";
+                        return false;
+                    }
+
+                    session = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(session))
+        {
+            error = "--session is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("interview compile");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only summary of accepted answers, open questions, and candidate execution units for a session.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = InterviewSessionStore.JsonOptions;
+}
+
+internal sealed record InterviewCompileResult
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("session")]
+    public required string Session { get; init; }
+
+    [JsonPropertyName("session_path")]
+    public required string SessionPath { get; init; }
+
+    [JsonPropertyName("session_exists")]
+    public required bool SessionExists { get; init; }
+
+    [JsonPropertyName("total_questions")]
+    public required int TotalQuestions { get; init; }
+
+    [JsonPropertyName("accepted_count")]
+    public required int AcceptedCount { get; init; }
+
+    [JsonPropertyName("open_count")]
+    public required int OpenCount { get; init; }
+
+    [JsonPropertyName("accepted_baseline")]
+    public required IReadOnlyList<InterviewCompileAccepted> AcceptedBaseline { get; init; }
+
+    [JsonPropertyName("open_questions")]
+    public required IReadOnlyList<InterviewCompileOpen> OpenQuestions { get; init; }
+
+    [JsonPropertyName("candidate_execution_units")]
+    public required IReadOnlyList<string> CandidateExecutionUnits { get; init; }
+
+    [JsonPropertyName("ready")]
+    public required bool Ready { get; init; }
+}
+
+internal sealed record InterviewCompileAccepted
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+
+    [JsonPropertyName("answer")]
+    public required string Answer { get; init; }
+}
+
+internal sealed record InterviewCompileOpen
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/InterviewCompileAndDraftCommandsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/InterviewCompileAndDraftCommandsTests.cs
@@ -1,0 +1,280 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class InterviewCompileAndDraftCommandsTests
+{
+    [Fact]
+    public void Compile_GivenMixedQuestions_BucketsAcceptedAndOpen()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        workspace.SeedSession("intent-cli", "alpha", new[]
+        {
+            (Id: "q1", Prompt: "Goal?", Answer: "deterministic CLI"),
+            (Id: "q2", Prompt: "Verification?", Answer: (string?)null),
+            (Id: "q3", Prompt: "In Scope?", Answer: "guide commands")
+        });
+
+        using var writer = new StringWriter();
+        var exitCode = InterviewCompileCommand.Execute(
+            workspace.Context,
+            ["--session", "alpha", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("session_exists").GetBoolean());
+        Assert.True(root.GetProperty("ready").GetBoolean());
+        Assert.Equal(2, root.GetProperty("accepted_count").GetInt32());
+        Assert.Equal(1, root.GetProperty("open_count").GetInt32());
+        Assert.Equal(2, root.GetProperty("accepted_baseline").GetArrayLength());
+        Assert.Equal(1, root.GetProperty("open_questions").GetArrayLength());
+        Assert.Equal("q2", root.GetProperty("open_questions")[0].GetProperty("id").GetString());
+    }
+
+    [Fact]
+    public void Compile_GivenMissingSession_ReportsNotReady()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewCompileCommand.Execute(
+            workspace.Context,
+            ["--session", "missing", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.False(document.RootElement.GetProperty("session_exists").GetBoolean());
+        Assert.False(document.RootElement.GetProperty("ready").GetBoolean());
+    }
+
+    [Fact]
+    public void Compile_MarkdownFormat_EmitsHumanReadableOutput()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        workspace.SeedSession("intent-cli", "alpha", new[]
+        {
+            (Id: "q1", Prompt: "Goal?", Answer: "deterministic CLI"),
+            (Id: "q2", Prompt: "In Scope?", Answer: (string?)null)
+        });
+
+        using var writer = new StringWriter();
+        var exitCode = InterviewCompileCommand.Execute(
+            workspace.Context,
+            ["--session", "alpha"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Interview compile — intent-cli / alpha", output, StringComparison.Ordinal);
+        Assert.Contains("## Accepted baseline", output, StringComparison.Ordinal);
+        Assert.Contains("## Open questions", output, StringComparison.Ordinal);
+        Assert.Contains("## Candidate execution units", output, StringComparison.Ordinal);
+        Assert.Contains("ready for draft: yes", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DraftFromInterview_DryRun_EmitsDraftWithoutWriting()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        workspace.SeedSession("intent-cli", "alpha", new[]
+        {
+            (Id: "q1", Prompt: "Goal?", Answer: "deterministic CLI"),
+            (Id: "q2", Prompt: "Verification?", Answer: (string?)null)
+        });
+
+        using var writer = new StringWriter();
+        var exitCode = IntentDraftFromInterviewCommand.Execute(
+            workspace.Context,
+            ["--session", "alpha", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("dry-run", root.GetProperty("mode").GetString());
+        Assert.Equal(1, root.GetProperty("accepted_count").GetInt32());
+        Assert.Equal(1, root.GetProperty("open_count").GetInt32());
+        Assert.Contains("# Draft intent — intent-cli / session alpha", root.GetProperty("draft_markdown").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("## Accepted baseline", root.GetProperty("draft_markdown").GetString()!, StringComparison.Ordinal);
+
+        var draftPath = root.GetProperty("draft_path").GetString()!;
+        Assert.False(File.Exists(draftPath));
+    }
+
+    [Fact]
+    public void DraftFromInterview_Write_CreatesDraftFile()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        workspace.SeedSession("intent-cli", "alpha", new[]
+        {
+            (Id: "q1", Prompt: "Goal?", Answer: "deterministic CLI")
+        });
+
+        using var writer = new StringWriter();
+        var exitCode = IntentDraftFromInterviewCommand.Execute(
+            workspace.Context,
+            ["--session", "alpha", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("write", root.GetProperty("mode").GetString());
+        var draftPath = root.GetProperty("draft_path").GetString()!;
+        Assert.True(File.Exists(draftPath));
+        var draft = File.ReadAllText(draftPath);
+        Assert.Contains("# Draft intent — intent-cli / session alpha", draft, StringComparison.Ordinal);
+        Assert.Contains("deterministic CLI", draft, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DraftFromInterview_GivenMissingSession_ReturnsError()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentDraftFromInterviewCommand.Execute(
+            workspace.Context,
+            ["--session", "missing", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Contains("interview session not found", document.RootElement.GetProperty("error").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DraftFromInterview_GivenNoAcceptedAnswers_ReturnsError()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        workspace.SeedSession("intent-cli", "alpha", new[]
+        {
+            (Id: "q1", Prompt: "Goal?", Answer: (string?)null)
+        });
+
+        using var writer = new StringWriter();
+        var exitCode = IntentDraftFromInterviewCommand.Execute(
+            workspace.Context,
+            ["--session", "alpha", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Contains("no accepted answers", document.RootElement.GetProperty("error").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Compile_MissingSession_ReturnsUsageError()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewCompileCommand.Execute(
+            workspace.Context,
+            [],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--session is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DraftFromInterview_MissingSession_ReturnsUsageError()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentDraftFromInterviewCommand.Execute(
+            workspace.Context,
+            [],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--session is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DraftFromInterview_HelpFlag_PrintsUsage()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentDraftFromInterviewCommand.Execute(
+            workspace.Context,
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("intent draft-from-interview", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Compile_HelpFlag_PrintsUsage()
+    {
+        using var workspace = new InterviewSessionWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = InterviewCompileCommand.Execute(
+            workspace.Context,
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("interview compile", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private sealed class InterviewSessionWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("interview-compile-tests-")
+            .FullName;
+
+        public InterviewSessionWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public void SeedSession(string domain, string session, IEnumerable<(string Id, string Prompt, string? Answer)> questions)
+        {
+            var path = InterviewSessionStore.ResolvePath(rootPath, domain, session);
+            var stored = new InterviewSession
+            {
+                Session = session,
+                Domain = domain,
+                Questions = questions
+                    .Select(q => new InterviewQuestion { Id = q.Id, Prompt = q.Prompt, Answer = q.Answer })
+                    .ToList()
+            };
+            InterviewSessionStore.Write(path, stored);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #605

## Summary

- Adds two commands that bridge from durable interview answers (G250) to a draft intent without publishing a child issue.
- `interview compile --session <id> [--domain <name>] [--format markdown|json]` is read-only. Buckets the session's questions into accepted baseline (answered) and open questions (pending), reports total/accepted/open counts, and emits a candidate-execution-units placeholder. Reports `ready: yes` when at least one answer is accepted.
- `intent draft-from-interview --session <id> [--domain <name>] [--write] [--format markdown|json]` compiles the accepted answers into a markdown draft at `intents/<domain>/drafts/<session>.md`. Without `--write` the draft is returned only in the response. With `--write` the file is created. Fails deterministically when the session does not exist or has no accepted answers.
- Both commands work on the per-domain JSON store introduced in G250. Never mutate canonical state without explicit `--write`, never create GitHub issues, never apply labels, never launch an AI provider.
- 11 focused tests cover compile (mixed answers, missing session, markdown format, missing arg, help) and draft-from-interview (dry-run, write, missing session, no accepted answers, missing arg, help).
- Lists the new G251 surface in `docs/automation-templates/README.md`.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~InterviewCompileAndDraftCommandsTests"` (11/11 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean