### PR TITLE
G257 Add intent-cli guide commands list with lifecycle classification

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -54,6 +54,7 @@ These templates assume:
 | G254  | `intent-cli guide rules list`           | Read-only listing of supported `guide rules --topic` ids, categories (automation / issue-contract / interview / review), and short descriptions |
 | G255  | `intent-cli guide workflow suggest`     | Read-only workflow recommendation: classifies a broad operator goal (`--goal` text or `--from-file` path) into feature-intake / next-slice-planning / review / child-implementation / clarification, returns the suggested command sequence and rule topics |
 | G256  | `intent-cli guide model`                | Read-only summary of the chat-first / CLI-internal collaboration model: roles (human, AI agent, intent-cli, host repo), primary data paths, optional advanced runtime, hard rules |
+| G257  | `intent-cli guide commands list`        | Read-only listing of intent-cli command groups with primary / support / advanced / experimental classification, mutability, and recommended caller |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -211,7 +211,8 @@ internal static class CommandRouter
                 ["collaborate"] = GuideCollaborateCommand.Execute,
                 ["rules"] = GuideRulesCommand.Execute,
                 ["workflow"] = GuideWorkflowCommand.Execute,
-                ["model"] = GuideModelCommand.Execute
+                ["model"] = GuideModelCommand.Execute,
+                ["commands"] = GuideCommandsCommand.Execute
             },
             ["intent"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/GuideCommandsCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsCommand.cs
@@ -1,0 +1,51 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G257: Dispatcher for the <c>guide commands</c> subcommand group. Peels
+/// the next token (<c>list</c>) and delegates to the matching handler.
+/// </summary>
+internal static class GuideCommandsCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (args.Length == 0)
+        {
+            writer.WriteLine("guide commands requires a subcommand. Supported: list.");
+            WriteHelp(writer);
+            return 1;
+        }
+
+        var subcommand = args[0];
+        return subcommand switch
+        {
+            "list" => GuideCommandsListCommand.Execute(context, args[1..], writer),
+            _ => UnknownSubcommand(writer, subcommand)
+        };
+    }
+
+    private static int UnknownSubcommand(TextWriter writer, string subcommand)
+    {
+        writer.WriteLine($"Unknown 'guide commands' subcommand '{subcommand}'. Supported: list.");
+        WriteHelp(writer);
+        return 1;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide commands");
+        writer.WriteLine("Usage: intent-cli guide commands list [--format markdown|json]");
+        writer.WriteLine();
+        writer.WriteLine("Subcommands:");
+        writer.WriteLine("- list — list intent-cli command groups with primary/support/advanced/experimental classification");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
@@ -1,0 +1,338 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G257: Read-only <c>intent-cli guide commands list</c>. Returns each
+/// top-level command group with a lifecycle classification (primary,
+/// support, advanced, experimental), short purpose, mutability hint
+/// (read-only / write), and recommended caller, so AI agents can pick
+/// the right surface without misreading legacy groups (e.g. <c>run</c>)
+/// as the primary product path. Never mutates state. Never launches an
+/// AI provider.
+/// </summary>
+internal static class GuideCommandsListCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string ClassificationPrimary = "primary";
+    private const string ClassificationSupport = "support";
+    private const string ClassificationAdvanced = "advanced";
+    private const string ClassificationExperimental = "experimental";
+
+    private const string MutabilityReadOnly = "read-only";
+    private const string MutabilityMixed = "mixed";
+
+    private const string CallerChatAgent = "chat-agent";
+    private const string CallerImplementationLoop = "implementation-loop";
+    private const string CallerHostLoop = "host-loop";
+    private const string CallerAdvancedRuntime = "advanced-runtime";
+    private const string CallerOperator = "operator";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide commands list [--format markdown|json]";
+
+    internal static readonly IReadOnlyList<CommandGroupEntry> Groups = new[]
+    {
+        new CommandGroupEntry
+        {
+            Name = "guide",
+            Classification = ClassificationPrimary,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Operator-facing guidance: collaboration model, rules-by-topic, workflow suggestion, one-shot/automation/review prompts."
+        },
+        new CommandGroupEntry
+        {
+            Name = "intent",
+            Classification = ClassificationPrimary,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Read-only domain status / search / explain / next-slice planning, plus draft-from-interview (write requires --write)."
+        },
+        new CommandGroupEntry
+        {
+            Name = "interview",
+            Classification = ClassificationPrimary,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Durable per-domain Q/A artifact: next-question/record-answer/compile (older start/answer/resume retained)."
+        },
+        new CommandGroupEntry
+        {
+            Name = "packet",
+            Classification = ClassificationPrimary,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Scaffold the canonical packet directory (packet.yaml / implementation.md / review-context.md / github-body.md); read-only without --write."
+        },
+        new CommandGroupEntry
+        {
+            Name = "worker",
+            Classification = ClassificationPrimary,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerImplementationLoop,
+            Purpose = "Child implementation loop selector: next-action / claim / complete / result-summary."
+        },
+        new CommandGroupEntry
+        {
+            Name = "automation",
+            Classification = ClassificationSupport,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerHostLoop,
+            Purpose = "Host-side label transitions and capability JSON: summary / doctor / host-review-preflight / issue-publish / pr-transition / check / complete / clarification-stop."
+        },
+        new CommandGroupEntry
+        {
+            Name = "metadata",
+            Classification = ClassificationSupport,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerHostLoop,
+            Purpose = "Read-only metadata validate plus the bounded controlled writer (`metadata update --mode completed-closeout`)."
+        },
+        new CommandGroupEntry
+        {
+            Name = "review",
+            Classification = ClassificationSupport,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerHostLoop,
+            Purpose = "Review-side surfaces: closeout-plan (read-only), run / comment / accept (older review surface)."
+        },
+        new CommandGroupEntry
+        {
+            Name = "closeout",
+            Classification = ClassificationSupport,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerHostLoop,
+            Purpose = "PR closeout: queue completion + runs append + continuation hint (`closeout pr --pr <n> --write`)."
+        },
+        new CommandGroupEntry
+        {
+            Name = "issue",
+            Classification = ClassificationSupport,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerOperator,
+            Purpose = "GitHub issue surfaces incl. publish-flow (validate packet → create issue → durable-state next-step), draft / create / status / validate-body / prepare / publish-reviewed / plan-candidate."
+        },
+        new CommandGroupEntry
+        {
+            Name = "queue",
+            Classification = ClassificationSupport,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerOperator,
+            Purpose = "Queue-state inspection and bounded transitions: list / show / next / enqueue / dispatch / transition."
+        },
+        new CommandGroupEntry
+        {
+            Name = "status",
+            Classification = ClassificationSupport,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Read-only status brief used by AI tasking threads (G179); see `intent status` for the canonical domain summary."
+        },
+        new CommandGroupEntry
+        {
+            Name = "context",
+            Classification = ClassificationSupport,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Read-only context surfaces consumed by AI tasking threads."
+        },
+        new CommandGroupEntry
+        {
+            Name = "clarify",
+            Classification = ClassificationSupport,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerOperator,
+            Purpose = "Clarification artifact CRUD: open / list / answer / draft / record. Operator-driven; not the chat-agent's first call."
+        },
+        new CommandGroupEntry
+        {
+            Name = "next-slice",
+            Classification = ClassificationSupport,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerOperator,
+            Purpose = "Older next-slice planning surface; prefer `intent next-slice --dry-run` for collaborative shaping."
+        },
+        new CommandGroupEntry
+        {
+            Name = "tasking",
+            Classification = ClassificationExperimental,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerOperator,
+            Purpose = "Cross-thread tasking handoff bundles and task-packet helpers; experimental compared to the chat-first flow."
+        },
+        new CommandGroupEntry
+        {
+            Name = "intake",
+            Classification = ClassificationExperimental,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerOperator,
+            Purpose = "Older concept-intake surface (init / concept / interview / compile / foldin / patch / apply / execution / advance / activate / issue / enqueue / autostart / launch / start). Prefer `guide collaborate` + `interview record-answer` for new flows."
+        },
+        new CommandGroupEntry
+        {
+            Name = "bug",
+            Classification = ClassificationExperimental,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerOperator,
+            Purpose = "Bug-intent CRUD (report / triage / start / repair). Not the primary collaboration path."
+        },
+        new CommandGroupEntry
+        {
+            Name = "projection",
+            Classification = ClassificationExperimental,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerOperator,
+            Purpose = "Projection generate / regenerate. Internal to specific tooling; not part of the chat-first product path."
+        },
+        new CommandGroupEntry
+        {
+            Name = "project",
+            Classification = ClassificationExperimental,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerOperator,
+            Purpose = "Project status. Older surface predating `intent status`; retained for compatibility."
+        },
+        new CommandGroupEntry
+        {
+            Name = "safety",
+            Classification = ClassificationExperimental,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerOperator,
+            Purpose = "Safety helpers (e.g. nested-provider-handoff). Used by advanced runtime, not the chat-first flow."
+        },
+        new CommandGroupEntry
+        {
+            Name = "run",
+            Classification = ClassificationAdvanced,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerAdvancedRuntime,
+            Purpose = "Integration smoke / deterministic replay / local dogfooding. Explicitly not the primary chat-first path; do not use from collaborative loops."
+        }
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            var payload = new GuideCommandsListResult { Groups = Groups };
+            writer.Write(JsonSerializer.Serialize(payload, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer);
+        }
+
+        return 0;
+    }
+
+    private static void WriteMarkdown(TextWriter writer)
+    {
+        writer.WriteLine("# Guide commands — top-level groups");
+        writer.WriteLine();
+        writer.WriteLine("Lifecycle classification: `primary` (chat-agent's first calls), `support` (used inside the same flow), `advanced` (optional runtime, not the chat-first path), `experimental` (older surfaces retained for compatibility).");
+        writer.WriteLine();
+        writer.WriteLine("| group | classification | mutability | caller | purpose |");
+        writer.WriteLine("|-------|----------------|------------|--------|---------|");
+        foreach (var group in Groups)
+        {
+            writer.WriteLine($"| {group.Name} | {group.Classification} | {group.Mutability} | {group.RecommendedCaller} | {group.Purpose} |");
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string format, out string error)
+    {
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide commands list");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only listing of intent-cli command groups with primary/support/advanced/experimental classification.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true
+    };
+}
+
+internal sealed record CommandGroupEntry
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("classification")]
+    public required string Classification { get; init; }
+
+    [JsonPropertyName("mutability")]
+    public required string Mutability { get; init; }
+
+    [JsonPropertyName("recommended_caller")]
+    public required string RecommendedCaller { get; init; }
+
+    [JsonPropertyName("purpose")]
+    public required string Purpose { get; init; }
+}
+
+internal sealed record GuideCommandsListResult
+{
+    [JsonPropertyName("groups")]
+    public required IReadOnlyList<CommandGroupEntry> Groups { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -78,7 +78,8 @@ internal static class Program
                 || string.Equals(args[1], "collaborate", StringComparison.Ordinal)
                 || string.Equals(args[1], "rules", StringComparison.Ordinal)
                 || string.Equals(args[1], "workflow", StringComparison.Ordinal)
-                || string.Equals(args[1], "model", StringComparison.Ordinal));
+                || string.Equals(args[1], "model", StringComparison.Ordinal)
+                || string.Equals(args[1], "commands", StringComparison.Ordinal));
     }
 
     private static CliContext CreateBootstrapContext(string currentDirectory, string[] args)

