### PR TITLE
G277 Add host-side safe reconcile lane for intent-cli metadata drift

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -58,6 +58,7 @@ These templates assume:
 | G258  | `guide workflow suggest --include-advanced-runtime` | Default chat-first guidance excludes `intent-cli run` / supervisor subprocess; the new flag opts the relevant workflow into advanced runtime suggestions |
 | G259  | `intent-cli guide onboarding`           | Read-only first-call sequence for an AI agent with no local skill files or copied rules: model → rules list → commands list → workflow suggest → status → next-slice dry-run → interview → automation summary; each step names its no-mutation behavior and the host data boundary |
 | G260  | `intent-cli guide automation setup`     | Read-only paste-ready setup prompts for child implementation loop or host review/next-slice loop: forces guide model/onboarding/commands list/automation summary as first calls, forbids `intents/rules/**` and local skill files, delegates label transitions to installed `intent-cli automation`/`worker` commands |
+| G277  | [`safe-reconcile-lane.md`](./safe-reconcile-lane.md) / `intent-cli automation reconcile` | Host-only safe reconcile lane: dry-run plan + opt-in `--write` for mechanically provable label drift; advisory entries point at the existing closeout/packet/next-slice surface; child loops are forbidden from invoking it |
 
 ## Installed host transition command adoption
 

--- a/docs/automation-templates/safe-reconcile-lane.md
+++ b/docs/automation-templates/safe-reconcile-lane.md
@@ -1,0 +1,142 @@
+# Host-Side Safe Reconcile Lane
+
+The **safe reconcile lane** is a host-only stage that runs *before* a host
+review/next-slice wake declares `idle` or `clarification-required`. It repairs
+mechanically provable intent-cli metadata drift (label misplacement and a small
+set of derivable bookkeeping gaps) using evidence from GitHub state plus the
+existing intent-cli artifacts. Anything that is not mechanically provable still
+stops with structured clarification — reconcile never guesses.
+
+This template is the host-side counterpart to
+[`host-review-loop.md`](./host-review-loop.md) and
+[`host-next-slice-loop.md`](./host-next-slice-loop.md). It is **not** part of
+[`coding-automation-loop.md`](./coding-automation-loop.md); child implementation
+loops MUST NOT call `automation reconcile`.
+
+> **Hard rules** (do not paraphrase):
+> - Host-only. The command refuses to run from a child loop context.
+> - `--write` mutates labels via the host-owned reconcile mutator only;
+>   advisory entries point at the appropriate existing surface
+>   (`intent-cli closeout pr`, `intent-cli packet draft`,
+>   `intent-cli intent next-slice`).
+> - High-confidence repairs cover **label drift only**. Queue-state mutations,
+>   PR body edits, and clarification record updates remain owned by their
+>   existing host surfaces.
+> - `intent-pr-created` is issue-only. The reconcile mutator allows removing
+>   a misplaced one from a PR but rejects adding it.
+> - Ambiguous links and any case lacking deterministic evidence stop with
+>   `unsafe_stops[]` instead of being repaired.
+
+## When to invoke
+
+Run reconcile only when Stage 1 (review/closeout) and Stage 2 (next-slice)
+would otherwise stop without action:
+
+- `automation host-review-preflight` returned `no-actionable-item`,
+- `intent next-slice --dry-run` returned `clarification-required` or
+  `inspect-manually`, **or**
+- a PR is open in the target repo without expected workflow labels.
+
+## Lanes
+
+- `--lane host-review` — inspects open PRs and intent-target issues, looking
+  for label drift on the review boundary.
+- `--lane next-slice` — inspects whether the next-slice classifier is stuck
+  in `clarification-required` while the source clarifications report no open
+  blockers.
+- `--lane all` (default) — both.
+
+## Detected drift types
+
+| Type | Confidence | Mutation |
+|------|-----------|----------|
+| `missing-pr-intent-target` — PR closes a published intent-target issue but lacks the label | high | add `intent-target` to the PR |
+| `misplaced-pr-intent-pr-created` — PR carries `intent-pr-created` (issue-only by policy) | high | remove `intent-pr-created` from the PR |
+| `missing-issue-intent-pr-created` — open PR closes a published intent-target issue but the issue lacks the completion marker | high | add `intent-pr-created` to the issue |
+| `missing-linked-pr-metadata` — PR closing-issue references uniquely identify a published issue, so `linked_pr` could be filled | advisory | followup: `intent-cli closeout pr ...` |
+| `stale-next-slice-candidate-cache` — classifier returned `clarification-required` but no open Hard Clarification exists | advisory | followup: `intent-cli intent next-slice --dry-run --format json` |
+
+`unsafe_stops[]` examples:
+
+- `ambiguous-issue-link` — a PR is `intent-target` but has no
+  `Closes` / `Fixes` / `Resolves` keyword and no closing-issue reference.
+- `open-clarification-present` — the next-slice classifier returned
+  `clarification-required` and at least one open Hard Clarification is still
+  present in the source files.
+- `stale-host-cli` — the installed CLI is missing or stale for the required
+  automation command surfaces.
+- `child-loop-prohibited` — emitted when `--child-loop-context` is passed,
+  to make the prohibition deterministically testable.
+
+## Dry-run plan
+
+```bash
+intent-cli automation reconcile \
+  --lane host-review \
+  --repo "$TARGET_REPO" \
+  --format json
+```
+
+The result has shape:
+
+```json
+{
+  "lane": "host-review",
+  "repo": "owner/repo",
+  "mode": "dry-run",
+  "host_only": true,
+  "safe_repairs": [
+    {
+      "type": "missing-pr-intent-target",
+      "target_kind": "pr",
+      "target_number": 420,
+      "add_labels": ["intent-target"],
+      "remove_labels": [],
+      "evidence": [
+        "PR #420 body or closing-issue references include #559",
+        "issue #559 carries 'intent-target' and 'intent-pr-created' (published intent-target issue)"
+      ],
+      "confidence": "high",
+      "applied": false,
+      "summary": "Add intent-target to PR #420 (links published intent-target issue #559).",
+      "requires_followup_command": null
+    }
+  ],
+  "unsafe_stops": [],
+  "warnings": [],
+  "summary": "reconcile dry-run: 1 high-confidence repair(s), 0 advisory entry(ies), 0 unsafe stop(s)."
+}
+```
+
+## Write mode
+
+```bash
+intent-cli automation reconcile \
+  --lane host-review \
+  --repo "$TARGET_REPO" \
+  --write \
+  --format json
+```
+
+Only `confidence: high` entries are applied. Advisory entries are emitted
+unchanged and must be addressed through their `requires_followup_command`.
+If the reconcile mutator rejects a transition (for example because of a hard
+policy like adding `intent-pr-created` to a PR), the entry stays with
+`applied: false` and a warning records the reason — the command does not fall
+back to raw `gh ... edit --add-label`.
+
+## Child-loop prohibition
+
+`automation reconcile` does not appear in the `child-loop` or `child-oneshot`
+prompt-matrix entries. The runtime guard `--child-loop-context` lets the test
+suite assert that calling it from a child surface returns exit code `2` with a
+`child-loop-prohibited` unsafe stop and never invokes the lister or mutator.
+
+## Hard out-of-scope
+
+- Semantic intent decisions.
+- Modifying child implementation code.
+- Guessing missing issue/PR links without deterministic evidence.
+- Broad label cleanup unrelated to intent-cli workflows.
+- Running from child implementation loops.
+- Hiding real contract gaps as automatic repairs.

--- a/ops/g277-host-side-safe-reconcile-lane.md
+++ b/ops/g277-host-side-safe-reconcile-lane.md
@@ -1,0 +1,59 @@
+# G277 Host-side safe reconcile lane
+
+## Why this slice
+
+Host review/next-slice loops were correctly stopping when intent-cli
+metadata was inconsistent, but the behavior was too rigid for obvious
+intent-cli-generated drift: missing `intent-target` on an intent-cli-created
+PR, a misplaced `intent-pr-created` on a PR, a missing source-issue
+completion marker, or a next-slice candidate cache that says
+`clarification-required` when no open Hard Clarification exists. These are
+host-owned bookkeeping problems, not child implementation problems, and
+should be repaired host-side before the wake declares idle / hard
+clarification.
+
+## What changed
+
+- `intent-cli automation reconcile` is the new host-only command that
+  produces a structured dry-run plan of mechanically provable label drift
+  and applies high-confidence label repairs through the host-owned
+  reconcile mutator on `--write`.
+- `IGitHubLabelMutator.ApplyReconcileTransitions` is the reconcile-only
+  mutator entry point: it allows removing a misplaced `intent-pr-created`
+  from a PR but still rejects adding it.
+- `intent-cli guide prompt-matrix --mode host-loop` now includes a
+  Stage 3 "safe reconcile" entry. `child-loop` and `child-oneshot`
+  prompts are unchanged — child implementation loops MUST NOT invoke
+  reconcile.
+- New template:
+  [`docs/automation-templates/safe-reconcile-lane.md`](../docs/automation-templates/safe-reconcile-lane.md).
+
+## Boundaries
+
+- Mechanically provable label drift only.
+  - `missing-pr-intent-target` — high
+  - `misplaced-pr-intent-pr-created` — high
+  - `missing-issue-intent-pr-created` — high
+- Advisory entries do not mutate; they emit a `requires_followup_command`
+  pointing at the existing surface that owns the underlying mutation:
+  - `missing-linked-pr-metadata` → `intent-cli closeout pr`
+  - `stale-next-slice-candidate-cache` → `intent-cli intent next-slice --dry-run`
+- Ambiguous cases stop with `unsafe_stops[]` rather than guess.
+- Child-loop prohibition is testable via `--child-loop-context` (exit `2`,
+  no GitHub or mutator side-effects), and is also enforced by the
+  prompt-matrix omission for `child-loop` / `child-oneshot`.
+
+## Verification
+
+```bash
+dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
+  --filter "FullyQualifiedName~AutomationReconcileCommandTests"
+
+git diff --check
+```
+
+The focused tests cover safe repair plans, dry-run vs `--write` gating,
+child-loop prohibition, ambiguous-link unsafe stops, next-slice clarified
+vs open-clarification handling, stale-host-cli refusal, command router
+registration, and the `child-loop` / `child-oneshot` prompt omission of the
+new command.

