### PR TITLE
G256 Add intent-cli guide model command

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -53,6 +53,7 @@ These templates assume:
 | G253  | [`collaborative-intent-shaping.md`](./collaborative-intent-shaping.md) | Smoke guide for the prompt-to-intent flow using the G249–G252 + G241–G243 surfaces; read-only by default, names operator decision gates |
 | G254  | `intent-cli guide rules list`           | Read-only listing of supported `guide rules --topic` ids, categories (automation / issue-contract / interview / review), and short descriptions |
 | G255  | `intent-cli guide workflow suggest`     | Read-only workflow recommendation: classifies a broad operator goal (`--goal` text or `--from-file` path) into feature-intake / next-slice-planning / review / child-implementation / clarification, returns the suggested command sequence and rule topics |
+| G256  | `intent-cli guide model`                | Read-only summary of the chat-first / CLI-internal collaboration model: roles (human, AI agent, intent-cli, host repo), primary data paths, optional advanced runtime, hard rules |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -210,7 +210,8 @@ internal static class CommandRouter
                 ["review"] = GuideReviewCommand.Execute,
                 ["collaborate"] = GuideCollaborateCommand.Execute,
                 ["rules"] = GuideRulesCommand.Execute,
-                ["workflow"] = GuideWorkflowCommand.Execute
+                ["workflow"] = GuideWorkflowCommand.Execute,
+                ["model"] = GuideModelCommand.Execute
             },
             ["intent"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/GuideModelCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideModelCommand.cs
@@ -1,0 +1,253 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G256: Read-only <c>intent-cli guide model</c>. Emits the canonical
+/// description of the primary collaboration model — chat-first product
+/// owner, Codex/Claude coding agent calls intent-cli internally,
+/// canonical state lives in the host git repository, intent-cli does
+/// not launch AI providers — so AI agents can discover the model
+/// without reading rule files. Never mutates state. Never launches an
+/// AI provider.
+/// </summary>
+internal static class GuideModelCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide model [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(BuildModel(), JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer);
+        }
+
+        return 0;
+    }
+
+    internal static GuideModelResult BuildModel()
+    {
+        return new GuideModelResult
+        {
+            PrimaryModel = "chat-first / CLI-internal: the human product owner stays in chat with a Codex/Claude coding agent, and the agent calls `intent-cli` internally for rules, workflows, questions, status, and validation.",
+            Roles = new[]
+            {
+                new GuideModelRole
+                {
+                    Actor = "Human product owner",
+                    Responsibilities = new[]
+                    {
+                        "Express goals and constraints in chat.",
+                        "Accept or reject drafts surfaced by the AI agent.",
+                        "Authorize publish-boundary mutations (intent-target apply, draft promotion to GitHub issue).",
+                        "Resolve clarifications when source-of-truth is ambiguous."
+                    }
+                },
+                new GuideModelRole
+                {
+                    Actor = "Codex / Claude coding agent",
+                    Responsibilities = new[]
+                    {
+                        "Run the conversation; ask one focused question at a time; surface tradeoffs.",
+                        "Call `intent-cli` internally to retrieve rules (`guide rules`), state (`intent status`), discovery (`intent search` / `explain`), and planning facts (`intent next-slice --dry-run`).",
+                        "Drive durable state through `interview record-answer --write` and `intent draft-from-interview --write` only after operator acceptance.",
+                        "Implement child issues via the `worker next-action` / `worker claim` / `worker complete` flow when running the implementation loop."
+                    }
+                },
+                new GuideModelRole
+                {
+                    Actor = "intent-cli",
+                    Responsibilities = new[]
+                    {
+                        "Deterministic guide / artifact authority for rules, workflows, packet contracts, queue/runs state, and label transitions.",
+                        "Read-only by default; explicit `--write` is required for any state mutation.",
+                        "Owns label state for `intent-target`, `intent-pr-created`, and the installed transition surfaces.",
+                        "Does not launch AI providers and does not replace operator decisions."
+                    }
+                },
+                new GuideModelRole
+                {
+                    Actor = "Host git repository",
+                    Responsibilities = new[]
+                    {
+                        "Canonical store for `intents/<domain>` (specs, rules, clarifications, drafts, interview sessions).",
+                        "Canonical store for `.intent-cli` (queue-state, runs.jsonl, packets per execution unit).",
+                        "Source of truth for submodule pointers and durable parent state."
+                    }
+                }
+            },
+            PrimaryDataPaths = new[]
+            {
+                "intents/<domain>/clarifications/open.md — open Hard Clarification blockers.",
+                "intents/<domain>/interviews/<session>.json — durable interview Q/A artifacts.",
+                "intents/<domain>/drafts/<session>.md — accepted-answer drafts before promotion.",
+                ".intent-cli/queue-state.json — execution-unit lifecycle state.",
+                ".intent-cli/runs.jsonl — append-only event log (pr-merged, closeout-recorded, etc.).",
+                ".intent-cli/issues/<execution-unit>/ — per-unit packet (packet.yaml, implementation.md, review-context.md, github-body.md)."
+            },
+            OptionalAdvancedRuntime = new[]
+            {
+                "`intent-cli run` is for integration smoke / deterministic replay / local dogfooding; not the primary collaboration path.",
+                "Direct AI-provider subprocess launch (Codex / Claude as a subprocess) is optional advanced runtime, not the default.",
+                "Supervisor backend orchestration is optional advanced runtime; chat-first / CLI-internal is the default."
+            },
+            HardRules = new[]
+            {
+                "intent-cli must not launch Codex/Claude or any AI provider.",
+                "intent-cli must not replace operator decisions; canonical mutation requires explicit operator acceptance.",
+                "Routine collaboration must not require manually opening `intents/rules` files; agents call `intent-cli guide ...` instead.",
+                "`intent-target` is the host-owned publish boundary; the child loop never adds or removes it.",
+                "`intent-pr-created` is an issue-side completion marker; never apply it to a PR."
+            }
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer)
+    {
+        var model = BuildModel();
+        writer.WriteLine("# Guide model — primary collaboration model");
+        writer.WriteLine();
+        writer.WriteLine("## Primary model");
+        writer.WriteLine();
+        writer.WriteLine(model.PrimaryModel);
+        writer.WriteLine();
+
+        writer.WriteLine("## Roles");
+        foreach (var role in model.Roles)
+        {
+            writer.WriteLine();
+            writer.WriteLine($"### {role.Actor}");
+            writer.WriteLine();
+            foreach (var responsibility in role.Responsibilities)
+            {
+                writer.WriteLine($"- {responsibility}");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Primary data paths (host git repository)");
+        foreach (var path in model.PrimaryDataPaths)
+        {
+            writer.WriteLine($"- {path}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Optional advanced runtime");
+        foreach (var item in model.OptionalAdvancedRuntime)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Hard rules");
+        foreach (var rule in model.HardRules)
+        {
+            writer.WriteLine($"- {rule}");
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string format, out string error)
+    {
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide model");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only summary of the chat-first / CLI-internal collaboration model and its hard rules.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true
+    };
+}
+
+internal sealed record GuideModelResult
+{
+    [JsonPropertyName("primary_model")]
+    public required string PrimaryModel { get; init; }
+
+    [JsonPropertyName("roles")]
+    public required IReadOnlyList<GuideModelRole> Roles { get; init; }
+
+    [JsonPropertyName("primary_data_paths")]
+    public required IReadOnlyList<string> PrimaryDataPaths { get; init; }
+
+    [JsonPropertyName("optional_advanced_runtime")]
+    public required IReadOnlyList<string> OptionalAdvancedRuntime { get; init; }
+
+    [JsonPropertyName("hard_rules")]
+    public required IReadOnlyList<string> HardRules { get; init; }
+}
+
+internal sealed record GuideModelRole
+{
+    [JsonPropertyName("actor")]
+    public required string Actor { get; init; }
+
+    [JsonPropertyName("responsibilities")]
+    public required IReadOnlyList<string> Responsibilities { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -77,7 +77,8 @@ internal static class Program
                 || string.Equals(args[1], "automation", StringComparison.Ordinal)
                 || string.Equals(args[1], "collaborate", StringComparison.Ordinal)
                 || string.Equals(args[1], "rules", StringComparison.Ordinal)
-                || string.Equals(args[1], "workflow", StringComparison.Ordinal));
+                || string.Equals(args[1], "workflow", StringComparison.Ordinal)
+                || string.Equals(args[1], "model", StringComparison.Ordinal));
     }
 
     private static CliContext CreateBootstrapContext(string currentDirectory, string[] args)

--- a/tests/IntentSystem.Cli.Tests/GuideModelCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideModelCommandTests.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideModelCommandTests
+{
+    [Fact]
+    public void Execute_DefaultMarkdown_EmitsAllSections()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideModelCommand.Execute(
+            CreateContext(),
+            [],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide model — primary collaboration model", output, StringComparison.Ordinal);
+        Assert.Contains("## Primary model", output, StringComparison.Ordinal);
+        Assert.Contains("## Roles", output, StringComparison.Ordinal);
+        Assert.Contains("## Primary data paths", output, StringComparison.Ordinal);
+        Assert.Contains("## Optional advanced runtime", output, StringComparison.Ordinal);
+        Assert.Contains("## Hard rules", output, StringComparison.Ordinal);
+
+        Assert.Contains("Human product owner", output, StringComparison.Ordinal);
+        Assert.Contains("Codex / Claude coding agent", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("Host git repository", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_EmitsStructuredFields()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideModelCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Contains("chat-first", root.GetProperty("primary_model").GetString()!, StringComparison.Ordinal);
+        Assert.Equal(4, root.GetProperty("roles").GetArrayLength());
+        Assert.True(root.GetProperty("primary_data_paths").GetArrayLength() >= 4);
+        Assert.True(root.GetProperty("optional_advanced_runtime").GetArrayLength() >= 2);
+        Assert.True(root.GetProperty("hard_rules").GetArrayLength() >= 3);
+
+        var roles = root.GetProperty("roles").EnumerateArray().Select(e => e.GetProperty("actor").GetString()).ToArray();
+        Assert.Contains("Human product owner", roles);
+        Assert.Contains("Codex / Claude coding agent", roles);
+        Assert.Contains("intent-cli", roles);
+        Assert.Contains("Host git repository", roles);
+    }
+
+    [Fact]
+    public void Execute_Output_NamesIntentCliRunAsOptional()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideModelCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var optional = document.RootElement.GetProperty("optional_advanced_runtime")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(optional, item => item!.Contains("intent-cli run", StringComparison.Ordinal));
+        Assert.Contains(optional, item => item!.Contains("subprocess", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(optional, item => item!.Contains("Supervisor", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Execute_HardRules_NameLabelOwnershipAndProviderBoundary()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideModelCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var rules = document.RootElement.GetProperty("hard_rules")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(rules, rule => rule!.Contains("must not launch Codex/Claude", StringComparison.Ordinal));
+        Assert.Contains(rules, rule => rule!.Contains("intent-target", StringComparison.Ordinal));
+        Assert.Contains(rules, rule => rule!.Contains("intent-pr-created", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_UnsupportedFormat_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideModelCommand.Execute(
+            CreateContext(),
+            ["--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideModelCommand.Execute(
+            CreateContext(),
+            ["--surprise"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument '--surprise'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideModelCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("guide model", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #615

## Summary

- Adds read-only `intent-cli guide model [--format markdown|json]`. Emits the canonical description of the chat-first / CLI-internal collaboration model so a fresh AI agent can learn the contract before choosing commands.
- Output sections:
  - Primary model — chat-first product owner; Codex/Claude coding agent calls intent-cli internally.
  - Roles — human product owner, Codex/Claude coding agent, intent-cli, host git repository (each with explicit responsibilities).
  - Primary data paths — `intents/<domain>/...` and `.intent-cli/...` files that hold canonical state.
  - Optional advanced runtime — explicitly names `intent-cli run`, direct provider subprocess launch, and supervisor backend orchestration as NOT the default path.
  - Hard rules — intent-cli does not launch AI providers; `intent-target` / `intent-pr-created` boundaries; no requirement to read `intents/rules` directly.
- Routed via the bootstrap path so the command works outside a child-repo worktree.
- Read-only: never mutates state, never launches an AI provider.
- 7 focused tests cover the markdown sections, JSON cardinalities, the explicit advanced-runtime call-out, the hard-rules content, and the usage error / help paths.
- Lists the new G256 command in `docs/automation-templates/README.md`.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~GuideModelCommandTests"` (7/7 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean