### PR TITLE
G258 Gate advanced runtime commands away from default AI-agent guidance

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -55,6 +55,7 @@ These templates assume:
 | G255  | `intent-cli guide workflow suggest`     | Read-only workflow recommendation: classifies a broad operator goal (`--goal` text or `--from-file` path) into feature-intake / next-slice-planning / review / child-implementation / clarification, returns the suggested command sequence and rule topics |
 | G256  | `intent-cli guide model`                | Read-only summary of the chat-first / CLI-internal collaboration model: roles (human, AI agent, intent-cli, host repo), primary data paths, optional advanced runtime, hard rules |
 | G257  | `intent-cli guide commands list`        | Read-only listing of intent-cli command groups with primary / support / advanced / experimental classification, mutability, and recommended caller |
+| G258  | `guide workflow suggest --include-advanced-runtime` | Default chat-first guidance excludes `intent-cli run` / supervisor subprocess; the new flag opts the relevant workflow into advanced runtime suggestions |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowSuggestCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowSuggestCommand.cs
@@ -24,7 +24,7 @@ internal static class GuideWorkflowSuggestCommand
     private const string WorkflowUnknown = "unknown";
 
     private const string UsageLine =
-        "Usage: intent-cli guide workflow suggest [--domain <name>] (--goal <text> | --from-file <path>) [--format markdown|json]";
+        "Usage: intent-cli guide workflow suggest [--domain <name>] (--goal <text> | --from-file <path>) [--include-advanced-runtime] [--format markdown|json]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -38,7 +38,7 @@ internal static class GuideWorkflowSuggestCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var goalInline, out var goalFile, out var domainOverride, out var format, out var error))
+        if (!TryParseArguments(args, out var goalInline, out var goalFile, out var domainOverride, out var includeAdvancedRuntime, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
@@ -80,7 +80,7 @@ internal static class GuideWorkflowSuggestCommand
             : domainOverride!;
 
         var (workflow, matchedKeywords) = Classify(goalText);
-        var recommendation = BuildRecommendation(workflow, domain, goalText, matchedKeywords);
+        var recommendation = BuildRecommendation(workflow, domain, goalText, matchedKeywords, includeAdvancedRuntime);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
@@ -143,7 +143,7 @@ internal static class GuideWorkflowSuggestCommand
         return (WorkflowUnknown, matched);
     }
 
-    private static GuideWorkflowSuggestion BuildRecommendation(string workflow, string domain, string goalText, IReadOnlyList<string> matchedKeywords)
+    private static GuideWorkflowSuggestion BuildRecommendation(string workflow, string domain, string goalText, IReadOnlyList<string> matchedKeywords, bool includeAdvancedRuntime)
     {
         var (commands, ruleTopics, summary) = workflow switch
         {
@@ -214,6 +214,18 @@ internal static class GuideWorkflowSuggestCommand
                 "Goal did not match a known workflow shape; start with collaborate and search to disambiguate.")
         };
 
+        var advancedRuntime = AdvancedRuntimeFor(workflow);
+        var defaultExcludesAdvancedRuntime = !includeAdvancedRuntime;
+        IReadOnlyList<string> finalCommands = includeAdvancedRuntime && advancedRuntime.Count > 0
+            ? commands.Concat(advancedRuntime).ToArray()
+            : commands;
+
+        var advancedRuntimeWarning = advancedRuntime.Count == 0
+            ? "no advanced-runtime suggestions for this workflow."
+            : (includeAdvancedRuntime
+                ? "advanced-runtime suggestions are included because --include-advanced-runtime was supplied; intent-cli run is integration smoke / replay / dogfooding, not the primary chat-first path."
+                : "advanced-runtime suggestions (intent-cli run, supervisor subprocess) are gated by --include-advanced-runtime; the chat-first default path does not recommend them.");
+
         return new GuideWorkflowSuggestion
         {
             Domain = domain,
@@ -221,8 +233,30 @@ internal static class GuideWorkflowSuggestCommand
             Goal = goalText,
             MatchedKeywords = matchedKeywords,
             Summary = summary,
-            RecommendedCommands = commands,
-            RuleTopics = ruleTopics
+            RecommendedCommands = finalCommands,
+            RuleTopics = ruleTopics,
+            DefaultExcludesAdvancedRuntime = defaultExcludesAdvancedRuntime,
+            AdvancedRuntimeIncluded = includeAdvancedRuntime,
+            AdvancedRuntimeSuggestions = advancedRuntime,
+            AdvancedRuntimeWarning = advancedRuntimeWarning
+        };
+    }
+
+    private static IReadOnlyList<string> AdvancedRuntimeFor(string workflow)
+    {
+        return workflow switch
+        {
+            WorkflowChildImplementation => new[]
+            {
+                "intent-cli run start --execution-unit <id> — integration smoke / deterministic replay; not the chat-first default path.",
+                "intent-cli run supervise --execution-unit <id> — supervisor backend orchestration; advanced runtime only."
+            },
+            WorkflowReview => new[]
+            {
+                "intent-cli run rereview --pr <n> — replay-mode rereview integration smoke; not the default review path."
+            },
+            WorkflowFeatureIntake or WorkflowNextSlicePlanning or WorkflowClarification or WorkflowUnknown => Array.Empty<string>(),
+            _ => Array.Empty<string>()
         };
     }
 
