### PR TITLE
G263 Prevent new-thread review loops and fix local wrapper help probing

### DIFF
--- a/ops/refresh-host-local-intent-cli.sh
+++ b/ops/refresh-host-local-intent-cli.sh
@@ -57,7 +57,7 @@ exec dotnet tool exec \\
   --yes \\
   --source "\$HOST_ROOT/.intent-cli/packages" \\
   --version "\$INTENT_CLI_LOCAL_VERSION" \\
-  intent-cli \\
+  intent-cli -- \\
   "\$@"
 EOF
 

--- a/src/IntentSystem.Cli/Commands/AutomationInstalledCliSurfaceProbe.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationInstalledCliSurfaceProbe.cs
@@ -44,22 +44,29 @@ internal static class AutomationInstalledCliSurfaceProbe
         }
 
         var output = $"{probe.Stdout}\n{probe.Stderr}";
-        var hasSurface = probe.ExitCode == 0
-            && surface.ExpectedTokens.All(token => output.Contains(token, StringComparison.Ordinal));
-        if (hasSurface)
+
+        // A surface is absent only when the router explicitly reports it is not implemented.
+        // Accept non-zero exit codes — probes intentionally omit required args so the command
+        // reaches intent-cli but fails validation, avoiding --help interception by wrapper layers
+        // such as dotnet tool exec.
+        if (output.Contains("not yet implemented", StringComparison.OrdinalIgnoreCase))
         {
-            return new InstalledCliSurfaceCheck(
-                surface.Command,
-                surface.Transition,
-                true,
-                null);
+            return Missing(surface, "installed CLI reports the command surface is not yet implemented");
         }
 
-        var reason = output.Contains("not yet implemented", StringComparison.OrdinalIgnoreCase)
-            ? "installed CLI reports the command surface is not yet implemented"
-            : $"installed CLI help did not expose required surface tokens: {string.Join(", ", surface.ExpectedTokens)}";
+        if (surface.ExpectedTokens.Count > 0)
+        {
+            var missing = surface.ExpectedTokens
+                .Where(t => !output.Contains(t, StringComparison.Ordinal))
+                .ToArray();
+            if (missing.Length > 0)
+            {
+                return Missing(surface,
+                    $"installed CLI output did not include required capability tokens: {string.Join(", ", missing)}");
+            }
+        }
 
-        return Missing(surface, reason);
+        return new InstalledCliSurfaceCheck(surface.Command, surface.Transition, true, null);
     }
 
     private static InstalledCliSurfaceCheck Missing(RequiredSurface surface, string reason) =>
@@ -98,38 +105,42 @@ internal static class AutomationInstalledCliSurfaceProbe
         return Path.Combine(repoRoot, CliRuntimeContracts.IntentCliDirectoryName, "bin", executableName);
     }
 
+    // Probes intentionally omit --help to avoid wrapper-layer interception (e.g., dotnet tool exec
+    // consuming --help before intent-cli sees it). Each probe runs the command with no required args
+    // so the router dispatches to intent-cli, which returns a usage/validation error instead of the
+    // wrapper's own help. Absence is detected by "not yet implemented" in the output.
     private static readonly IReadOnlyList<RequiredSurface> RequiredSurfaces =
     [
         new(
             "intent-cli automation summary",
             null,
-            ["automation", "summary", "--help"],
-            ["automation summary"]),
+            ["automation", "summary"],
+            []),
         new(
             "intent-cli automation host-review-preflight",
             null,
-            ["automation", "host-review-preflight", "--help"],
-            ["automation host-review-preflight"]),
+            ["automation", "host-review-preflight"],
+            []),
         new(
             "intent-cli automation issue-publish",
             null,
-            ["automation", "issue-publish", "--help"],
-            ["automation issue-publish"]),
+            ["automation", "issue-publish"],
+            []),
         new(
             "intent-cli automation pr-transition",
             "review-start",
-            ["automation", "pr-transition", "--help"],
-            ["automation pr-transition", "review-start"]),
+            ["automation", "pr-transition"],
+            ["review-start"]),
         new(
             "intent-cli automation pr-transition",
             "request-update",
-            ["automation", "pr-transition", "--help"],
-            ["automation pr-transition", "request-update"]),
+            ["automation", "pr-transition"],
+            ["request-update"]),
         new(
             "intent-cli automation pr-transition",
             "approved",
-            ["automation", "pr-transition", "--help"],
-            ["automation pr-transition", "approved"]),
+            ["automation", "pr-transition"],
+            ["approved"]),
     ];
 
     private sealed record RequiredSurface(

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -240,7 +240,8 @@ internal static class CommandRouter
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(writer);
 
-        if (args.Length == 0)
+        if (args.Length == 0
+            || (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal)))
         {
             WriteHelp(writer);
             return 0;

--- a/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
@@ -151,13 +151,17 @@ Hard rules:
     private static GuideAutomationSetupResult BuildHostReviewNextSlice(string domain, string targetRepo)
     {
         var prompt =
-$@"Set up the host review and next-slice loop for domain `{domain}` against `{targetRepo}` once. Do not register any cron, monitor, reminder, scheduler, or recurring wakeup as part of this setup unless the operator explicitly asks.
+$@"Set up the host review and next-slice loop for domain `{domain}` against `{targetRepo}` once, in this existing chat thread.
+
+IMPORTANT — do not create a new chat, a new Claude Code session, a cron job, a monitor, a cloud schedule, or any other recurring wakeup unless the operator explicitly asks for one. Run the loop body exactly once, in the current thread, then stop.
+
+Cloud and new-thread schedulers CANNOT access local paths (e.g. `/Users/.../.intent-cli`) or local dotnet packages. Only use a remote/cloud scheduler if the operator explicitly provides a cloud-compatible intent-cli endpoint.
 
 First-call sequence (read-only; required before any mutation):
 1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
 2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
 3. `intent-cli guide commands list --format json` — surface `primary` / `support` / `advanced` / `experimental` buckets.
-4. `intent-cli automation summary --format json` — canonical label-driven contract and capability JSON.
+4. `intent-cli automation summary --domain {domain} --format json` — canonical label-driven contract and capability JSON.
 5. `intent-cli intent status --domain {domain} --format json` — current baseline / WIP / queued / clarifications.
 6. `intent-cli intent next-slice --dry-run --domain {domain} --target-repo {targetRepo} --format json` — verify WIP cap and clarification gates.
 
@@ -179,6 +183,7 @@ Hard rules:
 - Do not call `intent-cli run`. `run` is advanced runtime, not the host review/closeout path.
 - Do not run `dotnet run` as a fallback for `intent-cli`.
 - Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- Do not open a new chat, session, cron, monitor, or scheduler. Run one wake in this thread; the operator controls subsequent wakes.
 - Every label transition (`intent-target`, `intent-pr-reviewing`, `intent-pr-request-update`, `intent-pr-approved`, `intent-pr-rereview-ready`, `intent-pr-update-in-progress`, `intent-issue-in-progress`, `intent-pr-created`) goes through installed `intent-cli automation pr-transition` / `intent-cli automation issue-publish` / `intent-cli worker claim` / `intent-cli worker complete`. No manual `gh ... edit --add-label` / `--remove-label` fallback.
 - Never apply `intent-pr-created` to a PR.
 - Honor the WIP cap: do not cut a new child issue while any open `intent-target` issue/PR remains in `{targetRepo}`.
@@ -196,7 +201,7 @@ Hard rules:
                 "intent-cli guide model --format json",
                 "intent-cli guide onboarding --format json",
                 "intent-cli guide commands list --format json",
-                "intent-cli automation summary --format json",
+                $"intent-cli automation summary --domain {domain} --format json",
                 $"intent-cli intent status --domain {domain} --format json",
                 $"intent-cli intent next-slice --dry-run --domain {domain} --target-repo {targetRepo} --format json"
             },

--- a/tests/IntentSystem.Cli.Tests/AutomationDoctorCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationDoctorCommandTests.cs
@@ -267,15 +267,15 @@ public sealed class AutomationDoctorCommandTests
             var scriptPath = Path.Combine(binPath, "intent-cli");
             var prTransitionBlock = stalePrTransition
                 ? "  echo \"Command 'automation pr-transition' is not yet implemented.\"\n  exit 1\n"
-                : "  echo 'automation pr-transition'\n  echo 'review-start'\n  echo 'request-update'\n  echo 'approved'\n  exit 0\n";
+                : "  echo '--transition is required (review-start, request-update, or approved).'\n  exit 1\n";
             File.WriteAllText(
                 scriptPath,
                 "#!/bin/sh\n"
                 + "case \"$*\" in\n"
-                + "  'automation summary --help') echo 'automation summary'; exit 0 ;;\n"
-                + "  'automation host-review-preflight --help') echo 'automation host-review-preflight'; exit 0 ;;\n"
-                + "  'automation issue-publish --help') echo 'automation issue-publish'; exit 0 ;;\n"
-                + "  'automation pr-transition --help')\n"
+                + "  'automation summary') echo '--domain is required.'; exit 1 ;;\n"
+                + "  'automation host-review-preflight') echo '--repo is required.'; exit 1 ;;\n"
+                + "  'automation issue-publish') echo '--issue is required.'; exit 1 ;;\n"
+                + "  'automation pr-transition')\n"
                 + prTransitionBlock
                 + "    ;;\n"
                 + "  *) echo \"unexpected probe: $*\"; exit 1 ;;\n"

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewPreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewPreflightCommandTests.cs
@@ -321,6 +321,76 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
         Assert.Contains("automation host-review-preflight", writer.ToString(), StringComparison.Ordinal);
     }
 
+    // ── focused-guide-automation-setup-same-thread-and-wrapper-help-tests ───────────
+
+    [Fact]
+    public void Execute_HelpInterceptedByWrapper_SurfacesStillAvailableWhenCommandWorks()
+    {
+        // Simulate a wrapper that intercepts --help (returns dotnet help instead of intent-cli help)
+        // but allows direct command invocation to reach intent-cli.
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        var lister = new FakeLister();
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => lister;
+
+        // Override ProbeRunner to simulate help interception: direct invocations return
+        // intent-cli's own error (missing required args), not dotnet's help output.
+        AutomationInstalledCliSurfaceProbe.ProbeRunner = (_, args) =>
+        {
+            var joined = string.Join(" ", args);
+            if (joined.Contains("--help", StringComparison.Ordinal))
+            {
+                // Simulate dotnet tool exec intercepting --help (would have happened with old probes)
+                return new InstalledCliProbeResult(0, "dotnet tool exec help — not intent-cli", string.Empty);
+            }
+            return joined switch
+            {
+                "automation summary" => new InstalledCliProbeResult(1, string.Empty, "--domain is required."),
+                "automation host-review-preflight" => new InstalledCliProbeResult(1, string.Empty, "--repo is required."),
+                "automation issue-publish" => new InstalledCliProbeResult(1, string.Empty, "--issue is required."),
+                "automation pr-transition" => new InstalledCliProbeResult(
+                    1, string.Empty,
+                    "--transition is required (review-start, request-update, or approved)."),
+                _ => new InstalledCliProbeResult(1, $"unexpected probe: {joined}", string.Empty)
+            };
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewPreflightCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewPreflightResult>(writer.ToString())!;
+        Assert.Equal("no-actionable-item", result.Action);
+        Assert.NotEqual("stale-host-cli", result.Action);
+    }
+
+    [Fact]
+    public void Execute_ProbeDoesNotUseHelpFlag_NoHelpInProbedArgs()
+    {
+        using var workspace = new AutomationHostReviewPreflightWorkspace();
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => new FakeLister();
+
+        var probedArgSets = new List<IReadOnlyList<string>>();
+        AutomationInstalledCliSurfaceProbe.ProbeRunner = (_, args) =>
+        {
+            probedArgSets.Add(args);
+            return new InstalledCliProbeResult(1, string.Empty,
+                "--transition is required (review-start, request-update, or approved).");
+        };
+
+        using var writer = new StringWriter();
+        AutomationHostReviewPreflightCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.NotEmpty(probedArgSets);
+        Assert.All(probedArgSets, args =>
+            Assert.DoesNotContain("--help", args, StringComparer.Ordinal));
+    }
+
     [Fact]
     public void CommandRouter_RegistersAutomationHostReviewPreflight()
     {
@@ -437,17 +507,20 @@ public sealed class AutomationHostReviewPreflightCommandTests : IDisposable
             var binPath = Path.Combine(RootPath, ".intent-cli", "bin");
             Directory.CreateDirectory(binPath);
             var scriptPath = Path.Combine(binPath, "intent-cli");
+            // Probes omit --help to avoid wrapper-layer interception. Each surface is probed
+            // without --help; the script returns intent-cli-style usage errors (not "not yet
+            // implemented") so the surface is detected as available.
             var prTransitionBlock = stalePrTransition
                 ? "  echo \"Command 'automation pr-transition' is not yet implemented.\"\n  exit 1\n"
-                : "  echo 'automation pr-transition'\n  echo 'review-start'\n  echo 'request-update'\n  echo 'approved'\n  exit 0\n";
+                : "  echo '--transition is required (review-start, request-update, or approved).'\n  exit 1\n";
             File.WriteAllText(
                 scriptPath,
                 "#!/bin/sh\n"
                 + "case \"$*\" in\n"
-                + "  'automation summary --help') echo 'automation summary'; exit 0 ;;\n"
-                + "  'automation host-review-preflight --help') echo 'automation host-review-preflight'; exit 0 ;;\n"
-                + "  'automation issue-publish --help') echo 'automation issue-publish'; exit 0 ;;\n"
-                + "  'automation pr-transition --help')\n"
+                + "  'automation summary') echo '--domain is required.'; exit 1 ;;\n"
+                + "  'automation host-review-preflight') echo '--repo is required.'; exit 1 ;;\n"
+                + "  'automation issue-publish') echo '--issue is required.'; exit 1 ;;\n"
+                + "  'automation pr-transition')\n"
                 + prTransitionBlock
                 + "    ;;\n"
                 + "  *) echo \"unexpected probe: $*\"; exit 1 ;;\n"

--- a/tests/IntentSystem.Cli.Tests/GuideAutomationSetupCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideAutomationSetupCommandTests.cs
@@ -314,6 +314,94 @@ public sealed class GuideAutomationSetupCommandTests
         Assert.Equal("child-implement", document.RootElement.GetProperty("kind").GetString());
     }
 
+    // ── focused-guide-automation-setup-same-thread-and-wrapper-help-tests ───────────
+
+    [Fact]
+    public void Execute_HostReviewNextSliceJson_PromptPreventsNewThreadCreation()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--domain", "intent-cli",
+             "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("do not create a new chat", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Run the loop body exactly once", prompt, StringComparison.Ordinal);
+        Assert.Contains("in the current thread", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_HostReviewNextSliceJson_PromptWarnsAboutCloudSchedulers()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--domain", "intent-cli",
+             "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("cloud", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("local paths", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(".intent-cli", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostReviewNextSliceJson_PromptBansNewSchedulerUnlessOperatorAsks()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--domain", "intent-cli",
+             "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Do not open a new chat, session, cron, monitor, or scheduler", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostReviewNextSliceJson_FirstCallsAutomationSummaryIncludesDomain()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--domain", "intent-cli",
+             "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var firstCalls = document.RootElement.GetProperty("first_calls")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls,
+            c => c!.Contains("automation summary --domain intent-cli --format json", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_HostReviewNextSliceMarkdown_ContainsSameThreadGuidance()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--domain", "intent-cli",
+             "--target-repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("do not create a new chat", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("local paths", output, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
@@ -108,15 +108,33 @@ public sealed class PackagedInvocationSmokeTests
             Assert.Contains("\"automationCommandCapabilities\"", summaryOutput, StringComparison.Ordinal);
             Assert.Equal(string.Empty, summaryError.Trim(), ignoreCase: false);
 
+            // Use -- to pass --help through dotnet tool exec to intent-cli rather than having
+            // dotnet tool exec intercept it and show its own help.
+            var prTransitionHelpOutputPath = tempDirectory.GetPath("pr-transition.stdout.txt");
             var prTransitionHelpErrorPath = tempDirectory.GetPath("pr-transition.stderr.txt");
             var prTransitionHelpResult = RunShellCommand(
-                $"dotnet tool exec --yes --source {QuoteForShell(packageOutputDirectory)} --version {QuoteForShell(packageVersion)} intent-cli automation pr-transition --help > {QuoteForShell(tempDirectory.GetPath("pr-transition.stdout.txt"))} 2> {QuoteForShell(prTransitionHelpErrorPath)}",
+                $"dotnet tool exec --yes --source {QuoteForShell(packageOutputDirectory)} --version {QuoteForShell(packageVersion)} intent-cli -- automation pr-transition --help > {QuoteForShell(prTransitionHelpOutputPath)} 2> {QuoteForShell(prTransitionHelpErrorPath)}",
                 fixtureRoot);
 
+            var prTransitionHelpOutput = File.ReadAllText(prTransitionHelpOutputPath);
             var prTransitionHelpError = File.ReadAllText(prTransitionHelpErrorPath);
 
             Assert.Equal(0, prTransitionHelpResult.ExitCode);
+            Assert.Contains("review-start", prTransitionHelpOutput, StringComparison.Ordinal);
+            Assert.Contains("request-update", prTransitionHelpOutput, StringComparison.Ordinal);
+            Assert.Contains("approved", prTransitionHelpOutput, StringComparison.Ordinal);
             Assert.Equal(string.Empty, prTransitionHelpError.Trim(), ignoreCase: false);
+
+            var topLevelHelpOutputPath = tempDirectory.GetPath("help.stdout.txt");
+            var topLevelHelpErrorPath = tempDirectory.GetPath("help.stderr.txt");
+            var topLevelHelpResult = RunShellCommand(
+                $"dotnet tool exec --yes --source {QuoteForShell(packageOutputDirectory)} --version {QuoteForShell(packageVersion)} intent-cli -- --help > {QuoteForShell(topLevelHelpOutputPath)} 2> {QuoteForShell(topLevelHelpErrorPath)}",
+                fixtureRoot);
+
+            var topLevelHelpOutput = File.ReadAllText(topLevelHelpOutputPath);
+
+            Assert.Equal(0, topLevelHelpResult.ExitCode);
+            Assert.Contains("Available command groups", topLevelHelpOutput, StringComparison.Ordinal);
         }
     }
 
@@ -147,6 +165,7 @@ public sealed class PackagedInvocationSmokeTests
         Assert.Contains("\"pr-transition.review-start\"", script, StringComparison.Ordinal);
         Assert.Contains("\"pr-transition.request-update\"", script, StringComparison.Ordinal);
         Assert.Contains("\"pr-transition.approved\"", script, StringComparison.Ordinal);
+        Assert.Contains("intent-cli -- \\\\", script, StringComparison.Ordinal);
         Assert.DoesNotContain("automation pr-transition --help", script, StringComparison.Ordinal);
         Assert.DoesNotContain("--version 0.1.0", script, StringComparison.Ordinal);
     }


### PR DESCRIPTION
## Summary
- Remove `--help` from `AutomationInstalledCliSurfaceProbe` surface probes; wrapper-layer interception (e.g. `dotnet tool exec` capturing `--help`) no longer causes false `stale-host-cli` results
- Add explicit same-thread / one-wake / local-path-warning guidance to the `host-review-next-slice` setup prompt so review loops run in the existing chat thread, not new sessions
- Add `--domain` to `automation summary` first-call in host-review-next-slice setup
- Update fake intent-cli shell scripts in test workspaces to match new probe invocations

## Test plan
- [ ] Run `dotnet test tests/IntentSystem.Cli.Tests/ --filter AutomationDoctorCommandTests` — 8 pass
- [ ] Run `dotnet test tests/IntentSystem.Cli.Tests/ --filter AutomationHostReviewPreflightCommandTests` — includes 2 new focused probe tests
- [ ] Run `dotnet test tests/IntentSystem.Cli.Tests/ --filter GuideAutomationSetupCommandTests` — includes 5 new focused same-thread/cloud-warning tests
- [ ] Run full suite: 1767 pass, 0 fail

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)