### PR TITLE
G278 Sync queue-state, publish.yaml, and runs.jsonl on issue publish-flow --write

### DIFF
--- a/docs/automation-templates/README.md
+++ b/docs/automation-templates/README.md
@@ -59,6 +59,7 @@ These templates assume:
 | G259  | `intent-cli guide onboarding`           | Read-only first-call sequence for an AI agent with no local skill files or copied rules: model → rules list → commands list → workflow suggest → status → next-slice dry-run → interview → automation summary; each step names its no-mutation behavior and the host data boundary |
 | G260  | `intent-cli guide automation setup`     | Read-only paste-ready setup prompts for child implementation loop or host review/next-slice loop: forces guide model/onboarding/commands list/automation summary as first calls, forbids `intents/rules/**` and local skill files, delegates label transitions to installed `intent-cli automation`/`worker` commands |
 | G277  | [`safe-reconcile-lane.md`](./safe-reconcile-lane.md) / `intent-cli automation reconcile` | Host-only safe reconcile lane: dry-run plan + opt-in `--write` for mechanically provable label drift; advisory entries point at the existing closeout/packet/next-slice surface; child loops are forbidden from invoking it |
+| G278  | `intent-cli issue publish-flow --write` | After `gh issue create`, atomically syncs `queue-state.json` `linked_issue`, `.intent-cli/issues/<execution-unit>/publish.yaml` (`issue-created` + URL/number), and appends one `issue-created` event to `.intent-cli/runs.jsonl`. Re-runs are idempotent on the publish.yaml marker; create-failure and durable-state failure both refuse to claim `created: true` |
 
 ## Installed host transition command adoption
 

--- a/ops/g278-issue-publish-flow-durable-state-sync.md
+++ b/ops/g278-issue-publish-flow-durable-state-sync.md
@@ -1,0 +1,59 @@
+# G278 Fix issue publish-flow durable state synchronization
+
+## Why this slice
+
+Publishing G277 created GitHub issue #657 but left
+`.intent-cli/queue-state.json` `linked_issue` and
+`.intent-cli/issues/G277/publish.yaml` null/drafted, so host-side manual
+repair was needed. `intent-cli issue publish-flow --write` must atomically
+reflect GitHub issue creation in parent durable artifacts before reporting
+success, so queue-state, publish.yaml, and runs.jsonl cannot drift from the
+created issue.
+
+## What changed
+
+- `intent-cli issue publish-flow --write` now updates three durable
+  artifacts in the same wake after the GitHub issue is created:
+  - `queue-state.json` — the matching execution-unit's
+    `linked_issue` is filled with `{ repo, number, url }` and
+    `updated_at` advances.
+  - `.intent-cli/issues/<execution-unit>/publish.yaml` — `publish_status`
+    advances to `issue-created` with the GitHub issue number/URL.
+  - `.intent-cli/runs.jsonl` — an `issue-created` event is appended
+    (one per successful create).
+- Re-running `--write` after a successful create is **idempotent**:
+  `publish.yaml`'s `issue-created` marker short-circuits both the
+  `gh issue create` call and the durable-state writes. The result reports
+  `created: false`, `idempotent: true`, `durable_state_synced: true`.
+- If `gh issue create` fails, no durable artifact is mutated.
+- If a durable write fails after the GitHub issue is created, the result
+  reports `created: false`, `durable_state_synced: false`, returns exit
+  code `1`, and points the operator at
+  `intent-cli automation reconcile` for repair. The command never claims
+  `created: true` while local artifacts remain unmodified.
+- Dry-run mode (no `--write`) remains read-only.
+
+## Boundaries
+
+- The command never applies `intent-target`. Use
+  `intent-cli automation issue-publish --write` at the explicit publish
+  boundary.
+- The command does not mutate the GitHub issue body, labels, or any
+  field other than the local durable artifacts described above.
+- Workflow label transitions remain CLI-owned; no raw `gh` label
+  fallback is introduced by this slice.
+
+## Verification
+
+```bash
+dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
+  --filter "FullyQualifiedName~IssuePublishFlowCommandTests"
+
+git diff --check
+```
+
+Focused tests cover: create-success patches all three artifacts and
+appends exactly one `issue-created` event; idempotent rerun does not
+call `gh` and does not append a duplicate event; create-failure leaves
+queue-state/publish.yaml/runs unchanged; dry-run never writes; the
+output never claims `created: true` without a synced durable state.

--- a/ops/g278-issue-publish-flow-durable-state-sync.md
+++ b/ops/g278-issue-publish-flow-durable-state-sync.md
@@ -39,6 +39,15 @@ created issue.
   code `1`, and points the operator at
   `intent-cli automation reconcile` for repair. The command never claims
   `created: true` while local artifacts remain unmodified.
+- The success path now requires all three artifacts to be patched.
+  If `queue-state.json` is missing entirely or has no item with the
+  given `execution_unit`, the command returns exit code `1` with
+  `created: false`, `durable_state_synced: false`,
+  `queue_state_patched: false`, and an actionable
+  `error` message naming the missing artifact and pointing at
+  `intent-cli automation reconcile` (or operator-driven seeding) before
+  re-running. Same treatment applies if `publish.yaml` or `runs.jsonl`
+  silently fails to patch.
 - Dry-run mode (no `--write`) remains read-only.
 
 ## Boundaries

--- a/ops/g278-issue-publish-flow-durable-state-sync.md
+++ b/ops/g278-issue-publish-flow-durable-state-sync.md
@@ -21,10 +21,18 @@ created issue.
     advances to `issue-created` with the GitHub issue number/URL.
   - `.intent-cli/runs.jsonl` — an `issue-created` event is appended
     (one per successful create).
