### PR TITLE
G253 Add collaborative intent shaping smoke guide

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -50,6 +50,7 @@ These templates assume:
 | G250  | `intent-cli interview next-question` / `interview record-answer` | Durable per-domain interview session store: returns first pending question and records (or appends new) answers under `intents/<domain>/interviews/<session>.json` |
 | G251  | `intent-cli interview compile` / `intent draft-from-interview` | Compile accepted interview answers into a draft intent under `intents/<domain>/drafts/<session>.md`; both commands are read-only by default (`--write` for the draft writer). |
 | G252  | `intent-cli guide rules --topic`        | Read-only operator-facing rule summaries for label-ownership / child-issue-contract / clarification / review-closeout / intake-interview, each with source references and installed-command hints |
+| G253  | [`collaborative-intent-shaping.md`](./collaborative-intent-shaping.md) | Smoke guide for the prompt-to-intent flow using the G249–G252 + G241–G243 surfaces; read-only by default, names operator decision gates |
 
 ## Installed host transition command adoption
 

--- a/docs/automation-templates/collaborative-intent-shaping.md
+++ b/docs/automation-templates/collaborative-intent-shaping.md
@@ -1,0 +1,200 @@
+# Collaborative intent shaping — smoke guide
+
+This guide shows the minimal prompt-to-intent flow an AI agent runs inside
+Codex/Claude when a product owner says something like
+`intent-cli に以下の機能を追加したいから一緒に作業して` (or any similar
+intake request). It uses only installed `intent-cli` commands; no
+`intents/rules` files or local skill files are required during normal
+operation.
+
+## Caller model
+
+- The product owner interacts through chat.
+- An AI agent (Codex / Claude) calls `intent-cli` internally to retrieve
+  rules, questions, context, drafts, and validation.
+- `intent-cli` is the deterministic guide/artifact authority. It does
+  not launch any AI provider.
+- The operator decides; the AI agent drafts and summarizes; `intent-cli`
+  records canonical state.
+- Canonical data lives under `intents/<domain>` and `.intent-cli` in the
+  host git repository.
+
+## Smoke flow (read-only by default)
+
+Each step below is read-only unless `--write` is explicitly passed.
+Operator acceptance is required before any source-of-truth mutation.
+
+### 1. Pull the collaboration boundaries
+
+The AI agent first asks intent-cli for the canonical responsibility
+boundaries and suggested command sequence so it does not need to read
+`intents/rules` files:
+
+```bash
+intent-cli guide collaborate --kind feature-intake --domain intent-cli --format markdown
+```
+
+The output names: who guides, who interviews, who decides; the suggested
+command sequence; interview rules; and draft handoff rules.
+
+### 2. Pull current state and prior art
+
+Before asking the operator deeper questions, the AI agent surfaces
+current state and prior art so its questions stay anchored:
+
+```bash
+intent-cli intent status --domain intent-cli --format json
+intent-cli intent search --domain intent-cli --query "<keyword>" --format json
+intent-cli intent explain <execution-unit> --domain intent-cli --format json
+```
+
+The agent also checks the `intent-cli` rule references for the topics
+that come up in conversation:
+
+```bash
+intent-cli guide rules --topic label-ownership --format markdown
+intent-cli guide rules --topic child-issue-contract --format markdown
+intent-cli guide rules --topic clarification --format markdown
+```
+
+### 3. Run the interview against a durable session
+
+The AI agent forms each question, asks the operator, and records the
+answer in the per-domain interview store. This is the only step that
+typically writes during the smoke flow — and only with `--write`:
+
+```bash
+intent-cli interview next-question --session alpha --domain intent-cli --format json
+
+intent-cli interview record-answer \
+  --session alpha \
+  --domain intent-cli \
+  --question q1 \
+  --prompt "What is the goal of this feature?" \
+  --from-file /tmp/answer-q1.txt \
+  --write \
+  --format json
+```
+
+`record-answer` adds a new question entry when `--question` is unknown
+and `--prompt` is provided; otherwise the unknown id is rejected. The
+session file lives at `intents/<domain>/interviews/<session>.json` and
+is resume-safe across calls.
+
+The agent can also peek at the durable interview state at any time:
+
+```bash
+intent-cli interview compile --session alpha --domain intent-cli --format markdown
+```
+
+This emits the accepted baseline (answered Qs), open questions
+(pending), and a placeholder for candidate execution units.
+
+### 4. Verify next-slice readiness before proposing a draft
+
+Before suggesting a draft, the AI agent verifies that the WIP cap and
+clarification gates allow a new slice:
+
+```bash
+intent-cli intent next-slice --dry-run --domain intent-cli --target-repo J-Tech-Japan/intent-system --format json
+```
+
+The `recommended_outcome` field will be one of
+`clarification-required`, `skip-next-slice-due-to-wip`,
+`no-actionable-item`, or `issue-cut-ready`. The agent must not propose a
+draft if a clarification or WIP block applies.
+
+### 5. Compile a draft (operator decision gate)
+
+When the operator is ready to see a candidate intent draft, the AI
+agent compiles the accepted answers without publishing anything:
+
+```bash
+intent-cli intent draft-from-interview \
+  --session alpha \
+  --domain intent-cli \
+  --format markdown
+```
+
+This is read-only by default. The draft contains an Accepted baseline
+(per-question summaries), Open questions, and a Candidate execution
+units placeholder. The operator reviews this draft. **Acceptance is the
+operator's decision.**
+
+When the operator accepts the draft, the AI agent writes it to disk:
+
+```bash
+intent-cli intent draft-from-interview \
+  --session alpha \
+  --domain intent-cli \
+  --write \
+  --format json
+```
+
+The draft lands at `intents/<domain>/drafts/<session>.md`. The
+collaborative-shaping smoke ends here. **No GitHub issue is created in
+this flow.**
+
+## Where operator decisions are required
+
+The flow has three explicit operator decision gates. Each gate must be
+crossed by the operator (in chat), not by the AI agent:
+
+1. **Acceptance of each interview answer** — the AI agent only records
+   answers the operator confirmed.
+2. **Acceptance of the compiled draft** — `intent draft-from-interview
+   --write` runs only after the operator accepts the dry-run draft.
+3. **Promotion to a published child issue** — that step is intentionally
+   out of scope for this smoke flow. It happens later via
+   `intent-cli packet draft` and `intent-cli issue publish-flow`, both
+   of which keep `intent-target` apply behind the parent host's publish
+   boundary (`intent-cli automation issue-publish --write`).
+
+## Skill-file independence
+
+This entire smoke flow runs without opening:
+
+- `intents/rules/*.md`
+- local skill files (`gh-issue-to-pr`, `gh-fix-pr-comment`, `intent-*`)
+- copied prompt fragments
+
+If the AI agent needs current rules for any topic, it asks
+`intent-cli guide rules --topic <name>` instead of reading rule files
+directly. If it needs the canonical label contract, it asks
+`intent-cli automation summary --format json`.
+
+## Failure modes (deterministic stops)
+
+- The intake selector returns nothing actionable: stop with status
+  `idle`. Do not invent a slice.
+- `intent next-slice --dry-run` returns `clarification-required`: stop
+  with status `clarification-required` and report background, question,
+  options, pros/cons, recommendation.
+- `intent next-slice --dry-run` returns `skip-next-slice-due-to-wip`:
+  do not draft a new slice; finish the in-flight WIP first.
+- `record-answer` with an unknown question id and no `--prompt`: stop
+  and ask the operator to confirm the new question text first.
+- `draft-from-interview` against a session with no accepted answers:
+  stop and continue the interview.
+
+## Related installed surfaces
+
+| Slice | Command | Role |
+|-------|---------|------|
+| G249  | `intent-cli guide collaborate` | Boundaries + suggested command sequence |
+| G250  | `intent-cli interview next-question` / `interview record-answer` | Durable Q/A store |
+| G251  | `intent-cli interview compile` / `intent draft-from-interview` | Compile accepted answers; write draft |
+| G252  | `intent-cli guide rules --topic` | Current operational rules by topic |
+| G241  | `intent-cli intent status` | Latest baseline, WIP, queued, clarifications |
+| G242  | `intent-cli intent search` / `intent explain` | Discovery and execution-unit explainer |
+| G243  | `intent-cli intent next-slice --dry-run` | Next-slice planning facts |
+
+## What this guide is not
+
+- It is not a replacement for the host review/closeout loop.
+- It does not publish a GitHub issue. Promotion happens later via
+  `intent-cli packet draft` (G244) → `intent-cli issue publish-flow`
+  (G245) → host `intent-cli automation issue-publish --write` (G226).
+- It does not include any `intent-cli run` invocation. `intent-cli run`
+  is for integration smoke / deterministic replay / local dogfooding,
+  not for collaborative intent shaping.

--- a/tests/IntentSystem.Cli.Tests/CollaborativeIntentShapingDocTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CollaborativeIntentShapingDocTests.cs
@@ -1,0 +1,121 @@
+namespace IntentSystem.Cli.Tests;
+
+public sealed class CollaborativeIntentShapingDocTests
+{
+    [Fact]
+    public void Doc_ExistsAndContainsCanonicalSections()
+    {
+        var path = Path.Combine(GetSolutionRoot(), "docs", "automation-templates", "collaborative-intent-shaping.md");
+        Assert.True(File.Exists(path), $"missing doc: {path}");
+
+        var content = File.ReadAllText(path);
+        Assert.Contains("# Collaborative intent shaping — smoke guide", content, StringComparison.Ordinal);
+        Assert.Contains("## Caller model", content, StringComparison.Ordinal);
+        Assert.Contains("## Smoke flow (read-only by default)", content, StringComparison.Ordinal);
+        Assert.Contains("## Where operator decisions are required", content, StringComparison.Ordinal);
+        Assert.Contains("## Skill-file independence", content, StringComparison.Ordinal);
+        Assert.Contains("## Failure modes (deterministic stops)", content, StringComparison.Ordinal);
+        Assert.Contains("## Related installed surfaces", content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Doc_ReferencesEachInstalledSurfaceFromTheArc()
+    {
+        var path = Path.Combine(GetSolutionRoot(), "docs", "automation-templates", "collaborative-intent-shaping.md");
+        var content = File.ReadAllText(path);
+
+        // G249 collaborate
+        Assert.Contains("intent-cli guide collaborate --kind feature-intake", content, StringComparison.Ordinal);
+
+        // G250 interview Q/A
+        Assert.Contains("intent-cli interview next-question", content, StringComparison.Ordinal);
+        Assert.Contains("intent-cli interview record-answer", content, StringComparison.Ordinal);
+
+        // G251 compile + draft
+        Assert.Contains("intent-cli interview compile", content, StringComparison.Ordinal);
+        Assert.Contains("intent-cli intent draft-from-interview", content, StringComparison.Ordinal);
+
+        // G252 rules
+        Assert.Contains("intent-cli guide rules --topic", content, StringComparison.Ordinal);
+
+        // G241/G242/G243 supporting commands
+        Assert.Contains("intent-cli intent status", content, StringComparison.Ordinal);
+        Assert.Contains("intent-cli intent search", content, StringComparison.Ordinal);
+        Assert.Contains("intent-cli intent explain", content, StringComparison.Ordinal);
+        Assert.Contains("intent-cli intent next-slice --dry-run", content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Doc_NamesOperatorDecisionGatesAndSkillIndependence()
+    {
+        var path = Path.Combine(GetSolutionRoot(), "docs", "automation-templates", "collaborative-intent-shaping.md");
+        var content = File.ReadAllText(path);
+
+        Assert.Contains("Acceptance of each interview answer", content, StringComparison.Ordinal);
+        Assert.Contains("Acceptance of the compiled draft", content, StringComparison.Ordinal);
+        Assert.Contains("Promotion to a published child issue", content, StringComparison.Ordinal);
+
+        Assert.Contains("intents/rules/*.md", content, StringComparison.Ordinal);
+        Assert.Contains("local skill files", content, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide rules --topic <name>", content, StringComparison.Ordinal);
+        Assert.Contains("intent-cli automation summary --format json", content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Doc_NamesDeterministicStopsForEachFailureMode()
+    {
+        var path = Path.Combine(GetSolutionRoot(), "docs", "automation-templates", "collaborative-intent-shaping.md");
+        var content = File.ReadAllText(path);
+
+        Assert.Contains("`idle`", content, StringComparison.Ordinal);
+        Assert.Contains("`clarification-required`", content, StringComparison.Ordinal);
+        Assert.Contains("`skip-next-slice-due-to-wip`", content, StringComparison.Ordinal);
+        Assert.Contains("unknown question id and no `--prompt`", content, StringComparison.Ordinal);
+        Assert.Contains("session with no accepted answers", content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Readme_ListsCollaborativeIntentShapingDoc()
+    {
+        var path = Path.Combine(GetSolutionRoot(), "docs", "automation-templates", "README.md");
+        var content = File.ReadAllText(path);
+
+        Assert.Contains("collaborative-intent-shaping.md", content, StringComparison.Ordinal);
+        Assert.Contains("G253", content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Doc_DoesNotReintroduceForbiddenInvocations()
+    {
+        // The collaborative shaping flow must not point operators at intent-cli run.
+        var path = Path.Combine(GetSolutionRoot(), "docs", "automation-templates", "collaborative-intent-shaping.md");
+        var content = File.ReadAllText(path);
+
+        // `intent-cli run` may appear only inside the "What this guide is not" disclaimer section.
+        var disclaimerIndex = content.IndexOf("## What this guide is not", StringComparison.Ordinal);
+        Assert.True(disclaimerIndex > 0, "missing 'What this guide is not' section");
+        var beforeDisclaimer = content[..disclaimerIndex];
+        Assert.DoesNotContain("intent-cli run", beforeDisclaimer, StringComparison.Ordinal);
+
+        // The flow must not recommend AI provider launch through intent-cli.
+        Assert.DoesNotContain("intent-cli launch", content, StringComparison.Ordinal);
+        Assert.DoesNotContain("intent-cli provider", content, StringComparison.Ordinal);
+    }
+
+    private static int CountSubstring(string content, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = content.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+
+    private static string GetSolutionRoot()
+    {
+        return Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+    }
+}


### PR DESCRIPTION
Closes #609

## Summary

- Adds `docs/automation-templates/collaborative-intent-shaping.md` — the minimal prompt-to-intent smoke flow an AI agent runs when the product owner says "intent-cli に以下の機能を追加したいから一緒に作業して" (or any similar intake request).
- Walks through, in order:
  1. `intent-cli guide collaborate --kind feature-intake` (G249) for responsibility boundaries and the suggested command sequence.
  2. `intent-cli intent status` / `intent search` / `intent explain` and `intent-cli guide rules --topic` (G241/G242/G252) for current state, prior art, and rule references.
  3. `intent-cli interview next-question` and `interview record-answer --write` (with `--prompt` for new question ids) against the durable per-domain session store (G250).
  4. `intent-cli interview compile` to read accepted baseline + open questions (G251).
  5. `intent-cli intent next-slice --dry-run` (G243) to verify WIP cap and clarification gates before drafting.
  6. `intent-cli intent draft-from-interview` — dry-run by default, `--write` only after operator acceptance — landing `intents/<domain>/drafts/<session>.md`. The smoke flow ends here; no GitHub issue is created.
- Names the three operator decision gates (per-answer acceptance, draft acceptance, promotion to published issue) and the deterministic stops (`idle`, `clarification-required`, `skip-next-slice-due-to-wip`, unknown question id without `--prompt`, draft against a session with no accepted answers).
- Adds 6 focused doc tests asserting canonical sections, full installed-command coverage, operator-decision-gate language, failure-mode names, README index entry, and that `intent-cli run` is only mentioned inside the "What this guide is not" disclaimer.
- Lists the new G253 entry in `docs/automation-templates/README.md`.

The guide does not introduce any new command implementation; it composes the surfaces shipped by G241–G252.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~CollaborativeIntentShapingDocTests"` (6/6 passed)
- [x] `git diff --check` clean