--- a/src/IntentSystem.Cli/Commands/AutomationReconcileAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationReconcileAnalyzer.cs
@@ -1,0 +1,311 @@
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G277: Pure analyzer for the host-side safe reconcile lane. Inspects open
+/// intent-target PRs and issues plus their cross-links to detect mechanically
+/// provable label drift (high confidence) and link-drift advisory entries
+/// (lower confidence). Never reads files, never mutates GitHub or local state,
+/// and never launches an AI provider. The command layer wraps this with I/O
+/// and the optional <c>--write</c> path that goes through the host-owned
+/// <see cref="IGitHubLabelMutator.ApplyReconcileTransitions"/> entry point.
+/// </summary>
+internal static class AutomationReconcileAnalyzer
+{
+    private static readonly Regex ClosesIssueRegex = new(
+        @"(?i)\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+(?:(?<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(?<number>\d+)\b",
+        RegexOptions.Compiled);
+
+    public static AutomationReconcileAnalysis AnalyzeHostReview(
+        string repo,
+        IReadOnlyList<GitHubAutomationPrCandidate> openPrs,
+        IReadOnlyList<GitHubAutomationIssueCandidate> publishedIntentTargetIssues)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentNullException.ThrowIfNull(openPrs);
+        ArgumentNullException.ThrowIfNull(publishedIntentTargetIssues);
+
+        var safeRepairs = new List<AutomationReconcileRepair>();
+        var unsafeStops = new List<AutomationReconcileUnsafeStop>();
+
+        var publishedIssuesByNumber = publishedIntentTargetIssues
+            .Where(IsPublishedIntentTargetIssue)
+            .ToDictionary(issue => issue.Number);
+
+        var prsLinkingPublishedIssue = new Dictionary<int, List<int>>();
+
+        foreach (var pr in openPrs)
+        {
+            var prLabels = LabelNames(pr.Labels);
+            var linkedIssueNumbers = ExtractLinkedIssueNumbers(repo, pr);
+            var publishedLinkedIssues = linkedIssueNumbers
+                .Where(publishedIssuesByNumber.ContainsKey)
+                .ToArray();
+
+            foreach (var issueNumber in publishedLinkedIssues)
+            {
+                if (!prsLinkingPublishedIssue.TryGetValue(issueNumber, out var list))
+                {
+                    list = new List<int>();
+                    prsLinkingPublishedIssue[issueNumber] = list;
+                }
+
+                if (!list.Contains(pr.Number))
+                {
+                    list.Add(pr.Number);
+                }
+            }
+
+            // Repair 1: PR closes a published intent-target issue but lacks intent-target.
+            if (publishedLinkedIssues.Length > 0
+                && !prLabels.Contains(WorkerNextActionConstants.Labels.IntentTarget, StringComparer.Ordinal))
+            {
+                var primary = publishedLinkedIssues[0];
+                safeRepairs.Add(new AutomationReconcileRepair
+                {
+                    Type = AutomationReconcileRepairTypes.MissingPrIntentTarget,
+                    TargetKind = GhCliGitHubLabelMutator.Kinds.Pr,
+                    TargetNumber = pr.Number,
+                    TargetUrl = pr.Url,
+                    AddLabels = [WorkerNextActionConstants.Labels.IntentTarget],
+                    RemoveLabels = Array.Empty<string>(),
+                    Evidence =
+                    [
+                        $"PR #{pr.Number} body or closing-issue references include #{primary}",
+                        $"issue #{primary} carries 'intent-target' and 'intent-pr-created' (published intent-target issue)"
+                    ],
+                    Confidence = AutomationReconcileConfidence.High,
+                    Applied = false,
+                    Summary = $"Add intent-target to PR #{pr.Number} (links published intent-target issue #{primary}).",
+                    RequiresFollowupCommand = null,
+                });
+            }
+
+            // Repair 2: PR carries intent-pr-created (which is issue-only by policy).
+            if (prLabels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal))
+            {
+                safeRepairs.Add(new AutomationReconcileRepair
+                {
+                    Type = AutomationReconcileRepairTypes.MisplacedPrIntentPrCreated,
+                    TargetKind = GhCliGitHubLabelMutator.Kinds.Pr,
+                    TargetNumber = pr.Number,
+                    TargetUrl = pr.Url,
+                    AddLabels = Array.Empty<string>(),
+                    RemoveLabels = [WorkerNextActionConstants.Labels.IntentPrCreated],
+                    Evidence =
+                    [
+                        $"PR #{pr.Number} carries 'intent-pr-created' which is issue-only by policy"
+                    ],
+                    Confidence = AutomationReconcileConfidence.High,
+                    Applied = false,
+                    Summary = $"Remove misplaced intent-pr-created from PR #{pr.Number}.",
+                    RequiresFollowupCommand = null,
+                });
+            }
+
+            // Advisory: PR is intent-target but body has no Closes/Fixes/Resolves keyword
+            // and no closing-issue reference. Cannot be repaired without operator input.
+            if (prLabels.Contains(WorkerNextActionConstants.Labels.IntentTarget, StringComparer.Ordinal)
+                && linkedIssueNumbers.Count == 0)
+            {
+                unsafeStops.Add(new AutomationReconcileUnsafeStop
+                {
+                    Kind = AutomationReconcileUnsafeStopKinds.AmbiguousIssueLink,
+                    TargetKind = GhCliGitHubLabelMutator.Kinds.Pr,
+                    TargetNumber = pr.Number,
+                    TargetUrl = pr.Url,
+                    Reason = $"PR #{pr.Number} is intent-target but body has no Closes/Fixes/Resolves keyword and no closing-issue reference; closeout keyword cannot be derived deterministically.",
+                    MissingEvidence =
+                    [
+                        "PR body lacks 'Closes #N' / 'Fixes #N' / 'Resolves #N'",
+                        "no GitHub closing-issue reference present"
+                    ],
+                });
+            }
+
+            // Advisory: PR closes a published issue, so linked_pr metadata is derivable.
+            // We do not mutate queue-state here; we surface the followup for a host
+            // closeout/packet command to apply through its existing surface.
+            if (publishedLinkedIssues.Length == 1)
+            {
+                var issueNumber = publishedLinkedIssues[0];
+                safeRepairs.Add(new AutomationReconcileRepair
+                {
+                    Type = AutomationReconcileRepairTypes.MissingLinkedPrMetadata,
+                    TargetKind = "queue-state",
+                    TargetNumber = issueNumber,
+                    TargetUrl = publishedIssuesByNumber[issueNumber].Url,
+                    AddLabels = Array.Empty<string>(),
+                    RemoveLabels = Array.Empty<string>(),
+                    Evidence =
+                    [
+                        $"PR #{pr.Number} closing-issue references uniquely include #{issueNumber}",
+                        $"issue #{issueNumber} is a published intent-target issue"
+                    ],
+                    Confidence = AutomationReconcileConfidence.Advisory,
+                    Applied = false,
+                    Summary = $"linked_pr for execution-unit of issue #{issueNumber} can be derived as PR #{pr.Number}; apply through the host closeout/packet surface, not this lane.",
+                    RequiresFollowupCommand = $"intent-cli closeout pr --pr {pr.Number} --repo {repo}",
+                });
+            }
+        }
+
+        // Repair 3: published intent-target issue with a linked open PR but no
+        // intent-pr-created on the issue (state mismatch).
+        foreach (var (issueNumber, prsLinking) in prsLinkingPublishedIssue)
+        {
+            var issue = publishedIssuesByNumber[issueNumber];
+            var issueLabels = LabelNames(issue.Labels);
+            if (!issueLabels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal))
+            {
+                var primaryPr = prsLinking.OrderBy(n => n).First();
+                safeRepairs.Add(new AutomationReconcileRepair
+                {
+                    Type = AutomationReconcileRepairTypes.MissingIssueIntentPrCreated,
+                    TargetKind = GhCliGitHubLabelMutator.Kinds.Issue,
+                    TargetNumber = issueNumber,
+                    TargetUrl = issue.Url,
+                    AddLabels = [WorkerNextActionConstants.Labels.IntentPrCreated],
+                    RemoveLabels = Array.Empty<string>(),
+                    Evidence =
+                    [
+                        $"open PR #{primaryPr} closes issue #{issueNumber}",
+                        $"issue #{issueNumber} lacks intent-pr-created completion marker"
+                    ],
+                    Confidence = AutomationReconcileConfidence.High,
+                    Applied = false,
+                    Summary = $"Add intent-pr-created to source issue #{issueNumber} (linked PR #{primaryPr}).",
+                    RequiresFollowupCommand = null,
+                });
+            }
+        }
+
+        return new AutomationReconcileAnalysis(safeRepairs, unsafeStops);
+    }
+
+    public static AutomationReconcileAnalysis AnalyzeNextSlice(
+        bool nextSliceClassifiedClarificationRequired,
+        bool clarificationFilesShowNoOpenBlocker)
+    {
+        var safeRepairs = new List<AutomationReconcileRepair>();
+        var unsafeStops = new List<AutomationReconcileUnsafeStop>();
+
+        if (nextSliceClassifiedClarificationRequired && clarificationFilesShowNoOpenBlocker)
+        {
+            safeRepairs.Add(new AutomationReconcileRepair
+            {
+                Type = AutomationReconcileRepairTypes.StaleNextSliceCandidateCache,
+                TargetKind = "queue-state",
+                TargetNumber = null,
+                TargetUrl = null,
+                AddLabels = Array.Empty<string>(),
+                RemoveLabels = Array.Empty<string>(),
+                Evidence =
+                [
+                    "next-slice classified clarification-required",
+                    "no open Hard Clarification entries are present in the source clarifications"
+                ],
+                Confidence = AutomationReconcileConfidence.Advisory,
+                Applied = false,
+                Summary = "Next-slice candidate cache appears stale; rerun next-slice classifier with refreshed inputs to clear the false-positive clarification-required state.",
+                RequiresFollowupCommand = "intent-cli intent next-slice --dry-run --format json",
+            });
+        }
+
+        if (nextSliceClassifiedClarificationRequired && !clarificationFilesShowNoOpenBlocker)
+        {
+            unsafeStops.Add(new AutomationReconcileUnsafeStop
+            {
+                Kind = "open-clarification-present",
+                TargetKind = null,
+                TargetNumber = null,
+                TargetUrl = null,
+                Reason = "next-slice classifier returned clarification-required and the source clarifications still show at least one open Hard Clarification; reconcile cannot bypass an unresolved blocker.",
+                MissingEvidence =
+                [
+                    "no source clarification file currently states 'no open blockers'"
+                ],
+            });
+        }
+
+        return new AutomationReconcileAnalysis(safeRepairs, unsafeStops);
+    }
+
+    public static AutomationReconcileAnalysis Combine(
+        AutomationReconcileAnalysis a,
+        AutomationReconcileAnalysis b) =>
+        new(
+            a.SafeRepairs.Concat(b.SafeRepairs).ToArray(),
+            a.UnsafeStops.Concat(b.UnsafeStops).ToArray());
+
+    private static IReadOnlyList<int> ExtractLinkedIssueNumbers(string repo, GitHubAutomationPrCandidate pr)
+    {
+        var numbers = new List<int>();
+
+        foreach (var reference in pr.ClosingIssuesReferences)
+        {
+            if (reference.Number <= 0)
+            {
+                continue;
+            }
+
+            var referenceRepo = repo;
+            if (reference.Repository is { Name.Length: > 0, Owner.Login.Length: > 0 } repository)
+            {
+                referenceRepo = $"{repository.Owner.Login}/{repository.Name}";
+            }
+
+            if (string.Equals(referenceRepo, repo, StringComparison.OrdinalIgnoreCase)
+                && !numbers.Contains(reference.Number))
+            {
+                numbers.Add(reference.Number);
+            }
+        }
+
+        foreach (Match match in ClosesIssueRegex.Matches(pr.Body ?? string.Empty))
+        {
+            var linkedRepo = match.Groups["repo"].Value;
+            if (!string.IsNullOrWhiteSpace(linkedRepo)
+                && !string.Equals(linkedRepo, repo, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (int.TryParse(
+                    match.Groups["number"].Value,
+                    System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out var issueNumber)
+                && !numbers.Contains(issueNumber))
+            {
+                numbers.Add(issueNumber);
+            }
+        }
+
+        return numbers;
+    }
+
+    private static bool IsPublishedIntentTargetIssue(GitHubAutomationIssueCandidate issue)
+    {
+        var labels = LabelNames(issue.Labels);
+        return labels.Contains(WorkerNextActionConstants.Labels.IntentTarget, StringComparer.Ordinal);
+    }
+
+    private static IReadOnlyCollection<string> LabelNames(IReadOnlyList<GitHubAutomationLabel>? labels)
+    {
+        if (labels is null || labels.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        return labels
+            .Select(label => label.Name)
+            .Where(name => !string.IsNullOrEmpty(name))
+            .ToArray();
+    }
+}
+
+internal sealed record AutomationReconcileAnalysis(
+    IReadOnlyList<AutomationReconcileRepair> SafeRepairs,
+    IReadOnlyList<AutomationReconcileUnsafeStop> UnsafeStops);

--- a/src/IntentSystem.Cli/Commands/AutomationReconcileCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationReconcileCommand.cs
@@ -1,0 +1,496 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G277: Host-side safe reconcile lane. Runs only on host loops and only
+/// before declaring idle / hard-clarification. Produces a dry-run plan
+/// describing mechanically provable label drift in the target repo, with
+/// evidence and confidence; <c>--write</c> applies high-confidence repairs
+/// through <see cref="IGitHubLabelMutator.ApplyReconcileTransitions"/>.
+/// Lower-confidence advisory entries are not applied — they carry a
+/// <c>requires_followup_command</c> that points the operator at the existing
+/// host-owned surface (closeout / packet / next-slice) responsible for the
+/// underlying mutation. The command itself never reads <c>intents/rules/**</c>
+/// and never launches an AI provider. Calling it from a child implementation
+/// loop is rejected via <c>--child-loop-context</c> so the prohibition is
+/// testable; child-loop guidance never references this command in the first
+/// place.
+/// </summary>
+internal static class AutomationReconcileCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private const string OptLane = "--lane";
+    private const string OptRepo = "--repo";
+    private const string OptWorkdir = "--workdir";
+    private const string OptDryRun = "--dry-run";
+    private const string OptWrite = "--write";
+    private const string OptFormat = "--format";
+    private const string OptChildLoopContext = "--child-loop-context";
+    private const string OptNextSliceClarificationRequired = "--next-slice-clarification-required";
+    private const string OptClarificationsAllResolved = "--clarifications-all-resolved";
+    private const string OptHelp = "--help";
+
+    public static Func<IGitHubAutomationCandidateLister>? CandidateListerFactory { get; set; }
+
+    public static Func<IGitHubLabelMutator>? MutatorFactory { get; set; }
+
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], OptHelp, StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(
+                args,
+                out var lane,
+                out var repo,
+                out var workdir,
+                out var mode,
+                out var format,
+                out var childLoopContext,
+                out var nextSliceClarificationRequired,
+                out var clarificationsAllResolved,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        if (childLoopContext)
+        {
+            var rejected = new AutomationReconcileResult
+            {
+                Lane = lane,
+                Repo = repo ?? string.Empty,
+                Mode = mode,
+                HostOnly = true,
+                SafeRepairs = Array.Empty<AutomationReconcileRepair>(),
+                UnsafeStops =
+                [
+                    new AutomationReconcileUnsafeStop
+                    {
+                        Kind = AutomationReconcileUnsafeStopKinds.ChildLoopProhibited,
+                        TargetKind = null,
+                        TargetNumber = null,
+                        TargetUrl = null,
+                        Reason = "automation reconcile is host-only; child implementation loops must not invoke it.",
+                        MissingEvidence = Array.Empty<string>(),
+                    }
+                ],
+                Warnings = Array.Empty<string>(),
+                Summary = "child-loop prohibited: automation reconcile is host-only.",
+            };
+
+            Emit(writer, rejected, format);
+            return 2;
+        }
+
+        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        if (string.IsNullOrWhiteSpace(repo)
+            && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        // Host-only reconcile depends on the same installed CLI surface as the
+        // host review preflight so high-confidence repairs are applied through
+        // the canonical automation surface, not raw gh fallbacks.
+        var surfaceReport = AutomationInstalledCliSurfaceProbe.Check(context);
+        if (!surfaceReport.Available)
+        {
+            var stale = new AutomationReconcileResult
+            {
+                Lane = lane,
+                Repo = repo!,
+                Mode = mode,
+                HostOnly = true,
+                SafeRepairs = Array.Empty<AutomationReconcileRepair>(),
+                UnsafeStops =
+                [
+                    new AutomationReconcileUnsafeStop
+                    {
+                        Kind = "stale-host-cli",
+                        TargetKind = null,
+                        TargetNumber = null,
+                        TargetUrl = null,
+                        Reason = $"installed CLI at {surfaceReport.InstalledCliPath} is missing or stale for required automation command surfaces; refresh the installed CLI before running reconcile.",
+                        MissingEvidence = Array.Empty<string>(),
+                    }
+                ],
+                Warnings = Array.Empty<string>(),
+                Summary = "stale-host-cli: installed automation surface is incomplete.",
+            };
+            Emit(writer, stale, format);
+            return 1;
+        }
+
+        IGitHubAutomationCandidateLister lister;
+        try
+        {
+            lister = CandidateListerFactory?.Invoke()
+                ?? new GhCliGitHubAutomationCandidateLister();
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub lister: {exception.Message}");
+            return 1;
+        }
+
+        var includeHostReview = !string.Equals(lane, AutomationReconcileLanes.NextSlice, StringComparison.Ordinal);
+        var includeNextSlice = !string.Equals(lane, AutomationReconcileLanes.HostReview, StringComparison.Ordinal);
+
+        AutomationReconcileAnalysis hostReviewAnalysis = new(
+            Array.Empty<AutomationReconcileRepair>(),
+            Array.Empty<AutomationReconcileUnsafeStop>());
+        AutomationReconcileAnalysis nextSliceAnalysis = hostReviewAnalysis;
+
+        if (includeHostReview)
+        {
+            IReadOnlyList<GitHubAutomationPrCandidate> openPrs;
+            IReadOnlyList<GitHubAutomationIssueCandidate> publishedIssues;
+            try
+            {
+                openPrs = lister.ListPullRequests(repo!, Array.Empty<string>());
+                publishedIssues = lister.ListIssues(
+                    repo!,
+                    [WorkerNextActionConstants.Labels.IntentTarget]);
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or IOException)
+            {
+                writer.WriteLine($"failed to list reconcile candidates for {repo}: {exception.Message}");
+                return 1;
+            }
+
+            hostReviewAnalysis = AutomationReconcileAnalyzer.AnalyzeHostReview(
+                repo!,
+                openPrs,
+                publishedIssues);
+        }
+
+        if (includeNextSlice)
+        {
+            nextSliceAnalysis = AutomationReconcileAnalyzer.AnalyzeNextSlice(
+                nextSliceClarificationRequired,
+                clarificationsAllResolved);
+        }
+
+        var combined = AutomationReconcileAnalyzer.Combine(hostReviewAnalysis, nextSliceAnalysis);
+
+        var appliedRepairs = combined.SafeRepairs;
+        var warnings = new List<string>();
+        if (string.Equals(mode, AutomationReconcileModes.Write, StringComparison.Ordinal))
+        {
+            IGitHubLabelMutator mutator;
+            try
+            {
+                mutator = MutatorFactory?.Invoke()
+                    ?? new GhCliGitHubLabelMutator();
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or IOException)
+            {
+                writer.WriteLine($"failed to initialize reconcile mutator: {exception.Message}");
+                return 1;
+            }
+
+            appliedRepairs = ApplyHighConfidenceRepairs(repo!, mutator, combined.SafeRepairs, warnings);
+        }
+
+        var result = new AutomationReconcileResult
+        {
+            Lane = lane,
+            Repo = repo!,
+            Mode = mode,
+            HostOnly = true,
+            SafeRepairs = appliedRepairs,
+            UnsafeStops = combined.UnsafeStops,
+            Warnings = warnings,
+            Summary = BuildSummary(combined.SafeRepairs, combined.UnsafeStops, mode),
+        };
+
+        Emit(writer, result, format);
+        return 0;
+    }
+
+    private static IReadOnlyList<AutomationReconcileRepair> ApplyHighConfidenceRepairs(
+        string repo,
+        IGitHubLabelMutator mutator,
+        IReadOnlyList<AutomationReconcileRepair> repairs,
+        List<string> warnings)
+    {
+        var applied = new List<AutomationReconcileRepair>(repairs.Count);
+        foreach (var repair in repairs)
+        {
+            if (!string.Equals(repair.Confidence, AutomationReconcileConfidence.High, StringComparison.Ordinal)
+                || repair.TargetNumber is null
+                || (string.Equals(repair.TargetKind, GhCliGitHubLabelMutator.Kinds.Pr, StringComparison.Ordinal) == false
+                    && string.Equals(repair.TargetKind, GhCliGitHubLabelMutator.Kinds.Issue, StringComparison.Ordinal) == false))
+            {
+                applied.Add(repair);
+                continue;
+            }
+
+            try
+            {
+                mutator.ApplyReconcileTransitions(
+                    repo,
+                    repair.TargetKind,
+                    repair.TargetNumber.Value,
+                    repair.AddLabels,
+                    repair.RemoveLabels);
+                applied.Add(repair with { Applied = true });
+            }
+            catch (InvalidOperationException exception)
+            {
+                warnings.Add($"failed to apply repair '{repair.Type}' on {repair.TargetKind} #{repair.TargetNumber}: {exception.Message}");
+                applied.Add(repair);
+            }
+        }
+
+        return applied;
+    }
+
+    private static string BuildSummary(
+        IReadOnlyList<AutomationReconcileRepair> safeRepairs,
+        IReadOnlyList<AutomationReconcileUnsafeStop> unsafeStops,
+        string mode)
+    {
+        var highCount = safeRepairs.Count(r => string.Equals(r.Confidence, AutomationReconcileConfidence.High, StringComparison.Ordinal));
+        var advisoryCount = safeRepairs.Count(r => string.Equals(r.Confidence, AutomationReconcileConfidence.Advisory, StringComparison.Ordinal));
+        var unsafeCount = unsafeStops.Count;
+
+        if (highCount == 0 && advisoryCount == 0 && unsafeCount == 0)
+        {
+            return $"no reconcile drift detected; {mode} mode produced no plan entries.";
+        }
+
+        return $"reconcile {mode}: {highCount.ToString(System.Globalization.CultureInfo.InvariantCulture)} high-confidence repair(s), {advisoryCount.ToString(System.Globalization.CultureInfo.InvariantCulture)} advisory entry(ies), {unsafeCount.ToString(System.Globalization.CultureInfo.InvariantCulture)} unsafe stop(s).";
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string lane,
+        out string? repo,
+        out string? workdir,
+        out string mode,
+        out string format,
+        out bool childLoopContext,
+        out bool nextSliceClarificationRequired,
+        out bool clarificationsAllResolved,
+        out string error)
+    {
+        lane = AutomationReconcileLanes.All;
+        repo = null;
+        workdir = null;
+        mode = AutomationReconcileModes.DryRun;
+        format = FormatText;
+        childLoopContext = false;
+        nextSliceClarificationRequired = false;
+        clarificationsAllResolved = false;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case OptLane:
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--lane requires a value (host-review, next-slice, or all).";
+                        return false;
+                    }
+                    var requestedLane = args[index + 1].Trim();
+                    if (!string.Equals(requestedLane, AutomationReconcileLanes.HostReview, StringComparison.Ordinal)
+                        && !string.Equals(requestedLane, AutomationReconcileLanes.NextSlice, StringComparison.Ordinal)
+                        && !string.Equals(requestedLane, AutomationReconcileLanes.All, StringComparison.Ordinal))
+                    {
+                        error = $"--lane must be 'host-review', 'next-slice', or 'all' (got '{requestedLane}').";
+                        return false;
+                    }
+                    lane = requestedLane;
+                    index++;
+                    break;
+
+                case OptRepo:
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case OptWorkdir:
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--workdir requires a value.";
+                        return false;
+                    }
+                    workdir = args[index + 1];
+                    index++;
+                    break;
+
+                case OptDryRun:
+                    mode = AutomationReconcileModes.DryRun;
+                    break;
+
+                case OptWrite:
+                    mode = AutomationReconcileModes.Write;
+                    break;
+
+                case OptFormat:
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                case OptChildLoopContext:
+                    childLoopContext = true;
+                    break;
+
+                case OptNextSliceClarificationRequired:
+                    nextSliceClarificationRequired = true;
+                    break;
+
+                case OptClarificationsAllResolved:
+                    clarificationsAllResolved = true;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: [--lane host-review|next-slice|all] [--repo <owner/repo>] [--workdir <path>] [--dry-run] [--write] [--next-slice-clarification-required] [--clarifications-all-resolved] [--child-loop-context] [--format text|json].";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string ResolveWorkdir(CliContext context, string? workdir)
+    {
+        if (string.IsNullOrWhiteSpace(workdir))
+        {
+            return context.RepoRoot;
+        }
+
+        return Path.IsPathRooted(workdir)
+            ? workdir
+            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
+    }
+
+    private static void Emit(TextWriter writer, AutomationReconcileResult result, string format)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+    }
+
+    private static void WriteText(TextWriter writer, AutomationReconcileResult result)
+    {
+        writer.WriteLine($"# Automation reconcile ({result.Lane}) for {result.Repo}");
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- host_only: {result.HostOnly.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"- {result.Summary}");
+        writer.WriteLine();
+        writer.WriteLine("## Safe repairs");
+        if (result.SafeRepairs.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        foreach (var repair in result.SafeRepairs)
+        {
+            writer.WriteLine($"- {repair.Type} ({repair.Confidence}, applied={repair.Applied.ToString().ToLowerInvariant()})");
+            writer.WriteLine($"  target: {repair.TargetKind} {(repair.TargetNumber is { } n ? "#" + n.ToString(System.Globalization.CultureInfo.InvariantCulture) : "(local)")}");
+            if (repair.AddLabels.Count > 0)
+            {
+                writer.WriteLine($"  add: {string.Join(", ", repair.AddLabels)}");
+            }
+            if (repair.RemoveLabels.Count > 0)
+            {
+                writer.WriteLine($"  remove: {string.Join(", ", repair.RemoveLabels)}");
+            }
+            writer.WriteLine($"  summary: {repair.Summary}");
+            foreach (var line in repair.Evidence)
+            {
+                writer.WriteLine($"  evidence: {line}");
+            }
+            if (!string.IsNullOrWhiteSpace(repair.RequiresFollowupCommand))
+            {
+                writer.WriteLine($"  followup: {repair.RequiresFollowupCommand}");
+            }
+        }
+        writer.WriteLine();
+        writer.WriteLine("## Unsafe stops");
+        if (result.UnsafeStops.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        foreach (var stop in result.UnsafeStops)
+        {
+            writer.WriteLine($"- {stop.Kind}: {stop.Reason}");
+            foreach (var line in stop.MissingEvidence)
+            {
+                writer.WriteLine($"  missing_evidence: {line}");
+            }
+        }
+        if (result.Warnings.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Warnings");
+            foreach (var w in result.Warnings)
+            {
+                writer.WriteLine($"- {w}");
+            }
+        }
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("automation reconcile");
+        writer.WriteLine("Usage: intent-cli automation reconcile [--lane host-review|next-slice|all] [--repo <owner/repo>] [--workdir <path>] [--dry-run] [--write] [--next-slice-clarification-required] [--clarifications-all-resolved] [--format text|json]");
+        writer.WriteLine("Host-only safe reconcile lane for mechanically provable intent-cli metadata drift.");
+        writer.WriteLine("Dry-run by default. --write applies high-confidence label repairs through the host-owned reconcile mutator.");
+        writer.WriteLine("Child implementation loops must not invoke this command. --child-loop-context exits with code 2 for testable prohibition.");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/AutomationReconcileResult.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationReconcileResult.cs
@@ -1,0 +1,178 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G277: Result of <c>intent-cli automation reconcile</c>. Lists the safe
+/// label-drift repairs detected for a repo, plus any unsafe stops that
+/// require operator clarification. Host-only by policy — never produced
+/// from a child implementation loop. Dry-run by default; <c>--write</c>
+/// applies high-confidence repairs through the host-owned reconcile mutator.
+/// </summary>
+internal sealed record AutomationReconcileResult
+{
+    [JsonPropertyName("lane")]
+    public required string Lane { get; init; }
+
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("host_only")]
+    public required bool HostOnly { get; init; }
+
+    [JsonPropertyName("hostOnly")]
+    public bool HostOnlyCamel => HostOnly;
+
+    [JsonPropertyName("safe_repairs")]
+    public required IReadOnlyList<AutomationReconcileRepair> SafeRepairs { get; init; }
+
+    [JsonPropertyName("safeRepairs")]
+    public IReadOnlyList<AutomationReconcileRepair> SafeRepairsCamel => SafeRepairs;
+
+    [JsonPropertyName("unsafe_stops")]
+    public required IReadOnlyList<AutomationReconcileUnsafeStop> UnsafeStops { get; init; }
+
+    [JsonPropertyName("unsafeStops")]
+    public IReadOnlyList<AutomationReconcileUnsafeStop> UnsafeStopsCamel => UnsafeStops;
+
+    [JsonPropertyName("warnings")]
+    public required IReadOnlyList<string> Warnings { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}
+
+/// <summary>
+/// G277: One mechanically provable repair entry. Confidence categorizes how
+/// strong the evidence is; only repairs with confidence
+/// <see cref="AutomationReconcileConfidence.High"/> are applied in
+/// <c>--write</c> mode. Lower-confidence entries are advisory and may carry
+/// a follow-up command for the operator to invoke through an existing
+/// intent-cli surface.
+/// </summary>
+internal sealed record AutomationReconcileRepair
+{
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
+
+    [JsonPropertyName("target_kind")]
+    public required string TargetKind { get; init; }
+
+    [JsonPropertyName("targetKind")]
+    public string TargetKindCamel => TargetKind;
+
+    [JsonPropertyName("target_number")]
+    public required int? TargetNumber { get; init; }
+
+    [JsonPropertyName("targetNumber")]
+    public int? TargetNumberCamel => TargetNumber;
+
+    [JsonPropertyName("target_url")]
+    public required string? TargetUrl { get; init; }
+
+    [JsonPropertyName("targetUrl")]
+    public string? TargetUrlCamel => TargetUrl;
+
+    [JsonPropertyName("add_labels")]
+    public required IReadOnlyList<string> AddLabels { get; init; }
+
+    [JsonPropertyName("addLabels")]
+    public IReadOnlyList<string> AddLabelsCamel => AddLabels;
+
+    [JsonPropertyName("remove_labels")]
+    public required IReadOnlyList<string> RemoveLabels { get; init; }
+
+    [JsonPropertyName("removeLabels")]
+    public IReadOnlyList<string> RemoveLabelsCamel => RemoveLabels;
+
+    [JsonPropertyName("evidence")]
+    public required IReadOnlyList<string> Evidence { get; init; }
+
+    [JsonPropertyName("confidence")]
+    public required string Confidence { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("requires_followup_command")]
+    public required string? RequiresFollowupCommand { get; init; }
+
+    [JsonPropertyName("requiresFollowupCommand")]
+    public string? RequiresFollowupCommandCamel => RequiresFollowupCommand;
+}
+
+internal sealed record AutomationReconcileUnsafeStop
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("target_kind")]
+    public required string? TargetKind { get; init; }
+
+    [JsonPropertyName("targetKind")]
+    public string? TargetKindCamel => TargetKind;
+
+    [JsonPropertyName("target_number")]
+    public required int? TargetNumber { get; init; }
+
+    [JsonPropertyName("targetNumber")]
+    public int? TargetNumberCamel => TargetNumber;
+
+    [JsonPropertyName("target_url")]
+    public required string? TargetUrl { get; init; }
+
+    [JsonPropertyName("targetUrl")]
+    public string? TargetUrlCamel => TargetUrl;
+
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
+
+    [JsonPropertyName("missing_evidence")]
+    public required IReadOnlyList<string> MissingEvidence { get; init; }
+
+    [JsonPropertyName("missingEvidence")]
+    public IReadOnlyList<string> MissingEvidenceCamel => MissingEvidence;
+}
+
+internal static class AutomationReconcileLanes
+{
+    public const string HostReview = "host-review";
+    public const string NextSlice = "next-slice";
+    public const string All = "all";
+}
+
+internal static class AutomationReconcileModes
+{
+    public const string DryRun = "dry-run";
+    public const string Write = "write";
+}
+
+internal static class AutomationReconcileConfidence
+{
+    public const string High = "high";
+    public const string Medium = "medium";
+    public const string Advisory = "advisory";
+}
+
+internal static class AutomationReconcileRepairTypes
+{
+    public const string MissingPrIntentTarget = "missing-pr-intent-target";
+    public const string MisplacedPrIntentPrCreated = "misplaced-pr-intent-pr-created";
+    public const string MissingIssueIntentPrCreated = "missing-issue-intent-pr-created";
+    public const string MissingPrClosesKeyword = "missing-pr-closes-keyword";
+    public const string MissingLinkedPrMetadata = "missing-linked-pr-metadata";
+    public const string StaleNextSliceCandidateCache = "stale-next-slice-candidate-cache";
+}
+
+internal static class AutomationReconcileUnsafeStopKinds
+{
+    public const string AmbiguousIssueLink = "ambiguous-issue-link";
+    public const string MissingPublishedIssueEvidence = "missing-published-issue-evidence";
+    public const string ChildLoopProhibited = "child-loop-prohibited";
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -42,6 +42,7 @@ internal static class CommandRouter
         "automation pr-transition --transition review-start --write",
         "automation pr-transition --transition request-update --write",
         "automation pr-transition --transition approved --write",
+        "automation reconcile [--lane host-review|next-slice|all] [--write]",
         "automation summary"
     ];
 
@@ -150,6 +151,7 @@ internal static class CommandRouter
                 ["host-review-preflight"] = AutomationHostReviewPreflightCommand.Execute,
                 ["issue-publish"] = AutomationIssuePublishCommand.Execute,
                 ["pr-transition"] = AutomationPrTransitionCommand.Execute,
+                ["reconcile"] = AutomationReconcileCommand.Execute,
                 ["summary"] = AutomationSummaryCommand.Execute
             },
             ["safety"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)

--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -199,16 +199,22 @@ Loop body (single wake):
    - `intent-cli packet draft --execution-unit <id> --target-repo {targetRepoPlaceholder} --dry-run --format markdown` — preview the packet.
    - With operator acceptance: `intent-cli packet draft --execution-unit <id> --target-repo {targetRepoPlaceholder} --format json` then `intent-cli issue publish-flow <id> --repo {targetRepoPlaceholder} --write --format json`.
    - After parent durable state is pushed: `intent-cli automation issue-publish --repo {targetRepoPlaceholder} --issue <n> --write --format json`.
+4. Stage 3 — safe reconcile (host-only; only if Stage 1 and Stage 2 would otherwise stop with idle / no-actionable-item / clarification-required):
+   - `intent-cli automation reconcile --lane host-review --repo {targetRepoPlaceholder} --format json` — dry-run plan with evidence and confidence per drift entry.
+   - High-confidence repairs are mechanically provable label drift only; advisory entries point at the existing closeout/packet/next-slice surface and must not be applied through this lane.
+   - With operator acceptance: re-run with `--write` to apply only high-confidence repairs through the host-owned reconcile mutator.
+   - If `unsafe_stops` is non-empty, stop with structured clarification rather than guessing.
 
 Hard rules:
 - Do not read `intents/rules/**`, local skill files, or copied prompt files for routine review/closeout. Use `intent-cli guide ...` and `intent-cli automation ...` instead.
 - Do not call `intent-cli run`. `run` is advanced runtime, not the host review/closeout path.
 - Do not run `dotnet run` as a fallback for `intent-cli`.
 - Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
-- Every label transition goes through installed `intent-cli automation pr-transition` / `automation issue-publish` / `worker claim` / `worker complete`. No manual `gh ... edit --add-label` / `--remove-label` fallback.
+- Every label transition goes through installed `intent-cli automation pr-transition` / `automation issue-publish` / `automation reconcile` / `worker claim` / `worker complete`. No manual `gh ... edit --add-label` / `--remove-label` fallback.
 - Never apply `intent-pr-created` to a PR.
 - Honor the WIP cap: do not cut a new child issue while any open `intent-target` issue/PR remains.
 - Stop on Hard Clarification rather than guessing when source-of-truth is ambiguous.
+- `automation reconcile --write` must come from this host loop only; child implementation loops never invoke it.
 - Process at most one PR review and one new child issue per wake.";
 
         return new GuidePromptMatrixEntry
@@ -309,16 +315,22 @@ Loop body (single wake only — do not repeat):
    - `intent-cli packet draft --execution-unit <id> --target-repo {targetRepoPlaceholder} --dry-run --format markdown` — preview the packet.
    - With operator acceptance: `intent-cli packet draft --execution-unit <id> --target-repo {targetRepoPlaceholder} --format json` then `intent-cli issue publish-flow <id> --repo {targetRepoPlaceholder} --write --format json`.
    - After parent durable state is pushed: `intent-cli automation issue-publish --repo {targetRepoPlaceholder} --issue <n> --write --format json`.
+4. Stage 3 — safe reconcile (host-only; only if Stage 1 and Stage 2 would otherwise stop with idle / no-actionable-item / clarification-required):
+   - `intent-cli automation reconcile --lane host-review --repo {targetRepoPlaceholder} --format json` — dry-run plan with evidence and confidence per drift entry.
+   - High-confidence repairs are mechanically provable label drift only; advisory entries point at the existing closeout/packet/next-slice surface and must not be applied through this lane.
+   - With operator acceptance: re-run with `--write` to apply only high-confidence repairs through the host-owned reconcile mutator.
+   - If `unsafe_stops` is non-empty, stop with structured clarification rather than guessing.
 
 Hard rules:
 - Do not read `intents/rules/**`, local skill files, or copied prompt files for routine review/closeout. Use `intent-cli guide ...` and `intent-cli automation ...` instead.
 - Do not call `intent-cli run`. `run` is advanced runtime, not the host review/closeout path.
 - Do not run `dotnet run` as a fallback for `intent-cli`.
 - Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
-- Every label transition goes through installed `intent-cli automation pr-transition` / `automation issue-publish` / `worker claim` / `worker complete`. No manual `gh ... edit --add-label` / `--remove-label` fallback.
+- Every label transition goes through installed `intent-cli automation pr-transition` / `automation issue-publish` / `automation reconcile` / `worker claim` / `worker complete`. No manual `gh ... edit --add-label` / `--remove-label` fallback.
 - Never apply `intent-pr-created` to a PR.
 - Honor the WIP cap: do not cut a new child issue while any open `intent-target` issue/PR remains.
 - Stop on Hard Clarification rather than guessing when source-of-truth is ambiguous.
+- `automation reconcile --write` must come from this host one-shot only; child implementation loops never invoke it.
 - Process at most one PR review and one new child issue per wake.
 - Do not create a cron, monitor, scheduler, reminder, or new thread after completing this wake.";
 

--- a/src/IntentSystem.Cli/Commands/IGitHubLabelMutator.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubLabelMutator.cs
@@ -32,6 +32,20 @@ internal interface IGitHubLabelMutator
         int number,
         IReadOnlyCollection<string> addLabels,
         IReadOnlyCollection<string> removeLabels);