--- a/tests/IntentSystem.Cli.Tests/GuideCommandsListCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideCommandsListCommandTests.cs
@@ -1,0 +1,175 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideCommandsListCommandTests
+{
+    [Fact]
+    public void Execute_DefaultMarkdown_EmitsTableForAllGroups()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCommandsListCommand.Execute(
+            CreateContext(),
+            [],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide commands — top-level groups", output, StringComparison.Ordinal);
+        Assert.Contains("| group | classification | mutability | caller | purpose |", output, StringComparison.Ordinal);
+        foreach (var group in new[] { "guide", "intent", "interview", "packet", "worker", "automation", "metadata", "review", "closeout", "issue", "queue", "intake", "bug", "run" })
+        {
+            Assert.Contains(group, output, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_EmitsClassifiedGroupArray()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCommandsListCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var groups = document.RootElement.GetProperty("groups");
+        Assert.True(groups.GetArrayLength() >= 18);
+
+        var byName = groups.EnumerateArray()
+            .ToDictionary(e => e.GetProperty("name").GetString()!, e => e);
+
+        Assert.Equal("primary", byName["guide"].GetProperty("classification").GetString());
+        Assert.Equal("primary", byName["intent"].GetProperty("classification").GetString());
+        Assert.Equal("primary", byName["interview"].GetProperty("classification").GetString());
+        Assert.Equal("primary", byName["packet"].GetProperty("classification").GetString());
+        Assert.Equal("primary", byName["worker"].GetProperty("classification").GetString());
+
+        Assert.Equal("support", byName["automation"].GetProperty("classification").GetString());
+        Assert.Equal("support", byName["metadata"].GetProperty("classification").GetString());
+        Assert.Equal("support", byName["review"].GetProperty("classification").GetString());
+        Assert.Equal("support", byName["closeout"].GetProperty("classification").GetString());
+        Assert.Equal("support", byName["issue"].GetProperty("classification").GetString());
+        Assert.Equal("support", byName["queue"].GetProperty("classification").GetString());
+
+        Assert.Equal("advanced", byName["run"].GetProperty("classification").GetString());
+        Assert.Equal("advanced-runtime", byName["run"].GetProperty("recommended_caller").GetString());
+
+        Assert.Equal("experimental", byName["intake"].GetProperty("classification").GetString());
+        Assert.Equal("experimental", byName["bug"].GetProperty("classification").GetString());
+    }
+
+    [Fact]
+    public void Execute_RoutedThroughGuideCommandsDispatcher_Works()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCommandsCommand.Execute(
+            CreateContext(),
+            ["list", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.True(document.RootElement.GetProperty("groups").GetArrayLength() >= 18);
+    }
+
+    [Fact]
+    public void Execute_GuideCommandsUnknownSubcommand_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCommandsCommand.Execute(
+            CreateContext(),
+            ["explore"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown 'guide commands' subcommand 'explore'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GuideCommandsMissingSubcommand_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCommandsCommand.Execute(
+            CreateContext(),
+            [],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("guide commands requires a subcommand", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedFormat_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCommandsListCommand.Execute(
+            CreateContext(),
+            ["--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCommandsListCommand.Execute(
+            CreateContext(),
+            ["--surprise"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument '--surprise'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCommandsListCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("guide commands list", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GroupsRegistry_CoversEveryClassificationValue()
+    {
+        var classifications = GuideCommandsListCommand.Groups
+            .Select(g => g.Classification)
+            .Distinct()
+            .ToHashSet();
+
+        Assert.Contains("primary", classifications);
+        Assert.Contains("support", classifications);
+        Assert.Contains("advanced", classifications);
+        Assert.Contains("experimental", classifications);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #617

## Summary

- Adds read-only `intent-cli guide commands list [--format markdown|json]` so AI agents can discover top-level command groups with a deterministic lifecycle classification before choosing a surface.
- Each group reports `name`, `classification` (`primary` / `support` / `advanced` / `experimental`), `mutability` (`read-only` / `mixed`), `recommended_caller` (`chat-agent` / `implementation-loop` / `host-loop` / `advanced-runtime` / `operator`), and a one-line purpose.
- Classification highlights:
  - `primary`: `guide`, `intent`, `interview`, `packet`, `worker`.
  - `support`: `automation`, `metadata`, `review`, `closeout`, `issue`, `queue`, `status`, `context`, `clarify`, `next-slice`.
  - `advanced`: `run` — integration smoke / deterministic replay / local dogfooding; explicitly NOT the chat-first path.
  - `experimental`: `intake`, `bug`, `projection`, `project`, `safety`, `tasking` — older surfaces retained for compatibility, not part of the chat-first product path.
- Routed via a new `guide commands` dispatcher (currently `list` only). Routed through the bootstrap path so the command works outside a child-repo worktree.
- Read-only: never mutates state, never launches an AI provider.
- 9 focused tests cover markdown table coverage, JSON classification shape, the dispatcher's list path, unknown/missing subcommand errors, unsupported format, unknown argument, help, and a registry-coverage check.
- Lists the new G257 entry in `docs/automation-templates/README.md`.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~GuideCommandsListCommandTests"` (9/9 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean