### PR TITLE
G267 Add skill-free review run guide prompt

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
@@ -63,6 +63,12 @@ internal static class GuideReviewCommand
             return 0;
         }
 
+        // G267: nested `guide review run` paste-ready review-prompt subcommand.
+        if (args.Length >= 1 && string.Equals(args[0], "run", StringComparison.Ordinal))
+        {
+            return GuideReviewRunCommand.Execute(context, args[1..], writer);
+        }
+
         if (!TryParseArguments(args, out var pr, out var repo, out var domainOverride, out var format, out var error))
         {
             writer.WriteLine(error);

--- a/src/IntentSystem.Cli/Commands/GuideReviewRunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideReviewRunCommand.cs
@@ -1,0 +1,294 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G267: Read-only <c>intent-cli guide review run</c>. Returns a paste-ready,
+/// skill-free deterministic PR review prompt for AI agents, replacing routine
+/// dependence on local <c>intent-review</c> skill files. The prompt uses
+/// <c>automation host-review-preflight</c>, <c>guide review</c>, <c>review
+/// closeout-plan</c>, PR diff, linked issue, and packet refs to drive a
+/// findings-first review, then delegates all label transitions to installed
+/// <c>intent-cli automation pr-transition</c> commands.
+/// Never mutates state. Never launches an AI provider.
+/// </summary>
+internal static class GuideReviewRunCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide review run [--domain <name>] [--target-repo <owner/repo>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var domain, out var targetRepo, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = BuildReviewRun(domain, targetRepo);
+        return EmitResult(writer, format, result);
+    }
+
+    private static int EmitResult(TextWriter writer, string format, GuideReviewRunResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static GuideReviewRunResult BuildReviewRun(string? domain, string? targetRepo)
+    {
+        var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
+        var targetRepoPlaceholder = string.IsNullOrWhiteSpace(targetRepo) ? "<TARGET_REPO>" : targetRepo;
+
+        var prompt =
+$@"Run one PR review wake for domain `{domainPlaceholder}` against `{targetRepoPlaceholder}`. Do not use the `intent-review` skill file, local skill files, or copied prompt files.
+
+First-call sequence (read-only; required before any review work):
+1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
+2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
+3. `intent-cli guide commands list --format json` — primary vs support vs advanced vs experimental classification.
+4. `intent-cli automation summary --domain {domainPlaceholder} --format json` — canonical label-driven contract and capability JSON.
+
+Stage 1 — preflight (required before reading any PR):
+1. `intent-cli automation host-review-preflight --repo {targetRepoPlaceholder} --format json` → selects an eligible PR.
+   - If the result has no eligible PR, stop with `idle`. Do not proceed.
+2. Note the selected PR number from the preflight result.
+
+Stage 2 — collect review inputs (all read-only):
+1. `intent-cli guide review --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --format json` → review guidance, packet refs, review checklist, and review boundaries.
+2. `gh pr view <n> --repo {targetRepoPlaceholder}` → PR title, body, linked issue number.
+3. `gh pr diff <n> --repo {targetRepoPlaceholder}` → full diff.
+4. `gh issue view <LINKED_ISSUE> --repo {targetRepoPlaceholder}` → linked issue body (Acceptance Criteria, In Scope, Out Of Scope, Verification).
+5. `intent-cli review closeout-plan --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --format json` → closeout plan and any blocking items.
+
+Stage 3 — review (findings-first; performed by the AI agent):
+- Read the diff against the linked issue's Acceptance Criteria and In Scope / Out Of Scope sections.
+- Read the PR against any packet refs returned by `guide review`.
+- Use a findings-first approach: enumerate concrete findings before rendering a verdict.
+- A finding is a concrete, actionable observation tied to a specific file/line or a specific Acceptance Criterion.
+- If all findings are minor (style, nit) and Acceptance Criteria are met: verdict is `approved`.
+- If any finding blocks an Acceptance Criterion or violates an Out Of Scope boundary: verdict is `request-update`.
+- Render the review as a structured report: findings list, verdict, next action.
+
+Stage 4 — label transition (required; delegate to intent-cli):
+- If verdict is `approved`:
+  `intent-cli automation pr-transition --transition approved --repo {targetRepoPlaceholder} --pr <n> --write --format json`
+- If verdict is `request-update`:
+  1. Post an actionable PR comment: `gh pr comment <n> --repo {targetRepoPlaceholder} --body ""...""`  listing each finding with file/line, description, and a concrete suggested fix.
+  2. `intent-cli automation pr-transition --transition request-update --repo {targetRepoPlaceholder} --pr <n> --write --format json`
+
+Hard rules:
+- Do not use the `intent-review` skill file or any local skill file.
+- Do not merge the PR. Merging happens via the host closeout path after `approved`.
+- Do not read `intents/rules/**`, local skill files, or copied prompt files.
+- All label transitions go through installed `intent-cli automation pr-transition`. No manual `gh ... edit --add-label` / `--remove-label` fallback for workflow labels.
+- Do not call `intent-cli run`. `run` is for integration smoke/replay/dogfooding, not the host review path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- Process at most one PR review per wake.";
+
+        return new GuideReviewRunResult
+        {
+            Kind = "run",
+            Domain = string.IsNullOrWhiteSpace(domain) ? null : domain,
+            TargetRepo = string.IsNullOrWhiteSpace(targetRepo) ? null : targetRepo,
+            Prompt = prompt,
+            FirstCalls = new[]
+            {
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                $"intent-cli automation summary --domain {domainPlaceholder} --format json"
+            },
+            ForbiddenSources = new[]
+            {
+                "intent-review skill file",
+                "local skill files",
+                "copied prompt files",
+                "intents/rules/**"
+            },
+            LabelOwnership = "All review label transitions delegated to installed `intent-cli automation pr-transition`. Manual `gh ... edit --label` fallback is forbidden.",
+            WorktreeFriendly = "The prompt resolves domain and target-repo from CLI args; no hard-coded local paths."
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideReviewRunResult result)
+    {
+        writer.WriteLine($"# Guide review — {result.Kind}");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.Domain))
+        {
+            writer.WriteLine($"- domain: {result.Domain}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.TargetRepo))
+        {
+            writer.WriteLine($"- target repo: {result.TargetRepo}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## First-call sequence (read-only)");
+        foreach (var call in result.FirstCalls)
+        {
+            writer.WriteLine($"- `{call}`");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Forbidden rule sources");
+        foreach (var src in result.ForbiddenSources)
+        {
+            writer.WriteLine($"- {src}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Label ownership");
+        writer.WriteLine();
+        writer.WriteLine(result.LabelOwnership);
+        writer.WriteLine();
+
+        writer.WriteLine("## Worktree-friendly assumption");
+        writer.WriteLine();
+        writer.WriteLine(result.WorktreeFriendly);
+        writer.WriteLine();
+
+        writer.WriteLine("## Prompt");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(result.Prompt);
+        writer.WriteLine("```");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? domain,
+        out string? targetRepo,
+        out string format,
+        out string error)
+    {
+        domain = null;
+        targetRepo = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domain = args[index + 1];
+                    index++;
+                    break;
+
+                case "--target-repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--target-repo requires a value.";
+                        return false;
+                    }
+
+                    targetRepo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide review run");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only paste-ready skill-free PR review prompt for AI agents.");
+        writer.WriteLine();
+        writer.WriteLine("  --domain is optional; omit to emit a <DOMAIN> placeholder.");
+        writer.WriteLine("  --target-repo is optional; omit to emit a <TARGET_REPO> placeholder.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record GuideReviewRunResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
+
+    [JsonPropertyName("target_repo")]
+    public string? TargetRepo { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+
+    [JsonPropertyName("first_calls")]
+    public required IReadOnlyList<string> FirstCalls { get; init; }
+
+    [JsonPropertyName("forbidden_sources")]
+    public required IReadOnlyList<string> ForbiddenSources { get; init; }
+
+    [JsonPropertyName("label_ownership")]
+    public required string LabelOwnership { get; init; }
+
+    [JsonPropertyName("worktree_friendly")]
+    public required string WorktreeFriendly { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideReviewRunCommandTests.cs
@@ -1,0 +1,278 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideReviewRunCommandTests
+{
+    [Fact]
+    public void Execute_NoArgs_ReturnsMarkdownWithPromptAndForbiddenSources()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            [],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide review — run", output, StringComparison.Ordinal);
+        Assert.Contains("## First-call sequence", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide model --format json", output, StringComparison.Ordinal);
+        Assert.Contains("## Forbidden rule sources", output, StringComparison.Ordinal);
+        Assert.Contains("## Prompt", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithDomainAndTargetRepo_EmitsValuesInMarkdownAndPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("domain: intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("target repo: J-Tech-Japan/intent-system", output, StringComparison.Ordinal);
+        Assert.Contains("J-Tech-Japan/intent-system", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithDomain_EmitsDomainInFirstCallsAndPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        var firstCalls = root.GetProperty("first_calls").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls, c => c!.Contains("automation summary --domain intent-cli --format json", StringComparison.Ordinal));
+        var prompt = root.GetProperty("prompt").GetString()!;
+        Assert.Contains("intent-cli", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("<DOMAIN>", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NoDomain_EmitsDomainPlaceholderInPromptAndFirstCalls()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var firstCalls = document.RootElement.GetProperty("first_calls")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls, c => c!.Contains("automation summary --domain <DOMAIN>", StringComparison.Ordinal));
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("<DOMAIN>", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_EmitsStructuredFields()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("run", root.GetProperty("kind").GetString());
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("target_repo").GetString());
+        Assert.Equal(4, root.GetProperty("first_calls").GetArrayLength());
+        Assert.True(root.GetProperty("forbidden_sources").GetArrayLength() >= 3);
+        Assert.True(root.TryGetProperty("label_ownership", out _));
+        Assert.True(root.TryGetProperty("worktree_friendly", out _));
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("guide review run", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownFormat_ReturnsError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            ["--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Dispatch_GuideReviewRunRoutedThroughCommandRouter_Works()
+    {
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["guide", "review", "run", "--format", "json"],
+            CreateContext(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("run", document.RootElement.GetProperty("kind").GetString());
+    }
+
+    // ── focused-guide-review-run-prompt-tests ───────────
+
+    [Fact]
+    public void Execute_Json_PromptForbidsIntentReviewSkill()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("intent-review", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do not use the `intent-review` skill file", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCoversPreflightBeforeReading()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("automation host-review-preflight", prompt, StringComparison.Ordinal);
+        Assert.Contains("Stage 1", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preflight", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptUsesGuideReviewAndCloseoutPlan()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("guide review --pr", prompt, StringComparison.Ordinal);
+        Assert.Contains("review closeout-plan", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCoversFindingsFirstReviewApproach()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("findings-first", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("approved", prompt, StringComparison.Ordinal);
+        Assert.Contains("request-update", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptDelegatesLabelTransitionsToPrTransition()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("automation pr-transition --transition approved", prompt, StringComparison.Ordinal);
+        Assert.Contains("automation pr-transition --transition request-update", prompt, StringComparison.Ordinal);
+        Assert.Contains("No manual `gh ... edit", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptForbidsMerging()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Do not merge the PR", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_ContainsStagesAndForbiddenSources()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewRunCommand.Execute(
+            CreateContext(),
+            ["--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Stage 1", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Stage 2", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Stage 3", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Stage 4", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("## Forbidden rule sources", output, StringComparison.Ordinal);
+        Assert.Contains("intent-review skill file", output, StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Add `intent-cli guide review run` command (`GuideReviewRunCommand`)
- Generated prompt covers: `automation host-review-preflight` preflight, `guide review` + `review closeout-plan` inputs, findings-first review approach, and `automation pr-transition` label delegation for `approved`/`request-update`
- Prompt explicitly forbids `intent-review` skill files and copied prompt files
- Extend `GuideReviewCommand` to route `run` subtoken (consistent with `guide automation setup` pattern)
- Add 15 focused tests under `focused-guide-review-run-prompt-tests`

Closes #637

## Test plan

- [ ] `dotnet test --filter "FullyQualifiedName~GuideReviewRunCommandTests"` — 15 tests pass
- [ ] `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)