### PR TITLE
G266 Add skill-free PR comment fix worker guide prompt

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideWorkerCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerCommand.cs
@@ -9,7 +9,7 @@ namespace IntentSystem.Cli.Commands;
 internal static class GuideWorkerCommand
 {
     private const string UsageLine =
-        "Usage: intent-cli guide worker <issue-to-pr> [--repo <owner/repo>] [--domain <name>] [--format markdown|json]";
+        "Usage: intent-cli guide worker <issue-to-pr|pr-comment-fix> [--repo <owner/repo>] [--domain <name>] [--format markdown|json]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -28,6 +28,11 @@ internal static class GuideWorkerCommand
             return GuideWorkerIssueToPrCommand.Execute(context, args[1..], writer);
         }
 
+        if (args.Length >= 1 && string.Equals(args[0], "pr-comment-fix", StringComparison.Ordinal))
+        {
+            return GuideWorkerPrCommentFixCommand.Execute(context, args[1..], writer);
+        }
+
         writer.WriteLine("A subcommand is required for 'guide worker'.");
         writer.WriteLine(UsageLine);
         return 1;
@@ -37,6 +42,6 @@ internal static class GuideWorkerCommand
     {
         writer.WriteLine("guide worker");
         writer.WriteLine(UsageLine);
-        writer.WriteLine("Subcommands: issue-to-pr");
+        writer.WriteLine("Subcommands: issue-to-pr, pr-comment-fix");
     }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkerPrCommentFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerPrCommentFixCommand.cs
@@ -1,0 +1,301 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G266: Read-only <c>intent-cli guide worker pr-comment-fix</c>. Returns a
+/// paste-ready, skill-free PR comment fix prompt so AI agents can repair a PR
+/// branch without depending on local <c>gh-fix-pr-comment</c> skill files or
+/// copied prompt files. The prompt covers selecting unresolved actionable
+/// comments, checking out the existing PR branch, applying a narrow fix,
+/// focused validation, push, worker result-summary, and worker complete.
+/// Never mutates state. Never launches an AI provider.
+/// </summary>
+internal static class GuideWorkerPrCommentFixCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide worker pr-comment-fix [--repo <owner/repo>] [--domain <name>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var repo, out var domain, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = BuildPrCommentFix(repo, domain);
+        return EmitResult(writer, format, result);
+    }
+
+    private static int EmitResult(TextWriter writer, string format, GuideWorkerPrCommentFixResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static GuideWorkerPrCommentFixResult BuildPrCommentFix(string? repo, string? domain)
+    {
+        var repoLabel = string.IsNullOrWhiteSpace(repo) ? "the repo in the current worktree" : $"`{repo}`";
+        var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
+
+        var prompt =
+$@"Repair the PR branch for {repoLabel} based on review comments. Do not use the `gh-fix-pr-comment` skill file, local skill files, or copied prompt files.
+
+First-call sequence (read-only; required before any code work):
+1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
+2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
+3. `intent-cli guide commands list --format json` — primary vs support vs advanced vs experimental classification.
+4. `intent-cli automation summary --domain {domainPlaceholder} --format json` — canonical label-driven contract and capability JSON.
+
+Comment triage (required before checkout or code changes):
+Read review comments with `gh pr view <n> --repo <OWNER>/<REPO> --comments` and `gh api repos/<OWNER>/<REPO>/pulls/<n>/reviews`. Identify all unresolved, actionable review comments.
+- If there are no unresolved actionable comments, stop. Set outcome to `no-actionable-comments`.
+- If a comment is ambiguous and cannot be resolved without guessing, stop. Set outcome to `clarification-required`. Report which comment and why.
+- If the requested change is already applied in the existing branch, stop. Set outcome to `already-resolved`.
+
+Repair steps:
+1. Claim the PR: `intent-cli worker claim --kind pr --number <n> --repo <OWNER>/<REPO> --write --format json`.
+2. Check out the existing PR branch: `gh pr checkout <n> --repo <OWNER>/<REPO>`. Do not create a new branch.
+3. Apply only the narrow change requested in the review comments. Do not add unrequested refactors or opportunistic cleanups.
+4. Run the most relevant targeted tests. Report the command and the result.
+5. Push the repaired branch: `git push`. Do not force-push unless the PR branch explicitly requires it.
+6. From the parent host root, run `intent-cli worker result-summary --kind pr-comment-fix --pr <n> --repo <OWNER>/<REPO> --format json`, then `intent-cli worker complete --kind pr --number <n> --repo <OWNER>/<REPO> --outcome repair-pushed --write --format json`.
+
+Outcome classification:
+- `repair-pushed` — narrow fix pushed to the existing PR branch.
+- `no-actionable-comments` — no unresolved actionable review comments; nothing to fix.
+- `already-resolved` — the requested change is already applied in the branch.
+- `clarification-required` — ambiguous comment or blocker found; cannot proceed without operator input.
+- `failed` — fix failed (build/test failure, unresolvable conflict).
+- `label-cleanup-required` — stale labels prevent clean claim/complete flow.
+
+Hard rules:
+- Do not use the `gh-fix-pr-comment` skill file or any local skill file.
+- Do not create a new branch. Check out and repair the existing PR branch.
+- Repair only the narrow change requested in review comments. Do not widen scope.
+- Do not read `intents/rules/**`, local skill files, or copied prompt files.
+- All label transitions go through `intent-cli worker claim` / `intent-cli worker complete`. No manual `gh ... edit --add-label` / `--remove-label` fallback for workflow labels.
+- Do not call `intent-cli run`. `run` is for integration smoke/replay/dogfooding, not the chat-first repair path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- Do not add `intent-target` to the PR; it is host-owned.
+- Do not add `intent-pr-created` to the PR; it is an issue-side completion marker.";
+
+        return new GuideWorkerPrCommentFixResult
+        {
+            Kind = "pr-comment-fix",
+            Repo = string.IsNullOrWhiteSpace(repo) ? null : repo,
+            Domain = string.IsNullOrWhiteSpace(domain) ? null : domain,
+            Prompt = prompt,
+            FirstCalls = new[]
+            {
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                $"intent-cli automation summary --domain {domainPlaceholder} --format json"
+            },
+            OutcomeClassification = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["repair-pushed"] = "Narrow fix pushed to the existing PR branch.",
+                ["no-actionable-comments"] = "No unresolved actionable review comments; nothing to fix.",
+                ["already-resolved"] = "The requested change is already applied in the branch.",
+                ["clarification-required"] = "Ambiguous comment or blocker found; cannot proceed without operator input.",
+                ["failed"] = "Fix failed (build/test failure, unresolvable conflict).",
+                ["label-cleanup-required"] = "Stale labels prevent clean claim/complete flow."
+            },
+            ForbiddenSources = new[]
+            {
+                "gh-fix-pr-comment skill file",
+                "local skill files",
+                "copied prompt files",
+                "intents/rules/**"
+            },
+            LabelOwnership = "All label transitions delegated to installed intent-cli worker claim / worker complete. Manual `gh ... edit --label` fallback is forbidden.",
+            WorktreeFriendly = "The prompt resolves the repo from the current worktree's `gh` / `git remote` and runs worker commands from the parent host root with --repo; no hard-coded paths."
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideWorkerPrCommentFixResult result)
+    {
+        writer.WriteLine($"# Guide worker — {result.Kind}");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.Repo))
+        {
+            writer.WriteLine($"- repo: {result.Repo}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.Domain))
+        {
+            writer.WriteLine($"- domain: {result.Domain}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## First-call sequence (read-only)");
+        foreach (var call in result.FirstCalls)
+        {
+            writer.WriteLine($"- `{call}`");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Forbidden rule sources");
+        foreach (var src in result.ForbiddenSources)
+        {
+            writer.WriteLine($"- {src}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Label ownership");
+        writer.WriteLine();
+        writer.WriteLine(result.LabelOwnership);
+        writer.WriteLine();
+
+        writer.WriteLine("## Worktree-friendly assumption");
+        writer.WriteLine();
+        writer.WriteLine(result.WorktreeFriendly);
+        writer.WriteLine();
+
+        writer.WriteLine("## Prompt");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(result.Prompt);
+        writer.WriteLine("```");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string? domain,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        domain = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value.";
+                        return false;
+                    }
+
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domain = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide worker pr-comment-fix");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only paste-ready skill-free PR comment fix prompt for AI agents.");
+        writer.WriteLine();
+        writer.WriteLine("  --repo is optional; omit to derive the repo from the current child worktree.");
+        writer.WriteLine("  --domain is optional; omit to emit a <DOMAIN> placeholder in the generated prompt.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record GuideWorkerPrCommentFixResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("repo")]
+    public string? Repo { get; init; }
+
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+
+    [JsonPropertyName("first_calls")]
+    public required IReadOnlyList<string> FirstCalls { get; init; }
+
+    [JsonPropertyName("outcome_classification")]
+    public required IReadOnlyDictionary<string, string> OutcomeClassification { get; init; }
+
+    [JsonPropertyName("forbidden_sources")]
+    public required IReadOnlyList<string> ForbiddenSources { get; init; }
+
+    [JsonPropertyName("label_ownership")]
+    public required string LabelOwnership { get; init; }
+
+    [JsonPropertyName("worktree_friendly")]
+    public required string WorktreeFriendly { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideWorkerPrCommentFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkerPrCommentFixCommandTests.cs
@@ -1,0 +1,280 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideWorkerPrCommentFixCommandTests
+{
+    [Fact]
+    public void Execute_NoArgs_ReturnsMarkdownWithPromptAndForbiddenSources()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            [],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide worker — pr-comment-fix", output, StringComparison.Ordinal);
+        Assert.Contains("## First-call sequence", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide model --format json", output, StringComparison.Ordinal);
+        Assert.Contains("## Forbidden rule sources", output, StringComparison.Ordinal);
+        Assert.Contains("## Prompt", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithRepo_EmitsRepoInMarkdownPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("repo: J-Tech-Japan/intent-system", output, StringComparison.Ordinal);
+        Assert.Contains("`J-Tech-Japan/intent-system`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithDomain_EmitsDomainInFirstCallsAndPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        var firstCalls = root.GetProperty("first_calls").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls, c => c!.Contains("automation summary --domain intent-cli --format json", StringComparison.Ordinal));
+        var prompt = root.GetProperty("prompt").GetString()!;
+        Assert.Contains("automation summary --domain intent-cli --format json", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("<DOMAIN>", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NoDomain_EmitsDomainPlaceholderInFirstCallsAndPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var firstCalls = document.RootElement.GetProperty("first_calls")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls, c => c!.Contains("automation summary --domain <DOMAIN>", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_Json_EmitsStructuredFields()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("pr-comment-fix", root.GetProperty("kind").GetString());
+        Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("repo").GetString());
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        Assert.Equal(4, root.GetProperty("first_calls").GetArrayLength());
+        Assert.True(root.GetProperty("forbidden_sources").GetArrayLength() >= 3);
+        Assert.True(root.GetProperty("outcome_classification").EnumerateObject().Count() >= 5);
+        Assert.True(root.TryGetProperty("label_ownership", out _));
+        Assert.True(root.TryGetProperty("worktree_friendly", out _));
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("guide worker pr-comment-fix", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownFormat_ReturnsError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Dispatch_GuideWorkerPrCommentFixRoutedThroughCommandRouter_Works()
+    {
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["guide", "worker", "pr-comment-fix", "--format", "json"],
+            CreateContext(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("pr-comment-fix", document.RootElement.GetProperty("kind").GetString());
+    }
+
+    // ── focused-guide-worker-pr-comment-fix-prompt-tests ───────────
+
+    [Fact]
+    public void Execute_Json_PromptForbidsGhFixPrCommentSkill()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("gh-fix-pr-comment", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do not use the `gh-fix-pr-comment` skill file", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCoversCommentTriage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Comment triage", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("no-actionable-comments", prompt, StringComparison.Ordinal);
+        Assert.Contains("clarification-required", prompt, StringComparison.Ordinal);
+        Assert.Contains("already-resolved", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCheckoutsExistingBranchNotCreatesNew()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("gh pr checkout", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do not create a new branch", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCoversWorkerClaimCompleteHandoff()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("intent-cli worker claim --kind pr", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli worker complete --kind pr", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli worker result-summary --kind pr-comment-fix", prompt, StringComparison.Ordinal);
+        Assert.Contains("repair-pushed", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptContainsOutcomeClassificationWithAllRequiredOutcomes()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var outcomes = document.RootElement.GetProperty("outcome_classification")
+            .EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Contains("repair-pushed", outcomes, StringComparer.Ordinal);
+        Assert.Contains("no-actionable-comments", outcomes, StringComparer.Ordinal);
+        Assert.Contains("already-resolved", outcomes, StringComparer.Ordinal);
+        Assert.Contains("clarification-required", outcomes, StringComparer.Ordinal);
+        Assert.Contains("failed", outcomes, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptEnforcesNarrowScopeRepair()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("narrow", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Do not add unrequested refactors", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_ContainsForbiddenSourcesAndWorktreetFriendly()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("## Forbidden rule sources", output, StringComparison.Ordinal);
+        Assert.Contains("gh-fix-pr-comment skill file", output, StringComparison.Ordinal);
+        Assert.Contains("intents/rules/**", output, StringComparison.Ordinal);
+        Assert.Contains("## Worktree-friendly assumption", output, StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Add `intent-cli guide worker pr-comment-fix` command (`GuideWorkerPrCommentFixCommand`)
- Generated prompt covers comment triage gates (no-actionable, clarification-required, already-resolved), `gh pr checkout` existing branch (not new branch), narrow fix only, focused validation, push, `worker result-summary`, and `worker claim`/`worker complete` handoff
- Prompt explicitly forbids `gh-fix-pr-comment` skill files and copied prompt files
- Extend `GuideWorkerCommand` to route the `pr-comment-fix` subtoken
- Add 15 focused tests under `focused-guide-worker-pr-comment-fix-prompt-tests`

Closes #635

## Test plan

- [ ] `dotnet test --filter "FullyQualifiedName~GuideWorkerPrCommentFixCommandTests"` — 15 tests pass
- [ ] `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)