-- Re-running `--write` after a successful create is **idempotent**:
-  `publish.yaml`'s `issue-created` marker short-circuits both the
-  `gh issue create` call and the durable-state writes. The result reports
-  `created: false`, `idempotent: true`, `durable_state_synced: true`.
+- Re-running `--write` after a successful create is **idempotent**.
+  Two independent artifacts can short-circuit the rerun before any
+  `gh issue create` call:
+  - `publish.yaml` with `publish_status: issue-created` and a non-empty
+    `created_issue_url`, OR
+  - `queue-state.json` whose matching execution-unit already has
+    `linked_issue` populated.
+  Either match returns `created: false`, `idempotent: true`,
+  `durable_state_synced: true` and performs no GitHub call and no
+  durable-state writes, so a stale or missing `publish.yaml` cannot
+  cause a duplicate child issue when queue-state already records the
+  link.
 - If `gh issue create` fails, no durable artifact is mutated.
 - If a durable write fails after the GitHub issue is created, the result
   reports `created: false`, `durable_state_synced: false`, returns exit

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -163,6 +163,8 @@ internal static class IssuePublishFlowCommand
             return 0;
         }
 
+        var queueStatePathForIdempotency = context.GetQueueStatePath();
+
         // G278 idempotency: if publish.yaml already records issue-created with a
         // URL, do NOT call gh again and do NOT re-mutate durable state.
         if (TryReadExistingIssueCreatedArtifact(publishYamlPath, out var existing))
@@ -182,6 +184,30 @@ internal static class IssuePublishFlowCommand
                 runsAppended: false,
                 error: null);
             EmitResult(writer, idempotentResult, format);
+            return 0;
+        }
+
+        // G278 idempotency (PR #660 follow-up): if publish.yaml is missing or stale
+        // but queue-state.json already records linked_issue for this execution
+        // unit, treat as idempotent so a rerun cannot create a duplicate GitHub
+        // issue. Both artifact-level checks must short-circuit before any gh call.
+        if (TryReadExistingQueueStateLinkedIssue(queueStatePathForIdempotency, executionUnit!, out var queueLinkedIssue))
+        {
+            var queueIdempotentResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
+                packetExists: true,
+                githubBodyPresent: true,
+                missingSections: Array.Empty<string>(),
+                title: title,
+                created: false,
+                idempotent: true,
+                durableStateSynced: true,
+                issueUrl: queueLinkedIssue.Url,
+                issueNumber: queueLinkedIssue.Number,
+                queueStatePatched: false,
+                publishYamlPatched: false,
+                runsAppended: false,
+                error: null);
+            EmitResult(writer, queueIdempotentResult, format);
             return 0;
         }
 
@@ -329,6 +355,44 @@ internal static class IssuePublishFlowCommand
         catch (Exception exception) when (exception is InvalidOperationException or IOException)
         {
             // fall through; treat as no existing publish artifact
+        }
+
+        return false;
+    }
+
+    private static bool TryReadExistingQueueStateLinkedIssue(
+        string queueStatePath,
+        string executionUnit,
+        out LinkedIssue linkedIssue)
+    {
+        linkedIssue = default!;
+        if (!File.Exists(queueStatePath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            foreach (var item in queueState.Items)
+            {
+                if (!string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (item.LinkedIssue is { } existing && !string.IsNullOrWhiteSpace(existing.Url))
+                {
+                    linkedIssue = existing;
+                    return true;
+                }
+
+                break;
+            }
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            // fall through; treat as no idempotency hit
         }
 
         return false;

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -2,6 +2,8 @@ using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -12,11 +14,16 @@ namespace IntentSystem.Cli.Commands;
 ///
 /// Validates the packet's <c>github-body.md</c> for required Child Issue
 /// Contract sections before any GitHub mutation. With <c>--write</c>,
-/// creates the GitHub issue WITHOUT <c>intent-target</c> and reports the
-/// required parent durable-state step (commit/push) plus the next
-/// command to run for the actual publish boundary
-/// (<c>automation issue-publish --write</c>). The command never applies
-/// <c>intent-target</c> directly. Never launches an AI provider.
+/// creates the GitHub issue WITHOUT <c>intent-target</c>, then atomically
+/// reflects the creation in parent durable artifacts (G278): the
+/// matching <c>queue-state.json</c> item gets a populated
+/// <c>LinkedIssue</c>, <c>publish.yaml</c> advances to
+/// <c>issue-created</c> with the GitHub URL/number, and an
+/// <c>issue-created</c> event is appended to <c>runs.jsonl</c>. Re-running
+/// after a successful publish is idempotent: the <c>publish.yaml</c>
+/// issue-created marker short-circuits both the GitHub call and the
+/// durable-state writes. The command never applies <c>intent-target</c>
+/// directly. Never launches an AI provider.
 /// </summary>
 internal static class IssuePublishFlowCommand
 {
@@ -26,6 +33,16 @@ internal static class IssuePublishFlowCommand
     private const string ModeWrite = "write";
     private const string ModeDryRun = "dry-run";
 
+    public const string PublishStatusIssueCreated = "issue-created";
+
+    public const string IssueCreatedEventName = "issue-created";
+
+    public const string IssueCreatedEventBy = "issue-publish-flow";
+
+    private static readonly Regex IssueUrlNumberRegex = new(
+        @"/issues/(?<number>\d+)(?:[/#?].*)?$",
+        RegexOptions.Compiled);
+
     private const string UsageLine =
         "Usage: intent-cli issue publish-flow <execution-unit> --repo <owner/repo> [--domain <name>] [--write] [--format json|markdown]";
 
@@ -33,10 +50,11 @@ internal static class IssuePublishFlowCommand
         @"^[A-Za-z][A-Za-z0-9-]*$",
         RegexOptions.Compiled);
 
-    /// <summary>
-    /// Test seam — replaces the default <c>gh issue create</c> shell out.
-    /// </summary>
+    /// <summary>Test seam — replaces the default <c>gh issue create</c> shell out.</summary>
     public static Func<IIssueCreator>? CreatorFactory { get; set; }
+
+    /// <summary>G278: test seam for the durable-state event timestamp.</summary>
+    public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -70,16 +88,23 @@ internal static class IssuePublishFlowCommand
 
         var packetDirectory = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit!);
         var githubBodyPath = Path.Combine(packetDirectory, "github-body.md");
+        var publishYamlPath = Path.Combine(context.RepoRoot, IssuePublishArtifactPathResolver.Resolve(executionUnit!));
 
         if (!Directory.Exists(packetDirectory))
         {
-            var earlyResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, write,
+            var earlyResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
                 packetExists: false,
                 githubBodyPresent: false,
                 missingSections: PacketDraftCommand.RequiredContractSections,
                 title: null,
                 created: false,
+                idempotent: false,
+                durableStateSynced: false,
                 issueUrl: null,
+                issueNumber: null,
+                queueStatePatched: false,
+                publishYamlPatched: false,
+                runsAppended: false,
                 error: $"packet directory not found: {packetDirectory}");
             EmitResult(writer, earlyResult, format);
             return 1;
@@ -98,13 +123,19 @@ internal static class IssuePublishFlowCommand
 
         if (!githubBodyPresent || missing.Count > 0)
         {
-            var validationResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, write,
+            var validationResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
                 packetExists: true,
                 githubBodyPresent: githubBodyPresent,
                 missingSections: missing,
                 title: title,
                 created: false,
+                idempotent: false,
+                durableStateSynced: false,
                 issueUrl: null,
+                issueNumber: null,
+                queueStatePatched: false,
+                publishYamlPatched: false,
+                runsAppended: false,
                 error: githubBodyPresent
                     ? "Child Issue Contract is incomplete; required sections are missing."
                     : "github-body.md is missing in the packet directory.");
@@ -114,15 +145,43 @@ internal static class IssuePublishFlowCommand
 
         if (!write)
         {
-            var dryRunResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, write,
+            var dryRunResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
                 packetExists: true,
                 githubBodyPresent: true,
                 missingSections: Array.Empty<string>(),
                 title: title,
                 created: false,
+                idempotent: false,
+                durableStateSynced: false,
                 issueUrl: null,
+                issueNumber: null,
+                queueStatePatched: false,
+                publishYamlPatched: false,
+                runsAppended: false,
                 error: null);
             EmitResult(writer, dryRunResult, format);
+            return 0;
+        }
+
+        // G278 idempotency: if publish.yaml already records issue-created with a
+        // URL, do NOT call gh again and do NOT re-mutate durable state.
+        if (TryReadExistingIssueCreatedArtifact(publishYamlPath, out var existing))
+        {
+            var idempotentResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
+                packetExists: true,
+                githubBodyPresent: true,
+                missingSections: Array.Empty<string>(),
+                title: title,
+                created: false,
+                idempotent: true,
+                durableStateSynced: true,
+                issueUrl: existing.CreatedIssueUrl,
+                issueNumber: existing.CreatedIssueNumber,
+                queueStatePatched: false,
+                publishYamlPatched: false,
+                runsAppended: false,
+                error: null);
+            EmitResult(writer, idempotentResult, format);
             return 0;
         }
 
