### PR TITLE
G262 Stabilize child automation setup repo and domain discovery

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
@@ -50,14 +50,7 @@ internal static class GuideAutomationSetupCommand
         switch (kind)
         {
             case KindChildImplement:
-                if (string.IsNullOrWhiteSpace(repo))
-                {
-                    writer.WriteLine("--repo is required for --kind child-implement.");
-                    writer.WriteLine(UsageLine);
-                    return 1;
-                }
-
-                return EmitResult(writer, format, BuildChildImplement(repo!));
+                return EmitResult(writer, format, BuildChildImplement(repo, domain));
 
             case KindHostReviewNextSlice:
                 if (string.IsNullOrWhiteSpace(domain))
@@ -98,22 +91,25 @@ internal static class GuideAutomationSetupCommand
         return 0;
     }
 
-    private static GuideAutomationSetupResult BuildChildImplement(string repo)
+    private static GuideAutomationSetupResult BuildChildImplement(string? repo, string? domain)
     {
+        var repoLabel = string.IsNullOrWhiteSpace(repo) ? "the repo in the current worktree" : $"`{repo}`";
+        var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
+
         var prompt =
-$@"Set up the child implementation loop for `{repo}` once. Do not register any cron, monitor, reminder, scheduler, or recurring wakeup as part of this setup unless the operator explicitly asks.
+$@"Set up the child implementation loop for {repoLabel} once. Do not register any cron, monitor, reminder, scheduler, or recurring wakeup as part of this setup unless the operator explicitly asks.
 
 First-call sequence (read-only; required before any mutation):
 1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
 2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
 3. `intent-cli guide commands list --format json` — `primary` vs `support` vs `advanced` (`run`) vs `experimental` classification.
-4. `intent-cli automation summary --format json` — current label-driven contract and capability JSON.
+4. `intent-cli automation summary --domain {domainPlaceholder} --format json` — canonical label-driven contract and capability JSON for the parent intent domain.
 
 Loop body (single wake; the operator drives subsequent wakes if any):
-1. Confirm cwd is the child repo worktree root for `{repo}`. Stop with `wrong-worktree` if not.
-2. Resolve `<OWNER>/<REPO>` via `gh repo view --json nameWithOwner --jq .nameWithOwner` (fall back to `git remote get-url origin`).
+1. Save the child worktree path: `CHILD_WORKTREE=""$PWD""`. Confirm it is a git worktree root. Stop with `wrong-worktree` if not.
+2. Resolve `<OWNER>/<REPO>` from the child cwd: `gh repo view --json nameWithOwner --jq .nameWithOwner` (fall back to `git remote get-url origin`).
 3. `git fetch --all --prune` and `git status --short`. If dirty in a dedicated automation worktree, clean local residue (`git reset --hard`, `git clean -fd`, submodule reset). Never `git clean -fdx`. Never clean a personal/shared checkout.
-4. From the parent host root, run `intent-cli worker next-action --repo <OWNER>/<REPO> --workdir $CHILD_WORKTREE --format json`. Dispatch on `action`:
+4. From the parent host root (NOT the child cwd), run `intent-cli worker next-action --repo <OWNER>/<REPO> --workdir $CHILD_WORKTREE --format json`. Dispatch on `action`:
    - `none` → stop with `idle`.
    - `issue-to-pr` → claim with `intent-cli worker claim --kind issue --number <n> --write --format json`, run the issue-to-PR workflow on the returned URL only, classify outcome, then `worker result-summary --kind issue-to-pr ...` and `worker complete --kind issue --number <n> --outcome <outcome> --write --format json`.
    - `pr-comment-fix` → claim with `intent-cli worker claim --kind pr --number <n> --write --format json`, repair only the narrow requested change on the PR branch, classify outcome, then `worker result-summary --kind pr-comment-fix ...` and `worker complete --kind pr --number <n> --outcome <outcome> --write --format json`.
@@ -131,14 +127,15 @@ Hard rules:
         return new GuideAutomationSetupResult
         {
             Kind = KindChildImplement,
-            Repo = repo,
+            Repo = string.IsNullOrWhiteSpace(repo) ? null : repo,
+            Domain = string.IsNullOrWhiteSpace(domain) ? null : domain,
             Prompt = prompt,
             FirstCalls = new[]
             {
                 "intent-cli guide model --format json",
                 "intent-cli guide onboarding --format json",
                 "intent-cli guide commands list --format json",
-                "intent-cli automation summary --format json"
+                $"intent-cli automation summary --domain {domainPlaceholder} --format json"
             },
             ForbiddenSources = new[]
             {
@@ -147,7 +144,7 @@ Hard rules:
                 "copied prompt files"
             },
             LabelOwnership = "All label transitions delegated to installed intent-cli automation / worker commands. Manual `gh ... edit --label` fallback is forbidden.",
-            WorktreeFriendly = "The prompt resolves the repo from the child worktree's `gh` / `git remote` and runs the selector from the parent host root with --workdir; no hard-coded paths beyond the parent host root, and the same prompt works across local worktrees."
+            WorktreeFriendly = "The prompt resolves the repo from the child worktree's `gh` / `git remote` and runs the selector from the parent host root with --workdir; no hard-coded paths, and the same prompt works across local worktrees."
         };
     }
 