+
+    /// <summary>
+    /// G277: Apply reconcile-mode label changes from the host-side safe
+    /// reconcile lane. Allows specifically the misplacement-repair cases
+    /// the strict transition path forbids — namely removing a misplaced
+    /// <c>intent-pr-created</c> from a PR. Adding <c>intent-pr-created</c>
+    /// to a PR is still rejected as a hard policy violation.
+    /// </summary>
+    void ApplyReconcileTransitions(
+        string repo,
+        string kind,
+        int number,
+        IReadOnlyCollection<string> addLabels,
+        IReadOnlyCollection<string> removeLabels);
 }
 
 /// <summary>
@@ -187,6 +201,38 @@ internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator
         var args = BuildEditArguments(repo, kind, number, addLabels, removeLabels);
         RunGh(args,
             $"apply label transitions on {kind} #{number} in {repo}");
+    }
+
+    public void ApplyReconcileTransitions(
+        string repo,
+        string kind,
+        int number,
+        IReadOnlyCollection<string> addLabels,
+        IReadOnlyCollection<string> removeLabels)
+    {
+        ArgumentNullException.ThrowIfNull(addLabels);
+        ArgumentNullException.ThrowIfNull(removeLabels);
+
+        // G277 reconcile policy: the strict transition path bars any touch
+        // of intent-pr-created on a PR. Reconcile is the lane that exists
+        // precisely to clean up misplacement, so removing a misplaced
+        // intent-pr-created from a PR is allowed. Adding intent-pr-created
+        // to a PR is still a hard policy violation.
+        if (string.Equals(kind, Kinds.Pr, StringComparison.Ordinal)
+            && addLabels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"label policy violation: '{WorkerNextActionConstants.Labels.IntentPrCreated}' is issue-only and must not be added to a PR even from the reconcile lane.");
+        }
+
+        if (addLabels.Count == 0 && removeLabels.Count == 0)
+        {
+            return; // nothing to do
+        }
+
+        var args = BuildEditArguments(repo, kind, number, addLabels, removeLabels);
+        RunGh(args,
+            $"apply reconcile label transitions on {kind} #{number} in {repo}");
     }
 
     private static string RunGh(IReadOnlyList<string> arguments, string description)

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -66,6 +66,7 @@ internal static class Program
                 || string.Equals(args[1], "host-review-preflight", StringComparison.Ordinal)
                 || string.Equals(args[1], "issue-publish", StringComparison.Ordinal)
                 || string.Equals(args[1], "pr-transition", StringComparison.Ordinal)
