### PR TITLE
G272 Add intent-shape kind to guide intent-work setup

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideIntentWorkSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideIntentWorkSetupCommand.cs
@@ -4,12 +4,13 @@ using System.Text.Json.Serialization;
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// G261: Read-only <c>intent-cli guide intent-work setup</c>. Returns
+/// G261/G272: Read-only <c>intent-cli guide intent-work setup</c>. Returns
 /// paste-ready, worktree-friendly prompts for parent-side intent work so
 /// an AI agent can ask intent-cli how to organize intents, analyze next
-/// slices, preload packets, ask clarifications, and prepare one issue
-/// without reading local rules files, local skill files, or copied prompt
-/// files. Never mutates state. Never launches an AI provider.
+/// slices, preload packets, ask clarifications, shape intents via
+/// explain/interview, and prepare one issue without reading local rules
+/// files, local skill files, or copied prompt files.
+/// Never mutates state. Never launches an AI provider.
 /// </summary>
 internal static class GuideIntentWorkSetupCommand
 {
@@ -20,9 +21,10 @@ internal static class GuideIntentWorkSetupCommand
     private const string KindNextSlice = "next-slice";
     private const string KindPacketPreload = "packet-preload";
     private const string KindClarification = "clarification";
+    private const string KindIntentShape = "intent-shape";
 
     private const string UsageLine =
-        "Usage: intent-cli guide intent-work setup --kind <domain-organize|next-slice|packet-preload|clarification> "
+        "Usage: intent-cli guide intent-work setup --kind <domain-organize|next-slice|packet-preload|clarification|intent-shape> "
         + "--domain <domain> --target-repo <owner/repo> [--format markdown|json]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
@@ -64,13 +66,14 @@ internal static class GuideIntentWorkSetupCommand
             KindNextSlice => BuildNextSlice(domain!, targetRepo!),
             KindPacketPreload => BuildPacketPreload(domain!, targetRepo!),
             KindClarification => BuildClarification(domain!, targetRepo!),
+            KindIntentShape => BuildIntentShape(domain!, targetRepo!),
             _ => null
         };
 
         if (result is null)
         {
             writer.WriteLine(
-                $"--kind must be '{KindDomainOrganize}', '{KindNextSlice}', '{KindPacketPreload}', or '{KindClarification}' (got '{kind}').");
+                $"--kind must be '{KindDomainOrganize}', '{KindNextSlice}', '{KindPacketPreload}', '{KindClarification}', or '{KindIntentShape}' (got '{kind}').");
             writer.WriteLine(UsageLine);
             return 1;
         }
@@ -342,6 +345,91 @@ Hard rules:
         };
     }
 
+    private static GuideIntentWorkSetupResult BuildIntentShape(string domain, string targetRepo)
+    {
+        var prompt =
+$@"Shape and adjust intents for domain `{domain}` against `{targetRepo}`. Conduct clarification interviews with the product owner as needed, preload future packets, and publish at most one GitHub issue per wake.
+
+First-call sequence (read-only; required before any mutation):
+1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
+2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
+3. `intent-cli guide commands list --format json` — surface `primary` / `support` / `advanced` / `experimental` buckets.
+4. `intent-cli automation summary --format json` — canonical label-driven contract and capability JSON.
+5. `intent-cli intent status --domain {domain} --format json` — current baseline / WIP / queued / clarifications.
+6. `intent-cli intent search --domain {domain} --format json` — locate related intents across the domain.
+7. `intent-cli intent next-slice --dry-run --domain {domain} --target-repo {targetRepo} --format json` — verify WIP cap and clarification gates.
+
+For each intent needing deeper review:
+- `intent-cli intent explain <id> --format json` — surface the full intent tree, dependencies, and current execution state.
+
+If PO input is needed for a clarification:
+- `intent-cli interview <flow> [--format json]` — run a structured intake interview to record PO answers. Use the result to update the clarification record before proceeding.
+
+Each clarification question must include:
+- **Background**: what accepted parent state is known; what the ambiguity is.
+- **Question**: one focused, answerable question.
+- **Options**: 2–4 concrete options with short labels.
+- **Pros / Cons**: for each option, 1–2 bullet pros and 1–2 bullet cons.
+- **Recommendation**: the agent's recommended option with a single-sentence rationale.
+
+Intent-shaping steps:
+1. Confirm cwd is the parent host repo root.
+2. Read `intent status` and `intent search` output to map accepted intents, execution units, open clarifications, and WIP.
+3. For intents needing adjustment: run `intent explain <id>` to get full context before proposing any change.
+4. Identify: intents to merge, split, re-scope, or retire; clarifications that must be resolved first.
+5. Present the proposed adjustments to the operator for acceptance. Do not write anything until accepted.
+6. After acceptance: apply only the operator-approved adjustments to the intent tree. Commit and push before packet work.
+
+Packet preload (optional, after intent shaping is accepted):
+1. For each accepted continuation candidate: `intent-cli packet draft --execution-unit <id> --target-repo {targetRepo} --dry-run --format markdown`.
+2. Present each preview to the operator. Accept or reject independently.
+3. For accepted packets: `intent-cli packet draft --execution-unit <id> --target-repo {targetRepo} --format json`.
+4. Multiple packets may be preloaded; mark each as `queued` in queue-state without linked issues.
+
+Issue publication (at most one per wake):
+1. After parent durable state (intent files, packet files, queue-state) is committed and pushed:
+   `intent-cli issue publish-flow <id> --repo {targetRepo} --write --format json`
+2. After parent state is pushed: `intent-cli automation issue-publish --repo {targetRepo} --issue <n> --write --format json`.
+3. Publish at most one GitHub issue per wake regardless of how many packets are preloaded.
+
+Hard rules:
+- Do not read `intents/rules/**`, local skill files, or copied prompt files. Use `intent-cli guide ...`, `intent-cli intent ...`, and `intent-cli interview ...` instead.
+- Do not call `intent-cli run`. `run` is advanced runtime, not the intent-work path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- All label transitions go through installed `intent-cli automation` commands.
+- `intent-target` is the host-owned publish boundary; apply it only via `intent-cli automation issue-publish` after parent state is pushed.
+- Publish at most one GitHub issue per wake.
+- Stop on Hard Clarification rather than guessing when source-of-truth is ambiguous.";
+
+        return new GuideIntentWorkSetupResult
+        {
+            Kind = KindIntentShape,
+            Domain = domain,
+            TargetRepo = targetRepo,
+            Prompt = prompt,
+            FirstCalls = new[]
+            {
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                "intent-cli automation summary --format json",
+                $"intent-cli intent status --domain {domain} --format json",
+                $"intent-cli intent search --domain {domain} --format json",
+                $"intent-cli intent next-slice --dry-run --domain {domain} --target-repo {targetRepo} --format json"
+            },
+            ForbiddenSources = new[]
+            {
+                "intents/rules/**",
+                "local skill files",
+                "copied prompt files"
+            },
+            ClarificationFormat = "background, question, options, pros/cons, and recommendation",
+            IssuePublishBoundary = "Publish at most one GitHub issue per wake even when multiple packets are preloaded. Use `intent-cli issue publish-flow` then `intent-cli automation issue-publish` after parent durable state is committed and pushed.",
+            WorktreeFriendly = "The prompt names the parent host repo worktree root as cwd and references domain/target-repo from arguments; no operator-specific paths are hard-coded, so it works across host-side worktrees."
+        };
+    }
+
     private static void WriteMarkdown(TextWriter writer, GuideIntentWorkSetupResult result)
     {
         writer.WriteLine($"# Guide intent-work setup — {result.Kind}");
@@ -476,13 +564,14 @@ Hard rules:
     {
         writer.WriteLine("guide intent-work setup");
         writer.WriteLine(UsageLine);
-        writer.WriteLine("Read-only paste-ready prompts for parent-side intent work: domain organization, next-slice analysis, packet preload, and clarification drafting.");
+        writer.WriteLine("Read-only paste-ready prompts for parent-side intent work: domain organization, next-slice analysis, packet preload, clarification drafting, and intent shaping.");
         writer.WriteLine();
         writer.WriteLine("Supported kinds:");
         writer.WriteLine($"- {KindDomainOrganize}  (--domain, --target-repo required)");
         writer.WriteLine($"- {KindNextSlice}        (--domain, --target-repo required)");
         writer.WriteLine($"- {KindPacketPreload}    (--domain, --target-repo required)");
         writer.WriteLine($"- {KindClarification}   (--domain, --target-repo required)");
+        writer.WriteLine($"- {KindIntentShape}     (--domain, --target-repo required)");
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/tests/IntentSystem.Cli.Tests/GuideIntentWorkSetupCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideIntentWorkSetupCommandTests.cs
@@ -316,6 +316,155 @@ public sealed class GuideIntentWorkSetupCommandTests
         Assert.Equal("next-slice", document.RootElement.GetProperty("kind").GetString());
     }
 
+    // ── intent-shape (G272) ───────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_IntentShapeMarkdown_EmitsPasteReadyPromptWithExplainAndInterview()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "intent-shape", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide intent-work setup — intent-shape", output, StringComparison.Ordinal);
+        Assert.Contains("domain: intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("target repo: J-Tech-Japan/intent-system", output, StringComparison.Ordinal);
+        Assert.Contains("## First-call sequence", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide model --format json", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli intent status --domain intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli intent search --domain intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli intent next-slice --dry-run --domain intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli intent explain", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli interview", output, StringComparison.Ordinal);
+        Assert.Contains("## Forbidden rule sources", output, StringComparison.Ordinal);
+        Assert.Contains("intents/rules/**", output, StringComparison.Ordinal);
+        Assert.Contains("## Clarification format", output, StringComparison.Ordinal);
+        Assert.Contains("background, question, options, pros/cons, and recommendation", output, StringComparison.Ordinal);
+        Assert.Contains("## Issue publish boundary", output, StringComparison.Ordinal);
+        Assert.Contains("at most one GitHub issue", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_IntentShapeJson_EmitsStructuredFields()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "intent-shape", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("intent-shape", root.GetProperty("kind").GetString());
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("target_repo").GetString());
+        Assert.Equal(7, root.GetProperty("first_calls").GetArrayLength());
+        Assert.True(root.GetProperty("forbidden_sources").GetArrayLength() >= 3);
+        Assert.Contains("background, question, options, pros/cons", root.GetProperty("clarification_format").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("worktree", root.GetProperty("worktree_friendly").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_IntentShapeJson_PromptCoversExplainAndInterviewCommands()
+    {
+        using var writer = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "intent-shape", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("intent-cli intent explain", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli interview", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_IntentShapeJson_PromptCoversStatusSearchNextSlicePacketFlow()
+    {
+        using var writer = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "intent-shape", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("intent status", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent search", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent explain", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent next-slice", prompt, StringComparison.Ordinal);
+        Assert.Contains("interview", prompt, StringComparison.Ordinal);
+        Assert.Contains("packet draft", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_IntentShapeJson_PromptEnforcesAtMostOnePublicationAndDurableCommit()
+    {
+        using var writer = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "intent-shape", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("at most one GitHub issue per wake", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("durable", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_IntentShapeJson_PromptForbidsLocalRulesAndSkillsAndProvider()
+    {
+        using var writer = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "intent-shape", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("intents/rules/**", prompt, StringComparison.Ordinal);
+        Assert.Contains("local skill files", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do not call `intent-cli run`", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do not run `dotnet run`", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_IntentShapeJson_ClarificationFormatRequiresFiveParts()
+    {
+        using var writer = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "intent-shape", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Background", prompt, StringComparison.Ordinal);
+        Assert.Contains("Question", prompt, StringComparison.Ordinal);
+        Assert.Contains("Options", prompt, StringComparison.Ordinal);
+        Assert.Contains("Pros", prompt, StringComparison.Ordinal);
+        Assert.Contains("Recommendation", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_ListsIntentShapeKind()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("intent-shape", writer.ToString(), StringComparison.Ordinal);
+    }
+
     // ── shared contract ───────────────────────────────────────────────────
 
     [Theory]
@@ -323,6 +472,7 @@ public sealed class GuideIntentWorkSetupCommandTests
     [InlineData("next-slice")]
     [InlineData("packet-preload")]
     [InlineData("clarification")]
+    [InlineData("intent-shape")]
     public void Execute_AllKinds_PromptForbidsLocalRulesFilesAndSkillFiles(string kind)
     {
         using var writer = new StringWriter();
@@ -342,6 +492,7 @@ public sealed class GuideIntentWorkSetupCommandTests
     [InlineData("next-slice")]
     [InlineData("packet-preload")]
     [InlineData("clarification")]
+    [InlineData("intent-shape")]
     public void Execute_AllKinds_FirstCallsIncludeModelOnboardingAndCommandsList(string kind)
     {
         using var writer = new StringWriter();
@@ -363,6 +514,7 @@ public sealed class GuideIntentWorkSetupCommandTests
     [InlineData("next-slice")]
     [InlineData("packet-preload")]
     [InlineData("clarification")]
+    [InlineData("intent-shape")]
     public void Execute_AllKinds_PromptRequiresClarificationFormat(string kind)
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

- Adds `intent-shape` as a fifth kind to `guide intent-work setup`, covering the canonical intent-shaping and packet-preparation flow for chat agents
- The new kind's prompt explicitly covers `intent explain`, `interview`, `status`, `search`, `next-slice`, and `packet` commands per the acceptance criteria
- All 5 kinds now appear in `AllKinds` theory tests; help text updated to list `intent-shape`

## Changes

- `src/IntentSystem.Cli/Commands/GuideIntentWorkSetupCommand.cs`: added `KindIntentShape = "intent-shape"`, `BuildIntentShape()`, routing, error message, and help text
- `tests/IntentSystem.Cli.Tests/GuideIntentWorkSetupCommandTests.cs`: 11 new focused tests for `intent-shape` markdown/json output, prompt content, and shared `[Theory]` rows extended to include `intent-shape`

## Test plan

- [ ] `dotnet test tests/IntentSystem.Cli.Tests/ --filter "GuideIntentWork"` — all 60 guide intent-work tests pass
- [ ] Full suite `dotnet test tests/IntentSystem.Cli.Tests/` — 1942 passed, 1 skipped, 0 failed
- [ ] `git diff --check` — no trailing whitespace

Closes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)