### PR TITLE
G268 Harden closeout pr as intent-closeout skill replacement

### DIFF
--- a/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
@@ -28,7 +28,7 @@ internal static class CloseoutPrCommand
     private const string ContinuationClarificationRequired = "clarification-required";
 
     private const string UsageLine =
-        "Usage: intent-cli closeout pr --pr <n> --repo <owner/repo> [--domain <name>] [--dry-run|--write] [--format json|markdown]";
+        "Usage: intent-cli closeout pr --pr <n> --repo <owner/repo> [--issue <n>] [--domain <name>] [--dry-run|--write] [--format json|markdown]";
 
     /// <summary>
     /// Test seam — replaces the default UTC timestamp source for runs events.
@@ -47,7 +47,7 @@ internal static class CloseoutPrCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var pr, out var repo, out var domainOverride, out var write, out var format, out var error))
+        if (!TryParseArguments(args, out var pr, out var repo, out var domainOverride, out var linkedIssueNumber, out var write, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
@@ -88,10 +88,20 @@ internal static class CloseoutPrCommand
 
         var prToken = pr!.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var matchedItem = queueState.Items.FirstOrDefault(item => MatchesLinkedPr(item.LinkedPr, prToken));
+
+        // Fallback: when linked_pr is absent, resolve via --issue (linked_issue.Number).
+        if (matchedItem is null && linkedIssueNumber.HasValue)
+        {
+            matchedItem = queueState.Items.FirstOrDefault(item =>
+                item.LinkedIssue?.Number == linkedIssueNumber.Value);
+        }
+
         if (matchedItem is null)
         {
-            EmitErrorResult(writer, format, NewFailureResult(domain, repo!, pr.Value, queueStatePath, runsLogPath, write,
-                $"no queue item found with linked_pr matching #{pr}."));
+            var hint = linkedIssueNumber.HasValue
+                ? $"no queue item found with linked_pr matching #{pr} or linked_issue.number {linkedIssueNumber.Value}."
+                : $"no queue item found with linked_pr matching #{pr}. If the queue item has linked_issue but not linked_pr, retry with --issue <n>.";
+            EmitErrorResult(writer, format, NewFailureResult(domain, repo!, pr.Value, queueStatePath, runsLogPath, write, hint));
             return 1;
         }
 
@@ -365,6 +375,7 @@ internal static class CloseoutPrCommand
         out int? pr,
         out string? repo,
         out string? domainOverride,
+        out int? linkedIssueNumber,
         out bool write,
         out string format,
         out string error)
@@ -372,6 +383,7 @@ internal static class CloseoutPrCommand
         pr = null;
         repo = null;
         domainOverride = null;
+        linkedIssueNumber = null;
         write = false;
         var dryRun = false;
         format = FormatMarkdown;
@@ -418,6 +430,23 @@ internal static class CloseoutPrCommand
                     }
 
                     domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--issue":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--issue requires a value.";
+                        return false;
+                    }
+
+                    if (!int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var issueValue) || issueValue <= 0)
+                    {
+                        error = $"--issue must be a positive integer (got '{args[index + 1]}').";
+                        return false;
+                    }
+
+                    linkedIssueNumber = issueValue;
                     index++;
                     break;
 
@@ -486,6 +515,7 @@ internal static class CloseoutPrCommand
         writer.WriteLine("closeout pr");
         writer.WriteLine(UsageLine);
         writer.WriteLine("Records the queue/runs closeout for an accepted child PR. --dry-run plans only; --write applies queue + runs updates. Submodule sync remains a manual next step.");
+        writer.WriteLine("  --issue <n>  Optional: fallback linked-issue number for queue items where linked_pr is absent.");
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
@@ -146,11 +146,31 @@ internal static class CloseoutPrCommand
 
         var continuation = ClassifyContinuation(queueState, matchedItem.ExecutionUnit);
 