@@ -133,13 +192,19 @@ internal static class IssuePublishFlowCommand
         }
         catch (Exception exception) when (exception is InvalidOperationException or IOException)
         {
-            var creatorErrorResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, write,
+            var creatorErrorResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
                 packetExists: true,
                 githubBodyPresent: true,
                 missingSections: Array.Empty<string>(),
                 title: title,
                 created: false,
+                idempotent: false,
+                durableStateSynced: false,
                 issueUrl: null,
+                issueNumber: null,
+                queueStatePatched: false,
+                publishYamlPatched: false,
+                runsAppended: false,
                 error: $"failed to initialize GitHub issue creator: {exception.Message}");
             EmitResult(writer, creatorErrorResult, format);
             return 1;
@@ -152,28 +217,262 @@ internal static class IssuePublishFlowCommand
         }
         catch (Exception exception) when (exception is InvalidOperationException or IOException)
         {
-            var createErrorResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, write,
+            var createErrorResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
                 packetExists: true,
                 githubBodyPresent: true,
                 missingSections: Array.Empty<string>(),
                 title: title,
                 created: false,
+                idempotent: false,
+                durableStateSynced: false,
                 issueUrl: null,
+                issueNumber: null,
+                queueStatePatched: false,
+                publishYamlPatched: false,
+                runsAppended: false,
                 error: $"gh issue create failed: {exception.Message}");
             EmitResult(writer, createErrorResult, format);
             return 1;
         }
 
-        var successResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, write,
+        var issueNumber = ParseIssueNumber(outcome.IssueUrl);
+        var queueStatePath = context.GetQueueStatePath();
+        var runLogPath = context.GetRunLogPath();
+        var publishedAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
+
+        bool queueStatePatched;
+        bool publishYamlPatched;
+        bool runsAppended;
+        try
+        {
+            queueStatePatched = TryPatchQueueStateLinkedIssue(
+                queueStatePath,
+                executionUnit!,
+                repo!,
+                issueNumber,
+                outcome.IssueUrl,
+                publishedAt);
+
+            publishYamlPatched = WritePublishArtifact(
+                publishYamlPath,
+                packetDirectory,
+                githubBodyPath,
+                executionUnit!,
+                issueNumber,
+                outcome.IssueUrl);
+
+            runsAppended = AppendIssueCreatedRunEvent(
+                runLogPath,
+                executionUnit!,
+                repo!,
+                issueNumber,
+                outcome.IssueUrl,
+                publishedAt);
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException)
+        {
+            var partialResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
+                packetExists: true,
+                githubBodyPresent: true,
+                missingSections: Array.Empty<string>(),
+                title: title,
+                // G278: do not claim created:true while local durable artifacts remain unmodified.
+                created: false,
+                idempotent: false,
+                durableStateSynced: false,
+                issueUrl: outcome.IssueUrl,
+                issueNumber: issueNumber,
+                queueStatePatched: false,
+                publishYamlPatched: false,
+                runsAppended: false,
+                error: $"GitHub issue {outcome.IssueUrl} was created but parent durable state could not be updated: {exception.Message}. Reconcile via 'intent-cli automation reconcile' before re-running.");
+            EmitResult(writer, partialResult, format);
+            return 1;
+        }
+
+        var successResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
             packetExists: true,
             githubBodyPresent: true,
             missingSections: Array.Empty<string>(),
             title: title,
             created: true,
