### PR TITLE
G274 Add agent-specific local loop setup guidance for Claude loop and Codex local automation

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideAutomationCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationCommand.cs
@@ -43,6 +43,12 @@ internal static class GuideAutomationCommand
             return GuideAutomationSetupCommand.Execute(context, args[1..], writer);
         }
 
+        // G274: nested `guide automation local-loop ...` agent-specific local recurring loop guide.
+        if (args.Length >= 1 && string.Equals(args[0], "local-loop", StringComparison.Ordinal))
+        {
+            return GuideAutomationLocalLoopCommand.Execute(context, args[1..], writer);
+        }
+
         if (!TryParseArguments(args, out var kind, out var domain, out var repo, out var format, out var error))
         {
             writer.WriteLine(error);

--- a/src/IntentSystem.Cli/Commands/GuideAutomationLocalLoopCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationLocalLoopCommand.cs
@@ -1,0 +1,375 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G274: Read-only <c>intent-cli guide automation local-loop</c>. Returns a
+/// paste-ready, agent-specific local recurring loop setup guide for Claude Code
+/// (<c>/loop</c>), Codex local automation/heartbeat, or a generic unknown-agent
+/// variant that requires clarification before scheduling. Covers frequency
+/// policy (5m high-frequency, ~20m low-frequency), same-thread-only rule for
+/// local-path workflows, local rules/skills prohibition, and
+/// intent-cli-as-guide-source rule. Never mutates state. Never launches an AI
+/// provider.
+/// </summary>
+internal static class GuideAutomationLocalLoopCommand
+{
+    private const string AgentClaude = "claude";
+    private const string AgentCodex = "codex";
+    private const string AgentGeneric = "generic";
+    private const string AgentUnknown = "unknown";
+
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide automation local-loop [--agent claude|codex|generic] [--repo <owner/repo>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var agent, out var repo, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = BuildLocalLoop(agent ?? AgentUnknown, repo);
+        return EmitResult(writer, format, result);
+    }
+
+    private static int EmitResult(TextWriter writer, string format, GuideAutomationLocalLoopResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static GuideAutomationLocalLoopResult BuildLocalLoop(string agent, string? repo)
+    {
+        var repoLabel = string.IsNullOrWhiteSpace(repo) ? "the repo in the current worktree" : $"`{repo}`";
+
+        var (prompt, clarificationRequired, schedulerGuidance) = agent switch
+        {
+            AgentClaude => BuildClaudeVariant(repoLabel),
+            AgentCodex => BuildCodexVariant(repoLabel),
+            AgentGeneric => BuildGenericVariant(repoLabel),
+            _ => BuildUnknownVariant(repoLabel)
+        };
+
+        return new GuideAutomationLocalLoopResult
+        {
+            Kind = "local-loop",
+            Agent = agent,
+            Repo = string.IsNullOrWhiteSpace(repo) ? null : repo,
+            Prompt = prompt,
+            SchedulerGuidance = schedulerGuidance,
+            FrequencyPolicy = "High-frequency local loops (active development): 5 minutes. Low-frequency local loops (background / idle polling): about 20 minutes. Ask the operator for the desired frequency before scheduling if it is not supplied.",
+            ClarificationRequired = clarificationRequired,
+            ForbiddenSources = new[]
+            {
+                "intents/rules/**",
+                "local skill files (gh-issue-to-pr, gh-fix-pr-comment, etc.)",
+                "copied prompt files",
+                "cloud or new-thread schedulers when the workflow depends on local paths or local .intent-cli packages"
+            },
+            WorktreeFriendly = "The prompt derives the repo from the current child worktree and does not hard-code operator-specific paths; the same guide works across worktrees."
+        };
+    }
+
+    private static (string Prompt, bool ClarificationRequired, string SchedulerGuidance) BuildClaudeVariant(string repoLabel)
+    {
+        var prompt =
+$@"Set up a Claude Code local recurring loop for {repoLabel}. Use same-thread `/loop` semantics; do not create any cloud routine, remote scheduler, or new-thread automation.
+
+Scheduler setup:
+- High-frequency (active development): type `/loop 5m <task-prompt>` in this Claude Code thread.
+- Low-frequency (background / idle polling): type `/loop 20m <task-prompt>`.
+- Ask the operator for the desired frequency if it was not supplied.
+- Never create a cloud schedule, CronCreate job, or remote CCR session for a workflow that depends on local paths or local `.intent-cli` packages; those schedulers cannot access local state.
+
+Task prompt construction:
+1. Run `intent-cli guide automation setup --kind child-implement [--repo <OWNER/REPO>] --format json` to obtain the full child-implement loop prompt.
+2. Use the emitted `prompt` field verbatim as the `/loop` task prompt so the agent receives complete, up-to-date guidance each wake.
+
+Hard rules:
+- Do not read `intents/rules/**`, local skill files, or copied prompt files. Use `intent-cli guide ...` instead.
+- Do not call `intent-cli run`; it is advanced runtime, not the chat-first path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- Use same-thread `/loop`; never launch a cloud or new-thread scheduler for local-path workflows.
+- Ask for frequency before scheduling if the operator has not supplied it.";
+
+        var schedulerGuidance = "Claude Code same-thread `/loop 5m` or `/loop 20m`. Never cloud/new-thread for local-path workflows.";
+        return (prompt, false, schedulerGuidance);
+    }
+
+    private static (string Prompt, bool ClarificationRequired, string SchedulerGuidance) BuildCodexVariant(string repoLabel)
+    {
+        var prompt =
+$@"Set up a Codex local automation/heartbeat loop for {repoLabel}. Attach the recurring automation to the current thread; do not create any cloud routine, remote scheduler, or new-thread session.
+
+Scheduler setup:
+- High-frequency (active development): attach a local automation/heartbeat to the current Codex thread with 5-minute recurrence.
+- Low-frequency (background / idle polling): attach with about 20-minute recurrence.
+- Ask the operator for the desired frequency if it was not supplied.
+- Never create a cloud schedule or new-thread scheduler for a workflow that depends on local paths or local `.intent-cli` packages; those schedulers cannot access local state.
+
+Task prompt construction:
+1. Run `intent-cli guide automation setup --kind child-implement [--repo <OWNER/REPO>] --format json` to obtain the full child-implement loop prompt.
+2. Use the emitted `prompt` field verbatim as the automation/heartbeat task prompt so the agent receives complete, up-to-date guidance each wake.
+
+Hard rules:
+- Do not read `intents/rules/**`, local skill files, or copied prompt files. Use `intent-cli guide ...` instead.
+- Do not call `intent-cli run`; it is advanced runtime, not the chat-first path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- Use local automation/heartbeat attached to the current thread; never launch a cloud or new-thread scheduler for local-path workflows.
+- Ask for frequency before scheduling if the operator has not supplied it.";
+
+        var schedulerGuidance = "Codex local automation/heartbeat attached to current thread at 5m or 20m. Never cloud/new-thread for local-path workflows.";
+        return (prompt, false, schedulerGuidance);
+    }
+
+    private static (string Prompt, bool ClarificationRequired, string SchedulerGuidance) BuildGenericVariant(string repoLabel)
+    {
+        var prompt =
+$@"Set up a local recurring loop for {repoLabel} using a provider-neutral approach.
+
+Before scheduling, confirm the agent runtime with the operator:
+- ""Are you using Claude Code (uses same-thread `/loop`), Codex local automation/heartbeat, or another agent runner?""
+- Do not create any scheduler until the operator confirms the agent type.
+
+Once the agent type is confirmed:
+- Claude Code: use same-thread `/loop 5m` or `/loop 20m`.
+- Codex: attach a local automation/heartbeat to the current thread at 5m or ~20m recurrence.
+- Other: use the agent's native same-thread recurring mechanism.
+- Ask for frequency if not supplied before scheduling.
+
+Frequency defaults:
+- High-frequency (active development): 5 minutes.
+- Low-frequency (background / idle polling): about 20 minutes.
+
+Task prompt construction:
+1. Run `intent-cli guide automation setup --kind child-implement [--repo <OWNER/REPO>] --format json` to obtain the full child-implement loop prompt.
+2. Use the emitted `prompt` field verbatim as the task prompt.
+
+Hard rules:
+- Do not read `intents/rules/**`, local skill files, or copied prompt files. Use `intent-cli guide ...` instead.
+- Do not call `intent-cli run`.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- Never create a cloud or new-thread scheduler for workflows that depend on local paths or local `.intent-cli` packages.
+- Ask for agent type and frequency if they were not supplied before scheduling.";
+
+        var schedulerGuidance = "Generic: confirm agent type (Claude `/loop`, Codex heartbeat, or other) and frequency before scheduling. Never cloud/new-thread for local-path workflows.";
+        return (prompt, true, schedulerGuidance);
+    }
+
+    private static (string Prompt, bool ClarificationRequired, string SchedulerGuidance) BuildUnknownVariant(string repoLabel)
+    {
+        var prompt =
+$@"Set up a local recurring loop for {repoLabel}. The agent type is not known yet.
+
+Before scheduling anything, ask the operator:
+""Are you using Claude Code (uses same-thread `/loop`), Codex local automation/heartbeat, or another agent runner?""
+
+Do not create any cron job, scheduler, automation, or recurring wakeup until the operator confirms the agent type and the desired frequency.
+
+Once confirmed, re-run `intent-cli guide automation local-loop --agent <claude|codex|generic> [--repo <OWNER/REPO>] --format json` to get the agent-specific setup guidance.
+
+Hard rules:
+- Do not guess the agent type from environment variables alone.
+- Do not create any scheduler before the agent type is confirmed.
+- Do not read `intents/rules/**`, local skill files, or copied prompt files. Use `intent-cli guide ...` instead.
+- Never create a cloud or new-thread scheduler for workflows that depend on local paths or local `.intent-cli` packages.";
+
+        var schedulerGuidance = "Unknown agent: ask the operator for agent type (claude, codex, or generic) and frequency before scheduling.";
+        return (prompt, true, schedulerGuidance);
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideAutomationLocalLoopResult result)
+    {
+        writer.WriteLine($"# Guide automation local-loop — agent: {result.Agent}");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.Repo))
+        {
+            writer.WriteLine($"- repo: {result.Repo}");
+        }
+        writer.WriteLine($"- clarification required: {result.ClarificationRequired}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Scheduler guidance");
+        writer.WriteLine();
+        writer.WriteLine(result.SchedulerGuidance);
+        writer.WriteLine();
+
+        writer.WriteLine("## Frequency policy");
+        writer.WriteLine();
+        writer.WriteLine(result.FrequencyPolicy);
+        writer.WriteLine();
+
+        writer.WriteLine("## Forbidden sources");
+        foreach (var src in result.ForbiddenSources)
+        {
+            writer.WriteLine($"- {src}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Worktree-friendly assumption");
+        writer.WriteLine();
+        writer.WriteLine(result.WorktreeFriendly);
+        writer.WriteLine();
+
+        writer.WriteLine("## Prompt");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(result.Prompt);
+        writer.WriteLine("```");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? agent,
+        out string? repo,
+        out string format,
+        out string error)
+    {
+        agent = null;
+        repo = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--agent":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--agent requires a value (claude, codex, or generic).";
+                        return false;
+                    }
+
+                    var requestedAgent = args[index + 1];
+                    if (!string.Equals(requestedAgent, AgentClaude, StringComparison.Ordinal)
+                        && !string.Equals(requestedAgent, AgentCodex, StringComparison.Ordinal)
+                        && !string.Equals(requestedAgent, AgentGeneric, StringComparison.Ordinal))
+                    {
+                        error = $"--agent must be 'claude', 'codex', or 'generic' (got '{requestedAgent}').";
+                        return false;
+                    }
+
+                    agent = requestedAgent;
+                    index++;
+                    break;
+
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value.";
+                        return false;
+                    }
+
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide automation local-loop");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only agent-specific local recurring loop setup guide.");
+        writer.WriteLine();
+        writer.WriteLine("  --agent claude   Same-thread /loop semantics (Claude Code).");
+        writer.WriteLine("  --agent codex    Local automation/heartbeat attached to current thread (Codex).");
+        writer.WriteLine("  --agent generic  Provider-neutral with required operator clarification.");
+        writer.WriteLine("  --agent omitted  Unknown agent: emits clarification-required guidance.");
+        writer.WriteLine("  --repo           Optional. Omit to derive the repo from the current worktree.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record GuideAutomationLocalLoopResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("agent")]
+    public required string Agent { get; init; }
+
+    [JsonPropertyName("repo")]
+    public string? Repo { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+
+    [JsonPropertyName("scheduler_guidance")]
+    public required string SchedulerGuidance { get; init; }
+
+    [JsonPropertyName("frequency_policy")]
+    public required string FrequencyPolicy { get; init; }
+
+    [JsonPropertyName("clarification_required")]
+    public required bool ClarificationRequired { get; init; }
+
+    [JsonPropertyName("forbidden_sources")]
+    public required IReadOnlyList<string> ForbiddenSources { get; init; }
+
+    [JsonPropertyName("worktree_friendly")]
+    public required string WorktreeFriendly { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideAutomationLocalLoopCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideAutomationLocalLoopCommandTests.cs
@@ -1,0 +1,418 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// focused-guide-automation-local-loop-tests
+/// </summary>
+public sealed class GuideAutomationLocalLoopCommandTests
+{
+    // ── claude variant ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_AgentClaude_Markdown_EmitsPromptWithLoopSemantics()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "claude", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide automation local-loop — agent: claude", output, StringComparison.Ordinal);
+        Assert.Contains("/loop 5m", output, StringComparison.Ordinal);
+        Assert.Contains("/loop 20m", output, StringComparison.Ordinal);
+        Assert.Contains("## Prompt", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_AgentClaude_Json_EmitsStructuredFields()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("local-loop", root.GetProperty("kind").GetString());
+        Assert.Equal("claude", root.GetProperty("agent").GetString());
+        Assert.False(root.GetProperty("clarification_required").GetBoolean());
+        Assert.True(root.TryGetProperty("prompt", out _));
+        Assert.True(root.TryGetProperty("scheduler_guidance", out _));
+        Assert.True(root.TryGetProperty("frequency_policy", out _));
+        Assert.True(root.GetProperty("forbidden_sources").GetArrayLength() >= 3);
+    }
+
+    [Fact]
+    public void Execute_AgentClaude_Json_PromptUsesSameThreadLoopForbidsCloudScheduler()
+    {
+        using var writer = new StringWriter();
+        GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "claude", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("/loop 5m", prompt, StringComparison.Ordinal);
+        Assert.Contains("/loop 20m", prompt, StringComparison.Ordinal);
+        Assert.Contains("same-thread", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cloud", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("never", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_AgentClaude_Json_PromptForbidsLocalSkillsAndRulesFiles()
+    {
+        using var writer = new StringWriter();
+        GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "claude", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("intents/rules/**", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("/Users/", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_AgentClaude_Json_PromptIncludesGuideAutomationSetupInstruction()
+    {
+        using var writer = new StringWriter();
+        GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "claude", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("intent-cli guide automation setup --kind child-implement", prompt, StringComparison.Ordinal);
+    }
+
+    // ── codex variant ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_AgentCodex_Markdown_EmitsPromptWithHeartbeatSemantics()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "codex", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide automation local-loop — agent: codex", output, StringComparison.Ordinal);
+        Assert.Contains("automation/heartbeat", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("## Prompt", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_AgentCodex_Json_EmitsStructuredFields()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "codex", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("local-loop", root.GetProperty("kind").GetString());
+        Assert.Equal("codex", root.GetProperty("agent").GetString());
+        Assert.False(root.GetProperty("clarification_required").GetBoolean());
+    }
+
+    [Fact]
+    public void Execute_AgentCodex_Json_PromptUsesLocalHeartbeatForbidsCloudScheduler()
+    {
+        using var writer = new StringWriter();
+        GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "codex", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("automation/heartbeat", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("current thread", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("cloud", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("never", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_AgentCodex_Json_PromptIncludesGuideAutomationSetupInstruction()
+    {
+        using var writer = new StringWriter();
+        GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "codex", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("intent-cli guide automation setup --kind child-implement", prompt, StringComparison.Ordinal);
+    }
+
+    // ── generic variant ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_AgentGeneric_Json_RequiresClarificationAndProviderNeutral()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "generic", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("generic", root.GetProperty("agent").GetString());
+        Assert.True(root.GetProperty("clarification_required").GetBoolean());
+        var prompt = root.GetProperty("prompt").GetString()!;
+        Assert.Contains("Claude Code", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Codex", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_AgentGeneric_Json_PromptAsksClarificationBeforeScheduling()
+    {
+        using var writer = new StringWriter();
+        GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "generic", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("confirm the agent runtime", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Do not create any scheduler", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── unknown (omitted) agent ───────────────────────────────────────────
+
+    [Fact]
+    public void Execute_AgentOmitted_Json_RequiresClarificationAndAsksOperator()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("unknown", root.GetProperty("agent").GetString());
+        Assert.True(root.GetProperty("clarification_required").GetBoolean());
+        var prompt = root.GetProperty("prompt").GetString()!;
+        Assert.Contains("ask the operator", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("claude", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("codex", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_AgentOmitted_Json_PromptForbidsSchedulingBeforeConfirmation()
+    {
+        using var writer = new StringWriter();
+        GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Do not create any cron job, scheduler, automation", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("local-loop --agent", prompt, StringComparison.Ordinal);
+    }
+
+    // ── frequency policy ──────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("claude")]
+    [InlineData("codex")]
+    [InlineData("generic")]
+    public void Execute_AllAgents_Json_FrequencyPolicyCoversHighAndLowCadence(string agentArg)
+    {
+        using var writer = new StringWriter();
+        GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", agentArg, "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var freqPolicy = document.RootElement.GetProperty("frequency_policy").GetString()!;
+        Assert.Contains("5 minutes", freqPolicy, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("20 minutes", freqPolicy, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("ask", freqPolicy, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("claude")]
+    [InlineData("codex")]
+    [InlineData("generic")]
+    public void Execute_AllAgents_Json_PromptForbidsIntentsRulesAndSkillFiles(string agentArg)
+    {
+        using var writer = new StringWriter();
+        GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", agentArg, "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("intents/rules/**", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide", prompt, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("claude")]
+    [InlineData("codex")]
+    [InlineData("generic")]
+    public void Execute_AllAgents_Json_ForbiddenSourcesContainCloudScheduler(string agentArg)
+    {
+        using var writer = new StringWriter();
+        GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", agentArg, "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var sources = document.RootElement.GetProperty("forbidden_sources")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(sources, s => s!.Contains("cloud", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── error cases ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_UnsupportedAgent_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "gpt"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--agent must be", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedFormat_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "claude", "--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "claude", "--unknown-flag", "x"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("guide automation local-loop", output, StringComparison.Ordinal);
+        Assert.Contains("claude", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("codex", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("generic", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── routing via GuideAutomationCommand ────────────────────────────────
+
+    [Fact]
+    public void Dispatch_LocalLoopRoutedThroughGuideAutomationCommand_Works()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["local-loop", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("local-loop", document.RootElement.GetProperty("kind").GetString());
+        Assert.Equal("claude", document.RootElement.GetProperty("agent").GetString());
+    }
+
+    // ── repo parameter ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_WithRepo_EmitsRepoInResult()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "claude", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("J-Tech-Japan/intent-system", document.RootElement.GetProperty("repo").GetString());
+    }
+
+    [Fact]
+    public void Execute_WithoutRepo_RepoFieldIsAbsentOrNull()
+    {
+        using var writer = new StringWriter();
+        GuideAutomationLocalLoopCommand.Execute(
+            CreateContext(),
+            ["--agent", "claude", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var hasRepo = document.RootElement.TryGetProperty("repo", out var repoElement);
+        Assert.True(!hasRepo || repoElement.ValueKind == JsonValueKind.Null);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- New `GuideAutomationLocalLoopCommand`: `intent-cli guide automation local-loop` with `--agent claude|codex|generic` (optional; defaults to `unknown`)
- Claude variant: same-thread `/loop 5m|20m` semantics, forbids cloud/new-thread schedulers for local-path workflows
- Codex variant: local automation/heartbeat attached to current thread, forbids cloud/new-thread schedulers
- Generic variant: provider-neutral with required operator clarification before scheduling
- Unknown (omitted) variant: instructs agent to ask operator for agent type, then re-run with `--agent <type>`
- Routing added in `GuideAutomationCommand` under `local-loop` sub-token
- 29 focused tests covering all variants, frequency policy, error cases, and routing

## Test plan

- [x] `dotnet test` — 1979 passed, 1 skipped
- [x] Targeted tests: `GuideAutomationLocalLoopCommandTests` (29 tests) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)