@@ -236,6 +270,8 @@ internal static class GuideWorkflowSuggestCommand
         {
             writer.WriteLine($"- matched keywords: {string.Join(", ", result.MatchedKeywords)}");
         }
+        writer.WriteLine($"- default excludes advanced runtime: {(result.DefaultExcludesAdvancedRuntime ? "yes" : "no")}");
+        writer.WriteLine($"- advanced runtime included: {(result.AdvancedRuntimeIncluded ? "yes" : "no")}");
         writer.WriteLine();
         writer.WriteLine($"## Summary");
         writer.WriteLine();
@@ -252,6 +288,18 @@ internal static class GuideWorkflowSuggestCommand
         {
             writer.WriteLine($"- `intent-cli guide rules --topic {topic} --format markdown`");
         }
+        writer.WriteLine();
+        writer.WriteLine("## Advanced runtime");
+        writer.WriteLine();
+        writer.WriteLine(result.AdvancedRuntimeWarning);
+        if (result.AdvancedRuntimeSuggestions.Count > 0)
+        {
+            writer.WriteLine();
+            foreach (var item in result.AdvancedRuntimeSuggestions)
+            {
+                writer.WriteLine($"- {item}");
+            }
+        }
     }
 
     private static bool TryParseArguments(
@@ -259,12 +307,14 @@ internal static class GuideWorkflowSuggestCommand
         out string? goalInline,
         out string? goalFile,
         out string? domainOverride,
+        out bool includeAdvancedRuntime,
         out string format,
         out string error)
     {
         goalInline = null;
         goalFile = null;
         domainOverride = null;
+        includeAdvancedRuntime = false;
         format = FormatMarkdown;
         error = string.Empty;
 
@@ -304,6 +354,10 @@ internal static class GuideWorkflowSuggestCommand
 
                     domainOverride = args[index + 1];
                     index++;
+                    break;
+
+                case "--include-advanced-runtime":
+                    includeAdvancedRuntime = true;
                     break;
 
                 case "--format":
@@ -370,4 +424,16 @@ internal sealed record GuideWorkflowSuggestion
 
     [JsonPropertyName("rule_topics")]
     public required IReadOnlyList<string> RuleTopics { get; init; }
+
+    [JsonPropertyName("default_excludes_advanced_runtime")]
+    public required bool DefaultExcludesAdvancedRuntime { get; init; }
+
+    [JsonPropertyName("advanced_runtime_included")]
+    public required bool AdvancedRuntimeIncluded { get; init; }
+
+    [JsonPropertyName("advanced_runtime_suggestions")]
+    public required IReadOnlyList<string> AdvancedRuntimeSuggestions { get; init; }
+
+    [JsonPropertyName("advanced_runtime_warning")]
+    public required string AdvancedRuntimeWarning { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/AdvancedRuntimeGuidanceGateTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AdvancedRuntimeGuidanceGateTests.cs
@@ -1,0 +1,222 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G258 — gate advanced runtime (root <c>run</c>, supervisor subprocess) away
+/// from default chat-first guidance unless the operator explicitly opts in.
+/// </summary>
+public sealed class AdvancedRuntimeGuidanceGateTests
+{
+    [Theory]
+    [InlineData("intent-cli に新機能を追加したい")]
+    [InlineData("plan the next slice")]
+    [InlineData("review PR 600")]
+    [InlineData("implement issue 605")]
+    [InlineData("we have a clarification blocker")]
+    [InlineData("xyzzy unknown")]
+    public void GuideWorkflowSuggest_DefaultRecommendedCommands_DoNotIncludeIntentCliRun(string goal)
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--goal", goal, "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+
+        Assert.True(root.GetProperty("default_excludes_advanced_runtime").GetBoolean());
+        Assert.False(root.GetProperty("advanced_runtime_included").GetBoolean());
+
+        var commands = root.GetProperty("recommended_commands")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        foreach (var command in commands)
+        {
+            Assert.DoesNotContain("intent-cli run ", command!, StringComparison.Ordinal);
+            Assert.DoesNotContain("supervisor subprocess", command!, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("provider subprocess", command!, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void GuideWorkflowSuggest_WithFlag_IncludesAdvancedRuntimeForChildImplementation()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--goal", "implement issue 605", "--include-advanced-runtime", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+
+        Assert.False(root.GetProperty("default_excludes_advanced_runtime").GetBoolean());
+        Assert.True(root.GetProperty("advanced_runtime_included").GetBoolean());
+
+        var commands = root.GetProperty("recommended_commands")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(commands, c => c!.Contains("intent-cli run start", StringComparison.Ordinal));
+        Assert.Contains(commands, c => c!.Contains("intent-cli run supervise", StringComparison.Ordinal));
+
+        var advanced = root.GetProperty("advanced_runtime_suggestions")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(advanced, item => item!.Contains("intent-cli run start", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GuideWorkflowSuggest_DefaultChildImplementation_StillExposesSuggestionsForOptIn()
+    {
+        // Default: do not include in recommended_commands, but advanced_runtime_suggestions
+        // is still populated so AI agents can see what's behind the gate.
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--goal", "implement issue 605", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+
+        var commands = root.GetProperty("recommended_commands")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        foreach (var command in commands)
+        {
+            Assert.DoesNotContain("intent-cli run", command!, StringComparison.Ordinal);
+        }
+
+        var advanced = root.GetProperty("advanced_runtime_suggestions")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(advanced, item => item!.Contains("intent-cli run", StringComparison.Ordinal));
+
+        var warning = root.GetProperty("advanced_runtime_warning").GetString();
+        Assert.Contains("--include-advanced-runtime", warning!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowSuggest_FeatureIntake_HasNoAdvancedRuntimeSuggestions()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--goal", "feature を一緒に追加したい", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+
+        Assert.Equal(0, root.GetProperty("advanced_runtime_suggestions").GetArrayLength());
+        Assert.Contains("no advanced-runtime suggestions", root.GetProperty("advanced_runtime_warning").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowSuggest_Markdown_NamesGateAndDefaultExclusion()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--goal", "implement issue 605", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("default excludes advanced runtime: yes", output, StringComparison.Ordinal);
+        Assert.Contains("advanced runtime included: no", output, StringComparison.Ordinal);
+        Assert.Contains("## Advanced runtime", output, StringComparison.Ordinal);
+        Assert.Contains("--include-advanced-runtime", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideCommandsList_RunGroup_StaysClassifiedAsAdvanced()
+    {
+        var run = GuideCommandsListCommand.Groups.Single(group => group.Name == "run");
+        Assert.Equal("advanced", run.Classification);
+        Assert.Equal("advanced-runtime", run.RecommendedCaller);
+    }
+
+    [Fact]
+    public void GuideCommandsList_DefaultMarkdown_FlagsRunAsAdvanced()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCommandsListCommand.Execute(
+            CreateContext(),
+            [],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        // Confirm the row for the `run` group surfaces the advanced bucket.
+        var runLine = output.Split('\n').First(line => line.StartsWith("| run ", StringComparison.Ordinal));
+        Assert.Contains("| advanced |", runLine, StringComparison.Ordinal);
+        Assert.Contains("| advanced-runtime |", runLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideCollaborate_DefaultOutput_DoesNotRecommendIntentCliRun()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCollaborateCommand.Execute(
+            CreateContext(),
+            ["--kind", "feature-intake", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.DoesNotContain("intent-cli run ", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideRules_DefaultTopics_DoNotRecommendIntentCliRun()
+    {
+        foreach (var topic in new[] { "label-ownership", "child-issue-contract", "clarification", "review-closeout", "intake-interview" })
+        {
+            using var writer = new StringWriter();
+            var exitCode = GuideRulesCommand.Execute(
+                CreateContext(),
+                ["--topic", topic, "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.DoesNotContain("intent-cli run ", output, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void GuideRulesList_DoesNotRecommendIntentCliRun()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideRulesListCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.DoesNotContain("intent-cli run ", output, StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #619

## Summary

- Adds an explicit advanced-runtime gate to `intent-cli guide workflow suggest` and locks in the chat-first default policy with focused tests across the broader guide surface.
- `guide workflow suggest` changes:
  - New `--include-advanced-runtime` flag.
  - Result now exposes `default_excludes_advanced_runtime`, `advanced_runtime_included`, `advanced_runtime_suggestions`, and `advanced_runtime_warning`.
  - Default behavior preserved: `recommended_commands` never includes `intent-cli run` or supervisor subprocess invocations.
  - With `--include-advanced-runtime`, the workflow's advanced suggestions (`intent-cli run start` / `intent-cli run supervise` for child-implementation, `intent-cli run rereview` for review) are appended to `recommended_commands` and the warning flips to acknowledge the explicit opt-in.
  - Markdown output gains an "Advanced runtime" section that names the gate and warning.
- New `AdvancedRuntimeGuidanceGateTests` class verifies the gate across the guide surface (15 tests):
  - All five workflows plus `unknown` exclude `intent-cli run` from `recommended_commands` by default.
  - `--include-advanced-runtime` adds `intent-cli run start` / `intent-cli run supervise` for child-implementation.
  - `advanced_runtime_suggestions` stays populated even in the default path so AI agents can inspect what the gate hides.
  - Workflows without an advanced equivalent (feature-intake / next-slice / clarification / unknown) report no suggestions and a matching warning.
  - `guide commands list` keeps `run` classified as `advanced` / `advanced-runtime`.
  - `guide collaborate`, `guide rules` (all five topics), and `guide rules list` never recommend `intent-cli run` in their default outputs.
- Lists the new gate in `docs/automation-templates/README.md`.

Existing tests stay green: the original `GuideWorkflowSuggestCommandTests` (22) all still pass after the refactor.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~AdvancedRuntimeGuidanceGateTests"` (15/15 passed)
- [x] `dotnet test ... --filter "FullyQualifiedName~GuideWorkflowSuggestCommandTests"` (22/22 passed)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean