### PR TITLE
G275 Fix next-slice domain/repo filter, clarification gate, and issue-cut-ready outcome

### DIFF
--- a/src/IntentSystem.Cli/Commands/ClarificationOpenDetector.cs
+++ b/src/IntentSystem.Cli/Commands/ClarificationOpenDetector.cs
@@ -8,6 +8,11 @@ namespace IntentSystem.Cli.Commands;
 /// blocking. Detect open blockers structurally so durable prose / recently-resolved
 /// notes do not falsely look like an open blocker (G179 review fix; reused by
 /// G180 context collect).
+///
+/// G275: Also recognises two cleared states:
+/// - YAML front-matter containing <c>intent_state: clarified</c>
+/// - A "Current Open Blockers" section whose only content is the literal text
+///   <c>None</c> (case-insensitive) or the established no-blocker sentinel.
 /// </summary>
 internal static class ClarificationOpenDetector
 {
@@ -18,8 +23,18 @@ internal static class ClarificationOpenDetector
             return false;
         }
 
+        // G275: If the file carries `intent_state: clarified` in YAML front-matter
+        // (either `---` fenced block or anywhere as a bare top-level field),
+        // treat the entire file as cleared regardless of body content.
+        if (HasClarifiedState(content!))
+        {
+            return false;
+        }
+
         var lines = content!.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
         var inBlockerSection = false;
+        var blockerSectionSeen = false;
+        var blockerSectionHasContent = false;
 
         foreach (var rawLine in lines)
         {
@@ -32,6 +47,11 @@ internal static class ClarificationOpenDetector
                     heading,
                     "Current Open Blockers",
                     StringComparison.OrdinalIgnoreCase);
+                if (inBlockerSection)
+                {
+                    blockerSectionSeen = true;
+                }
+
                 continue;
             }
 
@@ -40,14 +60,23 @@ internal static class ClarificationOpenDetector
                 continue;
             }
 
-            var trimmed = line.TrimStart();
-            if (!trimmed.StartsWith("- ", StringComparison.Ordinal)
-                && !trimmed.StartsWith("* ", StringComparison.Ordinal))
+            // G275: A section whose only non-empty non-heading content is the
+            // literal word "None" (bare line or as a paragraph) is treated as
+            // cleared — matching the English convention used in several host files.
+            var trimmedLine = line.Trim();
+            if (string.Equals(trimmedLine, "None", StringComparison.OrdinalIgnoreCase))
+            {
+                blockerSectionHasContent = true;
+                continue;
+            }
+
+            if (!trimmedLine.StartsWith("- ", StringComparison.Ordinal)
+                && !trimmedLine.StartsWith("* ", StringComparison.Ordinal))
             {
                 continue;
             }
 
-            var item = trimmed[2..].Trim();
+            var item = trimmedLine[2..].Trim();
             if (item.Length == 0)
             {
                 continue;
@@ -55,13 +84,91 @@ internal static class ClarificationOpenDetector
 
             if (IsNoBlockerSentinel(item))
             {
+                blockerSectionHasContent = true;
                 continue;
             }
 
             return true;
         }
 
+        // If we found a "Current Open Blockers" section but it was completely
+        // empty (no bullets, no None line), that is also not a blocker.
+        _ = blockerSectionSeen && blockerSectionHasContent; // suppress unused warning
+
         return false;
+    }
+
+    /// <summary>
+    /// Returns true when the file's YAML front-matter (or bare root field) contains
+    /// <c>intent_state: clarified</c>.
+    /// </summary>
+    private static bool HasClarifiedState(string content)
+    {
+        var lines = content.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var inFrontMatter = false;
+        var frontMatterClosed = false;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i].TrimEnd();
+
+            // Detect opening `---` front-matter fence on the very first non-blank line.
+            if (i == 0 && string.Equals(line, "---", StringComparison.Ordinal))
+            {
+                inFrontMatter = true;
+                continue;
+            }
+
+            if (inFrontMatter)
+            {
+                // Closing fence ends front-matter scanning.
+                if (string.Equals(line, "---", StringComparison.Ordinal)
+                    || string.Equals(line, "...", StringComparison.Ordinal))
+                {
+                    frontMatterClosed = true;
+                    break;
+                }
+
+                if (IsIntentStateClarified(line))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            // Also check bare root-level YAML fields before the first `##` heading
+            // for files that use unfenced front-matter conventions.
+            if (!frontMatterClosed && !line.StartsWith("#", StringComparison.Ordinal))
+            {
+                if (IsIntentStateClarified(line))
+                {
+                    return true;
+                }
+            }
+
+            // Stop scanning once body content (headings, bullets) begins.
+            if (line.StartsWith("# ", StringComparison.Ordinal)
+                || line.StartsWith("## ", StringComparison.Ordinal))
+            {
+                break;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsIntentStateClarified(string line)
+    {
+        // Match `intent_state: clarified` (with optional surrounding whitespace).
+        var trimmed = line.Trim();
+        if (!trimmed.StartsWith("intent_state:", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var value = trimmed["intent_state:".Length..].Trim();
+        return string.Equals(value, "clarified", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsNoBlockerSentinel(string item)

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -148,12 +148,23 @@ internal static class IntentNextSliceCommand
         if (Directory.Exists(packetRoot))
         {
             // Pick the first queued execution_unit in queue-state order whose packet
-            // directory exists. Falls back to the alphabetically-first packet
-            // directory not in completed if no queued match exists.
+            // directory exists AND whose domain/target-repo matches the filter.
+            // Falls back to the alphabetically-first packet directory not in completed
+            // if no queued match exists.
+            //
+            // G275: When --domain and/or --target-repo are specified, packets are
+            // filtered by those values. Domain is derived from the queue item's
+            // clarification_return_path (shape: intents/<domain>/clarifications/open.md).
+            // Target-repo is read from the packet.yaml file inside the packet directory.
             foreach (var executionUnit in queued)
             {
                 var directory = Path.Combine(packetRoot, executionUnit);
                 if (!Directory.Exists(directory))
+                {
+                    continue;
+                }
+
+                if (!MatchesDomainAndRepoFilter(domain, targetRepo, queueState, executionUnit, directory))
                 {
                     continue;
                 }
@@ -170,6 +181,11 @@ internal static class IntentNextSliceCommand
                 {
                     var executionUnit = Path.GetFileName(directory)!;
                     if (completed.Contains(executionUnit))
+                    {
+                        continue;
+                    }
+
+                    if (!MatchesDomainAndRepoFilter(domain, targetRepo, queueState, executionUnit, directory))
                     {
                         continue;
                     }
@@ -281,6 +297,161 @@ internal static class IntentNextSliceCommand
         }
 
         return OutcomeIssueCutReady;
+    }
+
+    /// <summary>
+    /// G275: Returns true when the given execution unit / packet directory matches
+    /// the requested domain and target-repo filters.
+    ///
+    /// Domain is inferred from the queue item's <c>clarification_return_path</c>
+    /// field (shape: <c>intents/&lt;domain&gt;/clarifications/open.md</c>).
+    /// When no queue item exists for the unit, domain filtering is skipped for
+    /// that unit (it remains a candidate).
+    ///
+    /// Target-repo is read from <c>packet.yaml</c> in the packet directory.
+    /// When the file is absent or unreadable, target-repo filtering is skipped
+    /// (the unit remains a candidate).
+    /// </summary>
+    private static bool MatchesDomainAndRepoFilter(
+        string domain,
+        string? targetRepo,
+        QueueState? queueState,
+        string executionUnit,
+        string directory)
+    {
+        // Domain filter: derive domain from queue item's clarification_return_path.
+        // Path shape: intents/<domain>/clarifications/open.md
+        if (queueState is not null)
+        {
+            QueueItem? item = null;
+            foreach (var candidate in queueState.Items)
+            {
+                if (string.Equals(candidate.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+                {
+                    item = candidate;
+                    break;
+                }
+            }
+
+            if (item is not null)
+            {
+                var itemDomain = ExtractDomainFromReturnPath(item.ClarificationReturnPath);
+                if (itemDomain is not null
+                    && !string.Equals(itemDomain, domain, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+        }
+
+        // Target-repo filter: read packet.yaml to get target_repo field.
+        if (!string.IsNullOrWhiteSpace(targetRepo))
+        {
+            var packetYamlPath = Path.Combine(directory, "packet.yaml");
+            if (File.Exists(packetYamlPath))
+            {
+                var packetTargetRepo = TryReadPacketTargetRepo(packetYamlPath);
+                if (packetTargetRepo is not null
+                    && !string.Equals(packetTargetRepo, targetRepo, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Extracts the domain segment from a clarification return path of the form
+    /// <c>intents/&lt;domain&gt;/clarifications/open.md</c>.
+    /// Returns null when the path does not match the expected shape.
+    /// </summary>
+    private static string? ExtractDomainFromReturnPath(string returnPath)
+    {
+        if (string.IsNullOrWhiteSpace(returnPath))
+        {
+            return null;
+        }
+
+        // Normalise path separators so this works on all platforms.
+        var normalised = returnPath.Replace('\\', '/');
+        var parts = normalised.Split('/');
+
+        // Expected: ["intents", "<domain>", "clarifications", "open.md"]
+        if (parts.Length < 4)
+        {
+            return null;
+        }
+
+        if (!string.Equals(parts[0], "intents", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return parts[1];
+    }
+
+    /// <summary>
+    /// Reads the <c>target_repo</c> scalar from a <c>packet.yaml</c> file using a
+    /// lightweight line scanner. Returns null when the file cannot be parsed or the
+    /// field is absent.
+    /// </summary>
+    private static string? TryReadPacketTargetRepo(string packetYamlPath)
+    {
+        try
+        {
+            var content = File.ReadAllText(packetYamlPath);
+            using var reader = new StringReader(content);
+            var inImplementationSection = false;
+            string? line;
+
+            while ((line = reader.ReadLine()) is not null)
+            {
+                var trimmedLine = line.TrimEnd();
+
+                // Track section headers (zero-indent, ends with colon).
+                if (!char.IsWhiteSpace(trimmedLine.Length > 0 ? trimmedLine[0] : ' ')
+                    && trimmedLine.EndsWith(":", StringComparison.Ordinal))
+                {
+                    var sectionName = trimmedLine[..^1];
+                    inImplementationSection = string.Equals(
+                        sectionName,
+                        "implementation_issue_packet",
+                        StringComparison.OrdinalIgnoreCase);
+                    continue;
+                }
+
+                if (!inImplementationSection)
+                {
+                    continue;
+                }
+
+                // Look for `  target_repo: <value>` (two-space indent).
+                if (!trimmedLine.StartsWith("  target_repo:", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var value = trimmedLine["  target_repo:".Length..].Trim();
+                if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+                {
+                    value = value[1..^1];
+                }
+
+                return string.IsNullOrWhiteSpace(value) ? null : value;
+            }
+        }
+        catch (IOException)
+        {
+            // File unreadable — skip filter.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // File unreadable — skip filter.
+        }
+
+        return null;
     }
 
     private static void WriteMarkdown(TextWriter writer, IntentNextSliceResult result)

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -112,6 +112,8 @@ internal static class IntentNextSliceCommand
             notes.Add($"no queue-state file at {queueStatePath}");
         }
 
+        var packetRoot = Path.Combine(context.RepoRoot, ".intent-cli", "issues");
+
         var wip = new List<string>();
         var queued = new List<string>();
         var completed = new HashSet<string>(StringComparer.Ordinal);
@@ -124,7 +126,13 @@ internal static class IntentNextSliceCommand
                     case QueueItemState.Active:
                     case QueueItemState.Review:
                     case QueueItemState.Fixing:
-                        wip.Add(item.ExecutionUnit);
+                        // G275: filter WIP by the same domain/repo predicates as candidate selection
+                        // so cross-domain in-flight items do not block the requested lane.
+                        if (MatchesDomainAndRepoFilter(domain, targetRepo, queueState, item.ExecutionUnit, Path.Combine(packetRoot, item.ExecutionUnit)))
+                        {
+                            wip.Add(item.ExecutionUnit);
+                        }
+
                         break;
 
                     case QueueItemState.Queued:
@@ -142,8 +150,6 @@ internal static class IntentNextSliceCommand
         var clarificationFilePresent = File.Exists(clarificationPath);
         var clarificationOpen = clarificationFilePresent
             && ClarificationOpenDetector.HasOpenBlocker(File.ReadAllText(clarificationPath));
-
-        var packetRoot = Path.Combine(context.RepoRoot, ".intent-cli", "issues");
         IntentNextSliceCandidate? candidate = null;
         if (Directory.Exists(packetRoot))
         {

--- a/src/IntentSystem.Cli/Commands/NextSliceClassifyAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceClassifyAnalyzer.cs
@@ -53,11 +53,37 @@ internal static class NextSliceClassifyAnalyzer
             }
         }
 
-        // (2) WIP precedence — reuse StatusBriefAnalyzer's canonical predicate.
+        // (2) WIP precedence — filtered by domain/targetRepo so cross-domain
+        // in-flight items do not block the requested lane (G275).
         var wipRefs = new List<string>();
         if (queueState is not null)
         {
-            StatusBriefAnalyzer.CollectWipUnits(queueState, wipRefs, reviewUnits: null);
+            var issuesRoot = Path.Combine(context.RepoRoot, ".intent-cli", "issues");
+            foreach (var item in queueState.Items)
+            {
+                switch (item.State)
+                {
+                    case QueueItemState.Active:
+                    case QueueItemState.Review:
+                    case QueueItemState.Fixing:
+                        if (!MatchesDomainFilter(domain, queueState, item.ExecutionUnit))
+                        {
+                            break;
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(targetRepo))
+                        {
+                            var dir = Path.Combine(issuesRoot, item.ExecutionUnit);
+                            if (!MatchesTargetRepoFilter(targetRepo, dir))
+                            {
+                                break;
+                            }
+                        }
+
+                        wipRefs.Add(item.ExecutionUnit);
+                        break;
+                }
+            }
         }
 
         if (wipRefs.Count > 0)

--- a/src/IntentSystem.Cli/Commands/NextSliceClassifyAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceClassifyAnalyzer.cs
@@ -16,7 +16,7 @@ internal static class NextSliceClassifyAnalyzer
 {
     private const int ClarificationSummaryCharLimit = 240;
 
-    public static NextSliceClassifyResult Analyze(CliContext context, string? domainOverride)
+    public static NextSliceClassifyResult Analyze(CliContext context, string? domainOverride, string? targetRepo = null)
     {
         ArgumentNullException.ThrowIfNull(context);
 
@@ -114,7 +114,9 @@ internal static class NextSliceClassifyAnalyzer
         // existing issue prepare/publish-reviewed flow without operator
         // intervention, so they degrade to `inspect-manually` rather than
         // `issue-cut-ready`.
-        var candidate = FindIssueCutCandidate(context, queueState);
+        //
+        // G275: Apply domain and target-repo filters when supplied.
+        var candidate = FindIssueCutCandidate(context, queueState, domain, targetRepo);
         if (candidate.Kind == IssueCutCandidateKind.Ambiguous)
         {
             return new NextSliceClassifyResult
@@ -260,7 +262,9 @@ internal static class NextSliceClassifyAnalyzer
 
     private static IssueCutCandidate FindIssueCutCandidate(
         CliContext context,
-        QueueState? queueState)
+        QueueState? queueState,
+        string domain,
+        string? targetRepo)
     {
         var issuesRoot = Path.Combine(context.RepoRoot, ".intent-cli", "issues");
         if (!Directory.Exists(issuesRoot))
@@ -288,6 +292,19 @@ internal static class NextSliceClassifyAnalyzer
             }
 
             if (linkedUnits.Contains(unit))
+            {
+                continue;
+            }
+
+            // G275: Apply domain filter using the queue item's clarification_return_path.
+            if (!MatchesDomainFilter(domain, queueState, unit))
+            {
+                continue;
+            }
+
+            // G275: Apply target-repo filter by reading packet.yaml.
+            if (!string.IsNullOrWhiteSpace(targetRepo)
+                && !MatchesTargetRepoFilter(targetRepo, unitDir))
             {
                 continue;
             }
@@ -330,6 +347,154 @@ internal static class NextSliceClassifyAnalyzer
         }
 
         return new IssueCutCandidate(IssueCutCandidateKind.None, null, null);
+    }
+
+    /// <summary>
+    /// G275: Returns true when the execution unit's domain (derived from its queue
+    /// item clarification_return_path) matches the requested domain, or when the
+    /// unit has no queue item (cannot be filtered).
+    /// </summary>
+    private static bool MatchesDomainFilter(string domain, QueueState? queueState, string executionUnit)
+    {
+        if (queueState is null)
+        {
+            return true;
+        }
+
+        QueueItem? item = null;
+        foreach (var candidate in queueState.Items)
+        {
+            if (string.Equals(candidate.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+            {
+                item = candidate;
+                break;
+            }
+        }
+
+        if (item is null)
+        {
+            // No queue entry — cannot derive domain; keep as candidate.
+            return true;
+        }
+
+        var itemDomain = ExtractDomainFromReturnPath(item.ClarificationReturnPath);
+        if (itemDomain is null)
+        {
+            return true;
+        }
+
+        return string.Equals(itemDomain, domain, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G275: Returns true when the packet.yaml in the given directory contains a
+    /// <c>target_repo</c> field matching <paramref name="targetRepo"/>, or when
+    /// the file is absent / unreadable (cannot be filtered).
+    /// </summary>
+    private static bool MatchesTargetRepoFilter(string targetRepo, string directory)
+    {
+        var packetYamlPath = Path.Combine(directory, "packet.yaml");
+        if (!File.Exists(packetYamlPath))
+        {
+            return true;
+        }
+
+        var packetTargetRepo = TryReadPacketTargetRepo(packetYamlPath);
+        if (packetTargetRepo is null)
+        {
+            return true;
+        }
+
+        return string.Equals(packetTargetRepo, targetRepo, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Extracts the domain segment from a clarification return path of the form
+    /// <c>intents/&lt;domain&gt;/clarifications/open.md</c>.
+    /// Returns null when the path does not match the expected shape.
+    /// </summary>
+    private static string? ExtractDomainFromReturnPath(string returnPath)
+    {
+        if (string.IsNullOrWhiteSpace(returnPath))
+        {
+            return null;
+        }
+
+        var normalised = returnPath.Replace('\\', '/');
+        var parts = normalised.Split('/');
+
+        // Expected: ["intents", "<domain>", "clarifications", "open.md"]
+        if (parts.Length < 4)
+        {
+            return null;
+        }
+
+        if (!string.Equals(parts[0], "intents", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return parts[1];
+    }
+
+    /// <summary>
+    /// Reads the <c>target_repo</c> scalar from a <c>packet.yaml</c> file using a
+    /// lightweight line scanner. Returns null when the file cannot be parsed or the
+    /// field is absent.
+    /// </summary>
+    private static string? TryReadPacketTargetRepo(string packetYamlPath)
+    {
+        try
+        {
+            var content = File.ReadAllText(packetYamlPath);
+            using var reader = new StringReader(content);
+            var inImplementationSection = false;
+            string? line;
+
+            while ((line = reader.ReadLine()) is not null)
+            {
+                var trimmedLine = line.TrimEnd();
+
+                if (!char.IsWhiteSpace(trimmedLine.Length > 0 ? trimmedLine[0] : ' ')
+                    && trimmedLine.EndsWith(":", StringComparison.Ordinal))
+                {
+                    var sectionName = trimmedLine[..^1];
+                    inImplementationSection = string.Equals(
+                        sectionName,
+                        "implementation_issue_packet",
+                        StringComparison.OrdinalIgnoreCase);
+                    continue;
+                }
+
+                if (!inImplementationSection)
+                {
+                    continue;
+                }
+
+                if (!trimmedLine.StartsWith("  target_repo:", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var value = trimmedLine["  target_repo:".Length..].Trim();
+                if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
+                {
+                    value = value[1..^1];
+                }
+
+                return string.IsNullOrWhiteSpace(value) ? null : value;
+            }
+        }
+        catch (IOException)
+        {
+            // File unreadable — skip filter.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // File unreadable — skip filter.
+        }
+
+        return null;
     }
 
     private static HashSet<string> BuildLinkedUnitSet(QueueState? queueState)

--- a/src/IntentSystem.Cli/Commands/NextSliceClassifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceClassifyCommand.cs
@@ -16,13 +16,13 @@ internal static class NextSliceClassifyCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
-        if (!TryParseArguments(args, out var domainOverride, out var format, out var error))
+        if (!TryParseArguments(args, out var domainOverride, out var targetRepo, out var format, out var error))
         {
             writer.WriteLine(error);
             return 1;
         }
 
-        var result = NextSliceClassifyAnalyzer.Analyze(context, domainOverride);
+        var result = NextSliceClassifyAnalyzer.Analyze(context, domainOverride, targetRepo);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
@@ -39,10 +39,12 @@ internal static class NextSliceClassifyCommand
     private static bool TryParseArguments(
         string[] args,
         out string? domainOverride,
+        out string? targetRepo,
         out string format,
         out string error)
     {
         domainOverride = null;
+        targetRepo = null;
         format = FormatText;
         error = string.Empty;
 
@@ -59,6 +61,17 @@ internal static class NextSliceClassifyCommand
                     }
 
                     domainOverride = args[index + 1];
+                    index++;
+                    break;
+
+                case "--target-repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--target-repo requires a value.";
+                        return false;
+                    }
+
+                    targetRepo = args[index + 1];
                     index++;
                     break;
 
@@ -82,7 +95,7 @@ internal static class NextSliceClassifyCommand
                     break;
 
                 default:
-                    error = $"Unknown argument '{argument}'. Supported: --domain <name> --format text|json.";
+                    error = $"Unknown argument '{argument}'. Supported: --domain <name> --target-repo <owner/repo> --format text|json.";
                     return false;
             }
         }

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -565,6 +565,132 @@ public sealed class IntentNextSliceCommandTests
         Assert.Equal("no-actionable-item", root.GetProperty("recommended_outcome").GetString());
     }
 
+    [Fact]
+    public void Execute_G275_CrossDomainActiveItem_DoesNotBlockIntentCliIssueCutReady()
+    {
+        // G275 WIP filter regression: an SKS item in Active state must not block
+        // an intent-cli G-series issue-cut-ready candidate when --domain intent-cli
+        // is specified.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G280/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-01T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "SKS-G183",
+                  "title": "sks wip item",
+                  "state": "active",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/sks/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_issue": {
+                    "repo": "J-Tech-Japan/SekibanAsAService",
+                    "number": 50,
+                    "url": "https://github.com/J-Tech-Japan/SekibanAsAService/issues/50"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                },
+                {
+                  "execution_unit": "G280",
+                  "title": "intent-cli queued slice",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        // SKS active item is filtered out of WIP; G280 is the intent-cli candidate.
+        Assert.NotEqual("skip-next-slice-due-to-wip", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal(0, root.GetProperty("wip").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_G275_CrossDomainReviewItem_DoesNotBlockIntentCliIssueCutReady()
+    {
+        // G275 WIP filter regression: an SKS item in Review state must not block
+        // an intent-cli G-series issue-cut-ready candidate when --domain intent-cli
+        // is specified.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G280/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-01T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "SKS-G183",
+                  "title": "sks wip item in review",
+                  "state": "review",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/sks/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_pr": {
+                    "repo": "J-Tech-Japan/SekibanAsAService",
+                    "number": 99,
+                    "url": "https://github.com/J-Tech-Japan/SekibanAsAService/pull/99"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                },
+                {
+                  "execution_unit": "G280",
+                  "title": "intent-cli queued slice",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        // SKS review item is filtered out of WIP; not skip-next-slice-due-to-wip.
+        Assert.NotEqual("skip-next-slice-due-to-wip", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal(0, root.GetProperty("wip").GetArrayLength());
+    }
+
     private sealed class IntentNextSliceWorkspace : IDisposable
     {
         private readonly string rootPath = Directory

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -291,6 +291,280 @@ public sealed class IntentNextSliceCommandTests
             """;
     }
 
+    // ─── G275 tests ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_G275_QueuedPacketNoLinkedIssue_ReturnsIssueCutReady()
+    {
+        // Queued packet with complete github-body.md, no linked issue → issue-cut-ready
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G275/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-01T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G275",
+                  "title": "next slice domain filter",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        var candidate = root.GetProperty("candidate");
+        Assert.Equal("G275", candidate.GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_G275_CrossDomainPacketExcluded_WhenDomainFilterActive()
+    {
+        // SKS-* packet has clarification_return_path pointing to sks domain.
+        // When domain=intent-cli is requested, it must be excluded.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/SKS-G183/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-01T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "SKS-G183",
+                  "title": "sks packet",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/sks/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        // SKS packet was excluded, so no candidate and no-actionable-item.
+        Assert.Equal("no-actionable-item", root.GetProperty("recommended_outcome").GetString());
+        Assert.False(root.TryGetProperty("candidate", out _));
+    }
+
+    [Fact]
+    public void Execute_G275_ClarificationFileWithIntentStateClarified_DoesNotBlock()
+    {
+        // A clarification file with `intent_state: clarified` in front-matter
+        // must not block next-slice, even if there are bullet items.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteClarificationOpen(
+            """
+            ---
+            intent_state: clarified
+            ---
+            ## Current Open Blockers
+
+            - Some old note that should no longer block
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("clarification_open").GetBoolean(),
+            "clarification_open must be false when intent_state is clarified");
+        // With no WIP and no candidate, falls to no-actionable-item (not clarification-required).
+        Assert.NotEqual("clarification-required", root.GetProperty("recommended_outcome").GetString());
+    }
+
+    [Fact]
+    public void Execute_G275_ClarificationSectionWithNone_DoesNotBlock()
+    {
+        // A clarification file where "## Current Open Blockers" contains only "None"
+        // must not block next-slice.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteClarificationOpen(
+            """
+            # intent-cli clarifications
+
+            ## Current Open Blockers
+
+            None
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("clarification_open").GetBoolean(),
+            "clarification_open must be false when 'None' is the only content");
+        Assert.NotEqual("clarification-required", root.GetProperty("recommended_outcome").GetString());
+    }
+
+    [Fact]
+    public void Execute_G275_WipPresent_ReturnsSkipDueToWip()
+    {
+        // When there is a WIP item, skip-next-slice-due-to-wip takes precedence.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G275/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-01T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G275",
+                  "title": "wip item",
+                  "state": "active",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_issue": {
+                    "repo": "J-Tech-Japan/intent-system",
+                    "number": 100,
+                    "url": "https://github.com/J-Tech-Japan/intent-system/issues/100"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("skip-next-slice-due-to-wip", root.GetProperty("recommended_outcome").GetString());
+    }
+
+    [Fact]
+    public void Execute_G275_TargetRepoFilter_ExcludesPacketWithDifferentRepo()
+    {
+        // A packet with target_repo != requested targetRepo must be excluded.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G275/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G275/packet.yaml",
+            """
+            implementation_issue_packet:
+              source_execution_unit: G275
+              target_repo: J-Tech-Japan/other-repo
+              issue_title: something
+              issue_kind: feature
+              goal: x
+              in_scope: []
+              out_of_scope: []
+              target_path: .
+              target_part: x
+              dependencies: []
+              technical_baseline: []
+              project_local_guide: []
+              intent_baseline: []
+              intent_references: []
+              rules_and_specs: []
+              acceptance_criteria: []
+              verification_evidence: []
+              review_mode: full
+              completion_action: close
+              landing_policy: merge
+            review_context_packet:
+              source_execution_unit: G275
+              parent_intent_root: .
+              intent_references: []
+              rules_and_specs: []
+              acceptance_criteria: []
+              deterministic_review_checks: []
+              clarification_return_path: intents/intent-cli/clarifications/open.md
+            """);
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-01T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G275",
+                  "title": "wrong repo packet",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": ".intent-cli/issues/G275/packet.yaml"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        // Packet excluded because target_repo doesn't match.
+        Assert.Equal("no-actionable-item", root.GetProperty("recommended_outcome").GetString());
+    }
+
     private sealed class IntentNextSliceWorkspace : IDisposable
     {
         private readonly string rootPath = Directory

--- a/tests/IntentSystem.Cli.Tests/NextSliceClassifyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NextSliceClassifyCommandTests.cs
@@ -299,6 +299,106 @@ public sealed class NextSliceClassifyCommandTests
         Assert.Equal(NextSliceClassification.NoActionableItem, result!.Classification);
     }
 
+    // ─── G275 tests ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_G275_CrossDomainPacketExcluded_WhenDomainAndTargetRepoSpecified()
+    {
+        // SKS-G183 has clarification_return_path pointing to sks domain.
+        // When --domain intent-cli is passed, it must be excluded.
+        using var workspace = new NextSliceWorkspace();
+        workspace.WriteIssuePacketWithQueueEntry(
+            "SKS-G183",
+            "# SKS packet body\n",
+            "intents/sks/clarifications/open.md");
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json", "--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        // SKS packet excluded → no actionable item.
+        Assert.Equal(NextSliceClassification.NoActionableItem, result!.Classification);
+        Assert.Null(result.CandidateExecutionUnit);
+    }
+
+    [Fact]
+    public void Execute_G275_ClarifiedIntentState_DoesNotBlock()
+    {
+        // A clarification file with intent_state: clarified must not classify as
+        // ClarificationRequired, even when there are bullet items in the section.
+        using var workspace = new NextSliceWorkspace();
+        workspace.WriteClarificationOpen(
+            """
+            ---
+            intent_state: clarified
+            ---
+            ## Current Open Blockers
+
+            - This note is present but the file is clarified
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.NotEqual(NextSliceClassification.ClarificationRequired, result!.Classification);
+    }
+
+    [Fact]
+    public void Execute_G275_ClarificationSectionNone_DoesNotBlock()
+    {
+        // A clarification file whose "Current Open Blockers" section contains only
+        // "None" (bare text) must not classify as ClarificationRequired.
+        using var workspace = new NextSliceWorkspace();
+        workspace.WriteClarificationOpen(
+            """
+            # intent-cli clarifications
+
+            ## Current Open Blockers
+
+            None
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        Assert.NotEqual(NextSliceClassification.ClarificationRequired, result!.Classification);
+        Assert.Equal(NextSliceClassification.NoActionableItem, result.Classification);
+    }
+
+    [Fact]
+    public void Execute_G275_TargetRepoFlag_IsAccepted()
+    {
+        // --target-repo flag must be parseable without error.
+        using var workspace = new NextSliceWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+    }
+
     private sealed class NextSliceWorkspace : IDisposable
     {
         private readonly string rootPath = Directory
@@ -358,6 +458,39 @@ public sealed class NextSliceClassifyCommandTests
             var path = Path.Combine(rootPath, ".intent-cli", "issues", executionUnit);
             Directory.CreateDirectory(path);
             File.WriteAllText(Path.Combine(path, "github-body.md"), body);
+        }
+
+        /// <summary>
+        /// G275: Writes a complete packet AND a queue-state entry with the given
+        /// clarification_return_path so domain filtering can be tested.
+        /// </summary>
+        public void WriteIssuePacketWithQueueEntry(
+            string executionUnit,
+            string body,
+            string clarificationReturnPath)
+        {
+            WriteIssuePacket(executionUnit, body);
+            WriteQueueState(
+                $$"""
+                {
+                  "schema_version": "1",
+                  "updated_at": "2026-05-01T00:00:00Z",
+                  "items": [
+                    {
+                      "execution_unit": "{{executionUnit}}",
+                      "title": "test packet",
+                      "state": "queued",
+                      "dependencies": [],
+                      "blocked_by": [],
+                      "clarification_return_path": "{{clarificationReturnPath}}",
+                      "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                      "worker_role": "coder",
+                      "review_role": "reviewer",
+                      "priority": "normal"
+                    }
+                  ]
+                }
+                """);
         }
 
         public void Dispose()

--- a/tests/IntentSystem.Cli.Tests/NextSliceClassifyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NextSliceClassifyCommandTests.cs
@@ -399,6 +399,104 @@ public sealed class NextSliceClassifyCommandTests
         Assert.NotNull(result);
     }
 
+    [Fact]
+    public void Execute_G275_CrossDomainActiveItem_DoesNotBlockIntentCliIssueCutReady()
+    {
+        // G275 WIP filter regression: an SKS item in Active state must not cause
+        // SkipDueToWip when classifying for the intent-cli domain.
+        using var workspace = new NextSliceWorkspace();
+        workspace.WriteIssuePacket("G280", "# intent-cli ready packet\n");
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-01T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "SKS-G183",
+                  "title": "sks wip active",
+                  "state": "active",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/sks/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_issue": {
+                    "repo": "J-Tech-Japan/SekibanAsAService",
+                    "number": 50,
+                    "url": "https://github.com/J-Tech-Japan/SekibanAsAService/issues/50"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json", "--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        // SKS active item filtered out; G280 packet is ready → IssueCutReady, not SkipDueToWip.
+        Assert.NotEqual(NextSliceClassification.SkipDueToWip, result!.Classification);
+        Assert.Equal(NextSliceClassification.IssueCutReady, result.Classification);
+        Assert.Empty(result.WipRefs);
+    }
+
+    [Fact]
+    public void Execute_G275_CrossDomainReviewItem_DoesNotBlockIntentCliIssueCutReady()
+    {
+        // G275 WIP filter regression: an SKS item in Review state must not cause
+        // SkipDueToWip when classifying for the intent-cli domain.
+        using var workspace = new NextSliceWorkspace();
+        workspace.WriteIssuePacket("G280", "# intent-cli ready packet\n");
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-01T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "SKS-G183",
+                  "title": "sks wip in review",
+                  "state": "review",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/sks/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_pr": {
+                    "repo": "J-Tech-Japan/SekibanAsAService",
+                    "number": 99,
+                    "url": "https://github.com/J-Tech-Japan/SekibanAsAService/pull/99"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = NextSliceClassifyCommand.Execute(
+            workspace.Context,
+            ["--format", "json", "--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<NextSliceClassifyResult>(writer.ToString());
+        Assert.NotNull(result);
+        // SKS review item filtered out; G280 packet is ready → IssueCutReady, not SkipDueToWip.
+        Assert.NotEqual(NextSliceClassification.SkipDueToWip, result!.Classification);
+        Assert.Equal(NextSliceClassification.IssueCutReady, result.Classification);
+        Assert.Empty(result.WipRefs);
+    }
+
     private sealed class NextSliceWorkspace : IDisposable
     {
         private readonly string rootPath = Directory


### PR DESCRIPTION
## Summary

- **Domain/repo filtering**: `intent-cli intent next-slice` and `next-slice classify` now filter candidates by `--domain` (derived from `clarification_return_path` in queue-state) and `--target-repo` (from `packet.yaml`). Cross-domain packets like `SKS-*` are excluded when `domain=intent-cli`.
- **Clarification gate**: `ClarificationOpenDetector.HasOpenBlocker` now recognises two cleared states: YAML front-matter with `intent_state: clarified`, and a `## Current Open Blockers` section containing only the bare text `None`.
- **`next-slice classify` gets `--target-repo` flag**: The `next-slice classify` command now accepts `--target-repo <owner/repo>` and applies it as an additional filter.

## Files changed

- `src/IntentSystem.Cli/Commands/ClarificationOpenDetector.cs` — add `intent_state: clarified` front-matter check and `None` body check
- `src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs` — add `MatchesDomainAndRepoFilter`, `ExtractDomainFromReturnPath`, `TryReadPacketTargetRepo` helpers
- `src/IntentSystem.Cli/Commands/NextSliceClassifyAnalyzer.cs` — add `targetRepo` param + domain/repo filter helpers
- `src/IntentSystem.Cli/Commands/NextSliceClassifyCommand.cs` — add `--target-repo` argument parsing

## Test plan

- [ ] `dotnet test tests/IntentSystem.Cli.Tests/ --filter "FullyQualifiedName~NextSlice" -q` → 72 pass
- [ ] `dotnet test tests/IntentSystem.Cli.Tests/ --filter "FullyQualifiedName!~DotnetToolExec" -q` → 1921 pass, 1 skip
- [ ] New G275 tests cover: queued-no-linked-issue → issue-cut-ready, cross-domain exclusion, intent_state:clarified clears blocker, None clears blocker, WIP cap, target-repo mismatch exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)