### PR TITLE
G271 Add intent-cli guide prompt-matrix command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -216,7 +216,8 @@ internal static class CommandRouter
                 ["onboarding"] = GuideOnboardingCommand.Execute,
                 ["intent-work"] = GuideIntentWorkCommand.Execute,
                 ["worker"] = GuideWorkerCommand.Execute,
-                ["closeout"] = GuideCloseoutCommand.Execute
+                ["closeout"] = GuideCloseoutCommand.Execute,
+                ["prompt-matrix"] = GuidePromptMatrixCommand.Execute
             },
             ["intent"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -1,0 +1,520 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G271: Read-only <c>intent-cli guide prompt-matrix</c>. Returns a canonical
+/// matrix of the four operational modes: recurring child implement/update loop,
+/// recurring host review/next-slice loop, one-shot child implement/update, and
+/// one-shot host review/next-slice. Each entry includes paste-ready prompt text
+/// and subordinate <c>intent-cli guide</c> commands. Never mutates state.
+/// Never launches an AI provider.
+/// </summary>
+internal static class GuidePromptMatrixCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string ModeChildLoop = "child-loop";
+    private const string ModeHostLoop = "host-loop";
+    private const string ModeChildOneshot = "child-oneshot";
+    private const string ModeHostOneshot = "host-oneshot";
+
+    private const string KindLoop = "loop";
+    private const string KindOneshot = "oneshot";
+
+    private const string TargetChild = "child";
+    private const string TargetHost = "host";
+
+    private const string FrequencyGuidanceRecurring =
+        "5 minutes for high-frequency local loops; ~20 minutes for low-frequency local loops; ask the operator for frequency before scheduling";
+
+    private const string FrequencyGuidanceOneshot =
+        "N/A — one-shot execution; frequency is forbidden";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide prompt-matrix [--mode child-loop|host-loop|child-oneshot|host-oneshot] [--format markdown|json]";
+
+    private static readonly string[] ForbiddenSources =
+    [
+        "intents/rules/**",
+        "local skill files (gh-issue-to-pr, gh-fix-pr-comment, etc.)",
+        "copied prompt files"
+    ];
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var mode, out var format, out var domain, out var targetRepo, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var entries = BuildEntries(mode, domain, targetRepo);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            if (mode is not null)
+            {
+                // Single entry
+                writer.Write(JsonSerializer.Serialize(entries[0], JsonOptions));
+            }
+            else
+            {
+                writer.Write(JsonSerializer.Serialize(entries, JsonOptions));
+            }
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, entries);
+        }
+
+        return 0;
+    }
+
+    private static IReadOnlyList<GuidePromptMatrixEntry> BuildEntries(
+        string? mode,
+        string? domain,
+        string? targetRepo)
+    {
+        var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
+        var targetRepoPlaceholder = string.IsNullOrWhiteSpace(targetRepo) ? "<TARGET-REPO>" : targetRepo;
+
+        var all = new[]
+        {
+            BuildChildLoop(domainPlaceholder),
+            BuildHostLoop(domainPlaceholder, targetRepoPlaceholder),
+            BuildChildOneshot(domainPlaceholder),
+            BuildHostOneshot(domainPlaceholder, targetRepoPlaceholder)
+        };
+
+        if (mode is null)
+        {
+            return all;
+        }
+
+        return mode switch
+        {
+            ModeChildLoop => [all[0]],
+            ModeHostLoop => [all[1]],
+            ModeChildOneshot => [all[2]],
+            ModeHostOneshot => [all[3]],
+            _ => all
+        };
+    }
+
+    private static GuidePromptMatrixEntry BuildChildLoop(string domainPlaceholder)
+    {
+        var prompt =
+$@"Set up the child implementation loop for the repo in the current worktree. Run the loop body exactly once per wake; the operator or scheduler drives subsequent wakes.
+
+IMPORTANT — ask the operator for the desired frequency before creating any cron, monitor, or recurring wakeup. Never guess or use a tool-default interval.
+- High-frequency local loops (active development): 5 minutes.
+- Low-frequency local loops (background / idle polling): ~20 minutes.
+- Local same-thread loops are the baseline for workflows that depend on local paths or local `.intent-cli` packages. Cloud or new-thread schedulers cannot access local paths.
+
+First-call sequence (read-only; required before any mutation):
+1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
+2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
+3. `intent-cli guide commands list --format json` — `primary` vs `support` vs `advanced` (`run`) vs `experimental` classification.
+4. `intent-cli automation summary --domain {domainPlaceholder} --format json` — canonical label-driven contract and capability JSON for the parent intent domain.
+
+Loop body (single wake; the operator drives subsequent wakes if any):
+1. Save the child worktree path: `CHILD_WORKTREE=""$PWD""`. Confirm it is a git worktree root. Stop with `wrong-worktree` if not.
+2. Resolve `<OWNER>/<REPO>` from the child cwd: `gh repo view --json nameWithOwner --jq .nameWithOwner` (fall back to `git remote get-url origin`).
+3. `git fetch --all --prune` and `git status --short`. If dirty in a dedicated automation worktree, clean local residue (`git reset --hard`, `git clean -fd`, submodule reset). Never `git clean -fdx`. Never clean a personal/shared checkout.
+4. From the parent host root (NOT the child cwd), run `intent-cli worker next-action --repo <OWNER>/<REPO> --workdir $CHILD_WORKTREE --format json`. Dispatch on `action`:
+   - `none` → stop with `idle`.
+   - `issue-to-pr` → claim with `intent-cli worker claim --kind issue --number <n> --write --format json`, run the issue-to-PR workflow on the returned URL only, classify outcome, then `worker result-summary --kind issue-to-pr ...` and `worker complete --kind issue --number <n> --outcome <outcome> --write --format json`.
+   - `pr-comment-fix` → claim with `intent-cli worker claim --kind pr --number <n> --write --format json`, repair only the narrow requested change on the PR branch, classify outcome, then `worker result-summary --kind pr-comment-fix ...` and `worker complete --kind pr --number <n> --outcome <outcome> --write --format json`.
+
+Hard rules:
+- Do not read `intents/rules/**`, local skill files (`gh-issue-to-pr`, `gh-fix-pr-comment`, etc.), or copied prompt files for routine collaboration. Use `intent-cli guide ...` instead.
+- Do not call `intent-cli run` from this loop. `run` is advanced runtime (integration smoke / replay / dogfooding), not the chat-first path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- All label transitions go through installed `intent-cli automation` / `intent-cli worker` commands. No manual `gh ... edit --add-label` / `--remove-label` fallback for workflow labels.
+- Never apply `intent-target` from the child loop; it is host-owned.
+- Never apply `intent-pr-created` to a PR; it is an issue-side completion marker.
+- Process at most one action per wake.";
+
+        return new GuidePromptMatrixEntry
+        {
+            Mode = ModeChildLoop,
+            Kind = KindLoop,
+            Target = TargetChild,
+            FrequencyGuidance = FrequencyGuidanceRecurring,
+            ForbiddenSources = ForbiddenSources,
+            FirstCalls =
+            [
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                $"intent-cli automation summary --domain {domainPlaceholder} --format json"
+            ],
+            Prompt = prompt
+        };
+    }
+
+    private static GuidePromptMatrixEntry BuildHostLoop(string domainPlaceholder, string targetRepoPlaceholder)
+    {
+        var prompt =
+$@"Set up the host review and next-slice loop for domain `{domainPlaceholder}` against `{targetRepoPlaceholder}`. Run the loop body exactly once per wake; the operator or scheduler drives subsequent wakes.
+
+IMPORTANT — ask the operator for the desired frequency before creating any cron, monitor, or recurring wakeup. Never guess or use a tool-default interval.
+- High-frequency local loops (active development): 5 minutes.
+- Low-frequency local loops (background / idle polling): ~20 minutes.
+- Local same-thread loops are the baseline for workflows that depend on local paths or local `.intent-cli` packages. Cloud or new-thread schedulers cannot access local paths.
+
+First-call sequence (read-only; required before any mutation):
+1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
+2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
+3. `intent-cli guide commands list --format json` — surface `primary` / `support` / `advanced` / `experimental` buckets.
+4. `intent-cli automation summary --domain {domainPlaceholder} --format json` — canonical label-driven contract and capability JSON.
+5. `intent-cli intent status --domain {domainPlaceholder} --format json` — current baseline / WIP / queued / clarifications.
+6. `intent-cli intent next-slice --dry-run --domain {domainPlaceholder} --target-repo {targetRepoPlaceholder} --format json` — verify WIP cap and clarification gates.
+
+Loop body (single wake):
+1. Confirm cwd is the parent host repo root.
+2. Stage 1 — review/closeout:
+   - `intent-cli automation host-review-preflight --repo {targetRepoPlaceholder} --format json` to find an eligible PR.
+   - For the selected PR: `intent-cli review closeout-plan --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --format json` and `intent-cli guide review --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --format json`.
+   - If review passes: `intent-cli automation pr-transition --transition approved --repo {targetRepoPlaceholder} --pr <n> --write --format json`, merge via the host's existing merge step, then `intent-cli closeout pr --pr <n> --repo {targetRepoPlaceholder} --write --format json`.
+   - If review needs repair: leave an actionable PR comment, then `intent-cli automation pr-transition --transition request-update --repo {targetRepoPlaceholder} --pr <n> --write --format json`.
+3. Stage 2 — next-slice (only if WIP cap and clarification gates allow):
+   - `intent-cli intent next-slice --dry-run --domain {domainPlaceholder} --target-repo {targetRepoPlaceholder} --format json` — confirm `recommended_outcome` is `issue-cut-ready`.
+   - `intent-cli packet draft --execution-unit <id> --target-repo {targetRepoPlaceholder} --dry-run --format markdown` — preview the packet.
+   - With operator acceptance: `intent-cli packet draft --execution-unit <id> --target-repo {targetRepoPlaceholder} --format json` then `intent-cli issue publish-flow <id> --repo {targetRepoPlaceholder} --write --format json`.
+   - After parent durable state is pushed: `intent-cli automation issue-publish --repo {targetRepoPlaceholder} --issue <n> --write --format json`.
+
+Hard rules:
+- Do not read `intents/rules/**`, local skill files, or copied prompt files for routine review/closeout. Use `intent-cli guide ...` and `intent-cli automation ...` instead.
+- Do not call `intent-cli run`. `run` is advanced runtime, not the host review/closeout path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- Every label transition goes through installed `intent-cli automation pr-transition` / `automation issue-publish` / `worker claim` / `worker complete`. No manual `gh ... edit --add-label` / `--remove-label` fallback.
+- Never apply `intent-pr-created` to a PR.
+- Honor the WIP cap: do not cut a new child issue while any open `intent-target` issue/PR remains.
+- Stop on Hard Clarification rather than guessing when source-of-truth is ambiguous.
+- Process at most one PR review and one new child issue per wake.";
+
+        return new GuidePromptMatrixEntry
+        {
+            Mode = ModeHostLoop,
+            Kind = KindLoop,
+            Target = TargetHost,
+            FrequencyGuidance = FrequencyGuidanceRecurring,
+            ForbiddenSources = ForbiddenSources,
+            FirstCalls =
+            [
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                $"intent-cli automation summary --domain {domainPlaceholder} --format json",
+                $"intent-cli intent status --domain {domainPlaceholder} --format json",
+                $"intent-cli intent next-slice --dry-run --domain {domainPlaceholder} --target-repo {targetRepoPlaceholder} --format json"
+            ],
+            Prompt = prompt
+        };
+    }
+
+    private static GuidePromptMatrixEntry BuildChildOneshot(string domainPlaceholder)
+    {
+        var prompt =
+$@"Run one child implementation/update wake exactly once.
+
+Do not create or update any automation, loop, cron, monitor, reminder, or recurring wakeup. This is a one-shot execution. Frequency is forbidden.
+
+First-call sequence (read-only; required before any mutation):
+1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
+2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
+3. `intent-cli guide commands list --format json` — `primary` vs `support` vs `advanced` (`run`) vs `experimental` classification.
+4. `intent-cli automation summary --domain {domainPlaceholder} --format json` — canonical label-driven contract and capability JSON for the parent intent domain.
+
+Loop body (single wake only — do not repeat):
+1. Save the child worktree path: `CHILD_WORKTREE=""$PWD""`. Confirm it is a git worktree root. Stop with `wrong-worktree` if not.
+2. Resolve `<OWNER>/<REPO>` from the child cwd: `gh repo view --json nameWithOwner --jq .nameWithOwner` (fall back to `git remote get-url origin`).
+3. `git fetch --all --prune` and `git status --short`. If dirty in a dedicated automation worktree, clean local residue (`git reset --hard`, `git clean -fd`, submodule reset). Never `git clean -fdx`. Never clean a personal/shared checkout.
+4. From the parent host root (NOT the child cwd), run `intent-cli worker next-action --repo <OWNER>/<REPO> --workdir $CHILD_WORKTREE --format json`. Dispatch on `action`:
+   - `none` → stop with `idle`.
+   - `issue-to-pr` → claim with `intent-cli worker claim --kind issue --number <n> --write --format json`, run the issue-to-PR workflow on the returned URL only, classify outcome, then `worker result-summary --kind issue-to-pr ...` and `worker complete --kind issue --number <n> --outcome <outcome> --write --format json`.
+   - `pr-comment-fix` → claim with `intent-cli worker claim --kind pr --number <n> --write --format json`, repair only the narrow requested change on the PR branch, classify outcome, then `worker result-summary --kind pr-comment-fix ...` and `worker complete --kind pr --number <n> --outcome <outcome> --write --format json`.
+
+Hard rules:
+- Do not read `intents/rules/**`, local skill files (`gh-issue-to-pr`, `gh-fix-pr-comment`, etc.), or copied prompt files for routine collaboration. Use `intent-cli guide ...` instead.
+- Do not call `intent-cli run` from this loop. `run` is advanced runtime (integration smoke / replay / dogfooding), not the chat-first path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- All label transitions go through installed `intent-cli automation` / `intent-cli worker` commands. No manual `gh ... edit --add-label` / `--remove-label` fallback for workflow labels.
+- Never apply `intent-target` from the child loop; it is host-owned.
+- Never apply `intent-pr-created` to a PR; it is an issue-side completion marker.
+- Process at most one action per wake.
+- Do not create a cron, monitor, scheduler, reminder, or new thread after completing this wake.";
+
+        return new GuidePromptMatrixEntry
+        {
+            Mode = ModeChildOneshot,
+            Kind = KindOneshot,
+            Target = TargetChild,
+            FrequencyGuidance = FrequencyGuidanceOneshot,
+            ForbiddenSources = ForbiddenSources,
+            FirstCalls =
+            [
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                $"intent-cli automation summary --domain {domainPlaceholder} --format json"
+            ],
+            Prompt = prompt
+        };
+    }
+
+    private static GuidePromptMatrixEntry BuildHostOneshot(string domainPlaceholder, string targetRepoPlaceholder)
+    {
+        var prompt =
+$@"Run the host review and next-slice for domain `{domainPlaceholder}` against `{targetRepoPlaceholder}` exactly once.
+
+Do not create or update any automation, loop, cron, monitor, reminder, or recurring wakeup. This is a one-shot execution. Frequency is forbidden.
+
+First-call sequence (read-only; required before any mutation):
+1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
+2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
+3. `intent-cli guide commands list --format json` — surface `primary` / `support` / `advanced` / `experimental` buckets.
+4. `intent-cli automation summary --domain {domainPlaceholder} --format json` — canonical label-driven contract and capability JSON.
+5. `intent-cli intent status --domain {domainPlaceholder} --format json` — current baseline / WIP / queued / clarifications.
+6. `intent-cli intent next-slice --dry-run --domain {domainPlaceholder} --target-repo {targetRepoPlaceholder} --format json` — verify WIP cap and clarification gates.
+
+Loop body (single wake only — do not repeat):
+1. Confirm cwd is the parent host repo root.
+2. Stage 1 — review/closeout:
+   - `intent-cli automation host-review-preflight --repo {targetRepoPlaceholder} --format json` to find an eligible PR.
+   - For the selected PR: `intent-cli review closeout-plan --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --format json` and `intent-cli guide review --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --format json`.
+   - If review passes: `intent-cli automation pr-transition --transition approved --repo {targetRepoPlaceholder} --pr <n> --write --format json`, merge via the host's existing merge step, then `intent-cli closeout pr --pr <n> --repo {targetRepoPlaceholder} --write --format json`.
+   - If review needs repair: leave an actionable PR comment, then `intent-cli automation pr-transition --transition request-update --repo {targetRepoPlaceholder} --pr <n> --write --format json`.
+3. Stage 2 — next-slice (only if WIP cap and clarification gates allow):
+   - `intent-cli intent next-slice --dry-run --domain {domainPlaceholder} --target-repo {targetRepoPlaceholder} --format json` — confirm `recommended_outcome` is `issue-cut-ready`.
+   - `intent-cli packet draft --execution-unit <id> --target-repo {targetRepoPlaceholder} --dry-run --format markdown` — preview the packet.
+   - With operator acceptance: `intent-cli packet draft --execution-unit <id> --target-repo {targetRepoPlaceholder} --format json` then `intent-cli issue publish-flow <id> --repo {targetRepoPlaceholder} --write --format json`.
+   - After parent durable state is pushed: `intent-cli automation issue-publish --repo {targetRepoPlaceholder} --issue <n> --write --format json`.
+
+Hard rules:
+- Do not read `intents/rules/**`, local skill files, or copied prompt files for routine review/closeout. Use `intent-cli guide ...` and `intent-cli automation ...` instead.
+- Do not call `intent-cli run`. `run` is advanced runtime, not the host review/closeout path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- Every label transition goes through installed `intent-cli automation pr-transition` / `automation issue-publish` / `worker claim` / `worker complete`. No manual `gh ... edit --add-label` / `--remove-label` fallback.
+- Never apply `intent-pr-created` to a PR.
+- Honor the WIP cap: do not cut a new child issue while any open `intent-target` issue/PR remains.
+- Stop on Hard Clarification rather than guessing when source-of-truth is ambiguous.
+- Process at most one PR review and one new child issue per wake.
+- Do not create a cron, monitor, scheduler, reminder, or new thread after completing this wake.";
+
+        return new GuidePromptMatrixEntry
+        {
+            Mode = ModeHostOneshot,
+            Kind = KindOneshot,
+            Target = TargetHost,
+            FrequencyGuidance = FrequencyGuidanceOneshot,
+            ForbiddenSources = ForbiddenSources,
+            FirstCalls =
+            [
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                $"intent-cli automation summary --domain {domainPlaceholder} --format json",
+                $"intent-cli intent status --domain {domainPlaceholder} --format json",
+                $"intent-cli intent next-slice --dry-run --domain {domainPlaceholder} --target-repo {targetRepoPlaceholder} --format json"
+            ],
+            Prompt = prompt
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, IReadOnlyList<GuidePromptMatrixEntry> entries)
+    {
+        writer.WriteLine("# Guide prompt matrix");
+        writer.WriteLine();
+        writer.WriteLine("Canonical matrix of the four operational modes.");
+        writer.WriteLine();
+
+        foreach (var entry in entries)
+        {
+            writer.WriteLine($"## Mode: {entry.Mode}");
+            writer.WriteLine();
+            writer.WriteLine($"- kind: {entry.Kind}");
+            writer.WriteLine($"- target: {entry.Target}");
+            writer.WriteLine($"- frequency_guidance: {entry.FrequencyGuidance}");
+            writer.WriteLine();
+
+            writer.WriteLine("### First-call sequence (read-only)");
+            foreach (var call in entry.FirstCalls)
+            {
+                writer.WriteLine($"- `{call}`");
+            }
+            writer.WriteLine();
+
+            writer.WriteLine("### Forbidden rule sources");
+            foreach (var src in entry.ForbiddenSources)
+            {
+                writer.WriteLine($"- {src}");
+            }
+            writer.WriteLine();
+
+            writer.WriteLine("### Prompt");
+            writer.WriteLine();
+            writer.WriteLine("```text");
+            writer.WriteLine(entry.Prompt);
+            writer.WriteLine("```");
+            writer.WriteLine();
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? mode,
+        out string format,
+        out string? domain,
+        out string? targetRepo,
+        out string error)
+    {
+        mode = null;
+        format = FormatMarkdown;
+        domain = null;
+        targetRepo = null;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--mode":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--mode requires a value (child-loop, host-loop, child-oneshot, host-oneshot).";
+                        return false;
+                    }
+
+                    var requestedMode = args[index + 1];
+                    if (!string.Equals(requestedMode, ModeChildLoop, StringComparison.Ordinal)
+                        && !string.Equals(requestedMode, ModeHostLoop, StringComparison.Ordinal)
+                        && !string.Equals(requestedMode, ModeChildOneshot, StringComparison.Ordinal)
+                        && !string.Equals(requestedMode, ModeHostOneshot, StringComparison.Ordinal))
+                    {
+                        error = $"--mode must be 'child-loop', 'host-loop', 'child-oneshot', or 'host-oneshot' (got '{requestedMode}').";
+                        return false;
+                    }
+
+                    mode = requestedMode;
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+
+                    domain = args[index + 1];
+                    index++;
+                    break;
+
+                case "--target-repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--target-repo requires a value.";
+                        return false;
+                    }
+
+                    targetRepo = args[index + 1];
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide prompt-matrix");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only canonical matrix of the four operational modes with paste-ready prompt text.");
+        writer.WriteLine();
+        writer.WriteLine("Modes:");
+        writer.WriteLine($"- {ModeChildLoop}    recurring child implement/update loop");
+        writer.WriteLine($"- {ModeHostLoop}     recurring host review/next-slice loop");
+        writer.WriteLine($"- {ModeChildOneshot} one-shot child implement/update");
+        writer.WriteLine($"- {ModeHostOneshot}  one-shot host review/next-slice");
+        writer.WriteLine();
+        writer.WriteLine("Omit --mode to get all four entries.");
+        writer.WriteLine("--domain and --target-repo are optional; omit to use placeholders.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record GuidePromptMatrixEntry
+{
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("target")]
+    public required string Target { get; init; }
+
+    [JsonPropertyName("frequency_guidance")]
+    public required string FrequencyGuidance { get; init; }
+
+    [JsonPropertyName("forbidden_sources")]
+    public required IReadOnlyList<string> ForbiddenSources { get; init; }
+
+    [JsonPropertyName("first_calls")]
+    public required IReadOnlyList<string> FirstCalls { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
@@ -1,0 +1,603 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuidePromptMatrixCommandTests
+{
+    // ── all-modes tests ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_NoArgs_DefaultsToMarkdownAllFourModes()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            [],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide prompt matrix", output, StringComparison.Ordinal);
+        Assert.Contains("child-loop", output, StringComparison.Ordinal);
+        Assert.Contains("host-loop", output, StringComparison.Ordinal);
+        Assert.Contains("child-oneshot", output, StringComparison.Ordinal);
+        Assert.Contains("host-oneshot", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_JsonNoMode_ReturnsArrayOfFourEntries()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+        Assert.Equal(4, document.RootElement.GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_JsonNoMode_AllEntriesHaveRequiredFields()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        foreach (var entry in document.RootElement.EnumerateArray())
+        {
+            Assert.True(entry.TryGetProperty("mode", out _), "mode missing");
+            Assert.True(entry.TryGetProperty("kind", out _), "kind missing");
+            Assert.True(entry.TryGetProperty("target", out _), "target missing");
+            Assert.True(entry.TryGetProperty("frequency_guidance", out _), "frequency_guidance missing");
+            Assert.True(entry.TryGetProperty("forbidden_sources", out _), "forbidden_sources missing");
+            Assert.True(entry.TryGetProperty("first_calls", out _), "first_calls missing");
+            Assert.True(entry.TryGetProperty("prompt", out _), "prompt missing");
+        }
+    }
+
+    [Fact]
+    public void Execute_JsonNoMode_AllEntriesContainForbiddenSources()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        foreach (var entry in document.RootElement.EnumerateArray())
+        {
+            var sources = entry.GetProperty("forbidden_sources")
+                .EnumerateArray().Select(e => e.GetString()).ToArray();
+            Assert.Contains(sources, s => s!.Contains("intents/rules/**", StringComparison.Ordinal));
+            Assert.Contains(sources, s => s!.Contains("local skill files", StringComparison.Ordinal));
+            Assert.Contains(sources, s => s!.Contains("copied prompt files", StringComparison.Ordinal));
+        }
+    }
+
+    // ── child-loop tests ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_ModeChildLoopJson_ReturnsLoopKindAndChildTarget()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("child-loop", root.GetProperty("mode").GetString());
+        Assert.Equal("loop", root.GetProperty("kind").GetString());
+        Assert.Equal("child", root.GetProperty("target").GetString());
+    }
+
+    [Fact]
+    public void Execute_ModeChildLoopJson_RecurringFrequencyGuidanceContains5mAnd20m()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var freq = document.RootElement.GetProperty("frequency_guidance").GetString()!;
+        Assert.Contains("5 minutes", freq, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("20 minutes", freq, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ModeChildLoopJson_FirstCallsIncludeGuideCommands()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var firstCalls = document.RootElement.GetProperty("first_calls")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls, c => c!.StartsWith("intent-cli guide model", StringComparison.Ordinal));
+        Assert.Contains(firstCalls, c => c!.StartsWith("intent-cli guide onboarding", StringComparison.Ordinal));
+        Assert.Contains(firstCalls, c => c!.StartsWith("intent-cli guide commands list", StringComparison.Ordinal));
+        Assert.Contains(firstCalls, c => c!.Contains("automation summary", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_ModeChildLoopJson_PromptContainsFrequencyAskAndRecurringGuidance()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("ask the operator for the desired frequency", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("5 minutes", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("20 minutes", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ModeChildLoopJson_PromptContainsForbiddenCalls()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Do not call `intent-cli run`", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do not run `dotnet run`", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-target", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-pr-created", prompt, StringComparison.Ordinal);
+    }
+
+    // ── host-loop tests ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_ModeHostLoopJson_ReturnsLoopKindAndHostTarget()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("host-loop", root.GetProperty("mode").GetString());
+        Assert.Equal("loop", root.GetProperty("kind").GetString());
+        Assert.Equal("host", root.GetProperty("target").GetString());
+    }
+
+    [Fact]
+    public void Execute_ModeHostLoopJson_RecurringFrequencyGuidanceContains5mAnd20m()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var freq = document.RootElement.GetProperty("frequency_guidance").GetString()!;
+        Assert.Contains("5 minutes", freq, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("20 minutes", freq, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ModeHostLoopJson_FirstCallsIncludeSixCommands()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var firstCalls = document.RootElement.GetProperty("first_calls")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Equal(6, firstCalls.Length);
+        Assert.Contains(firstCalls, c => c!.Contains("intent status", StringComparison.Ordinal));
+        Assert.Contains(firstCalls, c => c!.Contains("next-slice --dry-run", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_ModeHostLoopJson_PromptContainsFrequencyAskAndRecurringGuidance()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("ask the operator for the desired frequency", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("5 minutes", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("20 minutes", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── child-oneshot tests ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_ModeChildOneshotJson_ReturnsOneshotKindAndChildTarget()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-oneshot", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("child-oneshot", root.GetProperty("mode").GetString());
+        Assert.Equal("oneshot", root.GetProperty("kind").GetString());
+        Assert.Equal("child", root.GetProperty("target").GetString());
+    }
+
+    [Fact]
+    public void Execute_ModeChildOneshotJson_FrequencyGuidanceIsNAForbidden()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-oneshot", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var freq = document.RootElement.GetProperty("frequency_guidance").GetString()!;
+        Assert.Contains("N/A", freq, StringComparison.Ordinal);
+        Assert.Contains("forbidden", freq, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ModeChildOneshotJson_PromptContainsSchedulerProhibition()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-oneshot", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Do not create or update any automation", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cron", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("monitor", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("recurring wakeup", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ModeChildOneshotJson_PromptContainsForbiddenCalls()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-oneshot", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Do not call `intent-cli run`", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do not run `dotnet run`", prompt, StringComparison.Ordinal);
+    }
+
+    // ── host-oneshot tests ───────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_ModeHostOneshotJson_ReturnsOneshotKindAndHostTarget()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-oneshot", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("host-oneshot", root.GetProperty("mode").GetString());
+        Assert.Equal("oneshot", root.GetProperty("kind").GetString());
+        Assert.Equal("host", root.GetProperty("target").GetString());
+    }
+
+    [Fact]
+    public void Execute_ModeHostOneshotJson_FrequencyGuidanceIsNAForbidden()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-oneshot", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var freq = document.RootElement.GetProperty("frequency_guidance").GetString()!;
+        Assert.Contains("N/A", freq, StringComparison.Ordinal);
+        Assert.Contains("forbidden", freq, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ModeHostOneshotJson_PromptContainsSchedulerProhibition()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-oneshot", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Do not create or update any automation", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cron", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("monitor", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("recurring wakeup", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ModeHostOneshotJson_FirstCallsIncludeSixCommands()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-oneshot", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var firstCalls = document.RootElement.GetProperty("first_calls")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Equal(6, firstCalls.Length);
+    }
+
+    // ── domain / target-repo placeholder tests ───────────────────────────
+
+    [Fact]
+    public void Execute_NoDomainNoTargetRepo_UsesPlaceholders()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var hostLoop = document.RootElement.EnumerateArray()
+            .First(e => e.GetProperty("mode").GetString() == "host-loop");
+        var prompt = hostLoop.GetProperty("prompt").GetString()!;
+        Assert.Contains("<DOMAIN>", prompt, StringComparison.Ordinal);
+        Assert.Contains("<TARGET-REPO>", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithDomainAndTargetRepo_UsesParsedValues()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var hostLoop = document.RootElement.EnumerateArray()
+            .First(e => e.GetProperty("mode").GetString() == "host-loop");
+        var prompt = hostLoop.GetProperty("prompt").GetString()!;
+        Assert.Contains("intent-cli", prompt, StringComparison.Ordinal);
+        Assert.Contains("J-Tech-Japan/intent-system", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("<DOMAIN>", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("<TARGET-REPO>", prompt, StringComparison.Ordinal);
+    }
+
+    // ── markdown output tests ─────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_MarkdownAllModes_ContainsAllModeHeaders()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("## Mode: child-loop", output, StringComparison.Ordinal);
+        Assert.Contains("## Mode: host-loop", output, StringComparison.Ordinal);
+        Assert.Contains("## Mode: child-oneshot", output, StringComparison.Ordinal);
+        Assert.Contains("## Mode: host-oneshot", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MarkdownAllModes_ContainsForbiddenSourcesSections()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--format", "markdown"],
+            writer);
+
+        var output = writer.ToString();
+        Assert.Contains("### Forbidden rule sources", output, StringComparison.Ordinal);
+        Assert.Contains("intents/rules/**", output, StringComparison.Ordinal);
+        Assert.Contains("local skill files", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MarkdownSingleMode_ContainsOnlyThatModeHeader()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-oneshot", "--format", "markdown"],
+            writer);
+
+        var output = writer.ToString();
+        Assert.Contains("## Mode: child-oneshot", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("## Mode: child-loop", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("## Mode: host-loop", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("## Mode: host-oneshot", output, StringComparison.Ordinal);
+    }
+
+    // ── error cases ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_UnknownMode_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "unknown-mode"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--mode must be", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownFormat_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--bogus", "value"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument '--bogus'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("guide prompt-matrix", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    // ── routing via CommandRouter ─────────────────────────────────────────
+
+    [Fact]
+    public void Dispatch_GuidePromptMatrixRoutedThroughCommandRouter_Works()
+    {
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["guide", "prompt-matrix", "--mode", "child-loop", "--format", "json"],
+            CreateContext(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("child-loop", document.RootElement.GetProperty("mode").GetString());
+    }
+
+    [Fact]
+    public void Dispatch_GuidePromptMatrixJsonAllModes_RoutedSuccessfully()
+    {
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["guide", "prompt-matrix", "--format", "json"],
+            CreateContext(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+        Assert.Equal(4, document.RootElement.GetArrayLength());
+    }
+
+    // ── all entries must ban run and dotnet-run ──────────────────────────
+
+    [Theory]
+    [InlineData("child-loop")]
+    [InlineData("host-loop")]
+    [InlineData("child-oneshot")]
+    [InlineData("host-oneshot")]
+    public void Execute_AnyMode_PromptBansDotnetRunAndIntentCliRun(string modeValue)
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", modeValue, "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Do not run `dotnet run`", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli run", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("child-loop")]
+    [InlineData("host-loop")]
+    [InlineData("child-oneshot")]
+    [InlineData("host-oneshot")]
+    public void Execute_AnyMode_ForbiddenSourcesContainsAllThree(string modeValue)
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", modeValue, "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var sources = document.RootElement.GetProperty("forbidden_sources")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.True(sources.Length >= 3);
+        Assert.Contains(sources, s => s!.Contains("intents/rules/**", StringComparison.Ordinal));
+        Assert.Contains(sources, s => s!.Contains("local skill files", StringComparison.Ordinal));
+        Assert.Contains(sources, s => s!.Contains("copied prompt files", StringComparison.Ordinal));
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `intent-cli guide prompt-matrix` command (G271) with a canonical four-mode matrix
- Covers all four operational modes: `child-loop`, `host-loop`, `child-oneshot`, `host-oneshot`
- Each entry includes `mode`, `kind`, `target`, `frequency_guidance`, `forbidden_sources`, `first_calls`, and paste-ready `prompt`
- Recurring entries require explicit frequency and recommend 5m / ~20m; explicitly ask operator before scheduling
- One-shot entries explicitly forbid scheduler/cron/monitor/new-thread creation
- All entries forbid `intents/rules/**`, local skill files, copied prompt files, `dotnet run`, `intent-cli run`
- Supports `--format markdown` (default) and `--format json`
- Optional `--mode` flag filters to one entry; optional `--domain` and `--target-repo` replace placeholders
- Registered in `CommandRouter.cs` under `guide` group
- 40 new tests in `GuidePromptMatrixCommandTests.cs`; full suite: 1911 passed, 1 skipped, 0 failed

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~GuidePromptMatrixCommandTests"` — 40 passed
- [x] `dotnet test --filter "FullyQualifiedName!~DotnetToolExec"` — 1911 passed, 1 skipped, 0 failed
- [x] Verified all four modes return correct `kind` and `target` values
- [x] Verified recurring entries contain 5m/20m guidance and frequency-ask requirement
- [x] Verified one-shot entries contain scheduler prohibition
- [x] Verified all entries contain all three forbidden sources
- [x] Verified routing via `CommandRouter.Execute(["guide", "prompt-matrix", ...])`
- [x] Verified error cases: unknown mode, unknown format, unknown argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)