### PR TITLE
G254 Add intent-cli guide rules list command

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -51,6 +51,7 @@ These templates assume:
 | G251  | `intent-cli interview compile` / `intent draft-from-interview` | Compile accepted interview answers into a draft intent under `intents/<domain>/drafts/<session>.md`; both commands are read-only by default (`--write` for the draft writer). |
 | G252  | `intent-cli guide rules --topic`        | Read-only operator-facing rule summaries for label-ownership / child-issue-contract / clarification / review-closeout / intake-interview, each with source references and installed-command hints |
 | G253  | [`collaborative-intent-shaping.md`](./collaborative-intent-shaping.md) | Smoke guide for the prompt-to-intent flow using the G249–G252 + G241–G243 surfaces; read-only by default, names operator decision gates |
+| G254  | `intent-cli guide rules list`           | Read-only listing of supported `guide rules --topic` ids, categories (automation / issue-contract / interview / review), and short descriptions |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/GuideRulesCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideRulesCommand.cs
@@ -164,6 +164,12 @@ internal static class GuideRulesCommand
             return 0;
         }
 
+        // G254: nested `guide rules list` discovery sub-subcommand.
+        if (args.Length >= 1 && string.Equals(args[0], "list", StringComparison.Ordinal))
+        {
+            return GuideRulesListCommand.Execute(context, args[1..], writer);
+        }
+
         if (!TryParseArguments(args, out var topic, out var format, out var error))
         {
             writer.WriteLine(error);

--- a/src/IntentSystem.Cli/Commands/GuideRulesListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideRulesListCommand.cs
@@ -1,0 +1,180 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G254: Read-only <c>intent-cli guide rules list</c>. Lists the rule
+/// topics supported by <c>guide rules --topic</c> together with stable
+/// topic ids, a short description, and a category (automation,
+/// issue-contract, interview, review, closeout) so AI agents can
+/// discover available topics without opening local rules files. Never
+/// mutates state. Never launches an AI provider.
+/// </summary>
+internal static class GuideRulesListCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide rules list [--format markdown|json]";
+
+    internal static readonly IReadOnlyList<RulesTopicEntry> Topics = new[]
+    {
+        new RulesTopicEntry
+        {
+            Id = "label-ownership",
+            Title = "Label ownership",
+            Description = "intent-target / intent-pr-created boundaries and the installed transition surfaces.",
+            Category = "automation"
+        },
+        new RulesTopicEntry
+        {
+            Id = "child-issue-contract",
+            Title = "Child Issue Contract",
+            Description = "Required github-body sections for an implementation handoff.",
+            Category = "issue-contract"
+        },
+        new RulesTopicEntry
+        {
+            Id = "clarification",
+            Title = "Hard Clarification rule",
+            Description = "When source-of-truth is ambiguous, stop with clarification-required.",
+            Category = "automation"
+        },
+        new RulesTopicEntry
+        {
+            Id = "review-closeout",
+            Title = "Review and closeout",
+            Description = "Stage 1 review and Stage 2 closeout boundaries; installed transition path.",
+            Category = "review"
+        },
+        new RulesTopicEntry
+        {
+            Id = "intake-interview",
+            Title = "Intake and interview",
+            Description = "Operator-decides intake flow and durable interview Q/A artifacts.",
+            Category = "interview"
+        }
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            var payload = new RulesTopicListResult { Topics = Topics };
+            writer.Write(JsonSerializer.Serialize(payload, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer);
+        }
+
+        return 0;
+    }
+
+    private static void WriteMarkdown(TextWriter writer)
+    {
+        writer.WriteLine("# Guide rules — supported topics");
+        writer.WriteLine();
+        writer.WriteLine("Use `intent-cli guide rules --topic <id>` to retrieve the full rule summary.");
+        writer.WriteLine();
+
+        writer.WriteLine("| id | category | title | description |");
+        writer.WriteLine("|----|----------|-------|-------------|");
+        foreach (var topic in Topics)
+        {
+            writer.WriteLine($"| {topic.Id} | {topic.Category} | {topic.Title} | {topic.Description} |");
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string format, out string error)
+    {
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide rules list");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only listing of supported `guide rules --topic` topic ids, categories, and descriptions.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true
+    };
+}
+
+internal sealed record RulesTopicEntry
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    [JsonPropertyName("category")]
+    public required string Category { get; init; }
+}
+
+internal sealed record RulesTopicListResult
+{
+    [JsonPropertyName("topics")]
+    public required IReadOnlyList<RulesTopicEntry> Topics { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideRulesListCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideRulesListCommandTests.cs
@@ -1,0 +1,145 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideRulesListCommandTests
+{
+    [Fact]
+    public void Execute_DefaultMarkdown_EmitsTopicTable()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideRulesListCommand.Execute(
+            CreateContext(),
+            [],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide rules — supported topics", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide rules --topic <id>", output, StringComparison.Ordinal);
+        Assert.Contains("| id | category | title | description |", output, StringComparison.Ordinal);
+        foreach (var topic in new[] { "label-ownership", "child-issue-contract", "clarification", "review-closeout", "intake-interview" })
+        {
+            Assert.Contains(topic, output, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_EmitsStructuredTopicList()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideRulesListCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var topics = document.RootElement.GetProperty("topics");
+        Assert.Equal(5, topics.GetArrayLength());
+        var ids = topics.EnumerateArray().Select(e => e.GetProperty("id").GetString()).ToArray();
+        Assert.Contains("label-ownership", ids);
+        Assert.Contains("child-issue-contract", ids);
+        Assert.Contains("clarification", ids);
+        Assert.Contains("review-closeout", ids);
+        Assert.Contains("intake-interview", ids);
+
+        var categories = topics.EnumerateArray().Select(e => e.GetProperty("category").GetString()).ToArray();
+        Assert.Contains("automation", categories);
+        Assert.Contains("issue-contract", categories);
+        Assert.Contains("review", categories);
+        Assert.Contains("interview", categories);
+    }
+
+    [Fact]
+    public void Execute_RoutedThroughGuideRulesNested_EmitsList()
+    {
+        // `intent-cli guide rules list --format json` is dispatched through
+        // GuideRulesCommand which delegates to the list command.
+        using var writer = new StringWriter();
+        var exitCode = GuideRulesCommand.Execute(
+            CreateContext(),
+            ["list", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(5, document.RootElement.GetProperty("topics").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_UnsupportedFormat_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideRulesListCommand.Execute(
+            CreateContext(),
+            ["--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideRulesListCommand.Execute(
+            CreateContext(),
+            ["--surprise"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument '--surprise'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideRulesListCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("guide rules list", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TopicIds_MatchGuideRulesTopicCommandRegistry()
+    {
+        // Each id listed by `guide rules list` must be resolvable by `guide rules --topic`.
+        foreach (var topic in GuideRulesListCommand.Topics)
+        {
+            using var writer = new StringWriter();
+            var exitCode = GuideRulesCommand.Execute(
+                CreateContext(),
+                ["--topic", topic.Id, "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains($"\"topic\": \"{topic.Id}\"", writer.ToString(), StringComparison.Ordinal);
+        }
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #611

## Summary

- Adds read-only `intent-cli guide rules list [--format markdown|json]`. The output lists each supported topic with its stable id, short description, and a category bucket (`automation`, `issue-contract`, `interview`, `review`) so AI agents can discover `guide rules --topic` topics without opening local rules-folder paths.
- Routing: the existing `guide rules` handler (G252) now detects a leading `list` subcommand and delegates to `GuideRulesListCommand`. The existing `guide rules --topic <id>` form is unchanged.
- Read-only: never mutates state, never launches an AI provider.
- 7 focused tests cover markdown table output, JSON shape, the routed-through-`guide rules` path, unsupported format, unknown argument, help, and a registry-sync check that every id reported by `list` resolves through `guide rules --topic`.
- Lists the new G254 entry in `docs/automation-templates/README.md`.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~GuideRulesListCommandTests"` (7/7 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean