### PR TITLE
G255 Add intent-cli guide workflow suggest command

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -52,6 +52,7 @@ These templates assume:
 | G252  | `intent-cli guide rules --topic`        | Read-only operator-facing rule summaries for label-ownership / child-issue-contract / clarification / review-closeout / intake-interview, each with source references and installed-command hints |
 | G253  | [`collaborative-intent-shaping.md`](./collaborative-intent-shaping.md) | Smoke guide for the prompt-to-intent flow using the G249–G252 + G241–G243 surfaces; read-only by default, names operator decision gates |
 | G254  | `intent-cli guide rules list`           | Read-only listing of supported `guide rules --topic` ids, categories (automation / issue-contract / interview / review), and short descriptions |
+| G255  | `intent-cli guide workflow suggest`     | Read-only workflow recommendation: classifies a broad operator goal (`--goal` text or `--from-file` path) into feature-intake / next-slice-planning / review / child-implementation / clarification, returns the suggested command sequence and rule topics |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -209,7 +209,8 @@ internal static class CommandRouter
                 ["automation"] = GuideAutomationCommand.Execute,
                 ["review"] = GuideReviewCommand.Execute,
                 ["collaborate"] = GuideCollaborateCommand.Execute,
-                ["rules"] = GuideRulesCommand.Execute
+                ["rules"] = GuideRulesCommand.Execute,
+                ["workflow"] = GuideWorkflowCommand.Execute
             },
             ["intent"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowCommand.cs
@@ -1,0 +1,53 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G255: Dispatcher for the <c>guide workflow</c> subcommand group. The
+/// command router treats <c>guide</c> as a top-level group and
+/// <c>workflow</c> as its subcommand; this dispatcher peels the next
+/// token (<c>suggest</c>) and delegates to the matching handler.
+/// </summary>
+internal static class GuideWorkflowCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (args.Length == 0)
+        {
+            writer.WriteLine("guide workflow requires a subcommand. Supported: suggest.");
+            WriteHelp(writer);
+            return 1;
+        }
+
+        var subcommand = args[0];
+        return subcommand switch
+        {
+            "suggest" => GuideWorkflowSuggestCommand.Execute(context, args[1..], writer),
+            _ => UnknownSubcommand(writer, subcommand)
+        };
+    }
+
+    private static int UnknownSubcommand(TextWriter writer, string subcommand)
+    {
+        writer.WriteLine($"Unknown 'guide workflow' subcommand '{subcommand}'. Supported: suggest.");
+        WriteHelp(writer);
+        return 1;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide workflow");
+        writer.WriteLine("Usage: intent-cli guide workflow suggest [--domain <name>] (--goal <text> | --from-file <path>) [--format markdown|json]");
+        writer.WriteLine();
+        writer.WriteLine("Subcommands:");
+        writer.WriteLine("- suggest — recommend a workflow + commands + rule topics for a broad operator goal");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowSuggestCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowSuggestCommand.cs
@@ -1,0 +1,373 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G255: Read-only <c>intent-cli guide workflow suggest</c>. Classifies a
+/// broad operator goal into one of five canonical workflows
+/// (feature-intake, next-slice-planning, review, child-implementation,
+/// clarification) and returns the recommended <c>intent-cli</c> command
+/// sequence plus relevant rule topics. No semantic product decisions and
+/// no AI provider launch.
+/// </summary>
+internal static class GuideWorkflowSuggestCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string WorkflowFeatureIntake = "feature-intake";
+    private const string WorkflowNextSlicePlanning = "next-slice-planning";
+    private const string WorkflowReview = "review";
+    private const string WorkflowChildImplementation = "child-implementation";
+    private const string WorkflowClarification = "clarification";
+    private const string WorkflowUnknown = "unknown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide workflow suggest [--domain <name>] (--goal <text> | --from-file <path>) [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var goalInline, out var goalFile, out var domainOverride, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (goalInline is not null && goalFile is not null)
+        {
+            writer.WriteLine("--goal and --from-file are mutually exclusive.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        string goalText;
+        if (goalInline is not null)
+        {
+            goalText = goalInline;
+        }
+        else if (goalFile is not null)
+        {
+            if (!File.Exists(goalFile))
+            {
+                writer.WriteLine($"--from-file path not found: {goalFile}");
+                writer.WriteLine(UsageLine);
+                return 1;
+            }
+
+            goalText = File.ReadAllText(goalFile);
+        }
+        else
+        {
+            writer.WriteLine("either --goal <text> or --from-file <path> is required.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var domain = string.IsNullOrWhiteSpace(domainOverride)
+            ? context.Config.Project.Domain
+            : domainOverride!;
+
+        var (workflow, matchedKeywords) = Classify(goalText);
+        var recommendation = BuildRecommendation(workflow, domain, goalText, matchedKeywords);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(recommendation, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, recommendation);
+        }
+
+        return 0;
+    }
+
+    private static (string Workflow, IReadOnlyList<string> MatchedKeywords) Classify(string goalText)
+    {
+        var lower = goalText.ToLowerInvariant();
+        var matched = new List<string>();
+
+        bool ContainsAny(IEnumerable<string> needles)
+        {
+            var hit = false;
+            foreach (var needle in needles)
+            {
+                if (goalText.Contains(needle, StringComparison.OrdinalIgnoreCase)
+                    || lower.Contains(needle, StringComparison.Ordinal))
+                {
+                    matched.Add(needle);
+                    hit = true;
+                }
+            }
+            return hit;
+        }
+
+        if (ContainsAny(new[] { "clarif", "ambiguous", "blocker", "曖昧", "未決" }))
+        {
+            return (WorkflowClarification, matched);
+        }
+
+        if (ContainsAny(new[] { "review", "approve", "merge", "closeout", "request-update", "レビュー" }))
+        {
+            return (WorkflowReview, matched);
+        }
+
+        if (ContainsAny(new[] { "implement issue", "fix issue", "issue-to-pr", "implement #", "実装" }))
+        {
+            return (WorkflowChildImplementation, matched);
+        }
+
+        if (ContainsAny(new[] { "next slice", "next-slice", "plan", "candidate", "次のスライス", "次スライス" }))
+        {
+            return (WorkflowNextSlicePlanning, matched);
+        }
+
+        if (ContainsAny(new[] { "add", "新機能", "feature", "want to", "intake", "shape", "追加", "new feature", "新しい機能" }))
+        {
+            return (WorkflowFeatureIntake, matched);
+        }
+
+        return (WorkflowUnknown, matched);
+    }
+
+    private static GuideWorkflowSuggestion BuildRecommendation(string workflow, string domain, string goalText, IReadOnlyList<string> matchedKeywords)
+    {
+        var (commands, ruleTopics, summary) = workflow switch
+        {
+            WorkflowFeatureIntake => (
+                new[]
+                {
+                    $"intent-cli guide collaborate --kind feature-intake --domain {domain} --format markdown",
+                    $"intent-cli intent status --domain {domain} --format json",
+                    $"intent-cli intent search --domain {domain} --query <keyword> --format json",
+                    $"intent-cli interview record-answer --session <id> --question <q> --prompt <text> --from-file <path> --write --format json",
+                    $"intent-cli intent draft-from-interview --session <id> --domain {domain} --format markdown"
+                },
+                new[] { "intake-interview", "child-issue-contract", "label-ownership" },
+                "Feature intake — operator opens with a request to add functionality; the AI agent runs the interview-to-draft flow without publishing."),
+
+            WorkflowNextSlicePlanning => (
+                new[]
+                {
+                    $"intent-cli intent status --domain {domain} --format json",
+                    $"intent-cli intent search --domain {domain} --query <keyword> --format json",
+                    $"intent-cli intent next-slice --dry-run --domain {domain} --target-repo <owner/repo> --format json",
+                    $"intent-cli packet draft --execution-unit <id> --target-repo <owner/repo> --dry-run --format markdown"
+                },
+                new[] { "child-issue-contract", "clarification", "label-ownership" },
+                "Next-slice planning — verify WIP cap, clarification gates, and candidate readiness before promoting a draft."),
+
+            WorkflowReview => (
+                new[]
+                {
+                    $"intent-cli guide review --pr <n> --repo <owner/repo> --domain {domain} --format markdown",
+                    $"intent-cli review closeout-plan --pr <n> --repo <owner/repo> --domain {domain} --format json",
+                    "intent-cli automation host-review-preflight --repo <owner/repo> --format json",
+                    "intent-cli closeout pr --pr <n> --repo <owner/repo> --write --format json"
+                },
+                new[] { "review-closeout", "label-ownership" },
+                "Review and closeout — read-only checklist + closeout plan first; mutate state only via closeout pr after acceptance."),
+
+            WorkflowChildImplementation => (
+                new[]
+                {
+                    "intent-cli worker next-action --repo <owner/repo> --workdir $PWD --format json",
+                    "intent-cli worker claim --kind issue --number <n> --write --format json",
+                    "intent-cli worker result-summary --kind issue-to-pr --repo <owner/repo> --issue <n> --pr <m> --outcome <outcome> --format json",
+                    "intent-cli worker complete --kind issue --number <n> --outcome <outcome> --write --format json"
+                },
+                new[] { "child-issue-contract", "label-ownership", "clarification" },
+                "Child implementation — drive issue → draft PR through the worker selector and complete the queue/label transitions deterministically."),
+
+            WorkflowClarification => (
+                new[]
+                {
+                    $"intent-cli intent status --domain {domain} --format json",
+                    $"intent-cli intent next-slice --dry-run --domain {domain} --target-repo <owner/repo> --format json",
+                    "intent-cli automation clarification-stop"
+                },
+                new[] { "clarification", "child-issue-contract" },
+                "Clarification — surface open blockers and stop with a clarification-required summary; do not guess past ambiguous source-of-truth."),
+
+            _ => (
+                new[]
+                {
+                    $"intent-cli guide collaborate --kind feature-intake --domain {domain} --format markdown",
+                    $"intent-cli intent status --domain {domain} --format json",
+                    $"intent-cli intent search --domain {domain} --query <keyword> --format json",
+                    "intent-cli guide rules list --format markdown"
+                },
+                new[] { "intake-interview", "label-ownership" },
+                "Goal did not match a known workflow shape; start with collaborate and search to disambiguate.")
+        };
+
+        return new GuideWorkflowSuggestion
+        {
+            Domain = domain,
+            Workflow = workflow,
+            Goal = goalText,
+            MatchedKeywords = matchedKeywords,
+            Summary = summary,
+            RecommendedCommands = commands,
+            RuleTopics = ruleTopics
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideWorkflowSuggestion result)
+    {
+        writer.WriteLine($"# Guide workflow suggest — {result.Workflow}");
+        writer.WriteLine();
+        writer.WriteLine($"- domain: {result.Domain}");
+        writer.WriteLine($"- workflow: {result.Workflow}");
+        if (result.MatchedKeywords.Count > 0)
+        {
+            writer.WriteLine($"- matched keywords: {string.Join(", ", result.MatchedKeywords)}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"## Summary");
+        writer.WriteLine();
+        writer.WriteLine(result.Summary);
+        writer.WriteLine();
+        writer.WriteLine("## Recommended commands");
+        foreach (var command in result.RecommendedCommands)
+        {
+            writer.WriteLine($"- `{command}`");
+        }
+        writer.WriteLine();
+        writer.WriteLine("## Rule topics");
+        foreach (var topic in result.RuleTopics)
+        {
+            writer.WriteLine($"- `intent-cli guide rules --topic {topic} --format markdown`");
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? goalInline,
+        out string? goalFile,
+        out string? domainOverride,
+        out string format,
+        out string error)
+    {
+        goalInline = null;
+        goalFile = null;
+        domainOverride = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--goal":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--goal requires a value.";
+                        return false;
+                    }
+
+                    goalInline = args[index + 1];
+                    index++;
+                    break;
+
+                case "--from-file":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-file requires a path.";
+                        return false;
+                    }
+
+                    goalFile = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide workflow suggest");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only workflow recommendation for a broad operator goal. Returns the suggested intent-cli command sequence and rule topics.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true
+    };
+}
+
+internal sealed record GuideWorkflowSuggestion
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("workflow")]
+    public required string Workflow { get; init; }
+
+    [JsonPropertyName("goal")]
+    public required string Goal { get; init; }
+
+    [JsonPropertyName("matched_keywords")]
+    public required IReadOnlyList<string> MatchedKeywords { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("recommended_commands")]
+    public required IReadOnlyList<string> RecommendedCommands { get; init; }
+
+    [JsonPropertyName("rule_topics")]
+    public required IReadOnlyList<string> RuleTopics { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -76,7 +76,8 @@ internal static class Program
             && (string.Equals(args[1], "oneshot", StringComparison.Ordinal)
                 || string.Equals(args[1], "automation", StringComparison.Ordinal)
                 || string.Equals(args[1], "collaborate", StringComparison.Ordinal)
-                || string.Equals(args[1], "rules", StringComparison.Ordinal));
+                || string.Equals(args[1], "rules", StringComparison.Ordinal)
+                || string.Equals(args[1], "workflow", StringComparison.Ordinal));
     }
 
     private static CliContext CreateBootstrapContext(string currentDirectory, string[] args)

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowSuggestCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowSuggestCommandTests.cs
@@ -1,0 +1,235 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideWorkflowSuggestCommandTests
+{
+    [Theory]
+    [InlineData("intent-cli に新機能を追加したい", "feature-intake")]
+    [InlineData("operator wants to add a feature", "feature-intake")]
+    [InlineData("plan the next slice", "next-slice-planning")]
+    [InlineData("次のスライスを決めたい", "next-slice-planning")]
+    [InlineData("review PR 600 and approve if it passes", "review")]
+    [InlineData("PR をレビューして merge する", "review")]
+    [InlineData("implement issue 605", "child-implementation")]
+    [InlineData("issue 605 を実装してほしい", "child-implementation")]
+    [InlineData("source-of-truth が曖昧な部分がある", "clarification")]
+    [InlineData("we have a clarification blocker", "clarification")]
+    [InlineData("xyzzy mumble", "unknown")]
+    public void Execute_ClassifiesGoalIntoExpectedWorkflow(string goal, string expectedWorkflow)
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--goal", goal, "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(expectedWorkflow, document.RootElement.GetProperty("workflow").GetString());
+    }
+
+    [Fact]
+    public void Execute_FromFile_ReadsGoalFromDisk()
+    {
+        using var workspace = new ScratchWorkspace();
+        var path = workspace.WriteFile("goal.txt", "We need to plan the next slice for intent-cli");
+
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--from-file", path, "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("next-slice-planning", document.RootElement.GetProperty("workflow").GetString());
+    }
+
+    [Fact]
+    public void Execute_RecommendedCommandsReferenceOtherInstalledSurfaces()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--goal", "feature を一緒に追加したい", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var commands = document.RootElement.GetProperty("recommended_commands").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(commands, c => c!.StartsWith("intent-cli guide collaborate", StringComparison.Ordinal));
+        Assert.Contains(commands, c => c!.StartsWith("intent-cli intent status", StringComparison.Ordinal));
+        Assert.Contains(commands, c => c!.StartsWith("intent-cli intent draft-from-interview", StringComparison.Ordinal));
+
+        var ruleTopics = document.RootElement.GetProperty("rule_topics").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains("intake-interview", ruleTopics);
+    }
+
+    [Fact]
+    public void Execute_MarkdownFormat_EmitsHumanReadableOutput()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--goal", "review the latest PR", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide workflow suggest — review", output, StringComparison.Ordinal);
+        Assert.Contains("## Recommended commands", output, StringComparison.Ordinal);
+        Assert.Contains("## Rule topics", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide review", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MissingGoalAndFile_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--goal <text> or --from-file <path> is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_BothGoalAndFile_ReturnsUsageError()
+    {
+        using var workspace = new ScratchWorkspace();
+        var path = workspace.WriteFile("goal.txt", "x");
+
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--goal", "review", "--from-file", path],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("mutually exclusive", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_FromFileMissing_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--from-file", "/tmp/this/does/not/exist.txt"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-file path not found", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedFormat_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--goal", "review", "--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("guide workflow suggest", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Dispatch_GuideWorkflowSuggestThroughGuideWorkflowCommand_Works()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowCommand.Execute(
+            CreateContext(),
+            ["suggest", "--goal", "review", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("review", document.RootElement.GetProperty("workflow").GetString());
+    }
+
+    [Fact]
+    public void Dispatch_GuideWorkflowUnknownSubcommand_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowCommand.Execute(
+            CreateContext(),
+            ["analyze"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown 'guide workflow' subcommand 'analyze'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Dispatch_GuideWorkflowMissingSubcommand_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowCommand.Execute(
+            CreateContext(),
+            [],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("guide workflow requires a subcommand", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class ScratchWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("guide-workflow-suggest-tests-")
+            .FullName;
+
+        public string WriteFile(string name, string content)
+        {
+            var path = Path.Combine(rootPath, name);
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #613

## Summary

- Adds read-only `intent-cli guide workflow suggest [--domain <name>] (--goal <text> | --from-file <path>) [--format markdown|json]`. The command classifies a broad operator goal into one of five canonical workflows and returns the recommended command sequence plus rule topics so an AI agent's first internal CLI call can pick the right follow-up surface.
- Classification is keyword-based and mutually exclusive (clarification first, then review, child-implementation, next-slice-planning, feature-intake, with an `unknown` fallback). Both English and Japanese keywords are supported (e.g. `追加`, `実装`, `レビュー`, `次のスライス`, `曖昧`).
- Each recommendation interpolates `--domain`, lists canonical commands for that workflow, and names the relevant `guide rules --topic` ids.
- `--from-file` reads long goals from disk; `--goal` and `--from-file` are mutually exclusive.
- Routed via `guide workflow` (a small dispatcher that only recognises `suggest` for now). Routed through the bootstrap path so the command works outside a child-repo worktree.
- Read-only: never mutates state, never launches an AI provider.
- 22 focused tests cover every workflow bucket in both languages, the unknown-goal fallback, `--from-file` happy path and missing-path error, mutual-exclusivity, recommended-command/rule-topic shapes, markdown output, all usage errors, and the dispatcher's suggest / unknown-subcommand / missing-subcommand paths.
- Lists the new G255 command in `docs/automation-templates/README.md`.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~GuideWorkflowSuggestCommandTests"` (22/22 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean