### PR TITLE
G264 Add local loop frequency policy to automation setup guidance

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
@@ -122,7 +122,14 @@ Hard rules:
 - All label transitions go through installed `intent-cli automation` / `intent-cli worker` commands. No manual `gh ... edit --add-label` / `--remove-label` fallback for workflow labels.
 - Never apply `intent-target` from the child loop; it is host-owned.
 - Never apply `intent-pr-created` to a PR; it is an issue-side completion marker.
-- Process at most one action per wake.";
+- Process at most one action per wake.
+
+Frequency policy (applies only when a recurring local loop is explicitly requested; the default is one-wake execution):
+- This setup prompt describes a single-wake run, not a recurring loop. One-wake execution does not create any scheduler.
+- If the operator asks for a recurring loop, ask for the frequency before creating any cron, monitor, or scheduler. Never guess or use a tool-default interval.
+- High-frequency local loops (active development): 5 minutes.
+- Low-frequency local loops (background / idle polling): about 20 minutes.
+- Local same-thread loops are the baseline for workflows that depend on local paths or local `.intent-cli` packages. Cloud or new-thread schedulers cannot access local paths.";
 
         return new GuideAutomationSetupResult
         {
@@ -188,7 +195,14 @@ Hard rules:
 - Never apply `intent-pr-created` to a PR.
 - Honor the WIP cap: do not cut a new child issue while any open `intent-target` issue/PR remains in `{targetRepo}`.
 - Stop on Hard Clarification rather than guessing when source-of-truth is ambiguous.
-- Process at most one PR review and one new child issue per wake.";
+- Process at most one PR review and one new child issue per wake.
+
+Frequency policy (applies only when a recurring local loop is explicitly requested; the default is one-wake execution):
+- This setup prompt describes a single-wake run, not a recurring loop. One-wake execution does not create any scheduler.
+- If the operator asks for a recurring loop, ask for the frequency before creating any cron, monitor, or scheduler. Never guess or use a tool-default interval.
+- High-frequency local loops (active development): 5 minutes.
+- Low-frequency local loops (background / idle polling): about 20 minutes.
+- Local same-thread loops are the baseline for workflows that depend on local paths or local `.intent-cli` packages. Cloud or new-thread schedulers cannot access local paths.";
 
         return new GuideAutomationSetupResult
         {

--- a/tests/IntentSystem.Cli.Tests/GuideAutomationSetupCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideAutomationSetupCommandTests.cs
@@ -402,6 +402,113 @@ public sealed class GuideAutomationSetupCommandTests
         Assert.Contains("local paths", output, StringComparison.OrdinalIgnoreCase);
     }
 
+    // ── focused-guide-automation-setup-frequency-policy-tests ───────────
+
+    [Fact]
+    public void Execute_ChildImplementJson_PromptContainsFrequencyPolicy()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("5 minutes", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("20 minutes", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ask for the frequency", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("one-wake execution", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementJson_PromptDistinguishesOneWakeFromRecurring()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("one-wake execution does not create any scheduler", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("recurring loop", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Never guess or use a tool-default interval", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementMarkdown_ContainsFrequencyPolicy()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("5 minutes", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("20 minutes", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ask for the frequency", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_HostReviewNextSliceJson_PromptContainsFrequencyPolicy()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--domain", "intent-cli",
+             "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("5 minutes", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("20 minutes", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ask for the frequency", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("one-wake execution", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_HostReviewNextSliceJson_PromptDistinguishesOneWakeFromRecurring()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--domain", "intent-cli",
+             "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("one-wake execution does not create any scheduler", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("recurring loop", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Never guess or use a tool-default interval", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostReviewNextSliceMarkdown_ContainsFrequencyPolicy()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--domain", "intent-cli",
+             "--target-repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("5 minutes", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("20 minutes", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ask for the frequency", output, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext


### PR DESCRIPTION
## Summary

- Add `Frequency policy` section to both `child-implement` and `host-review-next-slice` automation setup prompts
- Generated prompts now explicitly require an interval before any recurring loop/scheduler is created
- Recommended local defaults: 5 minutes (high-frequency), ~20 minutes (low-frequency)
- Default remains one-wake execution (no recurring scheduler created)
- Add 6 focused tests under `focused-guide-automation-setup-frequency-policy-tests`

Closes #631

## Test plan

- [ ] Run `dotnet test --filter "FullyQualifiedName~GuideAutomationSetupCommandTests"` — 29 tests pass
- [ ] `git diff --check` — clean
- [ ] New tests cover: child-implement JSON/markdown and host-review-next-slice JSON/markdown frequency policy assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)