### PR TITLE
G273 Harden child implement/update loop guide against host-state repair detours

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
@@ -97,7 +97,7 @@ internal static class GuideAutomationSetupCommand
         var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
 
         var prompt =
-$@"Set up the child implementation loop for {repoLabel} once. Do not register any cron, monitor, reminder, scheduler, or recurring wakeup as part of this setup unless the operator explicitly asks.
+$@"Set up the child implementation and PR-comment-update loop for {repoLabel} once. Operator minimal trigger phrase: ""intent-cli に聞いて、この repo の実装と PR comment update loop を設定してください"" — the detailed procedure below is what intent-cli emits. Do not register any cron, monitor, reminder, scheduler, or recurring wakeup as part of this setup unless the operator explicitly asks.
 
 First-call sequence (read-only; required before any mutation):
 1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
@@ -112,7 +112,7 @@ Loop body (single wake; the operator drives subsequent wakes if any):
 4. From the parent host root (NOT the child cwd), run `intent-cli worker next-action --repo <OWNER>/<REPO> --workdir $CHILD_WORKTREE --format json`. Dispatch on `action`:
    - `none` → stop with `idle`.
    - `issue-to-pr` → claim with `intent-cli worker claim --kind issue --number <n> --write --format json`, run the issue-to-PR workflow on the returned URL only, classify outcome, then `worker result-summary --kind issue-to-pr ...` and `worker complete --kind issue --number <n> --outcome <outcome> --write --format json`.
-   - `pr-comment-fix` → claim with `intent-cli worker claim --kind pr --number <n> --write --format json`, repair only the narrow requested change on the PR branch, classify outcome, then `worker result-summary --kind pr-comment-fix ...` and `worker complete --kind pr --number <n> --outcome <outcome> --write --format json`.
+   - `pr-comment-fix` → The PR URL returned by `worker next-action` (or supplied directly by the operator) is the authoritative work input; do not look up queue-state or linked PR to decide what to repair. Claim with `intent-cli worker claim --kind pr --number <n> --write --format json`. Check out the existing PR head branch: `gh pr checkout <n> --repo <OWNER>/<REPO>`. Apply only the narrow change requested in review comments. Run targeted tests. Push to the same branch: `git push`. From the parent host root, run `worker result-summary --kind pr-comment-fix --pr <n> --repo <OWNER>/<REPO> --format json`, then `worker complete --kind pr --number <n> --outcome <outcome> --write --format json`.
 
 Hard rules:
 - Do not read `intents/rules/**`, local skill files (`gh-issue-to-pr`, `gh-fix-pr-comment`, etc.), or copied prompt files for routine collaboration. Use `intent-cli guide ...` instead.
@@ -123,6 +123,8 @@ Hard rules:
 - Never apply `intent-target` from the child loop; it is host-owned.
 - Never apply `intent-pr-created` to a PR; it is an issue-side completion marker.
 - Process at most one action per wake.
+- For `pr-comment-fix` turns: never edit `queue-state.json`, `linked_issue`, or `linked_pr`; those are host-owned durable bookkeeping and must not be repaired from the child loop.
+- For `pr-comment-fix` turns: never run `intent-cli automation issue-publish`; that command is for publishing child issues, not for resolving PR comment repairs.
 
 Frequency policy (applies only when a recurring local loop is explicitly requested; the default is one-wake execution):
 - This setup prompt describes a single-wake run, not a recurring loop. One-wake execution does not create any scheduler.

--- a/src/IntentSystem.Cli/Commands/GuideWorkerPrCommentFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerPrCommentFixCommand.cs
@@ -64,7 +64,7 @@ internal static class GuideWorkerPrCommentFixCommand
         var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
 
         var prompt =
-$@"Repair the PR branch for {repoLabel} based on review comments. Do not use the `gh-fix-pr-comment` skill file, local skill files, or copied prompt files.
+$@"Repair the PR branch for {repoLabel} based on review comments. The PR URL returned by `intent-cli worker next-action` (or supplied directly by the operator) is the authoritative work input for this turn; do not inspect parent host queue-state or linked PR fields to decide what to repair. Do not use the `gh-fix-pr-comment` skill file, local skill files, or copied prompt files.
 
 First-call sequence (read-only; required before any code work):
 1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
@@ -104,7 +104,9 @@ Hard rules:
 - Do not run `dotnet run` as a fallback for `intent-cli`.
 - Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
 - Do not add `intent-target` to the PR; it is host-owned.
-- Do not add `intent-pr-created` to the PR; it is an issue-side completion marker.";
+- Do not add `intent-pr-created` to the PR; it is an issue-side completion marker.
+- Do not edit `queue-state.json`, `linked_issue`, or `linked_pr`; those are host-owned durable bookkeeping and must not be touched during a PR comment fix turn.
+- Do not run `intent-cli automation issue-publish`; that command is for publishing child issues, not for resolving PR comment repairs.";
 
         return new GuideWorkerPrCommentFixResult
         {

--- a/tests/IntentSystem.Cli.Tests/GuideAutomationSetupCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideAutomationSetupCommandTests.cs
@@ -31,7 +31,7 @@ public sealed class GuideAutomationSetupCommandTests
         Assert.Contains("## Label ownership", output, StringComparison.Ordinal);
         Assert.Contains("intent-cli automation", output, StringComparison.Ordinal);
         Assert.Contains("## Prompt", output, StringComparison.Ordinal);
-        Assert.Contains("Set up the child implementation loop for `J-Tech-Japan/intent-system`", output, StringComparison.Ordinal);
+        Assert.Contains("Set up the child implementation and PR-comment-update loop for `J-Tech-Japan/intent-system`", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -50,7 +50,7 @@ public sealed class GuideAutomationSetupCommandTests
         Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("repo").GetString());
         Assert.Equal(4, root.GetProperty("first_calls").GetArrayLength());
         Assert.True(root.GetProperty("forbidden_sources").GetArrayLength() >= 3);
-        Assert.Contains("Set up the child implementation loop", root.GetProperty("prompt").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("Set up the child implementation and PR-comment-update loop", root.GetProperty("prompt").GetString()!, StringComparison.Ordinal);
         Assert.Contains("Manual `gh ... edit", root.GetProperty("label_ownership").GetString()!, StringComparison.Ordinal);
         Assert.Contains("worktree", root.GetProperty("worktree_friendly").GetString()!, StringComparison.Ordinal);
     }
@@ -507,6 +507,90 @@ public sealed class GuideAutomationSetupCommandTests
         Assert.Contains("5 minutes", output, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("20 minutes", output, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("ask for the frequency", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── focused-guide-automation-setup-pr-comment-fix-hardening-tests ───────────
+
+    [Fact]
+    public void Execute_ChildImplementPrompt_PrCommentFixTreatsSelectedPRAsAuthoritative()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("authoritative work input", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("queue-state", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementPrompt_PrCommentFixForbidsHostBookkeepingEdits()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("queue-state.json", prompt, StringComparison.Ordinal);
+        Assert.Contains("linked_issue", prompt, StringComparison.Ordinal);
+        Assert.Contains("linked_pr", prompt, StringComparison.Ordinal);
+        Assert.Contains("host-owned durable bookkeeping", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementPrompt_PrCommentFixForbidsAutomationIssuePublish()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("automation issue-publish", prompt, StringComparison.Ordinal);
+        Assert.Contains("never run `intent-cli automation issue-publish`", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementPrompt_PrCommentFixInstructsCheckoutExistingBranch()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("gh pr checkout", prompt, StringComparison.Ordinal);
+        Assert.Contains("existing PR head branch", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementPrompt_ContainsMinimalOperatorTriggerPhrase()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("PR comment update loop", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-cli に聞いて", prompt, StringComparison.Ordinal);
     }
 
     private static CliContext CreateContext()

--- a/tests/IntentSystem.Cli.Tests/GuideWorkerPrCommentFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkerPrCommentFixCommandTests.cs
@@ -261,6 +261,58 @@ public sealed class GuideWorkerPrCommentFixCommandTests
         Assert.Contains("## Worktree-friendly assumption", output, StringComparison.Ordinal);
     }
 
+    // ── focused-guide-worker-pr-comment-fix-host-bookkeeping-tests ───────────
+
+    [Fact]
+    public void Execute_Json_PromptForbidsParentHostBookkeepingEdits()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("queue-state.json", prompt, StringComparison.Ordinal);
+        Assert.Contains("linked_issue", prompt, StringComparison.Ordinal);
+        Assert.Contains("linked_pr", prompt, StringComparison.Ordinal);
+        Assert.Contains("host-owned durable bookkeeping", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptForbidsAutomationIssuePublish()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("automation issue-publish", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do not run `intent-cli automation issue-publish`", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_PromptTreatsSelectedPRURLAsAuthoritativeWorkInput()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("authoritative work input", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("worker next-action", prompt, StringComparison.Ordinal);
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext


### PR DESCRIPTION
## Summary

- `GuideAutomationSetupCommand`: hardened `pr-comment-fix` step in `child-implement` prompt to treat the PR URL from `worker next-action` as authoritative; added explicit `gh pr checkout` step; added hard rules forbidding `queue-state.json`/`linked_issue`/`linked_pr` edits and `automation issue-publish` from PR comment fix turns; added minimal operator trigger phrase
- `GuideWorkerPrCommentFixCommand`: added authoritative-work-input statement; added two new hard rules forbidding host bookkeeping edits and `automation issue-publish`
- Tests: 8 new focused tests covering pr-comment-fix hardening behaviors; updated 2 existing tests to match new prompt preamble

## Test plan

- [x] `dotnet test` — 1950 passed, 1 skipped
- [x] Targeted tests: `GuideAutomationSetupCommandTests` (37 tests) and `GuideWorkerPrCommentFixCommandTests` (15 tests) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)