### PR TITLE
G265 Add skill-free issue-to-PR worker guide prompt

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -214,7 +214,8 @@ internal static class CommandRouter
                 ["model"] = GuideModelCommand.Execute,
                 ["commands"] = GuideCommandsCommand.Execute,
                 ["onboarding"] = GuideOnboardingCommand.Execute,
-                ["intent-work"] = GuideIntentWorkCommand.Execute
+                ["intent-work"] = GuideIntentWorkCommand.Execute,
+                ["worker"] = GuideWorkerCommand.Execute
             },
             ["intent"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/GuideWorkerCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerCommand.cs
@@ -1,0 +1,42 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G265: Top-level router for <c>intent-cli guide worker ...</c>.
+/// Currently routes the <c>issue-to-pr</c> sub-token to
+/// <see cref="GuideWorkerIssueToPrCommand"/>. Future sub-tokens may be added
+/// here without touching the CommandRouter.
+/// </summary>
+internal static class GuideWorkerCommand
+{
+    private const string UsageLine =
+        "Usage: intent-cli guide worker <issue-to-pr> [--repo <owner/repo>] [--domain <name>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (args.Length >= 1 && string.Equals(args[0], "issue-to-pr", StringComparison.Ordinal))
+        {
+            return GuideWorkerIssueToPrCommand.Execute(context, args[1..], writer);
+        }
+
+        writer.WriteLine("A subcommand is required for 'guide worker'.");
+        writer.WriteLine(UsageLine);
+        return 1;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide worker");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Subcommands: issue-to-pr");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GuideWorkerIssueToPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerIssueToPrCommand.cs
@@ -1,0 +1,333 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G265: Read-only <c>intent-cli guide worker issue-to-pr</c>. Returns a
+/// paste-ready, skill-free issue-to-PR implementation prompt so AI agents can
+/// implement issues without depending on local <c>gh-issue-to-pr</c> skill
+/// files or copied prompt files. The prompt includes the standalone contract
+/// gate, origin/main branch creation, minimal implementation, focused
+/// validation, draft PR creation, and worker claim/complete handoff.
+/// Never mutates state. Never launches an AI provider.
+/// </summary>
+internal static class GuideWorkerIssueToPrCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide worker issue-to-pr [--repo <owner/repo>] [--domain <name>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var repo, out var domain, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = BuildIssueToPr(repo, domain);
+        return EmitResult(writer, format, result);
+    }
+
+    private static int EmitResult(TextWriter writer, string format, GuideWorkerIssueToPrResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static GuideWorkerIssueToPrResult BuildIssueToPr(string? repo, string? domain)
+    {
+        var repoLabel = string.IsNullOrWhiteSpace(repo) ? "the repo in the current worktree" : $"`{repo}`";
+        var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
+
+        var prompt =
+$@"Implement the issue returned by `intent-cli worker next-action` as a draft PR for {repoLabel}. Do not use the `gh-issue-to-pr` skill file, local skill files, or copied prompt files.
+
+First-call sequence (read-only; required before any code work):
+1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
+2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
+3. `intent-cli guide commands list --format json` — primary vs support vs advanced vs experimental classification.
+4. `intent-cli automation summary --domain {domainPlaceholder} --format json` — canonical label-driven contract and capability JSON.
+
+Standalone contract gate (required before branch creation or code changes):
+Read the issue body with `gh issue view <n> --repo <OWNER>/<REPO>`. The body must contain all of:
+- Goal
+- Why This Slice Exists Now
+- Current Observed State or Reproduction
+- Accepted Baseline You May Assume
+- Target Repo-Path-Part
+- In Scope
+- Out Of Scope
+- Acceptance Criteria
+- Verification
+
+If any required section is missing or if the real contract lives only in linked parent files, decline before creating any branch or code change. Report the missing sections and stop. Set outcome to `declined-contract-incomplete`.
+
+Implementation steps:
+1. Claim the issue: `intent-cli worker claim --kind issue --number <n> --repo <OWNER>/<REPO> --write --format json`.
+2. Fetch origin/main: `git fetch origin main`. Create a new branch `claude/<slug>` from `origin/main`. Never reuse an existing unrelated branch.
+3. Read only the source files needed to implement the issue correctly. Match the repository's existing style and patterns.
+4. Implement only the requested change. Do not widen scope. Do not add unrequested refactors.
+5. Run the most relevant targeted tests. Report the command and the result. If broader validation is required by the repository contract or the touched area, run it too.
+6. Push the branch and create a draft PR with `gh pr create --draft --title ""..."" --body ""..."" --repo <OWNER>/<REPO>`.
+7. Do not add `intent-target` or `intent-pr-created` to the PR.
+8. From the parent host root, run `intent-cli worker result-summary --kind issue-to-pr --issue <n> --pr <pr-n> --repo <OWNER>/<REPO> --format json`, then `intent-cli worker complete --kind issue --number <n> --repo <OWNER>/<REPO> --outcome pr-created --write --format json`.
+
+Outcome classification:
+- `pr-created` — draft PR created successfully.
+- `declined-contract-incomplete` — issue body missing required sections; no branch or PR created.
+- `clarification-required` — ambiguous contract or blocker found during implementation; no PR created.
+- `already-resolved` — the issue is already fixed in origin/main; no PR created.
+- `failed` — implementation failed (build/test failure, unresolvable merge conflict).
+- `label-cleanup-required` — stale labels prevent clean claim/complete flow.
+
+Hard rules:
+- Use the issue body as the standalone contract. Do not read parent host packet files, `intents/rules/**`, local skill files, or copied prompt files to fill contract gaps.
+- Do not use the `gh-issue-to-pr` skill file or any local skill file.
+- Do not add `intent-target` to the PR; it is host-owned.
+- Do not add `intent-pr-created` to the PR; it is an issue-side completion marker applied by `worker complete`.
+- All label transitions go through `intent-cli worker claim` / `intent-cli worker complete`. No manual `gh ... edit --add-label` / `--remove-label` fallback for workflow labels.
+- Do not call `intent-cli run`. `run` is for integration smoke/replay/dogfooding, not the chat-first implementation path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- If the issue body is a thin stub or points only to parent breadcrumbs for the real contract, decline before creating any branch.";
+
+        return new GuideWorkerIssueToPrResult
+        {
+            Kind = "issue-to-pr",
+            Repo = string.IsNullOrWhiteSpace(repo) ? null : repo,
+            Domain = string.IsNullOrWhiteSpace(domain) ? null : domain,
+            Prompt = prompt,
+            FirstCalls = new[]
+            {
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                $"intent-cli automation summary --domain {domainPlaceholder} --format json"
+            },
+            ContractGateSections = new[]
+            {
+                "Goal",
+                "Why This Slice Exists Now",
+                "Current Observed State or Reproduction",
+                "Accepted Baseline You May Assume",
+                "Target Repo-Path-Part",
+                "In Scope",
+                "Out Of Scope",
+                "Acceptance Criteria",
+                "Verification"
+            },
+            OutcomeClassification = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["pr-created"] = "Draft PR created successfully.",
+                ["declined-contract-incomplete"] = "Issue body missing required sections; no branch or PR created.",
+                ["clarification-required"] = "Ambiguous contract or blocker found during implementation; no PR created.",
+                ["already-resolved"] = "The issue is already fixed in origin/main; no PR created.",
+                ["failed"] = "Implementation failed (build/test failure, unresolvable merge conflict).",
+                ["label-cleanup-required"] = "Stale labels prevent clean claim/complete flow."
+            },
+            ForbiddenSources = new[]
+            {
+                "gh-issue-to-pr skill file",
+                "local skill files",
+                "copied prompt files",
+                "intents/rules/**",
+                "parent host packet files (for filling contract gaps)"
+            },
+            LabelOwnership = "All label transitions delegated to installed intent-cli worker claim / worker complete. Manual `gh ... edit --label` fallback is forbidden.",
+            WorktreeFriendly = "The prompt resolves the repo from the child worktree's `gh` / `git remote` and runs worker commands from the parent host root with --repo; no hard-coded paths."
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideWorkerIssueToPrResult result)
+    {
+        writer.WriteLine($"# Guide worker — {result.Kind}");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.Repo))
+        {
+            writer.WriteLine($"- repo: {result.Repo}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.Domain))
+        {
+            writer.WriteLine($"- domain: {result.Domain}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## First-call sequence (read-only)");
+        foreach (var call in result.FirstCalls)
+        {
+            writer.WriteLine($"- `{call}`");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Contract gate sections (required in issue body)");
+        foreach (var section in result.ContractGateSections)
+        {
+            writer.WriteLine($"- {section}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Forbidden rule sources");
+        foreach (var src in result.ForbiddenSources)
+        {
+            writer.WriteLine($"- {src}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Label ownership");
+        writer.WriteLine();
+        writer.WriteLine(result.LabelOwnership);
+        writer.WriteLine();
+
+        writer.WriteLine("## Worktree-friendly assumption");
+        writer.WriteLine();
+        writer.WriteLine(result.WorktreeFriendly);
+        writer.WriteLine();
+
+        writer.WriteLine("## Prompt");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(result.Prompt);
+        writer.WriteLine("```");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string? domain,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        domain = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value.";
+                        return false;
+                    }
+
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domain = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide worker issue-to-pr");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only paste-ready skill-free issue-to-PR implementation prompt for AI agents.");
+        writer.WriteLine();
+        writer.WriteLine("  --repo is optional; omit to derive the repo from the current child worktree.");
+        writer.WriteLine("  --domain is optional; omit to emit a <DOMAIN> placeholder in the generated prompt.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record GuideWorkerIssueToPrResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("repo")]
+    public string? Repo { get; init; }
+
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+
+    [JsonPropertyName("first_calls")]
+    public required IReadOnlyList<string> FirstCalls { get; init; }
+
+    [JsonPropertyName("contract_gate_sections")]
+    public required IReadOnlyList<string> ContractGateSections { get; init; }
+
+    [JsonPropertyName("outcome_classification")]
+    public required IReadOnlyDictionary<string, string> OutcomeClassification { get; init; }
+
+    [JsonPropertyName("forbidden_sources")]
+    public required IReadOnlyList<string> ForbiddenSources { get; init; }
+
+    [JsonPropertyName("label_ownership")]
+    public required string LabelOwnership { get; init; }
+
+    [JsonPropertyName("worktree_friendly")]
+    public required string WorktreeFriendly { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideWorkerIssueToPrCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkerIssueToPrCommandTests.cs
@@ -1,0 +1,287 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideWorkerIssueToPrCommandTests
+{
+    [Fact]
+    public void Execute_NoArgs_ReturnsMarkdownWithPromptAndContractGate()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            [],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide worker — issue-to-pr", output, StringComparison.Ordinal);
+        Assert.Contains("## First-call sequence", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide model --format json", output, StringComparison.Ordinal);
+        Assert.Contains("## Contract gate sections", output, StringComparison.Ordinal);
+        Assert.Contains("Acceptance Criteria", output, StringComparison.Ordinal);
+        Assert.Contains("## Prompt", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithRepo_EmitsRepoInMarkdownPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("repo: J-Tech-Japan/intent-system", output, StringComparison.Ordinal);
+        Assert.Contains("`J-Tech-Japan/intent-system`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithDomain_EmitsDomainInFirstCallsAndPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        var firstCalls = root.GetProperty("first_calls").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls, c => c!.Contains("automation summary --domain intent-cli --format json", StringComparison.Ordinal));
+        var prompt = root.GetProperty("prompt").GetString()!;
+        Assert.Contains("automation summary --domain intent-cli --format json", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("<DOMAIN>", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NoDomain_EmitsDomainPlaceholderInFirstCallsAndPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var firstCalls = document.RootElement.GetProperty("first_calls")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls, c => c!.Contains("automation summary --domain <DOMAIN>", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_Json_EmitsStructuredFields()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-to-pr", root.GetProperty("kind").GetString());
+        Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("repo").GetString());
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        Assert.Equal(4, root.GetProperty("first_calls").GetArrayLength());
+        Assert.True(root.GetProperty("contract_gate_sections").GetArrayLength() >= 9);
+        Assert.True(root.GetProperty("forbidden_sources").GetArrayLength() >= 3);
+        Assert.True(root.GetProperty("outcome_classification").EnumerateObject().Count() >= 5);
+        Assert.True(root.TryGetProperty("label_ownership", out _));
+        Assert.True(root.TryGetProperty("worktree_friendly", out _));
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("guide worker issue-to-pr", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownFormat_ReturnsError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Dispatch_GuideWorkerIssueToPrRoutedThroughCommandRouter_Works()
+    {
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["guide", "worker", "issue-to-pr", "--format", "json"],
+            CreateContext(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("issue-to-pr", document.RootElement.GetProperty("kind").GetString());
+    }
+
+    // ── focused-guide-worker-issue-to-pr-prompt-tests ───────────
+
+    [Fact]
+    public void Execute_Json_PromptForbidsGhIssueToPrSkill()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("gh-issue-to-pr", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do not use the `gh-issue-to-pr` skill file", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("Use the `gh-issue-to-pr` skill", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptContainsStandaloneContractGate()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Standalone contract gate", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Acceptance Criteria", prompt, StringComparison.Ordinal);
+        Assert.Contains("declined-contract-incomplete", prompt, StringComparison.Ordinal);
+        Assert.Contains("decline before creating any branch", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCoversOriginMainBranchCreation()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("origin/main", prompt, StringComparison.Ordinal);
+        Assert.Contains("git fetch origin main", prompt, StringComparison.Ordinal);
+        Assert.Contains("claude/<slug>", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCoversWorkerClaimCompleteHandoff()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("intent-cli worker claim", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli worker complete", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli worker result-summary", prompt, StringComparison.Ordinal);
+        Assert.Contains("pr-created", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCoversDraftPrCreation()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("draft PR", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("gh pr create --draft", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-target", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do not add `intent-target` to the PR", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptContainsOutcomeClassificationWithAllRequiredOutcomes()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var outcomes = document.RootElement.GetProperty("outcome_classification")
+            .EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Contains("pr-created", outcomes, StringComparer.Ordinal);
+        Assert.Contains("declined-contract-incomplete", outcomes, StringComparer.Ordinal);
+        Assert.Contains("clarification-required", outcomes, StringComparer.Ordinal);
+        Assert.Contains("already-resolved", outcomes, StringComparer.Ordinal);
+        Assert.Contains("failed", outcomes, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_ContainsContractGateSectionsAndForbiddenSources()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("## Contract gate sections", output, StringComparison.Ordinal);
+        Assert.Contains("Acceptance Criteria", output, StringComparison.Ordinal);
+        Assert.Contains("## Forbidden rule sources", output, StringComparison.Ordinal);
+        Assert.Contains("gh-issue-to-pr skill file", output, StringComparison.Ordinal);
+        Assert.Contains("intents/rules/**", output, StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Add `intent-cli guide worker issue-to-pr` command (new `GuideWorkerCommand` router + `GuideWorkerIssueToPrCommand`)
- Generated prompt is paste-ready and requires no local `gh-issue-to-pr` skill file
- Covers all acceptance criteria: standalone contract gate (9 required sections), origin/main branch creation, minimal implementation, focused validation, draft PR creation, `worker result-summary`, `worker claim`/`worker complete` handoff
- Add 15 focused tests under `focused-guide-worker-issue-to-pr-prompt-tests`
- Register `guide worker` subcommand in `CommandRouter`

Closes #633

## Test plan

- [ ] `dotnet test --filter "FullyQualifiedName~GuideWorkerIssueToPrCommandTests"` — 15 tests pass
- [ ] `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)