-        var nextSteps = new List<string>
+        var nextSteps = new List<string>();
+
+        var linkedIssue = matchedItem.LinkedIssue;
+        if (linkedIssue is not null)
         {
-            $"Sync the parent submodule pointer for {repo} to the merge commit (manual step: git -C submodules/<child> fetch && git -C submodules/<child> reset --hard <merge-sha>; git add submodules/<child>).",
-            "Commit and push the parent durable state (queue-state, runs, submodule pointer)."
-        };
+            if (linkedIssue.Number.HasValue)
+            {
+                nextSteps.Add($"Close the linked issue: `gh issue close {linkedIssue.Number.Value} --repo {linkedIssue.Repo} --comment 'Closed by PR #{pr}.'`");
+            }
+            else if (!string.IsNullOrWhiteSpace(linkedIssue.Url))
+            {
+                nextSteps.Add($"Close the linked issue at {linkedIssue.Url}: `gh issue close <n> --repo {linkedIssue.Repo} --comment 'Closed by PR #{pr}.'`");
+            }
+            else
+            {
+                nextSteps.Add($"Confirm and close the linked issue in {linkedIssue.Repo} (number not resolved): `gh issue close <n> --repo {linkedIssue.Repo} --comment 'Closed by PR #{pr}.'`");
+            }
+        }
+        else
+        {
+            nextSteps.Add("Confirm and close the linked issue if one exists (linked_issue not set in queue state).");
+        }
+
+        nextSteps.Add($"Sync the parent submodule pointer for {repo} to the merge commit (manual step: git -C submodules/<child> fetch && git -C submodules/<child> reset --hard <merge-sha>; git add submodules/<child>).");
+        nextSteps.Add("Commit and push the parent durable state (queue-state, runs, submodule pointer).");
 
         var result = new CloseoutPrResult
         {

--- a/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
@@ -109,14 +109,17 @@ internal static class CloseoutPrCommand
         var beforeState = matchedItem.State.ToString().ToLowerInvariant();
         var mode = write ? ModeWrite : ModeDryRun;
 
-        // Plan the queue transition. Only Active/Review/Fixing → Completed is supported here.
+        // Plan the queue transition. Queued/Active/Review/Fixing → Completed is supported here.
+        // Queued is included because the publish/review loop may leave items in queued state
+        // when the PR is accepted before all intermediate state transitions are recorded.
         if (!alreadyCompleted
+            && matchedItem.State != QueueItemState.Queued
             && matchedItem.State != QueueItemState.Active
             && matchedItem.State != QueueItemState.Review
             && matchedItem.State != QueueItemState.Fixing)
         {
             EmitErrorResult(writer, format, NewFailureResult(domain, repo!, pr.Value, queueStatePath, runsLogPath, write,
-                $"queue item '{matchedItem.ExecutionUnit}' is in state '{beforeState}'; closeout supports active/review/fixing → completed only."));
+                $"queue item '{matchedItem.ExecutionUnit}' is in state '{beforeState}'; closeout supports queued/active/review/fixing → completed only."));
             return 1;
         }
 
@@ -515,6 +518,7 @@ internal static class CloseoutPrCommand
         writer.WriteLine("closeout pr");
         writer.WriteLine(UsageLine);
         writer.WriteLine("Records the queue/runs closeout for an accepted child PR. --dry-run plans only; --write applies queue + runs updates. Submodule sync remains a manual next step.");
+        writer.WriteLine("  Supported states: queued, active, review, fixing → completed.");
         writer.WriteLine("  --issue <n>  Optional: fallback linked-issue number for queue items where linked_pr is absent.");
     }
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -215,7 +215,8 @@ internal static class CommandRouter
                 ["commands"] = GuideCommandsCommand.Execute,
                 ["onboarding"] = GuideOnboardingCommand.Execute,
                 ["intent-work"] = GuideIntentWorkCommand.Execute,
