### PR TITLE
G260 Add intent-cli guide automation setup prompts

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -57,6 +57,7 @@ These templates assume:
 | G257  | `intent-cli guide commands list`        | Read-only listing of intent-cli command groups with primary / support / advanced / experimental classification, mutability, and recommended caller |
 | G258  | `guide workflow suggest --include-advanced-runtime` | Default chat-first guidance excludes `intent-cli run` / supervisor subprocess; the new flag opts the relevant workflow into advanced runtime suggestions |
 | G259  | `intent-cli guide onboarding`           | Read-only first-call sequence for an AI agent with no local skill files or copied rules: model → rules list → commands list → workflow suggest → status → next-slice dry-run → interview → automation summary; each step names its no-mutation behavior and the host data boundary |
+| G260  | `intent-cli guide automation setup`     | Read-only paste-ready setup prompts for child implementation loop or host review/next-slice loop: forces guide model/onboarding/commands list/automation summary as first calls, forbids `intents/rules/**` and local skill files, delegates label transitions to installed `intent-cli automation`/`worker` commands |
 
 ## Installed host transition command adoption
 

--- a/src/IntentSystem.Cli/Commands/GuideAutomationCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationCommand.cs
@@ -37,6 +37,12 @@ internal static class GuideAutomationCommand
             return 0;
         }
 