+            idempotent: false,
+            durableStateSynced: true,
             issueUrl: outcome.IssueUrl,
+            issueNumber: issueNumber,
+            queueStatePatched: queueStatePatched,
+            publishYamlPatched: publishYamlPatched,
+            runsAppended: runsAppended,
             error: null);
         EmitResult(writer, successResult, format);
         return 0;
+    }
+
+    private static bool TryReadExistingIssueCreatedArtifact(string publishYamlPath, out IssuePublishArtifact existing)
+    {
+        existing = default!;
+        if (!File.Exists(publishYamlPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var artifact = IssuePublishArtifactYaml.Deserialize(File.ReadAllText(publishYamlPath));
+            if (string.Equals(artifact.PublishStatus, PublishStatusIssueCreated, StringComparison.Ordinal)
+                && !string.IsNullOrWhiteSpace(artifact.CreatedIssueUrl))
+            {
+                existing = artifact;
+                return true;
+            }
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            // fall through; treat as no existing publish artifact
+        }
+
+        return false;
+    }
+
+    private static int? ParseIssueNumber(string issueUrl)
+    {
+        if (string.IsNullOrWhiteSpace(issueUrl))
+        {
+            return null;
+        }
+
+        var match = IssueUrlNumberRegex.Match(issueUrl.Trim());
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        return int.TryParse(
+            match.Groups["number"].Value,
+            System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out var number)
+            ? number
+            : null;
+    }
+
+    private static bool TryPatchQueueStateLinkedIssue(
+        string queueStatePath,
+        string executionUnit,
+        string repo,
+        int? issueNumber,
+        string issueUrl,
+        DateTimeOffset publishedAt)
+    {
+        if (!File.Exists(queueStatePath))
+        {
+            return false;
+        }
+
+        var raw = File.ReadAllText(queueStatePath);
+        var queueState = QueueStateSerializer.Deserialize(raw);
+
+        var matchedIndex = -1;
+        for (var index = 0; index < queueState.Items.Count; index++)
+        {
+            if (string.Equals(queueState.Items[index].ExecutionUnit, executionUnit, StringComparison.Ordinal))
+            {
+                matchedIndex = index;
+                break;
+            }
+        }
+
+        if (matchedIndex < 0)
+        {
+            return false;
+        }
+
+        var existingItem = queueState.Items[matchedIndex];
+        var updatedItem = existingItem with
+        {
+            LinkedIssue = new LinkedIssue
+            {
+                Repo = repo,
+                Number = issueNumber,
+                Url = issueUrl,
+            }
+        };
+
+        var newItems = queueState.Items.ToArray();
+        newItems[matchedIndex] = updatedItem;
+
+        var updatedState = queueState with
+        {
+            Items = newItems,
+            UpdatedAt = publishedAt,
+        };
+
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+        return true;
+    }
+
+    private static bool WritePublishArtifact(
+        string publishYamlPath,
+        string packetDirectory,
+        string githubBodyPath,
+        string executionUnit,
+        int? issueNumber,
+        string issueUrl)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(publishYamlPath)!);
+
+        var artifact = new IssuePublishArtifact
+        {
+            ExecutionUnit = executionUnit,
+            PublishStatus = PublishStatusIssueCreated,
+            PacketPath = packetDirectory,
+            IssueBodyPath = githubBodyPath,
+            CreatedIssueNumber = issueNumber,
+            CreatedIssueUrl = issueUrl,
+            PublishedLabelName = null,
+        };
+
+        File.WriteAllText(publishYamlPath, IssuePublishArtifactYaml.Serialize(artifact));
+        return true;
+    }
+
+    private static bool AppendIssueCreatedRunEvent(
+        string runLogPath,
+        string executionUnit,
+        string repo,
+        int? issueNumber,
+        string issueUrl,
+        DateTimeOffset publishedAt)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(runLogPath)!);
+
+        var linkedIssueDescriptor = issueNumber.HasValue
+            ? $"{repo}#{issueNumber.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)}"
+            : issueUrl;
+
+        var runEvent = new RunEvent
+        {
+            Ts = publishedAt,
+            ExecutionUnit = executionUnit,
+            Event = IssueCreatedEventName,
+            By = IssueCreatedEventBy,
+            LinkedIssue = linkedIssueDescriptor,
+            Reason = issueUrl,
+        };
+
+        var line = RunLogSerializer.SerializeLine(runEvent);
+
+        if (File.Exists(runLogPath))
+        {
+            var existing = File.ReadAllText(runLogPath);
+            if (!existing.EndsWith("\n", StringComparison.Ordinal) && existing.Length > 0)
+            {
+                File.AppendAllText(runLogPath, "\n");
+            }
+        }
+
+        File.AppendAllText(runLogPath, line + "\n");
+        return true;
     }
 
     private static IssuePublishFlowResult NewResult(
@@ -182,20 +481,35 @@ internal static class IssuePublishFlowCommand
         string repo,
         string packetDirectory,
         string githubBodyPath,
+        string publishYamlPath,
         bool write,
         bool packetExists,
         bool githubBodyPresent,
         IReadOnlyList<string> missingSections,
         string? title,
         bool created,
+        bool idempotent,
+        bool durableStateSynced,
         string? issueUrl,
+        int? issueNumber,
+        bool queueStatePatched,
+        bool publishYamlPatched,
+        bool runsAppended,
         string? error)
     {
         var nextSteps = new List<string>();
         if (created)
         {
             nextSteps.Add("Commit and push the parent durable state for this execution unit (queue-state, runs, packet files).");
-            nextSteps.Add($"Then apply the publish boundary with: intent-cli automation issue-publish --repo {repo} --issue <issue-number> --write --format json");
+            nextSteps.Add($"Then apply the publish boundary with: intent-cli automation issue-publish --repo {repo} --issue {(issueNumber?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "<issue-number>")} --write --format json");
+        }
+        else if (idempotent)
+        {
+            nextSteps.Add("Issue already created; durable state is already in sync. No GitHub call was made.");
+            if (issueNumber.HasValue)
+            {
+                nextSteps.Add($"Apply the publish boundary if needed with: intent-cli automation issue-publish --repo {repo} --issue {issueNumber.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)} --write --format json");
+            }
         }
 
         return new IssuePublishFlowResult
@@ -205,13 +519,20 @@ internal static class IssuePublishFlowCommand
             Repo = repo,
             PacketDirectory = packetDirectory,
             GithubBodyPath = githubBodyPath,
+            PublishYamlPath = publishYamlPath,
             PacketExists = packetExists,
             GithubBodyPresent = githubBodyPresent,
             MissingContractSections = missingSections,
             Mode = write ? ModeWrite : ModeDryRun,
             Title = title,
             Created = created,
+            Idempotent = idempotent,
+            DurableStateSynced = durableStateSynced,
             IssueUrl = issueUrl,
+            IssueNumber = issueNumber,
+            QueueStatePatched = queueStatePatched,
+            PublishYamlPatched = publishYamlPatched,
+            RunsAppended = runsAppended,
             IntentTargetApplied = false,
             NextSteps = nextSteps,
             Error = error
@@ -238,6 +559,7 @@ internal static class IssuePublishFlowCommand
         writer.WriteLine($"- domain: {result.Domain}");
         writer.WriteLine($"- repo: {result.Repo}");
         writer.WriteLine($"- packet directory: {result.PacketDirectory}");
+        writer.WriteLine($"- publish.yaml: {result.PublishYamlPath}");
         writer.WriteLine($"- packet exists: {(result.PacketExists ? "yes" : "no")}");
         writer.WriteLine($"- github-body.md present: {(result.GithubBodyPresent ? "yes" : "no")}");
         writer.WriteLine($"- mode: {result.Mode}");
@@ -264,10 +586,19 @@ internal static class IssuePublishFlowCommand
 
         writer.WriteLine("## Outcome");
         writer.WriteLine($"- created: {(result.Created ? "yes" : "no")}");
+        writer.WriteLine($"- idempotent: {(result.Idempotent ? "yes" : "no")}");
+        writer.WriteLine($"- durable_state_synced: {(result.DurableStateSynced ? "yes" : "no")}");
+        if (result.IssueNumber is { } issueNumber)
+        {
+            writer.WriteLine($"- issue number: {issueNumber.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+        }
         if (!string.IsNullOrWhiteSpace(result.IssueUrl))
         {
             writer.WriteLine($"- issue URL: {result.IssueUrl}");
         }
+        writer.WriteLine($"- queue_state_patched: {(result.QueueStatePatched ? "yes" : "no")}");
+        writer.WriteLine($"- publish_yaml_patched: {(result.PublishYamlPatched ? "yes" : "no")}");
+        writer.WriteLine($"- runs_appended: {(result.RunsAppended ? "yes" : "no")}");
         writer.WriteLine($"- intent-target applied: {(result.IntentTargetApplied ? "yes" : "no — apply only at the explicit publish boundary after parent durable state is pushed")}");
         if (!string.IsNullOrWhiteSpace(result.Error))
         {
@@ -308,8 +639,6 @@ internal static class IssuePublishFlowCommand
 
     private static string ResolveTitle(string executionUnit, string githubBodyPath)
     {
-        // Look for the first non-empty top-of-file line. If the body starts with
-        // "## Goal" (canonical packet shape), fall back to the executionUnit + "TODO".
         var lines = File.ReadAllLines(githubBodyPath);
         foreach (var raw in lines)
         {
@@ -433,7 +762,7 @@ internal static class IssuePublishFlowCommand
     {
         writer.WriteLine("issue publish-flow");
         writer.WriteLine(UsageLine);
-        writer.WriteLine("Validates the packet, creates the GitHub issue without intent-target, and reports the durable-state + intent-target publish boundary as a next step.");
+        writer.WriteLine("Validates the packet, creates the GitHub issue without intent-target, syncs parent durable state (queue-state, publish.yaml, runs.jsonl), and reports the publish boundary as a next step.");
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -506,6 +835,9 @@ internal sealed record IssuePublishFlowResult
     [JsonPropertyName("github_body_path")]
     public required string GithubBodyPath { get; init; }
 
+    [JsonPropertyName("publish_yaml_path")]
+    public required string PublishYamlPath { get; init; }
+
     [JsonPropertyName("packet_exists")]
     public required bool PacketExists { get; init; }
 
@@ -524,8 +856,26 @@ internal sealed record IssuePublishFlowResult
     [JsonPropertyName("created")]
     public required bool Created { get; init; }
 
+    [JsonPropertyName("idempotent")]
+    public required bool Idempotent { get; init; }
+
+    [JsonPropertyName("durable_state_synced")]
+    public required bool DurableStateSynced { get; init; }
+
     [JsonPropertyName("issue_url")]
     public string? IssueUrl { get; init; }
+
+    [JsonPropertyName("issue_number")]
+    public int? IssueNumber { get; init; }
+
+    [JsonPropertyName("queue_state_patched")]
+    public required bool QueueStatePatched { get; init; }
+
+    [JsonPropertyName("publish_yaml_patched")]
+    public required bool PublishYamlPatched { get; init; }
+
+    [JsonPropertyName("runs_appended")]
+    public required bool RunsAppended { get; init; }
 
     [JsonPropertyName("intent_target_applied")]
     public required bool IntentTargetApplied { get; init; }

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -316,6 +316,47 @@ internal static class IssuePublishFlowCommand
             return 1;
         }
 
+        // G278 follow-up (PR #660 review): all three durable artifacts must be in
+        // sync for success. If any required artifact was not patched (most
+        // commonly the queue-state item, e.g. queue-state.json missing or the
+        // execution unit absent), refuse to claim created:true.
+        if (!queueStatePatched || !publishYamlPatched || !runsAppended)
+        {
+            var unsynchronizedReasons = new List<string>();
+            if (!queueStatePatched)
+            {
+                unsynchronizedReasons.Add(
+                    File.Exists(queueStatePath)
+                        ? $"queue-state.json has no item with execution_unit '{executionUnit}'"
+                        : $"queue-state.json not found at {queueStatePath}");
+            }
+            if (!publishYamlPatched)
+            {
+                unsynchronizedReasons.Add($"publish.yaml at {publishYamlPath} was not written");
+            }
+            if (!runsAppended)
+            {
+                unsynchronizedReasons.Add($"runs.jsonl at {runLogPath} did not receive the issue-created event");
+            }
+
+            var unsynchronizedResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
+                packetExists: true,
+                githubBodyPresent: true,
+                missingSections: Array.Empty<string>(),
+                title: title,
+                created: false,
+                idempotent: false,
+                durableStateSynced: false,
+                issueUrl: outcome.IssueUrl,
+                issueNumber: issueNumber,
+                queueStatePatched: queueStatePatched,
+                publishYamlPatched: publishYamlPatched,
+                runsAppended: runsAppended,
+                error: $"GitHub issue {outcome.IssueUrl} was created but parent durable state is not fully synchronized: {string.Join("; ", unsynchronizedReasons)}. Reconcile via 'intent-cli automation reconcile' or seed the missing parent artifact, then re-run.");
+            EmitResult(writer, unsynchronizedResult, format);
+            return 1;
+        }
+
         var successResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
             packetExists: true,
             githubBodyPresent: true,

--- a/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
@@ -98,6 +98,7 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
     {
         using var workspace = new IssuePublishFlowWorkspace();
         workspace.WriteGithubBody("G245", BuildCompleteContractBody("G245 Add intent-cli issue publish-flow command"));
+        workspace.SeedQueueState("G245", "G245 Add intent-cli issue publish-flow command");
 
         var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/593");
         IssuePublishFlowCommand.CreatorFactory = () => stub;
@@ -241,6 +242,66 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
         Assert.Equal("issue-publish-flow", runEvent.By);
         Assert.Equal("J-Tech-Japan/intent-system#659", runEvent.LinkedIssue);
         Assert.Equal(fixedNow, runEvent.Ts);
+    }
+
+    [Fact]
+    public void Execute_GivenWriteWithMissingQueueState_RefusesSuccessAfterCreate()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody("G278 Fix issue publish-flow durable state synchronization"));
+        // intentionally do NOT seed queue-state.json
+        Assert.False(File.Exists(workspace.QueueStatePath));
+
+        var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/659");
+        IssuePublishFlowCommand.CreatorFactory = () => stub;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("created").GetBoolean());
+        Assert.False(root.GetProperty("durable_state_synced").GetBoolean());
+        Assert.False(root.GetProperty("queue_state_patched").GetBoolean());
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/659", root.GetProperty("issue_url").GetString());
+        var error = root.GetProperty("error").GetString()!;
+        Assert.Contains("durable state is not fully synchronized", error, StringComparison.Ordinal);
+        Assert.Contains("queue-state.json", error, StringComparison.Ordinal);
+        Assert.Contains("automation reconcile", error, StringComparison.Ordinal);
+
+        // queue-state stays absent; reconcile is the operator-driven repair path.
+        Assert.False(File.Exists(workspace.QueueStatePath));
+    }
+
+    [Fact]
+    public void Execute_GivenWriteWithQueueStateMissingExecutionUnit_RefusesSuccessAfterCreate()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody("G278 Fix issue publish-flow durable state synchronization"));
+        // queue-state has a different unit, not G278
+        workspace.SeedQueueState("G999", "G999 unrelated unit");
+
+        var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/659");
+        IssuePublishFlowCommand.CreatorFactory = () => stub;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("created").GetBoolean());
+        Assert.False(root.GetProperty("durable_state_synced").GetBoolean());
+        Assert.False(root.GetProperty("queue_state_patched").GetBoolean());
+        var error = root.GetProperty("error").GetString()!;
+        Assert.Contains("execution_unit 'G278'", error, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
@@ -244,6 +244,48 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_GivenLinkedIssueInQueueStateButPublishYamlMissing_IsIdempotentAndDoesNotCallGitHub()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody("G278 Fix issue publish-flow durable state synchronization"));
+        workspace.SeedQueueStateWithLinkedIssue(
+            "G278",
+            "G278 Fix issue publish-flow durable state synchronization",
+            repo: "J-Tech-Japan/intent-system",
+            issueNumber: 659,
+            issueUrl: "https://github.com/J-Tech-Japan/intent-system/issues/659");
+
+        Assert.False(File.Exists(workspace.PublishYamlPath("G278")));
+
+        var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/9999");
+        IssuePublishFlowCommand.CreatorFactory = () => stub;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(0, stub.CallCount);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("created").GetBoolean());
+        Assert.True(root.GetProperty("idempotent").GetBoolean());
+        Assert.True(root.GetProperty("durable_state_synced").GetBoolean());
+        Assert.Equal(659, root.GetProperty("issue_number").GetInt32());
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/659", root.GetProperty("issue_url").GetString());
+        Assert.False(root.GetProperty("queue_state_patched").GetBoolean());
+        Assert.False(root.GetProperty("publish_yaml_patched").GetBoolean());
+        Assert.False(root.GetProperty("runs_appended").GetBoolean());
+
+        // queue-state must remain unchanged; no duplicate gh issue create was made
+        Assert.False(File.Exists(workspace.PublishYamlPath("G278")));
+        Assert.False(File.Exists(workspace.RunsLogPath));
+    }
+
+    [Fact]
     public void Execute_GivenWriteRerunAfterIssueCreated_IsIdempotentAndDoesNotCallGitHub()
     {
         using var workspace = new IssuePublishFlowWorkspace();
@@ -507,7 +549,26 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
             File.WriteAllText(Path.Combine(directory, "github-body.md"), content);
         }
 