@@ -367,6 +364,10 @@ Hard rules:
         writer.WriteLine("guide automation setup");
         writer.WriteLine(UsageLine);
         writer.WriteLine("Read-only paste-ready setup prompts for the child implementation loop or the host review / next-slice loop.");
+        writer.WriteLine();
+        writer.WriteLine("For --kind child-implement:");
+        writer.WriteLine("  --repo is optional; omit to derive the repo from the current child worktree via gh/git.");
+        writer.WriteLine("  --domain is optional; omit to emit a <DOMAIN> placeholder in the generated prompt.");
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/tests/IntentSystem.Cli.Tests/GuideAutomationSetupCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideAutomationSetupCommandTests.cs
@@ -24,7 +24,7 @@ public sealed class GuideAutomationSetupCommandTests
         Assert.Contains("intent-cli guide model --format json", output, StringComparison.Ordinal);
         Assert.Contains("intent-cli guide onboarding --format json", output, StringComparison.Ordinal);
         Assert.Contains("intent-cli guide commands list --format json", output, StringComparison.Ordinal);
-        Assert.Contains("intent-cli automation summary --format json", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli automation summary --domain", output, StringComparison.Ordinal);
         Assert.Contains("## Forbidden rule sources", output, StringComparison.Ordinal);
         Assert.Contains("intents/rules/**", output, StringComparison.Ordinal);
         Assert.Contains("local skill files", output, StringComparison.Ordinal);
@@ -140,17 +140,110 @@ public sealed class GuideAutomationSetupCommandTests
         Assert.Contains("--kind must be 'child-implement' or 'host-review-next-slice'", writer.ToString(), StringComparison.Ordinal);
     }
 
+    // ── focused-guide-automation-setup-child-domain-repo-tests ───────────
+
     [Fact]
-    public void Execute_ChildImplementMissingRepo_ReturnsUsageError()
+    public void Execute_ChildImplementNoRepo_EmitsRepoCwdGuidanceAndDomainPlaceholder()
     {
         using var writer = new StringWriter();
         var exitCode = GuideAutomationSetupCommand.Execute(
             CreateContext(),
-            ["--kind", "child-implement"],
+            ["--kind", "child-implement", "--format", "json"],
             writer);
 
-        Assert.Equal(1, exitCode);
-        Assert.Contains("--repo is required for --kind child-implement.", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("gh repo view --json nameWithOwner", prompt, StringComparison.Ordinal);
+        Assert.Contains("git remote get-url origin", prompt, StringComparison.Ordinal);
+        Assert.Contains("<DOMAIN>", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("/Users/", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementNoRepo_FirstCallsContainDomainPlaceholder()
+    {
+        using var writer = new StringWriter();
+        GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var firstCalls = document.RootElement.GetProperty("first_calls")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls,
+            c => c!.Contains("automation summary --domain <DOMAIN>", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_ChildImplementWithDomain_UsesDomainInAutomationSummary()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var firstCalls = document.RootElement.GetProperty("first_calls")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls,
+            c => c!.Contains("automation summary --domain intent-cli --format json", StringComparison.Ordinal));
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("automation summary --domain intent-cli --format json", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("<DOMAIN>", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementWithRepoAndDomain_EmitsExplicitValuesAndNoCwdPath()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--repo", "J-Tech-Japan/intent-system",
+             "--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("J-Tech-Japan/intent-system", document.RootElement.GetProperty("repo").GetString());
+        Assert.Equal("intent-cli", document.RootElement.GetProperty("domain").GetString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("`J-Tech-Japan/intent-system`", prompt, StringComparison.Ordinal);
+        Assert.Contains("automation summary --domain intent-cli --format json", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("/Users/", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementPrompt_SeparatesChildWorktreeFromParentHostRoot()
+    {
+        using var writer = new StringWriter();
+        GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("CHILD_WORKTREE", prompt, StringComparison.Ordinal);
+        Assert.Contains("parent host root", prompt, StringComparison.Ordinal);
+        Assert.Contains("--workdir $CHILD_WORKTREE", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementMarkdown_NoDomain_EmitsDomainPlaceholderInSection()
+    {
+        using var writer = new StringWriter();
+        GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--format", "markdown"],
+            writer);
+
+        var output = writer.ToString();
+        Assert.Contains("<DOMAIN>", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("/Users/", output, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #627

## Summary

- `guide automation setup --kind child-implement` now accepts optional `--domain <domain>`; omit to emit a `<DOMAIN>` placeholder.
- `--repo` is now optional; generated prompt instructs the agent to resolve `<OWNER>/<REPO>` from cwd via `gh repo view` / `git remote get-url origin`.
- First-call sequence uses `intent-cli automation summary --domain <domain> --format json` (stable form).
- Loop body step 1 saves `CHILD_WORKTREE="$PWD"` and step 4 explicitly separates child worktree cwd from parent host root.
- No hard-coded `/Users/...` paths in generated output.

## Verification

```
dotnet test tests/IntentSystem.Cli.Tests/ --filter GuideAutomationSetupCommandTests
# Passed: 18 / 18
git diff --check  # clean
```