+                || string.Equals(args[1], "reconcile", StringComparison.Ordinal)
                 || string.Equals(args[1], "summary", StringComparison.Ordinal));
     }
 

--- a/tests/IntentSystem.Cli.Tests/AutomationCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationCompleteCommandTests.cs
@@ -498,6 +498,14 @@ public sealed class AutomationCompleteCommandTests : IDisposable
                 addLabels.ToArray(),
                 removeLabels.ToArray()));
         }
+
+        public void ApplyReconcileTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels) =>
+            throw new NotSupportedException("reconcile path not exercised by these tests");
     }
 
     private sealed record AppliedTransition(

--- a/tests/IntentSystem.Cli.Tests/AutomationIssuePublishCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssuePublishCommandTests.cs
@@ -236,6 +236,14 @@ public sealed class AutomationIssuePublishCommandTests : IDisposable
                 addLabels.ToArray(),
                 removeLabels.ToArray()));
         }
+
+        public void ApplyReconcileTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels) =>
+            throw new NotSupportedException("reconcile path not exercised by these tests");
     }
 
     private sealed record AppliedTransition(

--- a/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
@@ -418,6 +418,14 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
                 addLabels.ToArray(),
                 removeLabels.ToArray()));
         }
+
+        public void ApplyReconcileTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels) =>
+            throw new NotSupportedException("reconcile path not exercised by these tests");
     }
 
     private sealed record AppliedTransition(

--- a/tests/IntentSystem.Cli.Tests/AutomationReconcileCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationReconcileCommandTests.cs
@@ -1,0 +1,595 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class AutomationReconcileCommandTests : IDisposable
+{
+    public AutomationReconcileCommandTests()
+    {
+        AutomationReconcileCommand.CandidateListerFactory = null;
+        AutomationReconcileCommand.MutatorFactory = null;
+        AutomationReconcileCommand.NestedProviderLauncher = null;
+    }
+
+    public void Dispose()
+    {
+        AutomationReconcileCommand.CandidateListerFactory = null;
+        AutomationReconcileCommand.MutatorFactory = null;
+        AutomationReconcileCommand.NestedProviderLauncher = null;
+        AutomationInstalledCliSurfaceProbe.ProbeRunner = null;
+    }
+
+    [Fact]
+    public void Execute_DryRun_DetectsMissingPrIntentTargetAndMissingIssueIntentPrCreated()
+    {
+        using var workspace = new ReconcileWorkspace();
+        var lister = new FakeLister
+        {
+            AllPrs =
+            [
+                BuildPr(420, "child impl", "https://github.com/J-Tech-Japan/intent-system/pull/420",
+                    body: "Closes #559", labels: Array.Empty<string>()),
+            ],
+            PublishedIssues =
+            [
+                BuildIssue(559, "G227 some unit", "https://github.com/J-Tech-Japan/intent-system/issues/559",
+                    labels: ["intent-target"]),
+            ],
+        };
+        AutomationReconcileCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationReconcileCommand.Execute(
+            workspace.Context,
+            ["--lane", "host-review", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
+        Assert.Equal("host-review", result.Lane);
+        Assert.Equal("dry-run", result.Mode);
+        Assert.True(result.HostOnly);
+        Assert.Empty(result.UnsafeStops);
+
+        Assert.Contains(result.SafeRepairs, repair =>
+            string.Equals(repair.Type, AutomationReconcileRepairTypes.MissingPrIntentTarget, StringComparison.Ordinal)
+            && repair.TargetNumber == 420
+            && repair.AddLabels.Contains("intent-target", StringComparer.Ordinal)
+            && string.Equals(repair.Confidence, AutomationReconcileConfidence.High, StringComparison.Ordinal)
+            && !repair.Applied);
+
+        Assert.Contains(result.SafeRepairs, repair =>
+            string.Equals(repair.Type, AutomationReconcileRepairTypes.MissingIssueIntentPrCreated, StringComparison.Ordinal)
+            && repair.TargetNumber == 559
+            && repair.AddLabels.Contains("intent-pr-created", StringComparer.Ordinal)
+            && string.Equals(repair.Confidence, AutomationReconcileConfidence.High, StringComparison.Ordinal)
+            && !repair.Applied);
+
+        Assert.Contains(result.SafeRepairs, repair =>
+            string.Equals(repair.Type, AutomationReconcileRepairTypes.MissingLinkedPrMetadata, StringComparison.Ordinal)
+            && string.Equals(repair.Confidence, AutomationReconcileConfidence.Advisory, StringComparison.Ordinal)
+            && !string.IsNullOrWhiteSpace(repair.RequiresFollowupCommand));
+    }
+
+    [Fact]
+    public void Execute_DryRun_DetectsMisplacedIntentPrCreatedOnPr()
+    {
+        using var workspace = new ReconcileWorkspace();
+        var lister = new FakeLister
+        {
+            AllPrs =
+            [
+                BuildPr(421, "should not have intent-pr-created",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/421",
+                    body: "Closes #560",
+                    labels: ["intent-target", "intent-pr-created"]),
+            ],
+            PublishedIssues =
+            [
+                BuildIssue(560, "G228", "https://github.com/J-Tech-Japan/intent-system/issues/560",
+                    labels: ["intent-target", "intent-pr-created"]),
+            ],
+        };
+        AutomationReconcileCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationReconcileCommand.Execute(
+            workspace.Context,
+            ["--lane", "host-review", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
+
+        Assert.Contains(result.SafeRepairs, repair =>
+            string.Equals(repair.Type, AutomationReconcileRepairTypes.MisplacedPrIntentPrCreated, StringComparison.Ordinal)
+            && repair.TargetNumber == 421
+            && repair.RemoveLabels.Contains("intent-pr-created", StringComparer.Ordinal)
+            && string.Equals(repair.Confidence, AutomationReconcileConfidence.High, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_NoDriftReturnsCleanPlanWithSummaryAndZeroExit()
+    {
+        using var workspace = new ReconcileWorkspace();
+        var lister = new FakeLister
+        {
+            AllPrs =
+            [
+                BuildPr(500, "clean", "https://github.com/J-Tech-Japan/intent-system/pull/500",
+                    body: "Closes #999",
+                    labels: ["intent-target"]),
+            ],
+            PublishedIssues =
+            [
+                BuildIssue(999, "G300", "https://github.com/J-Tech-Japan/intent-system/issues/999",
+                    labels: ["intent-target", "intent-pr-created"]),
+            ],
+        };
+        AutomationReconcileCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationReconcileCommand.Execute(
+            workspace.Context,
+            ["--lane", "host-review", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
+
+        Assert.DoesNotContain(result.SafeRepairs, repair =>
+            string.Equals(repair.Confidence, AutomationReconcileConfidence.High, StringComparison.Ordinal));
+        Assert.Empty(result.UnsafeStops);
+    }
+
+    [Fact]
+    public void Execute_DryRunNeverInvokesMutator()
+    {
+        using var workspace = new ReconcileWorkspace();
+        var lister = new FakeLister
+        {
+            AllPrs =
+            [
+                BuildPr(600, "needs intent-target", "https://github.com/J-Tech-Japan/intent-system/pull/600",
+                    body: "Closes #559", labels: Array.Empty<string>()),
+            ],
+            PublishedIssues =
+            [
+                BuildIssue(559, "G227", "https://github.com/J-Tech-Japan/intent-system/issues/559",
+                    labels: ["intent-target"]),
+            ],
+        };
+        AutomationReconcileCommand.CandidateListerFactory = () => lister;
+        var mutator = new RecordingMutator();
+        AutomationReconcileCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationReconcileCommand.Execute(
+            workspace.Context,
+            ["--lane", "host-review", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(mutator.Reconciles);
+    }
+
+    [Fact]
+    public void Execute_WriteAppliesOnlyHighConfidenceRepairs()
+    {
+        using var workspace = new ReconcileWorkspace();
+        var lister = new FakeLister
+        {
+            AllPrs =
+            [
+                BuildPr(700, "missing target", "https://github.com/J-Tech-Japan/intent-system/pull/700",
+                    body: "Closes #559", labels: Array.Empty<string>()),
+            ],
+            PublishedIssues =
+            [
+                BuildIssue(559, "G227", "https://github.com/J-Tech-Japan/intent-system/issues/559",
+                    labels: ["intent-target"]),
+            ],
+        };
+        AutomationReconcileCommand.CandidateListerFactory = () => lister;
+        var mutator = new RecordingMutator();
+        AutomationReconcileCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationReconcileCommand.Execute(
+            workspace.Context,
+            ["--lane", "host-review", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(2, mutator.Reconciles.Count);
+        Assert.Contains(mutator.Reconciles, t =>
+            t.Kind == "pr" && t.Number == 700
+            && t.AddLabels.Contains("intent-target", StringComparer.Ordinal));
+        Assert.Contains(mutator.Reconciles, t =>
+            t.Kind == "issue" && t.Number == 559
+            && t.AddLabels.Contains("intent-pr-created", StringComparer.Ordinal));
+
+        var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
+        Assert.Equal("write", result.Mode);
+        Assert.Contains(result.SafeRepairs, repair =>
+            string.Equals(repair.Confidence, AutomationReconcileConfidence.High, StringComparison.Ordinal)
+            && repair.Applied);
+        Assert.DoesNotContain(result.SafeRepairs, repair =>
+            string.Equals(repair.Confidence, AutomationReconcileConfidence.Advisory, StringComparison.Ordinal)
+            && repair.Applied);
+    }
+
+    [Fact]
+    public void Execute_AmbiguousIssueLinkProducesUnsafeStop()
+    {
+        using var workspace = new ReconcileWorkspace();
+        var lister = new FakeLister
+        {
+            AllPrs =
+            [
+                BuildPr(800, "no closes keyword",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/800",
+                    body: "free-form notes — no Closes keyword",
+                    labels: ["intent-target"]),
+            ],
+            PublishedIssues = Array.Empty<GitHubAutomationIssueCandidate>(),
+        };
+        AutomationReconcileCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationReconcileCommand.Execute(
+            workspace.Context,
+            ["--lane", "host-review", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
+        Assert.Contains(result.UnsafeStops, stop =>
+            string.Equals(stop.Kind, AutomationReconcileUnsafeStopKinds.AmbiguousIssueLink, StringComparison.Ordinal)
+            && stop.TargetNumber == 800);
+    }
+
+    [Fact]
+    public void Execute_ChildLoopContextRefusesEarlyAndExitsTwo()
+    {
+        using var workspace = new ReconcileWorkspace();
+        var lister = new ThrowingLister();
+        AutomationReconcileCommand.CandidateListerFactory = () => lister;
+        var mutator = new RecordingMutator();
+        AutomationReconcileCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationReconcileCommand.Execute(
+            workspace.Context,
+            ["--lane", "host-review", "--repo", "J-Tech-Japan/intent-system", "--child-loop-context", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(2, exitCode);
+        Assert.Empty(mutator.Reconciles);
+
+        var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
+        Assert.Empty(result.SafeRepairs);
+        Assert.Contains(result.UnsafeStops, stop =>
+            string.Equals(stop.Kind, AutomationReconcileUnsafeStopKinds.ChildLoopProhibited, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_NextSliceLane_StaleCacheClassifiedAsAdvisory()
+    {
+        using var workspace = new ReconcileWorkspace();
+        AutomationReconcileCommand.CandidateListerFactory = () => new ThrowingLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationReconcileCommand.Execute(
+            workspace.Context,
+            [
+                "--lane", "next-slice",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--next-slice-clarification-required",
+                "--clarifications-all-resolved",
+                "--format", "json"
+            ],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
+        Assert.Empty(result.UnsafeStops);
+        Assert.Contains(result.SafeRepairs, repair =>
+            string.Equals(repair.Type, AutomationReconcileRepairTypes.StaleNextSliceCandidateCache, StringComparison.Ordinal)
+            && string.Equals(repair.Confidence, AutomationReconcileConfidence.Advisory, StringComparison.Ordinal)
+            && !string.IsNullOrWhiteSpace(repair.RequiresFollowupCommand));
+    }
+
+    [Fact]
+    public void Execute_NextSliceLane_OpenClarificationProducesUnsafeStop()
+    {
+        using var workspace = new ReconcileWorkspace();
+        AutomationReconcileCommand.CandidateListerFactory = () => new ThrowingLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationReconcileCommand.Execute(
+            workspace.Context,
+            [
+                "--lane", "next-slice",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--next-slice-clarification-required",
+                "--format", "json"
+            ],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
+        Assert.DoesNotContain(result.SafeRepairs, repair =>
+            string.Equals(repair.Type, AutomationReconcileRepairTypes.StaleNextSliceCandidateCache, StringComparison.Ordinal));
+        Assert.Contains(result.UnsafeStops, stop =>
+            string.Equals(stop.Kind, "open-clarification-present", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_StaleHostCliReturnsStructuredStopAndDoesNotRunLister()
+    {
+        using var workspace = new ReconcileWorkspace();
+        workspace.WriteInstalledCliScript(stalePrTransition: true);
+        AutomationReconcileCommand.CandidateListerFactory = () => new ThrowingLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationReconcileCommand.Execute(
+            workspace.Context,
+            ["--lane", "host-review", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
+        Assert.Contains(result.UnsafeStops, stop =>
+            string.Equals(stop.Kind, "stale-host-cli", StringComparison.Ordinal));
+        Assert.Empty(result.SafeRepairs);
+    }
+
+    [Fact]
+    public void CommandRouter_RegistersAutomationReconcile()
+    {
+        using var workspace = new ReconcileWorkspace();
+        var lister = new FakeLister();
+        AutomationReconcileCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["automation", "reconcile", "--lane", "host-review", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            workspace.Context,
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
+        Assert.True(result.HostOnly);
+    }
+
+    [Fact]
+    public void CommandRouter_HelpListsAutomationReconcile()
+    {
+        using var workspace = new ReconcileWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute([], workspace.Context, writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("automation reconcile", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuidePromptMatrix_ChildLoopDoesNotMentionReconcile()
+    {
+        using var workspace = new ReconcileWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            workspace.Context,
+            ["--mode", "child-loop", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.DoesNotContain("automation reconcile", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuidePromptMatrix_ChildOneshotDoesNotMentionReconcile()
+    {
+        using var workspace = new ReconcileWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            workspace.Context,
+            ["--mode", "child-oneshot", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain("automation reconcile", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Adapter_ApplyReconcileTransitions_RejectsAddingIntentPrCreatedToPr()
+    {
+        var mutator = new GhCliGitHubLabelMutator();
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            mutator.ApplyReconcileTransitions(
+                "J-Tech-Japan/intent-system", "pr", 421,
+                new[] { "intent-pr-created" },
+                Array.Empty<string>()));
+        Assert.Contains("issue-only", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuidePromptMatrix_HostLoopMentionsReconcile()
+    {
+        using var workspace = new ReconcileWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            workspace.Context,
+            ["--mode", "host-loop", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("automation reconcile", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static GitHubAutomationPrCandidate BuildPr(
+        int number,
+        string title,
+        string url,
+        string body,
+        IReadOnlyList<string> labels) =>
+        new()
+        {
+            Number = number,
+            Title = title,
+            Url = url,
+            Body = body,
+            CreatedAt = "2026-05-06T00:00:00Z",
+            UpdatedAt = "2026-05-06T00:00:00Z",
+            Labels = labels.Select(label => new GitHubAutomationLabel { Name = label }).ToArray(),
+        };
+
+    private static GitHubAutomationIssueCandidate BuildIssue(
+        int number,
+        string title,
+        string url,
+        IReadOnlyList<string> labels) =>
+        new()
+        {
+            Number = number,
+            Title = title,
+            Url = url,
+            CreatedAt = "2026-05-06T00:00:00Z",
+            Labels = labels.Select(label => new GitHubAutomationLabel { Name = label }).ToArray(),
+        };
+
+    private sealed class FakeLister : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationPrCandidate> AllPrs { get; init; } = Array.Empty<GitHubAutomationPrCandidate>();
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> PublishedIssues { get; init; } = Array.Empty<GitHubAutomationIssueCandidate>();
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) =>
+            AllPrs;
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) =>
+            PublishedIssues;
+    }
+
+    private sealed class ThrowingLister : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) =>
+            throw new InvalidOperationException("lister should not be invoked in this test");
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) =>
+            throw new InvalidOperationException("lister should not be invoked in this test");
+    }
+
+    private sealed class RecordingMutator : IGitHubLabelMutator
+    {
+        public List<RecordedTransition> Transitions { get; } = new();
+        public List<RecordedTransition> Reconciles { get; } = new();
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
+            Array.Empty<GitHubAutomationLabel>();
+
+        public void ApplyLabelTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels) =>
+            Transitions.Add(new RecordedTransition(repo, kind, number, addLabels.ToArray(), removeLabels.ToArray()));
+
+        public void ApplyReconcileTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels) =>
+            Reconciles.Add(new RecordedTransition(repo, kind, number, addLabels.ToArray(), removeLabels.ToArray()));
+    }
+
+    private sealed record RecordedTransition(
+        string Repo,
+        string Kind,
+        int Number,
+        IReadOnlyList<string> AddLabels,
+        IReadOnlyList<string> RemoveLabels);
+
+    private sealed class ReconcileWorkspace : IDisposable
+    {
+        public ReconcileWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("automation-reconcile-tests-").FullName;
+            WriteInstalledCliScript(stalePrTransition: false);
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli"
+                    }
+                }
+            };
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public void WriteInstalledCliScript(bool stalePrTransition)
+        {
+            var binPath = Path.Combine(RootPath, ".intent-cli", "bin");
+            Directory.CreateDirectory(binPath);
+            var scriptPath = Path.Combine(binPath, "intent-cli");
+            var prTransitionBlock = stalePrTransition
+                ? "  echo \"Command 'automation pr-transition' is not yet implemented.\"\n  exit 1\n"
+                : "  echo '--transition is required (review-start, request-update, or approved).'\n  exit 1\n";
+            File.WriteAllText(
+                scriptPath,
+                "#!/bin/sh\n"
+                + "case \"$*\" in\n"
+                + "  'automation summary') echo '--domain is required.'; exit 1 ;;\n"
+                + "  'automation host-review-preflight') echo '--repo is required.'; exit 1 ;;\n"
+                + "  'automation issue-publish') echo '--issue is required.'; exit 1 ;;\n"
+                + "  'automation pr-transition')\n"
+                + prTransitionBlock
+                + "    ;;\n"
+                + "  *) echo \"unexpected probe: $*\"; exit 1 ;;\n"
+                + "esac\n");
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(
+                    scriptPath,
+                    UnixFileMode.UserRead
+                    | UnixFileMode.UserWrite
+                    | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead
+                    | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead
+                    | UnixFileMode.OtherExecute);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkerClaimCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerClaimCommandTests.cs
@@ -536,6 +536,14 @@ public sealed class WorkerClaimCommandTests : IDisposable
                 RemoveLabels = removeLabels.ToArray(),
             });
         }
+
+        public void ApplyReconcileTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels) =>
+            throw new NotSupportedException("reconcile path not exercised by these tests");
     }
 
     internal sealed record AppliedTransition

--- a/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
@@ -650,6 +650,14 @@ public sealed class WorkerCompleteCommandTests : IDisposable
                 RemoveLabels = removeLabels.ToArray(),
             });
         }
+
+        public void ApplyReconcileTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels) =>
+            throw new NotSupportedException("reconcile path not exercised by these tests");
     }
 
     internal sealed record AppliedTransition


### PR DESCRIPTION
## Summary

- New host-only command `intent-cli automation reconcile` that runs before host review/next-slice wakes declare idle / hard-clarification, emitting an evidence-based dry-run plan and applying only high-confidence label drift on opt-in `--write`.
- New `IGitHubLabelMutator.ApplyReconcileTransitions` entry point that allows removing a misplaced `intent-pr-created` from a PR (the strict transition path bars all touches of that label on a PR), while still rejecting adding `intent-pr-created` to a PR.
- `intent-cli guide prompt-matrix --mode host-loop` / `host-oneshot` now describe a Stage 3 safe reconcile step. `child-loop` / `child-oneshot` prompts are unchanged so the prohibition is also enforced at the prompt level (in addition to the `--child-loop-context` runtime guard).
- Template `docs/automation-templates/safe-reconcile-lane.md` and ops note `ops/g277-host-side-safe-reconcile-lane.md` document the boundaries (label-only mutation, advisory entries point at the existing surface, structured unsafe stops on ambiguity).

## Drift coverage

| Type | Confidence | Effect |
|------|------------|--------|
| `missing-pr-intent-target` | high | add `intent-target` to PR |
| `misplaced-pr-intent-pr-created` | high | remove misplaced label from PR |
| `missing-issue-intent-pr-created` | high | add `intent-pr-created` to source issue |
| `missing-linked-pr-metadata` | advisory | followup: `intent-cli closeout pr` |
| `stale-next-slice-candidate-cache` | advisory | followup: `intent-cli intent next-slice --dry-run` |

Unsafe stops include `ambiguous-issue-link`, `open-clarification-present`, `stale-host-cli`, and `child-loop-prohibited`.

Closes #657

## Test plan

- [x] `dotnet build IntentSystem.sln` — succeeds with 0 errors / 0 warnings.
- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~AutomationReconcileCommandTests"` — 16 new focused tests pass (safe repair plans, dry-run vs `--write` gating, child-loop prohibition, ambiguous-link unsafe stop, next-slice advisory + open-clarification stop, stale-host-cli refusal, command router registration, child-loop / child-oneshot prompt omission).
- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — full CLI suite: 2005 passed, 1 skipped (preexisting), 0 failed.
- [x] `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)