+        // G260: nested `guide automation setup ...` paste-ready setup-prompt subcommand.
+        if (args.Length >= 1 && string.Equals(args[0], "setup", StringComparison.Ordinal))
+        {
+            return GuideAutomationSetupCommand.Execute(context, args[1..], writer);
+        }
+
         if (!TryParseArguments(args, out var kind, out var domain, out var repo, out var format, out var error))
         {
             writer.WriteLine(error);

--- a/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
@@ -1,0 +1,408 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G260: Read-only <c>intent-cli guide automation setup</c>. Returns
+/// paste-ready, worktree-friendly setup prompts an AI coding agent
+/// (Codex/Claude) consumes when an operator says "set up the
+/// implementation loop" or "set up the host review/next-slice loop".
+/// The generated prompts always instruct the AI agent to call
+/// <c>guide model</c> / <c>guide onboarding</c> / <c>guide commands
+/// list</c> / <c>automation summary</c> first; forbid reading
+/// <c>intents/rules/**</c>, local skill files, or copied prompts; and
+/// delegate label transitions to installed <c>intent-cli automation</c>
+/// / <c>worker</c> commands. Never mutates state. Never launches an AI
+/// provider.
+/// </summary>
+internal static class GuideAutomationSetupCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string KindChildImplement = "child-implement";
+    private const string KindHostReviewNextSlice = "host-review-next-slice";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide automation setup --kind <child-implement|host-review-next-slice> "
+        + "[--repo <owner/repo>] [--domain <name>] [--target-repo <owner/repo>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var kind, out var repo, out var domain, out var targetRepo, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        switch (kind)
+        {
+            case KindChildImplement:
+                if (string.IsNullOrWhiteSpace(repo))
+                {
+                    writer.WriteLine("--repo is required for --kind child-implement.");
+                    writer.WriteLine(UsageLine);
+                    return 1;
+                }
+
+                return EmitResult(writer, format, BuildChildImplement(repo!));
+
+            case KindHostReviewNextSlice:
+                if (string.IsNullOrWhiteSpace(domain))
+                {
+                    writer.WriteLine("--domain is required for --kind host-review-next-slice.");
+                    writer.WriteLine(UsageLine);
+                    return 1;
+                }
+                if (string.IsNullOrWhiteSpace(targetRepo))
+                {
+                    writer.WriteLine("--target-repo is required for --kind host-review-next-slice.");
+                    writer.WriteLine(UsageLine);
+                    return 1;
+                }
+
+                return EmitResult(writer, format, BuildHostReviewNextSlice(domain!, targetRepo!));
+
+            default:
+                writer.WriteLine(
+                    $"--kind must be '{KindChildImplement}' or '{KindHostReviewNextSlice}' (got '{kind}').");
+                writer.WriteLine(UsageLine);
+                return 1;
+        }
+    }
+
+    private static int EmitResult(TextWriter writer, string format, GuideAutomationSetupResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static GuideAutomationSetupResult BuildChildImplement(string repo)
+    {
+        var prompt =
+$@"Set up the child implementation loop for `{repo}` once. Do not register any cron, monitor, reminder, scheduler, or recurring wakeup as part of this setup unless the operator explicitly asks.
+
+First-call sequence (read-only; required before any mutation):
+1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
+2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
+3. `intent-cli guide commands list --format json` — `primary` vs `support` vs `advanced` (`run`) vs `experimental` classification.
+4. `intent-cli automation summary --format json` — current label-driven contract and capability JSON.
+
+Loop body (single wake; the operator drives subsequent wakes if any):
+1. Confirm cwd is the child repo worktree root for `{repo}`. Stop with `wrong-worktree` if not.
+2. Resolve `<OWNER>/<REPO>` via `gh repo view --json nameWithOwner --jq .nameWithOwner` (fall back to `git remote get-url origin`).
+3. `git fetch --all --prune` and `git status --short`. If dirty in a dedicated automation worktree, clean local residue (`git reset --hard`, `git clean -fd`, submodule reset). Never `git clean -fdx`. Never clean a personal/shared checkout.
+4. From the parent host root, run `intent-cli worker next-action --repo <OWNER>/<REPO> --workdir $CHILD_WORKTREE --format json`. Dispatch on `action`:
+   - `none` → stop with `idle`.
+   - `issue-to-pr` → claim with `intent-cli worker claim --kind issue --number <n> --write --format json`, run the issue-to-PR workflow on the returned URL only, classify outcome, then `worker result-summary --kind issue-to-pr ...` and `worker complete --kind issue --number <n> --outcome <outcome> --write --format json`.
+   - `pr-comment-fix` → claim with `intent-cli worker claim --kind pr --number <n> --write --format json`, repair only the narrow requested change on the PR branch, classify outcome, then `worker result-summary --kind pr-comment-fix ...` and `worker complete --kind pr --number <n> --outcome <outcome> --write --format json`.
+
+Hard rules:
+- Do not read `intents/rules/**`, local skill files (`gh-issue-to-pr`, `gh-fix-pr-comment`, etc.), or copied prompt files for routine collaboration. Use `intent-cli guide ...` instead.
+- Do not call `intent-cli run` from this loop. `run` is advanced runtime (integration smoke / replay / dogfooding), not the chat-first path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- All label transitions go through installed `intent-cli automation` / `intent-cli worker` commands. No manual `gh ... edit --add-label` / `--remove-label` fallback for workflow labels.
+- Never apply `intent-target` from the child loop; it is host-owned.
+- Never apply `intent-pr-created` to a PR; it is an issue-side completion marker.
+- Process at most one action per wake.";
+
+        return new GuideAutomationSetupResult
+        {
+            Kind = KindChildImplement,
+            Repo = repo,
+            Prompt = prompt,
+            FirstCalls = new[]
+            {
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                "intent-cli automation summary --format json"
+            },
+            ForbiddenSources = new[]
+            {
+                "intents/rules/**",
+                "local skill files (gh-issue-to-pr, gh-fix-pr-comment, etc.)",
+                "copied prompt files"
+            },
+            LabelOwnership = "All label transitions delegated to installed intent-cli automation / worker commands. Manual `gh ... edit --label` fallback is forbidden.",
+            WorktreeFriendly = "The prompt resolves the repo from the child worktree's `gh` / `git remote` and runs the selector from the parent host root with --workdir; no hard-coded paths beyond the parent host root, and the same prompt works across local worktrees."
+        };
+    }
+
+    private static GuideAutomationSetupResult BuildHostReviewNextSlice(string domain, string targetRepo)
+    {
+        var prompt =
+$@"Set up the host review and next-slice loop for domain `{domain}` against `{targetRepo}` once. Do not register any cron, monitor, reminder, scheduler, or recurring wakeup as part of this setup unless the operator explicitly asks.
+
+First-call sequence (read-only; required before any mutation):
+1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
+2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
+3. `intent-cli guide commands list --format json` — surface `primary` / `support` / `advanced` / `experimental` buckets.
+4. `intent-cli automation summary --format json` — canonical label-driven contract and capability JSON.
+5. `intent-cli intent status --domain {domain} --format json` — current baseline / WIP / queued / clarifications.
+6. `intent-cli intent next-slice --dry-run --domain {domain} --target-repo {targetRepo} --format json` — verify WIP cap and clarification gates.
+
+Loop body (single wake):
+1. Confirm cwd is the parent host repo root.
+2. Stage 1 — review/closeout:
+   - `intent-cli automation host-review-preflight --repo {targetRepo} --format json` to find an eligible PR.
+   - For the selected PR: `intent-cli review closeout-plan --pr <n> --repo {targetRepo} --domain {domain} --format json` and `intent-cli guide review --pr <n> --repo {targetRepo} --domain {domain} --format json`.
+   - If review passes: `intent-cli automation pr-transition --transition approved --repo {targetRepo} --pr <n> --write --format json`, merge via the host's existing merge step, then `intent-cli closeout pr --pr <n> --repo {targetRepo} --write --format json`.
+   - If review needs repair: leave an actionable PR comment, then `intent-cli automation pr-transition --transition request-update --repo {targetRepo} --pr <n> --write --format json`.
+3. Stage 2 — next-slice (only if WIP cap and clarification gates allow):
+   - `intent-cli intent next-slice --dry-run --domain {domain} --target-repo {targetRepo} --format json` — confirm `recommended_outcome` is `issue-cut-ready`.
+   - `intent-cli packet draft --execution-unit <id> --target-repo {targetRepo} --dry-run --format markdown` — preview the packet.
+   - With operator acceptance: `intent-cli packet draft --execution-unit <id> --target-repo {targetRepo} --format json` then `intent-cli issue publish-flow <id> --repo {targetRepo} --write --format json`.
+   - After parent durable state is pushed: `intent-cli automation issue-publish --repo {targetRepo} --issue <n> --write --format json`.
+
+Hard rules:
+- Do not read `intents/rules/**`, local skill files, or copied prompt files for routine review/closeout. Use `intent-cli guide ...` and `intent-cli automation ...` instead.
+- Do not call `intent-cli run`. `run` is advanced runtime, not the host review/closeout path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- Every label transition (`intent-target`, `intent-pr-reviewing`, `intent-pr-request-update`, `intent-pr-approved`, `intent-pr-rereview-ready`, `intent-pr-update-in-progress`, `intent-issue-in-progress`, `intent-pr-created`) goes through installed `intent-cli automation pr-transition` / `intent-cli automation issue-publish` / `intent-cli worker claim` / `intent-cli worker complete`. No manual `gh ... edit --add-label` / `--remove-label` fallback.
+- Never apply `intent-pr-created` to a PR.
+- Honor the WIP cap: do not cut a new child issue while any open `intent-target` issue/PR remains in `{targetRepo}`.
+- Stop on Hard Clarification rather than guessing when source-of-truth is ambiguous.
+- Process at most one PR review and one new child issue per wake.";
+
+        return new GuideAutomationSetupResult
+        {
+            Kind = KindHostReviewNextSlice,
+            Domain = domain,
+            TargetRepo = targetRepo,
+            Prompt = prompt,
+            FirstCalls = new[]
+            {
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                "intent-cli automation summary --format json",
+                $"intent-cli intent status --domain {domain} --format json",
+                $"intent-cli intent next-slice --dry-run --domain {domain} --target-repo {targetRepo} --format json"
+            },
+            ForbiddenSources = new[]
+            {
+                "intents/rules/**",
+                "local skill files",
+                "copied prompt files"
+            },
+            LabelOwnership = "All review-side and issue-side label transitions delegated to installed `intent-cli automation pr-transition` / `automation issue-publish` / `worker claim` / `worker complete`. Manual `gh ... edit --label` fallback is forbidden.",
+            WorktreeFriendly = "The prompt names the parent host root as cwd but does not hardcode any operator-specific path beyond that; the same prompt works across host-side checkouts."
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideAutomationSetupResult result)
+    {
+        writer.WriteLine($"# Guide automation setup — {result.Kind}");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.Repo))
+        {
+            writer.WriteLine($"- repo: {result.Repo}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.Domain))
+        {
+            writer.WriteLine($"- domain: {result.Domain}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.TargetRepo))
+        {
+            writer.WriteLine($"- target repo: {result.TargetRepo}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## First-call sequence (read-only)");
+        foreach (var call in result.FirstCalls)
+        {
+            writer.WriteLine($"- `{call}`");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Forbidden rule sources");
+        foreach (var src in result.ForbiddenSources)
+        {
+            writer.WriteLine($"- {src}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Label ownership");
+        writer.WriteLine();
+        writer.WriteLine(result.LabelOwnership);
+        writer.WriteLine();
+
+        writer.WriteLine("## Worktree-friendly assumption");
+        writer.WriteLine();
+        writer.WriteLine(result.WorktreeFriendly);
+        writer.WriteLine();
+
+        writer.WriteLine("## Prompt");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(result.Prompt);
+        writer.WriteLine("```");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? kind,
+        out string? repo,
+        out string? domain,
+        out string? targetRepo,
+        out string format,
+        out string error)
+    {
+        kind = null;
+        repo = null;
+        domain = null;
+        targetRepo = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--kind":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--kind requires a value.";
+                        return false;
+                    }
+
+                    kind = args[index + 1];
+                    index++;
+                    break;
+
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value.";
+                        return false;
+                    }
+
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domain = args[index + 1];
+                    index++;
+                    break;
+
+                case "--target-repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--target-repo requires a value.";
+                        return false;
+                    }
+
+                    targetRepo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(kind))
+        {
+            error = "--kind is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide automation setup");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only paste-ready setup prompts for the child implementation loop or the host review / next-slice loop.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record GuideAutomationSetupResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("repo")]
+    public string? Repo { get; init; }
+
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
+
+    [JsonPropertyName("target_repo")]
+    public string? TargetRepo { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+
+    [JsonPropertyName("first_calls")]
+    public required IReadOnlyList<string> FirstCalls { get; init; }
+
+    [JsonPropertyName("forbidden_sources")]
+    public required IReadOnlyList<string> ForbiddenSources { get; init; }
+
+    [JsonPropertyName("label_ownership")]
+    public required string LabelOwnership { get; init; }
+
+    [JsonPropertyName("worktree_friendly")]
+    public required string WorktreeFriendly { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideAutomationSetupCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideAutomationSetupCommandTests.cs
@@ -1,0 +1,240 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideAutomationSetupCommandTests
+{
+    [Fact]
+    public void Execute_ChildImplementMarkdown_EmitsPasteReadyPromptAndForbiddenSources()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide automation setup — child-implement", output, StringComparison.Ordinal);
+        Assert.Contains("repo: J-Tech-Japan/intent-system", output, StringComparison.Ordinal);
+        Assert.Contains("## First-call sequence", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide model --format json", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide onboarding --format json", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide commands list --format json", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli automation summary --format json", output, StringComparison.Ordinal);
+        Assert.Contains("## Forbidden rule sources", output, StringComparison.Ordinal);
+        Assert.Contains("intents/rules/**", output, StringComparison.Ordinal);
+        Assert.Contains("local skill files", output, StringComparison.Ordinal);
+        Assert.Contains("## Label ownership", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli automation", output, StringComparison.Ordinal);
+        Assert.Contains("## Prompt", output, StringComparison.Ordinal);
+        Assert.Contains("Set up the child implementation loop for `J-Tech-Japan/intent-system`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementJson_EmitsStructuredFields()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("child-implement", root.GetProperty("kind").GetString());
+        Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("repo").GetString());
+        Assert.Equal(4, root.GetProperty("first_calls").GetArrayLength());
+        Assert.True(root.GetProperty("forbidden_sources").GetArrayLength() >= 3);
+        Assert.Contains("Set up the child implementation loop", root.GetProperty("prompt").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("Manual `gh ... edit", root.GetProperty("label_ownership").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("worktree", root.GetProperty("worktree_friendly").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementPrompt_BansAdvancedRuntimeAndManualLabelMutation()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Do not call `intent-cli run`", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do not run `dotnet run`", prompt, StringComparison.Ordinal);
+        Assert.Contains("No manual `gh ... edit", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-target", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-pr-created", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostReviewNextSliceMarkdown_NamesEveryFirstCallAndStageStep()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide automation setup — host-review-next-slice", output, StringComparison.Ordinal);
+        Assert.Contains("domain: intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("target repo: J-Tech-Japan/intent-system", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli intent status --domain intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli intent next-slice --dry-run --domain intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli automation pr-transition", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli closeout pr", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli packet draft", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli issue publish-flow", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostReviewNextSliceJson_FirstCallsContainHostSpecificCommands()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var firstCalls = document.RootElement.GetProperty("first_calls")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls, c => c!.StartsWith("intent-cli intent status --domain intent-cli", StringComparison.Ordinal));
+        Assert.Contains(firstCalls, c => c!.StartsWith("intent-cli intent next-slice --dry-run --domain intent-cli", StringComparison.Ordinal));
+        Assert.Equal(6, firstCalls.Length);
+    }
+
+    [Fact]
+    public void Execute_MissingKind_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--kind is required.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedKind_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-bootstrap"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--kind must be 'child-implement' or 'host-review-next-slice'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementMissingRepo_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--repo is required for --kind child-implement.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostReviewNextSliceMissingDomain_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--domain is required for --kind host-review-next-slice.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostReviewNextSliceMissingTargetRepo_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--target-repo is required for --kind host-review-next-slice.", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedFormat_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--repo", "J-Tech-Japan/intent-system", "--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("guide automation setup", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Dispatch_GuideAutomationSetupRoutedThroughGuideAutomation_Works()
+    {
+        // `intent-cli guide automation setup ...` flows through GuideAutomationCommand,
+        // which delegates to GuideAutomationSetupCommand for the leading `setup` token.
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["setup", "--kind", "child-implement", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("child-implement", document.RootElement.GetProperty("kind").GetString());
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #623

## Summary

- Adds read-only `intent-cli guide automation setup --kind <name> ... [--format markdown|json]` so an AI coding agent can ask intent-cli for paste-ready loop setup prompts when an operator says "set up the implementation loop" or "set up the host review / next-slice loop" without reading local rules files or skill files.
- Two kinds:
  - `--kind child-implement --repo <owner/repo>` — single-wake child implementation prompt opening with the canonical first-call sequence (`guide model` → `guide onboarding` → `guide commands list` → `automation summary`), then `worker next-action` / `worker claim` / `worker result-summary` / `worker complete --write`.
  - `--kind host-review-next-slice --domain <name> --target-repo <owner/repo>` — single-wake host review + next-slice prompt that adds `intent status` and `intent next-slice --dry-run` to the first-call sequence and stages review/closeout via `automation host-review-preflight`, `review closeout-plan`, `automation pr-transition`, and `closeout pr` before optionally promoting a next slice via `packet draft` and `issue publish-flow`.
- The result envelope exposes the prompt plus structured `first_calls`, `forbidden_sources`, `label_ownership`, and `worktree_friendly` fields so callers can assert each constraint:
  - Forbidden rule sources: `intents/rules/**`, local skill files, copied prompt files.
  - Label ownership: every transition runs through installed `intent-cli automation` / `intent-cli worker` commands; no manual `gh ... edit --add-label`/`--remove-label` fallback.
  - Both prompts forbid `intent-cli run`, `dotnet run` fallbacks, and any provider launch from intent-cli.
- Routing: `guide automation setup ...` is dispatched through the existing `guide automation` (G240) handler, which delegates the leading `setup` token to the new command. The existing `guide automation --kind ...` form is unchanged.
- 13 focused tests cover both kinds in markdown and JSON, the forbidden-runtime / label-mutation language inside the generated prompt, every required-argument error path, the unsupported-format path, the help flag, and the routed-through-`guide automation` dispatcher path.
- Lists the new G260 command in `docs/automation-templates/README.md`.

## Test plan

- [x] `dotnet test ... --filter "FullyQualifiedName~GuideAutomationSetupCommandTests|FullyQualifiedName~GuideAutomationCommandTests"` (25/25 passed; 13 new + 12 existing)
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` (0 errors, 8 pre-existing warnings)
- [x] `git diff --check` clean