-                ["worker"] = GuideWorkerCommand.Execute
+                ["worker"] = GuideWorkerCommand.Execute,
+                ["closeout"] = GuideCloseoutCommand.Execute
             },
             ["intent"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/GuideCloseoutCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCloseoutCommand.cs
@@ -1,0 +1,40 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G268: Top-level router for <c>intent-cli guide closeout ...</c>.
+/// Routes the <c>run</c> sub-token to <see cref="GuideCloseoutRunCommand"/>.
+/// </summary>
+internal static class GuideCloseoutCommand
+{
+    private const string UsageLine =
+        "Usage: intent-cli guide closeout <run> [--repo <owner/repo>] [--domain <name>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (args.Length >= 1 && string.Equals(args[0], "run", StringComparison.Ordinal))
+        {
+            return GuideCloseoutRunCommand.Execute(context, args[1..], writer);
+        }
+
+        writer.WriteLine("A subcommand is required for 'guide closeout'.");
+        writer.WriteLine(UsageLine);
+        return 1;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide closeout");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Subcommands: run");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GuideCloseoutRunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCloseoutRunCommand.cs
@@ -1,0 +1,301 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G268: Read-only <c>intent-cli guide closeout run</c>. Returns a paste-ready,
+/// skill-free deterministic accepted-PR closeout prompt for AI agents, replacing
+/// routine dependence on local <c>intent-closeout</c> skill files. The prompt
+/// uses <c>closeout pr --dry-run</c> to plan, confirms merge state, closes the
+/// linked issue, syncs the submodule pointer, applies queue/runs state with
+/// <c>closeout pr --write</c>, and emits a parent commit/push checklist.
+/// Never mutates state. Never launches an AI provider.
+/// </summary>
+internal static class GuideCloseoutRunCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide closeout run [--domain <name>] [--repo <owner/repo>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var domain, out var targetRepo, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = BuildCloseoutRun(domain, targetRepo);
+        return EmitResult(writer, format, result);
+    }
+
+    private static int EmitResult(TextWriter writer, string format, GuideCloseoutRunResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static GuideCloseoutRunResult BuildCloseoutRun(string? domain, string? targetRepo)
+    {
+        var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
+        var targetRepoPlaceholder = string.IsNullOrWhiteSpace(targetRepo) ? "<TARGET_REPO>" : targetRepo;
+
+        var prompt =
+$@"Run one accepted-PR closeout wake for domain `{domainPlaceholder}` against `{targetRepoPlaceholder}`. Do not use the `intent-closeout` skill file, local skill files, or copied prompt files.
+
+First-call sequence (read-only; required before any mutation):
+1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
+2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
+3. `intent-cli guide commands list --format json` — primary vs support vs advanced vs experimental classification.
+4. `intent-cli automation summary --domain {domainPlaceholder} --format json` — canonical label-driven contract and capability JSON.
+
+Stage 1 — select an accepted PR (read-only; required before any mutation):
+1. `intent-cli automation host-review-preflight --repo {targetRepoPlaceholder} --format json` → selects an eligible PR (state must include `approved`/`accepted` label).
+   - If the result has no eligible PR, stop with `idle`. Do not proceed.
+2. Note the selected PR number from the preflight result.
+3. `gh pr view <n> --repo {targetRepoPlaceholder}` → confirm the PR is merged (state: `MERGED`). If not yet merged, stop and report `not-yet-merged`.
+
+Stage 2 — plan (dry-run; required before any write):
+1. `intent-cli closeout pr --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --dry-run --format json` → inspect planned queue transition, runs events, continuation hint, and next_steps.
+   - If the result has an `error` field, stop and report the error. Do not apply.
+   - Confirm: execution_unit, queue_state_before → completed, linked issue close command in next_steps.
+2. Note the linked issue close command from `next_steps[0]` if present.
+
+Stage 3 — linked issue close (required before queue write):
+1. If `next_steps[0]` contains a concrete `gh issue close` command: run it exactly as emitted.
+2. If it says `(number not resolved)`: resolve the issue number from `gh pr view <n>` or the linked issue URL, then run `gh issue close <resolved-n> --repo <issue-repo> --comment 'Closed by PR #<n>.'`.
+3. If `next_steps[0]` says `linked_issue not set`: skip this step and note the gap.
+
+Stage 4 — submodule pointer sync (manual operator step):
+1. The operator must sync the parent submodule pointer to the merge commit SHA:
+   ```
+   git -C submodules/<child-repo-name> fetch
+   git -C submodules/<child-repo-name> reset --hard <merge-sha>
+   git add submodules/<child-repo-name>
+   ```
+2. Do not guess the merge SHA; read it from `gh pr view <n> --repo {targetRepoPlaceholder} --json mergeCommit`.
+
+Stage 5 — apply queue/runs state (write):
+1. `intent-cli closeout pr --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --write --format json` → applies queue-state completed transition and appends runs events.
+   - If the result has an `error` field, stop and report the error.
+   - Confirm: mode is `write`, queue_state_after is `completed`.
+
+Stage 6 — parent commit/push checklist (required last step):
+1. Stage parent durable state: `git add .intent-cli/queue-state.json .intent-cli/runs.jsonl submodules/<child-repo-name>`.
+2. Commit: `git commit -m ""closeout: PR #{targetRepoPlaceholder}#<n> — <execution-unit>""`.
+3. Push: `git push`.
+4. Report continuation hint from the closeout result (`next-slice-ready`, `no-actionable-item`, or `clarification-required`).
+
+Hard rules:
+- Do not use the `intent-closeout` skill file or any local skill file.
+- Do not merge the PR from this loop; merging must have happened before closeout is triggered.
+- All label transitions go through installed `intent-cli automation pr-transition`. No manual `gh ... edit --add-label` / `--remove-label` fallback for workflow labels.
+- Do not call `intent-cli run`. `run` is for integration smoke/replay/dogfooding, not the host closeout path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- Process at most one PR closeout per wake.";
+
+        return new GuideCloseoutRunResult
+        {
+            Kind = "run",
+            Domain = string.IsNullOrWhiteSpace(domain) ? null : domain,
+            TargetRepo = string.IsNullOrWhiteSpace(targetRepo) ? null : targetRepo,
+            Prompt = prompt,
+            FirstCalls = new[]
+            {
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                $"intent-cli automation summary --domain {domainPlaceholder} --format json"
+            },
+            ForbiddenSources = new[]
+            {
+                "intent-closeout skill file",
+                "local skill files",
+                "copied prompt files",
+                "intents/rules/**"
+            },
+            LabelOwnership = "All closeout label transitions delegated to installed `intent-cli automation pr-transition`. Manual `gh ... edit --label` fallback is forbidden.",
+            WorktreeFriendly = "The prompt resolves domain and target-repo from CLI args; no hard-coded local paths."
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideCloseoutRunResult result)
+    {
+        writer.WriteLine($"# Guide closeout — {result.Kind}");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.Domain))
+        {
+            writer.WriteLine($"- domain: {result.Domain}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.TargetRepo))
+        {
+            writer.WriteLine($"- target repo: {result.TargetRepo}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## First-call sequence (read-only)");
+        foreach (var call in result.FirstCalls)
+        {
+            writer.WriteLine($"- `{call}`");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Forbidden rule sources");
+        foreach (var src in result.ForbiddenSources)
+        {
+            writer.WriteLine($"- {src}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Label ownership");
+        writer.WriteLine();
+        writer.WriteLine(result.LabelOwnership);
+        writer.WriteLine();
+
+        writer.WriteLine("## Worktree-friendly assumption");
+        writer.WriteLine();
+        writer.WriteLine(result.WorktreeFriendly);
+        writer.WriteLine();
+
+        writer.WriteLine("## Prompt");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(result.Prompt);
+        writer.WriteLine("```");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? domain,
+        out string? targetRepo,
+        out string format,
+        out string error)
+    {
+        domain = null;
+        targetRepo = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domain = args[index + 1];
+                    index++;
+                    break;
+
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value.";
+                        return false;
+                    }
+
+                    targetRepo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide closeout run");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only paste-ready skill-free accepted-PR closeout prompt for AI agents.");
+        writer.WriteLine();
+        writer.WriteLine("  --domain is optional; omit to emit a <DOMAIN> placeholder.");
+        writer.WriteLine("  --repo is optional; omit to emit a <TARGET_REPO> placeholder.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record GuideCloseoutRunResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
+
+    [JsonPropertyName("target_repo")]
+    public string? TargetRepo { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+
+    [JsonPropertyName("first_calls")]
+    public required IReadOnlyList<string> FirstCalls { get; init; }
+
+    [JsonPropertyName("forbidden_sources")]
+    public required IReadOnlyList<string> ForbiddenSources { get; init; }
+
+    [JsonPropertyName("label_ownership")]
+    public required string LabelOwnership { get; init; }
+
+    [JsonPropertyName("worktree_friendly")]
+    public required string WorktreeFriendly { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GuideCloseoutRunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCloseoutRunCommand.cs
@@ -80,7 +80,10 @@ Stage 1 — select an accepted PR (read-only; required before any mutation):
 
 Stage 2 — plan (dry-run; required before any write):
 1. `intent-cli closeout pr --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --dry-run --format json` → inspect planned queue transition, runs events, continuation hint, and next_steps.
-   - If the result has an `error` field, stop and report the error. Do not apply.
+   - If the result contains `linked_issue but not linked_pr` or `retry with --issue`: the queue item has a linked_issue but no linked_pr. Resolve the linked issue number:
+     a. `gh pr view <n> --repo {targetRepoPlaceholder} --json closingIssuesReferences` → extract the issue number from `closingIssuesReferences[0].number`.
+     b. Retry: `intent-cli closeout pr --pr <n> --issue <linked-issue-n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --dry-run --format json`
+   - If the result still has an `error` field after the retry, stop and report the error. Do not apply.
    - Confirm: execution_unit, queue_state_before → completed, linked issue close command in next_steps.
 2. Note the linked issue close command from `next_steps[0]` if present.
 
@@ -99,7 +102,8 @@ Stage 4 — submodule pointer sync (manual operator step):
 2. Do not guess the merge SHA; read it from `gh pr view <n> --repo {targetRepoPlaceholder} --json mergeCommit`.
 
 Stage 5 — apply queue/runs state (write):
-1. `intent-cli closeout pr --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --write --format json` → applies queue-state completed transition and appends runs events.
+1. `intent-cli closeout pr --pr <n> [--issue <linked-issue-n>] --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --write --format json` → applies queue-state completed transition and appends runs events.
+   - Include `--issue <n>` if it was required in Stage 2 dry-run.
    - If the result has an `error` field, stop and report the error.
    - Confirm: mode is `write`, queue_state_after is `completed`.
 

--- a/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
@@ -92,7 +92,7 @@ public sealed class CloseoutPrCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_GivenQueuedItem_FailsWithUnsupportedTransition()
+    public void Execute_GivenQueuedItem_TransitionsToCompleted()
     {
         using var workspace = new CloseoutPrWorkspace();
         workspace.WriteQueueState(BuildQueueState("G246", "queued", linkedPr: "594"));
@@ -103,9 +103,10 @@ public sealed class CloseoutPrCommandTests : IDisposable
             ["--repo", "J-Tech-Japan/intent-system", "--pr", "594", "--write", "--format", "json"],
             writer);
 
-        Assert.Equal(1, exitCode);
+        Assert.Equal(0, exitCode);
         using var document = JsonDocument.Parse(writer.ToString());
-        Assert.Contains("active/review/fixing → completed only", document.RootElement.GetProperty("error").GetString()!, StringComparison.Ordinal);
+        Assert.Equal("queued", document.RootElement.GetProperty("queue_state_before").GetString());
+        Assert.Equal("completed", document.RootElement.GetProperty("queue_state_after").GetString());
     }
 
     [Fact]
@@ -256,6 +257,50 @@ public sealed class CloseoutPrCommandTests : IDisposable
     }
 
     // ── focused-closeout-pr-skill-replacement-tests ───────────
+
+    [Fact]
+    public void Execute_GivenQueuedStateWithLinkedIssueAndNoLinkedPr_ResolvesViaIssueFlagDryRun()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueStateWithLinkedIssue("G268", "queued", linkedIssueNumber: 639));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "640", "--issue", "639", "--dry-run", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("G268", root.GetProperty("execution_unit").GetString());
+        Assert.Equal("dry-run", root.GetProperty("mode").GetString());
+        Assert.Equal("queued", root.GetProperty("queue_state_before").GetString());
+        Assert.Equal("completed", root.GetProperty("queue_state_after").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenQueuedStateWithLinkedIssueAndNoLinkedPr_ResolvesViaIssueFlagWrite()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueStateWithLinkedIssue("G268", "queued", linkedIssueNumber: 639));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "640", "--issue", "639", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("write", root.GetProperty("mode").GetString());
+        Assert.Equal("queued", root.GetProperty("queue_state_before").GetString());
+        Assert.Equal("completed", root.GetProperty("queue_state_after").GetString());
+
+        var queueOnDisk = File.ReadAllText(workspace.Context.GetQueueStatePath());
+        Assert.Contains("\"state\": \"completed\"", queueOnDisk, StringComparison.Ordinal);
+    }
 
     [Fact]
     public void Execute_GivenLinkedIssueWithNoLinkedPr_ResolvesViaIssueFlagDryRun()

--- a/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
@@ -255,6 +255,131 @@ public sealed class CloseoutPrCommandTests : IDisposable
         Assert.Contains("closeout pr", writer.ToString(), StringComparison.Ordinal);
     }
 
+    // ── focused-closeout-pr-skill-replacement-tests ───────────
+
+    [Fact]
+    public void Execute_GivenLinkedIssueWithNoLinkedPr_ResolvesViaIssueFlagDryRun()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueStateWithLinkedIssue("G268", "review", linkedIssueNumber: 639));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "640", "--issue", "639", "--dry-run", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("G268", root.GetProperty("execution_unit").GetString());
+        Assert.Equal("dry-run", root.GetProperty("mode").GetString());
+        Assert.Equal("review", root.GetProperty("queue_state_before").GetString());
+        Assert.Equal("completed", root.GetProperty("queue_state_after").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenLinkedIssueWithNoLinkedPr_ResolvesViaIssueFlagWrite()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueStateWithLinkedIssue("G268", "review", linkedIssueNumber: 639));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "640", "--issue", "639", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("write", root.GetProperty("mode").GetString());
+        Assert.Equal("completed", root.GetProperty("queue_state_after").GetString());
+
+        var queueOnDisk = File.ReadAllText(workspace.Context.GetQueueStatePath());
+        Assert.Contains("\"state\": \"completed\"", queueOnDisk, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenNoLinkedPrAndNoIssueFlagProvided_HintsRetryWithIssueFlag()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueStateWithLinkedIssue("G268", "review", linkedIssueNumber: 639));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "640", "--dry-run", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("retry with --issue", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenLinkedIssueWithNoLinkedPr_NextStepsContainsIssueCloseCommand()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueStateWithLinkedIssue("G268", "review", linkedIssueNumber: 639));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "640", "--issue", "639", "--dry-run", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var nextSteps = document.RootElement.GetProperty("next_steps")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(nextSteps, s => s!.Contains("gh issue close 639", StringComparison.Ordinal));
+        Assert.Contains(nextSteps, s => s!.Contains("Closed by PR #640", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenIssueFlagWithBothLinkedPrAndIssuePresent_PrefersLinkedPrMatch()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G246", "review", linkedPr: "594"));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "594", "--issue", "100", "--dry-run", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("G246", document.RootElement.GetProperty("execution_unit").GetString());
+    }
+
+    private static string BuildQueueStateWithLinkedIssue(string executionUnit, string state, int linkedIssueNumber)
+    {
+        return $$"""
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "{{executionUnit}}",
+                  "title": "title",
+                  "state": "{{state}}",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_issue": {"repo": "J-Tech-Japan/intent-system", "number": {{linkedIssueNumber}}},
+                  "linked_pr": null,
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """;
+    }
+
     private static string BuildQueueState(string executionUnit, string state, string? linkedPr)
     {
         var linked = linkedPr is null ? "null" : $"\"{linkedPr}\"";

--- a/tests/IntentSystem.Cli.Tests/GuideCloseoutRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideCloseoutRunCommandTests.cs
@@ -1,0 +1,316 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideCloseoutRunCommandTests
+{
+    [Fact]
+    public void Execute_NoArgs_ReturnsMarkdownWithPromptAndForbiddenSources()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            [],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide closeout — run", output, StringComparison.Ordinal);
+        Assert.Contains("## First-call sequence", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide model --format json", output, StringComparison.Ordinal);
+        Assert.Contains("## Forbidden rule sources", output, StringComparison.Ordinal);
+        Assert.Contains("## Prompt", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithDomainAndRepo_EmitsValuesInMarkdownAndPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("domain: intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("target repo: J-Tech-Japan/intent-system", output, StringComparison.Ordinal);
+        Assert.Contains("J-Tech-Japan/intent-system", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithDomain_EmitsDomainInFirstCallsAndPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        var firstCalls = root.GetProperty("first_calls").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls, c => c!.Contains("automation summary --domain intent-cli --format json", StringComparison.Ordinal));
+        var prompt = root.GetProperty("prompt").GetString()!;
+        Assert.Contains("intent-cli", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("<DOMAIN>", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NoDomain_EmitsDomainPlaceholderInPromptAndFirstCalls()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var firstCalls = document.RootElement.GetProperty("first_calls")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls, c => c!.Contains("automation summary --domain <DOMAIN>", StringComparison.Ordinal));
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("<DOMAIN>", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_EmitsStructuredFields()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("run", root.GetProperty("kind").GetString());
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("target_repo").GetString());
+        Assert.Equal(4, root.GetProperty("first_calls").GetArrayLength());
+        Assert.True(root.GetProperty("forbidden_sources").GetArrayLength() >= 3);
+        Assert.True(root.TryGetProperty("label_ownership", out _));
+        Assert.True(root.TryGetProperty("worktree_friendly", out _));
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("guide closeout run", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownFormat_ReturnsError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Dispatch_GuideCloseoutRunRoutedThroughCommandRouter_Works()
+    {
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["guide", "closeout", "run", "--format", "json"],
+            CreateContext(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("run", document.RootElement.GetProperty("kind").GetString());
+    }
+
+    // ── focused-closeout-pr-skill-replacement-tests ───────────
+
+    [Fact]
+    public void Execute_Json_PromptForbidsIntentCloseoutSkill()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("intent-closeout", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do not use the `intent-closeout` skill file", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCoversPreflightAndMergeStateCheck()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("automation host-review-preflight", prompt, StringComparison.Ordinal);
+        Assert.Contains("MERGED", prompt, StringComparison.Ordinal);
+        Assert.Contains("not-yet-merged", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCoversDryRunBeforeWrite()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("closeout pr --pr", prompt, StringComparison.Ordinal);
+        Assert.Contains("--dry-run", prompt, StringComparison.Ordinal);
+        Assert.Contains("--write", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCoversLinkedIssueClose()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("gh issue close", prompt, StringComparison.Ordinal);
+        Assert.Contains("Closed by PR", prompt, StringComparison.Ordinal);
+        Assert.Contains("linked issue", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCoversSubmodulePointerSync()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("submodule", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("mergeCommit", prompt, StringComparison.Ordinal);
+        Assert.Contains("reset --hard", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCoversParentCommitPush()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("git commit", prompt, StringComparison.Ordinal);
+        Assert.Contains("git push", prompt, StringComparison.Ordinal);
+        Assert.Contains("queue-state.json", prompt, StringComparison.Ordinal);
+        Assert.Contains("runs.jsonl", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptCoversContinuationClassification()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("continuation", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("next-slice-ready", prompt, StringComparison.Ordinal);
+        Assert.Contains("no-actionable-item", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptForbidsMerging()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Do not merge the PR", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_ContainsStagesAndForbiddenSources()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideCloseoutRunCommand.Execute(
+            CreateContext(),
+            ["--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Stage 1", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Stage 2", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Stage 3", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Stage 4", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Stage 5", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Stage 6", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("## Forbidden rule sources", output, StringComparison.Ordinal);
+        Assert.Contains("intent-closeout skill file", output, StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Harden `intent-cli closeout pr` `next_steps` to include a concrete linked issue close command resolved from `LinkedIssue` (with number, URL, or unresolved fallback)
- Add `intent-cli guide closeout run` — paste-ready skill-free 6-stage accepted-PR closeout prompt covering preflight, merge-state check, dry-run plan, linked issue close, submodule pointer sync, queue/runs write, and parent commit/push
- Add `intent-cli guide closeout` router and wire `["closeout"] = GuideCloseoutCommand.Execute` in the guide group of `CommandRouter`
- 17 tests in `GuideCloseoutRunCommandTests` covering markdown/JSON output, focused `focused-closeout-pr-skill-replacement-tests` section

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~GuideCloseoutRunCommandTests"` — 17/17 passed
- [x] `git diff --check` — no whitespace errors
- [x] `dotnet build` — 0 errors

Fixes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)