-        public void SeedQueueState(string executionUnit, string title)
+        public void SeedQueueState(string executionUnit, string title) =>
+            WriteQueueStateForUnit(executionUnit, title, linkedIssue: null);
+
+        public void SeedQueueStateWithLinkedIssue(
+            string executionUnit,
+            string title,
+            string repo,
+            int issueNumber,
+            string issueUrl) =>
+            WriteQueueStateForUnit(
+                executionUnit,
+                title,
+                linkedIssue: new LinkedIssue
+                {
+                    Repo = repo,
+                    Number = issueNumber,
+                    Url = issueUrl,
+                });
+
+        private void WriteQueueStateForUnit(string executionUnit, string title, LinkedIssue? linkedIssue)
         {
             Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
             var state = new QueueState
@@ -530,6 +591,7 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
                             ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
                             Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml",
                         },
+                        LinkedIssue = linkedIssue,
                         WorkerRole = "child-impl",
                         ReviewRole = "host-review",
                         Priority = "normal",

--- a/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -10,11 +12,13 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
     public IssuePublishFlowCommandTests()
     {
         IssuePublishFlowCommand.CreatorFactory = null;
+        IssuePublishFlowCommand.UtcNowFactory = null;
     }
 
     public void Dispose()
     {
         IssuePublishFlowCommand.CreatorFactory = null;
+        IssuePublishFlowCommand.UtcNowFactory = null;
     }
 
     [Fact]
@@ -188,6 +192,196 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_GivenWriteWithCompletePacket_PatchesQueueStatePublishYamlAndRunsLog()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody("G278 Fix issue publish-flow durable state synchronization"));
+        workspace.SeedQueueState("G278", "G278 Fix issue publish-flow durable state synchronization");
+
+        var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/659");
+        IssuePublishFlowCommand.CreatorFactory = () => stub;
+        var fixedNow = new DateTimeOffset(2026, 5, 6, 12, 30, 0, TimeSpan.Zero);
+        IssuePublishFlowCommand.UtcNowFactory = () => fixedNow;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("created").GetBoolean());
+        Assert.True(root.GetProperty("durable_state_synced").GetBoolean());
+        Assert.False(root.GetProperty("idempotent").GetBoolean());
+        Assert.Equal(659, root.GetProperty("issue_number").GetInt32());
+        Assert.True(root.GetProperty("queue_state_patched").GetBoolean());
+        Assert.True(root.GetProperty("publish_yaml_patched").GetBoolean());
+        Assert.True(root.GetProperty("runs_appended").GetBoolean());
+
+        var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        var item = Assert.Single(queueState.Items);
+        Assert.NotNull(item.LinkedIssue);
+        Assert.Equal("J-Tech-Japan/intent-system", item.LinkedIssue!.Repo);
+        Assert.Equal(659, item.LinkedIssue.Number);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/659", item.LinkedIssue.Url);
+        Assert.Equal(fixedNow, queueState.UpdatedAt);
+
+        var publishArtifact = IssuePublishArtifactYaml.Deserialize(File.ReadAllText(workspace.PublishYamlPath("G278")));
+        Assert.Equal("issue-created", publishArtifact.PublishStatus);
+        Assert.Equal(659, publishArtifact.CreatedIssueNumber);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/659", publishArtifact.CreatedIssueUrl);
+
+        var runsContent = File.ReadAllText(workspace.RunsLogPath);
+        var runEvents = RunLogSerializer.DeserializeAll(runsContent);
+        var runEvent = Assert.Single(runEvents);
+        Assert.Equal("issue-created", runEvent.Event);
+        Assert.Equal("G278", runEvent.ExecutionUnit);
+        Assert.Equal("issue-publish-flow", runEvent.By);
+        Assert.Equal("J-Tech-Japan/intent-system#659", runEvent.LinkedIssue);
+        Assert.Equal(fixedNow, runEvent.Ts);
+    }
+
+    [Fact]
+    public void Execute_GivenWriteRerunAfterIssueCreated_IsIdempotentAndDoesNotCallGitHub()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody("G278 Fix issue publish-flow durable state synchronization"));
+        workspace.SeedQueueState("G278", "G278 Fix issue publish-flow durable state synchronization");
+
+        var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/659");
+        IssuePublishFlowCommand.CreatorFactory = () => stub;
+        var fixedNow = new DateTimeOffset(2026, 5, 6, 12, 30, 0, TimeSpan.Zero);
+        IssuePublishFlowCommand.UtcNowFactory = () => fixedNow;
+
+        using (var first = new StringWriter())
+        {
+            Assert.Equal(0, IssuePublishFlowCommand.Execute(
+                workspace.Context,
+                ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+                first));
+        }
+
+        Assert.Equal(1, stub.CallCount);
+        var runsAfterFirst = File.ReadAllText(workspace.RunsLogPath);
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, stub.CallCount); // unchanged — no second gh call
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("created").GetBoolean());
+        Assert.True(root.GetProperty("idempotent").GetBoolean());
+        Assert.True(root.GetProperty("durable_state_synced").GetBoolean());
+        Assert.Equal(659, root.GetProperty("issue_number").GetInt32());
+        Assert.False(root.GetProperty("queue_state_patched").GetBoolean());
+        Assert.False(root.GetProperty("publish_yaml_patched").GetBoolean());
+        Assert.False(root.GetProperty("runs_appended").GetBoolean());
+
+        var runsAfterSecond = File.ReadAllText(workspace.RunsLogPath);
+        Assert.Equal(runsAfterFirst, runsAfterSecond);
+        var events = RunLogSerializer.DeserializeAll(runsAfterSecond);
+        Assert.Single(events); // exactly one issue-created event total
+    }
+
+    [Fact]
+    public void Execute_GivenCreatorFailure_LeavesQueueStatePublishYamlAndRunsUnchanged()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody("G278 Fix issue publish-flow durable state synchronization"));
+        workspace.SeedQueueState("G278", "G278 Fix issue publish-flow durable state synchronization");
+
+        var queueStateBefore = File.ReadAllText(workspace.QueueStatePath);
+        var publishYamlExistsBefore = File.Exists(workspace.PublishYamlPath("G278"));
+        var runsLogExistsBefore = File.Exists(workspace.RunsLogPath);
+
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("created").GetBoolean());
+        Assert.False(root.GetProperty("durable_state_synced").GetBoolean());
+        Assert.False(root.GetProperty("queue_state_patched").GetBoolean());
+        Assert.False(root.GetProperty("publish_yaml_patched").GetBoolean());
+        Assert.False(root.GetProperty("runs_appended").GetBoolean());
+
+        Assert.Equal(queueStateBefore, File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal(publishYamlExistsBefore, File.Exists(workspace.PublishYamlPath("G278")));
+        Assert.Equal(runsLogExistsBefore, File.Exists(workspace.RunsLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenDryRun_NeverWritesToQueueStatePublishYamlOrRuns()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody("G278 Fix issue publish-flow durable state synchronization"));
+        workspace.SeedQueueState("G278", "G278 Fix issue publish-flow durable state synchronization");
+
+        var queueStateBefore = File.ReadAllText(workspace.QueueStatePath);
+        var publishYamlExistsBefore = File.Exists(workspace.PublishYamlPath("G278"));
+        var runsLogExistsBefore = File.Exists(workspace.RunsLogPath);
+
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator(); // would throw if called
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(queueStateBefore, File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal(publishYamlExistsBefore, File.Exists(workspace.PublishYamlPath("G278")));
+        Assert.Equal(runsLogExistsBefore, File.Exists(workspace.RunsLogPath));
+    }
+
+    [Fact]
+    public void Execute_OutputAndLocalStateConsistent_DoesNotClaimCreatedTrueWithoutWrites()
+    {
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody("G278 Fix issue publish-flow durable state synchronization"));
+        workspace.SeedQueueState("G278", "G278 Fix issue publish-flow durable state synchronization");
+
+        var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/659");
+        IssuePublishFlowCommand.CreatorFactory = () => stub;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        var created = root.GetProperty("created").GetBoolean();
+        var durableSynced = root.GetProperty("durable_state_synced").GetBoolean();
+
+        if (created)
+        {
+            Assert.True(durableSynced,
+                "command must not claim created:true while local durable artifacts remain unmodified");
+            Assert.True(File.Exists(workspace.PublishYamlPath("G278")));
+            Assert.True(File.Exists(workspace.RunsLogPath));
+            var artifact = IssuePublishArtifactYaml.Deserialize(File.ReadAllText(workspace.PublishYamlPath("G278")));
+            Assert.Equal("issue-created", artifact.PublishStatus);
+        }
+    }
+
+    [Fact]
     public void Execute_HelpFlag_PrintsUsage()
     {
         using var workspace = new IssuePublishFlowWorkspace();
@@ -254,11 +448,14 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
 
         public string? LastBodyFile { get; private set; }
 
+        public int CallCount { get; private set; }
+
         public IssueCreateOutcome CreateIssue(string repo, string title, string bodyFilePath)
         {
             LastRepo = repo;
             LastTitle = title;
             LastBodyFile = bodyFilePath;
+            CallCount++;
             return new IssueCreateOutcome(url);
         }
     }
@@ -296,11 +493,50 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
 
         public CliContext Context { get; }
 
+        public string QueueStatePath => Path.Combine(rootPath, ".intent-cli", "queue-state.json");
+
+        public string RunsLogPath => Path.Combine(rootPath, ".intent-cli", "runs.jsonl");
+
+        public string PublishYamlPath(string executionUnit) =>
+            Path.Combine(rootPath, ".intent-cli", "issues", executionUnit, "publish.yaml");
+
         public void WriteGithubBody(string executionUnit, string content)
         {
             var directory = Path.Combine(rootPath, ".intent-cli", "issues", executionUnit);
             Directory.CreateDirectory(directory);
             File.WriteAllText(Path.Combine(directory, "github-body.md"), content);
+        }
+
+        public void SeedQueueState(string executionUnit, string title)
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            var state = new QueueState
+            {
+                SchemaVersion = "1",
+                UpdatedAt = new DateTimeOffset(2026, 5, 6, 0, 0, 0, TimeSpan.Zero),
+                Items =
+                [
+                    new QueueItem
+                    {
+                        ExecutionUnit = executionUnit,
+                        Title = title,
+                        State = QueueItemState.Queued,
+                        Dependencies = Array.Empty<string>(),
+                        BlockedBy = Array.Empty<string>(),
+                        ClarificationReturnPath = string.Empty,
+                        PacketPaths = new PacketPaths
+                        {
+                            Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                            ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                            Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        },
+                        WorkerRole = "child-impl",
+                        ReviewRole = "host-review",
+                        Priority = "normal",
+                    }
+                ]
+            };
+            File.WriteAllText(QueueStatePath, QueueStateSerializer.Serialize(state));
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary

- `intent-cli issue publish-flow --write` now atomically reflects GitHub issue creation in three parent durable artifacts before reporting success: the matching `queue-state.json` execution-unit gets `linked_issue` filled with `{ repo, number, url }`, `.intent-cli/issues/<execution-unit>/publish.yaml` advances to `publish_status: issue-created` with the GitHub URL/number, and `.intent-cli/runs.jsonl` gets exactly one appended `issue-created` event.
- Re-running `--write` after a successful create is idempotent — the `publish.yaml` `issue-created` marker short-circuits both the `gh issue create` call and the durable-state writes (`created: false`, `idempotent: true`, `durable_state_synced: true`).
- `gh issue create` failure leaves all durable artifacts untouched.
- A durable-write failure that lands after a successful `gh` call refuses to claim `created: true`; the result reports `durable_state_synced: false`, returns exit code `1`, and points the operator at `intent-cli automation reconcile` for repair.
- Dry-run mode (no `--write`) remains read-only.

Closes #659

## Test plan

- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` — succeeds with 0 errors.
- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~IssuePublishFlowCommandTests"` — 14 tests pass (5 new focused tests covering create-success-patches-all-three-artifacts, idempotent rerun-does-not-call-gh-or-append-duplicate, create-failure-leaves-state-unchanged, dry-run-never-writes, and output-vs-local-state-consistency).
- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — full CLI suite: 2010 passed, 1 skipped (preexisting), 0 failed.
- [x] `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)