### PR TITLE
G293: add chat-first intent init host-domain command

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -225,6 +225,7 @@ internal static class CommandRouter
             },
             ["intent"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
+                ["init"] = IntentInitCommand.Execute,
                 ["status"] = IntentStatusCommand.Execute,
                 ["search"] = IntentSearchCommand.Execute,
                 ["explain"] = IntentExplainCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
@@ -50,7 +50,7 @@ internal static class GuideCommandsListCommand
             Classification = ClassificationPrimary,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerChatAgent,
-            Purpose = "Read-only domain status / search / explain / next-slice planning, plus draft-from-interview (write requires --write)."
+            Purpose = "Host-domain init (`intent init --domain <name> [--target-repo <owner/repo>] [--write]`) plus read-only status / search / explain / next-slice planning and draft-from-interview (write requires --write)."
         },
         new CommandGroupEntry
         {

--- a/src/IntentSystem.Cli/Commands/IntentInitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentInitCommand.cs
@@ -1,0 +1,378 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G293: chat-first host-domain initialization command. Bootstraps an
+/// <c>.intent-cli/config.toml</c> and a minimal <c>intents/&lt;domain&gt;</c>
+/// scaffold in a parent host repository so a fresh AI agent can ask
+/// <c>intent-cli</c> to set up a new domain without reading
+/// <c>intents/rules/**</c>, copied prompt files, or local skills.
+///
+/// Idempotent: existing files are preserved (reported as <c>existing</c>),
+/// missing files are created when <c>--write</c> is supplied. Without
+/// <c>--write</c> the command is a dry-run.
+///
+/// Refuses to run inside an automation child worktree
+/// (<c>.intent-cli/worktrees/**</c>) because host bootstrap belongs in the
+/// parent host repo, not in a child checkout.
+/// </summary>
+internal static class IntentInitCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli intent init --domain <name> [--target-repo <owner/repo>] [--write] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine(UsageLine);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var request, out var parseError))
+        {
+            writer.WriteLine(parseError);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        try
+        {
+            var result = ExecuteCore(context.RepoRoot, request);
+            WriteOutput(writer, request.Format, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static IntentInitResult ExecuteCore(string hostRepoRoot, IntentInitRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(hostRepoRoot);
+        ArgumentNullException.ThrowIfNull(request);
+
+        EnsureNotChildWorktree(hostRepoRoot);
+
+        var planned = new List<string>
+        {
+            $"{CliRuntimeContracts.IntentCliDirectoryName}/{CliRuntimeContracts.ConfigFileName}",
+            $"intents/{request.Domain}/README.md",
+            $"intents/{request.Domain}/clarifications/open.md",
+            $"intents/{request.Domain}/intent-tree/00-map.md"
+        };
+
+        var written = new List<string>();
+        var existing = new List<string>();
+
+        foreach (var relativePath in planned)
+        {
+            var absolutePath = ResolveHostPath(hostRepoRoot, relativePath);
+            if (File.Exists(absolutePath))
+            {
+                existing.Add(relativePath);
+                continue;
+            }
+
+            if (!request.Write)
+            {
+                continue;
+            }
+
+            var directoryPath = Path.GetDirectoryName(absolutePath)
+                ?? throw new InvalidOperationException(
+                    $"Intent init target '{absolutePath}' did not contain a directory.");
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(absolutePath, RenderContent(relativePath, request));
+            written.Add(relativePath);
+        }
+
+        return new IntentInitResult
+        {
+            Domain = request.Domain,
+            TargetRepo = request.TargetRepo,
+            HostRepoRoot = Path.GetFullPath(hostRepoRoot),
+            WriteApplied = request.Write,
+            PlannedPaths = planned,
+            WrittenPaths = written,
+            ExistingPaths = existing,
+            NextSteps = BuildNextSteps(request, written.Count, existing.Count)
+        };
+    }
+
+    private static void EnsureNotChildWorktree(string hostRepoRoot)
+    {
+        var normalized = Path.GetFullPath(hostRepoRoot)
+            .Replace('\\', '/');
+        var segments = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        for (var index = 0; index + 1 < segments.Length; index++)
+        {
+            if (string.Equals(segments[index], ".intent-cli", StringComparison.Ordinal)
+                && string.Equals(segments[index + 1], "worktrees", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Refusing to run 'intent init' inside an automation child worktree at '{hostRepoRoot}'. Run this command from the parent host repository (the directory that owns '.intent-cli/').");
+            }
+        }
+    }
+
+    private static IReadOnlyList<string> BuildNextSteps(
+        IntentInitRequest request,
+        int writtenCount,
+        int existingCount)
+    {
+        var domain = request.Domain;
+        var verb = request.Write
+            ? (writtenCount == 0 ? "Already initialized" : "Initialized")
+            : "Plan";
+
+        var steps = new List<string>
+        {
+            $"{verb}: domain '{domain}' (written: {writtenCount}, existing: {existingCount})."
+        };
+
+        if (!request.Write)
+        {
+            steps.Add($"Re-run with --write to create the planned files: intent-cli intent init --domain {domain}{TargetArg(request)} --write");
+        }
+
+        steps.Add($"Open `intents/{domain}/intent-tree/00-map.md` and capture the initial domain shape.");
+        steps.Add($"Use `intent-cli interview record-answer --write` (chat-first) to durably record durable Q/A for '{domain}'.");
+        steps.Add($"Use `intent-cli intent next-slice --domain {domain} --dry-run` to plan the first publishable slice.");
+        steps.Add("Run this command from the parent host repository, never inside `.intent-cli/worktrees/**`.");
+
+        return steps;
+    }
+
+    private static string TargetArg(IntentInitRequest request)
+    {
+        return string.IsNullOrWhiteSpace(request.TargetRepo)
+            ? string.Empty
+            : $" --target-repo {request.TargetRepo}";
+    }
+
+    private static string ResolveHostPath(string hostRepoRoot, string relativePath)
+    {
+        return Path.Combine(hostRepoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+    }
+
+    private static string RenderContent(string relativePath, IntentInitRequest request)
+    {
+        return relativePath switch
+        {
+            var path when path.EndsWith($"/{CliRuntimeContracts.ConfigFileName}", StringComparison.Ordinal)
+                => RenderConfigToml(request),
+            var path when path.EndsWith("/README.md", StringComparison.Ordinal)
+                => RenderDomainReadme(request),
+            var path when path.EndsWith("/clarifications/open.md", StringComparison.Ordinal)
+                => RenderOpenClarifications(),
+            var path when path.EndsWith("/intent-tree/00-map.md", StringComparison.Ordinal)
+                => RenderIntentMap(request),
+            _ => throw new InvalidOperationException(
+                $"Intent init has no template for '{relativePath}'.")
+        };
+    }
+
+    private static string RenderConfigToml(IntentInitRequest request)
+    {
+        return $$"""
+        [project]
+        domain = "{{EscapeTomlString(request.Domain)}}"
+        artifact_root = ".intent-cli"
+        worktree_root = ".intent-cli/worktrees"
+        """;
+    }
+
+    private static string RenderDomainReadme(IntentInitRequest request)
+    {
+        var targetLine = string.IsNullOrWhiteSpace(request.TargetRepo)
+            ? string.Empty
+            : $"Target repo: `{request.TargetRepo}`" + Environment.NewLine + Environment.NewLine;
+
+        return $$"""
+        # {{request.Domain}}
+
+        {{targetLine}}Bootstrapped by `intent-cli intent init`.
+
+        Treat this as the parent host record for the `{{request.Domain}}` domain. Add
+        upstream references and the canonical domain shape under
+        `intent-tree/`, durable Q/A under `interviews/`, and open
+        clarifications under `clarifications/open.md`.
+        """;
+    }
+
+    private static string RenderOpenClarifications()
+    {
+        return """
+        # Open Clarifications
+
+        - none
+        """;
+    }
+
+    private static string RenderIntentMap(IntentInitRequest request)
+    {
+        var targetLine = string.IsNullOrWhiteSpace(request.TargetRepo)
+            ? string.Empty
+            : $"- Target repo: `{request.TargetRepo}`" + Environment.NewLine;
+
+        return $$"""
+        # Intent Map
+
+        - Domain: `{{request.Domain}}`
+        {{targetLine}}- Initial map: pending
+
+        Capture the canonical domain shape here. Each child intent should
+        link back to this map and the host data under `.intent-cli/`.
+        """;
+    }
+
+    private static string EscapeTomlString(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out IntentInitRequest request,
+        out string error)
+    {
+        request = default!;
+        error = string.Empty;
+
+        string? domain = null;
+        string? targetRepo = null;
+        var write = false;
+        var format = FormatMarkdown;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "Missing value for '--domain'.";
+                        return false;
+                    }
+                    domain = args[++index].Trim();
+                    break;
+                case "--target-repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "Missing value for '--target-repo'.";
+                        return false;
+                    }
+                    targetRepo = args[++index].Trim();
+                    break;
+                case "--write":
+                    write = true;
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "Missing value for '--format'.";
+                        return false;
+                    }
+                    var nextValue = args[++index].Trim();
+                    if (!string.Equals(nextValue, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(nextValue, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"Unsupported format '{nextValue}'. Expected 'markdown' or 'json'.";
+                        return false;
+                    }
+                    format = nextValue;
+                    break;
+                default:
+                    error = $"Unknown intent init option '{args[index]}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            error = "Intent init requires '--domain <name>'.";
+            return false;
+        }
+
+        if (!IsValidDomainSlug(domain))
+        {
+            error = $"Intent init '--domain' value '{domain}' must be a slug (letters, digits, '-', '_').";
+            return false;
+        }
+
+        request = new IntentInitRequest
+        {
+            Domain = domain!,
+            TargetRepo = targetRepo,
+            Write = write,
+            Format = format
+        };
+        return true;
+    }
+
+    private static bool IsValidDomainSlug(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        foreach (var character in value)
+        {
+            var isValid = char.IsLetterOrDigit(character)
+                || character == '-'
+                || character == '_';
+            if (!isValid)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteOutput(TextWriter writer, string format, IntentInitResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+            return;
+        }
+
+        IntentInitRenderer.WriteMarkdown(writer, result);
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+
+    internal sealed record IntentInitRequest
+    {
+        public required string Domain { get; init; }
+
+        public string? TargetRepo { get; init; }
+
+        public required bool Write { get; init; }
+
+        public required string Format { get; init; }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntentInitRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntentInitRenderer.cs
@@ -1,0 +1,49 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class IntentInitRenderer
+{
+    public static void WriteMarkdown(TextWriter writer, IntentInitResult result)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(result);
+
+        writer.WriteLine($"# Intent init — domain '{result.Domain}'");
+        writer.WriteLine();
+        writer.WriteLine($"- Host repo root: `{result.HostRepoRoot}`");
+        writer.WriteLine($"- Target repo: {(string.IsNullOrWhiteSpace(result.TargetRepo) ? "_unspecified_" : "`" + result.TargetRepo + "`")}");
+        writer.WriteLine($"- Mode: {(result.WriteApplied ? "write" : "dry-run")}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Planned paths");
+        WriteList(writer, result.PlannedPaths);
+
+        writer.WriteLine();
+        writer.WriteLine("## Written paths");
+        WriteList(writer, result.WrittenPaths);
+
+        writer.WriteLine();
+        writer.WriteLine("## Existing paths (preserved)");
+        WriteList(writer, result.ExistingPaths);
+
+        writer.WriteLine();
+        writer.WriteLine("## Next steps");
+        foreach (var step in result.NextSteps)
+        {
+            writer.WriteLine($"- {step}");
+        }
+    }
+
+    private static void WriteList(TextWriter writer, IReadOnlyList<string> values)
+    {
+        if (values.Count == 0)
+        {
+            writer.WriteLine("- _none_");
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            writer.WriteLine($"- `{value}`");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IntentInitResult.cs
+++ b/src/IntentSystem.Cli/Commands/IntentInitResult.cs
@@ -1,0 +1,20 @@
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record IntentInitResult
+{
+    public required string Domain { get; init; }
+
+    public required string? TargetRepo { get; init; }
+
+    public required string HostRepoRoot { get; init; }
+
+    public required bool WriteApplied { get; init; }
+
+    public required IReadOnlyList<string> PlannedPaths { get; init; }
+
+    public required IReadOnlyList<string> WrittenPaths { get; init; }
+
+    public required IReadOnlyList<string> ExistingPaths { get; init; }
+
+    public required IReadOnlyList<string> NextSteps { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -21,7 +21,10 @@ internal static class Program
             }
 
             var currentDirectory = Directory.GetCurrentDirectory();
-            if (IsIntakeInitCommand(args) || IsAutomationWorktreeCommand(args) || IsGuideOneshotCommand(args))
+            if (IsIntakeInitCommand(args)
+                || IsIntentInitCommand(args)
+                || IsAutomationWorktreeCommand(args)
+                || IsGuideOneshotCommand(args))
             {
                 return CommandRouter.Execute(args, CreateBootstrapContext(currentDirectory, args), Console.Out);
             }
@@ -52,6 +55,13 @@ internal static class Program
     {
         return args.Length >= 2
             && string.Equals(args[0], "intake", StringComparison.Ordinal)
+            && string.Equals(args[1], "init", StringComparison.Ordinal);
+    }
+
+    private static bool IsIntentInitCommand(string[] args)
+    {
+        return args.Length >= 2
+            && string.Equals(args[0], "intent", StringComparison.Ordinal)
             && string.Equals(args[1], "init", StringComparison.Ordinal);
     }
 

--- a/tests/IntentSystem.Cli.Tests/IntentInitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentInitCommandTests.cs
@@ -1,0 +1,185 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntentInitCommandTests
+{
+    [Fact]
+    public void Execute_WithoutWrite_PerformsDryRun_AndCreatesNoFiles()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var hostRoot = tempDirectory.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--target-repo", "owner/repo"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(File.Exists(Path.Combine(hostRoot, ".intent-cli", "config.toml")));
+        Assert.False(File.Exists(Path.Combine(hostRoot, "intents", "auth", "README.md")));
+
+        var output = writer.ToString();
+        Assert.Contains("Mode: dry-run", output, StringComparison.Ordinal);
+        Assert.Contains("`.intent-cli/config.toml`", output, StringComparison.Ordinal);
+        Assert.Contains("`intents/auth/README.md`", output, StringComparison.Ordinal);
+        Assert.Contains("--write", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithWrite_CreatesScaffold_AndIsIdempotentOnSecondRun()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var hostRoot = tempDirectory.CreateDirectory("host");
+        using var firstWriter = new StringWriter();
+
+        var firstExitCode = IntentInitCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write"],
+            firstWriter);
+
+        Assert.Equal(0, firstExitCode);
+        var configPath = Path.Combine(hostRoot, ".intent-cli", "config.toml");
+        var readmePath = Path.Combine(hostRoot, "intents", "auth", "README.md");
+        var clarificationsPath = Path.Combine(hostRoot, "intents", "auth", "clarifications", "open.md");
+        var intentMapPath = Path.Combine(hostRoot, "intents", "auth", "intent-tree", "00-map.md");
+        Assert.True(File.Exists(configPath));
+        Assert.True(File.Exists(readmePath));
+        Assert.True(File.Exists(clarificationsPath));
+        Assert.True(File.Exists(intentMapPath));
+
+        var configContent = File.ReadAllText(configPath);
+        Assert.Contains("domain = \"auth\"", configContent, StringComparison.Ordinal);
+        Assert.Contains("artifact_root = \".intent-cli\"", configContent, StringComparison.Ordinal);
+
+        File.WriteAllText(readmePath, "operator override\n");
+
+        using var secondWriter = new StringWriter();
+        var secondExitCode = IntentInitCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write"],
+            secondWriter);
+
+        Assert.Equal(0, secondExitCode);
+        Assert.Equal("operator override\n", File.ReadAllText(readmePath));
+        var secondOutput = secondWriter.ToString();
+        Assert.Contains("Already initialized", secondOutput, StringComparison.Ordinal);
+        Assert.Contains("Existing paths", secondOutput, StringComparison.Ordinal);
+        Assert.Contains("`intents/auth/README.md`", secondOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_FromChildWorktree_ReturnsExitCodeOne_WithGuidance()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var childRoot = tempDirectory.CreateDirectory(Path.Combine("host", ".intent-cli", "worktrees", "auth-2026"));
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitCommand.Execute(
+            CreateContext(childRoot),
+            ["--domain", "auth", "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("automation child worktree", output, StringComparison.Ordinal);
+        Assert.Contains("parent host repository", output, StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(childRoot, ".intent-cli", "config.toml")));
+    }
+
+    [Fact]
+    public void Execute_MissingDomain_ReturnsExitCodeOne_WithUsageHint()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var hostRoot = tempDirectory.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitCommand.Execute(
+            CreateContext(hostRoot),
+            ["--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("--domain", output, StringComparison.Ordinal);
+        Assert.Contains("Usage: intent-cli intent init", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RejectsInvalidDomainSlug()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var hostRoot = tempDirectory.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "not a slug", "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must be a slug", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_ProducesParseableJson()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var hostRoot = tempDirectory.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString().Trim();
+        Assert.StartsWith("{", json, StringComparison.Ordinal);
+        Assert.Contains("\"domain\": \"auth\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"write_applied\": true", json, StringComparison.Ordinal);
+        Assert.Contains("\"planned_paths\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"written_paths\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"existing_paths\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"next_steps\"", json, StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "bootstrap",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-intent-init-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `intent-cli intent init --domain <name> [--target-repo <owner/repo>] [--write] [--format markdown|json]` as a primary chat-first surface that bootstraps a parent host repo's `.intent-cli/config.toml` plus a minimal `intents/<domain>/{README.md, clarifications/open.md, intent-tree/00-map.md}` scaffold.
- Bootstrap-friendly (works in a directory without `.intent-cli` via `Program.cs`), idempotent (existing files reported under `existing` and never overwritten), and dry-run by default; `--write` materializes only missing files.
- Refuses to run inside an automation child worktree (`.intent-cli/worktrees/**`) so host-domain initialization stays in the parent host repository, never in a child checkout.
- Updates `guide commands list` `intent` purpose to mention the new init surface so a fresh AI agent can discover it via the canonical guide instead of copied rules or local skills.

## Test plan
- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — 2114 passed, 1 skipped, 0 failed.
- [x] New `IntentInitCommandTests` covers: dry-run plan, `--write` create-then-idempotent (existing operator override preserved), child-worktree refusal, missing-`--domain` usage hint, invalid slug rejection, JSON format shape.
- [x] Smoke-tested the built CLI in a fresh temp directory: dry-run lists planned paths, `--write` creates the four files, second `--write` reports them as existing.

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)