### PR TITLE
G294: add host base_branch_policy and base-branch-check diagnostic

### DIFF
--- a/src/IntentSystem.Cli/CliRuntimeContracts.cs
+++ b/src/IntentSystem.Cli/CliRuntimeContracts.cs
@@ -30,6 +30,12 @@ internal static class CliRuntimeContracts
     public const string RetryDelayMinutesKey = "retry_delay_minutes";
     public const string RetryBudgetKey = "retry_budget";
     public const string PostFixWorktreeProgressPolicyKey = "post_fix_worktree_progress_policy";
+    public const string BaseBranchPolicyKey = "base_branch_policy";
+    public const string DirectMainBaseBranchPolicy = "direct-main";
+    public const string MainAiBaseBranchPolicy = "main-ai";
+    public const string DefaultBaseBranchPolicy = DirectMainBaseBranchPolicy;
+    public const string DirectMainBaseBranch = "main";
+    public const string MainAiIntegrationBaseBranch = "main-ai";
     public const string DefaultWorktreeRoot = ".intent-cli/worktrees";
     public const string DefaultSupervisionArtifactRoot = ".intent-cli/supervision";
     public const string DefaultDirectRunArtifactRoot = ".intent-cli/runs";

--- a/src/IntentSystem.Cli/Commands/AutomationBaseBranchCheckCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationBaseBranchCheckCommand.cs
@@ -1,0 +1,269 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G294: read-only diagnostic that compares an observed PR base branch
+/// against the configured <c>base_branch_policy</c> for a host domain. The
+/// caller passes <c>--actual-base</c> (typically captured from
+/// <c>gh pr view &lt;n&gt; --json baseRefName --jq .baseRefName</c>) so this
+/// command stays deterministic and easy to test without invoking
+/// GitHub. When <c>--policy</c> is omitted, the command reads
+/// <c>base_branch_policy</c> from the loaded host config (defaulting to
+/// <c>direct-main</c>). Never mutates state.
+/// </summary>
+internal static class AutomationBaseBranchCheckCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string StatusOk = "ok";
+    private const string StatusMismatch = "mismatch";
+
+    private const string UsageLine =
+        "Usage: intent-cli automation base-branch-check --repo <owner/repo> --pr <n> --actual-base <branch> [--policy direct-main|main-ai] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine(UsageLine);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var request, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var configuredPolicy = string.IsNullOrWhiteSpace(request.PolicyOverride)
+            ? context.Config.Project.BaseBranchPolicy
+            : request.PolicyOverride!;
+
+        if (string.IsNullOrWhiteSpace(configuredPolicy))
+        {
+            configuredPolicy = CliRuntimeContracts.DefaultBaseBranchPolicy;
+        }
+
+        if (!BaseBranchPolicyContract.IsKnownPolicy(configuredPolicy))
+        {
+            writer.WriteLine(
+                $"Unknown base branch policy '{configuredPolicy}'. Expected '{CliRuntimeContracts.DirectMainBaseBranchPolicy}' or '{CliRuntimeContracts.MainAiBaseBranchPolicy}'.");
+            return 1;
+        }
+
+        var expectedBase = BaseBranchPolicyContract.ResolveExpectedBaseBranch(configuredPolicy);
+        var actualBase = request.ActualBase.Trim();
+        var matches = string.Equals(actualBase, expectedBase, StringComparison.Ordinal);
+
+        var result = new BaseBranchCheckResult
+        {
+            Repo = request.Repo,
+            Pr = request.PrNumber,
+            Policy = configuredPolicy,
+            ExpectedBase = expectedBase,
+            ActualBase = actualBase,
+            Status = matches ? StatusOk : StatusMismatch,
+            Summary = matches
+                ? $"PR #{request.PrNumber} targets `{actualBase}`, matching policy `{configuredPolicy}`."
+                : $"PR #{request.PrNumber} targets `{actualBase}` but policy `{configuredPolicy}` requires `{expectedBase}`. Re-target the PR or update `base_branch_policy` to match the project workflow.",
+            RecommendedActions = matches
+                ? Array.Empty<string>()
+                : new[]
+                {
+                    $"Re-target PR #{request.PrNumber} so its base branch is `{expectedBase}`, OR",
+                    $"Update `[project] base_branch_policy` in `.intent-cli/config.toml` if `{actualBase}` is the intended base."
+                }
+        };
+
+        if (string.Equals(request.Format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return matches ? 0 : 1;
+    }
+
+    private static void WriteMarkdown(TextWriter writer, BaseBranchCheckResult result)
+    {
+        writer.WriteLine($"# Base branch check — {result.Repo} PR #{result.Pr}");
+        writer.WriteLine();
+        writer.WriteLine($"- Policy: `{result.Policy}`");
+        writer.WriteLine($"- Expected base: `{result.ExpectedBase}`");
+        writer.WriteLine($"- Actual base: `{result.ActualBase}`");
+        writer.WriteLine($"- Status: **{result.Status}**");
+        writer.WriteLine();
+        writer.WriteLine(result.Summary);
+        if (result.RecommendedActions.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Recommended actions");
+            foreach (var action in result.RecommendedActions)
+            {
+                writer.WriteLine($"- {action}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out BaseBranchCheckRequest request, out string error)
+    {
+        request = default!;
+        error = string.Empty;
+
+        string? repo = null;
+        int? prNumber = null;
+        string? actualBase = null;
+        string? policyOverride = null;
+        var format = FormatMarkdown;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (owner/repo).";
+                        return false;
+                    }
+                    repo = args[++index].Trim();
+                    break;
+                case "--pr":
+                    if (index + 1 >= args.Length || !int.TryParse(args[index + 1], out var parsedPr) || parsedPr <= 0)
+                    {
+                        error = "--pr requires a positive integer.";
+                        return false;
+                    }
+                    prNumber = parsedPr;
+                    index++;
+                    break;
+                case "--actual-base":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--actual-base requires a branch name (e.g. 'main' or 'main-ai').";
+                        return false;
+                    }
+                    actualBase = args[++index].Trim();
+                    break;
+                case "--policy":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = $"--policy requires a value ('{CliRuntimeContracts.DirectMainBaseBranchPolicy}' or '{CliRuntimeContracts.MainAiBaseBranchPolicy}').";
+                        return false;
+                    }
+                    policyOverride = args[++index].Trim();
+                    if (!BaseBranchPolicyContract.IsKnownPolicy(policyOverride))
+                    {
+                        error = $"--policy must be '{CliRuntimeContracts.DirectMainBaseBranchPolicy}' or '{CliRuntimeContracts.MainAiBaseBranchPolicy}' (got '{policyOverride}').";
+                        return false;
+                    }
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[++index].Trim();
+                    if (!string.Equals(requestedFormat, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    break;
+                default:
+                    error = $"Unknown argument '{args[index]}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "Base branch check requires '--repo <owner/repo>'.";
+            return false;
+        }
+
+        if (prNumber is null)
+        {
+            error = "Base branch check requires '--pr <n>'.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(actualBase))
+        {
+            error = "Base branch check requires '--actual-base <branch>' (e.g. captured via 'gh pr view <n> --json baseRefName --jq .baseRefName').";
+            return false;
+        }
+
+        request = new BaseBranchCheckRequest
+        {
+            Repo = repo!,
+            PrNumber = prNumber.Value,
+            ActualBase = actualBase!,
+            PolicyOverride = policyOverride,
+            Format = format
+        };
+        return true;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never
+    };
+
+    private sealed record BaseBranchCheckRequest
+    {
+        public required string Repo { get; init; }
+
+        public required int PrNumber { get; init; }
+
+        public required string ActualBase { get; init; }
+
+        public required string Format { get; init; }
+
+        public string? PolicyOverride { get; init; }
+    }
+
+    internal sealed record BaseBranchCheckResult
+    {
+        [JsonPropertyName("repo")]
+        public required string Repo { get; init; }
+
+        [JsonPropertyName("pr")]
+        public required int Pr { get; init; }
+
+        [JsonPropertyName("policy")]
+        public required string Policy { get; init; }
+
+        [JsonPropertyName("expected_base")]
+        public required string ExpectedBase { get; init; }
+
+        [JsonPropertyName("actual_base")]
+        public required string ActualBase { get; init; }
+
+        [JsonPropertyName("status")]
+        public required string Status { get; init; }
+
+        [JsonPropertyName("summary")]
+        public required string Summary { get; init; }
+
+        [JsonPropertyName("recommended_actions")]
+        public required IReadOnlyList<string> RecommendedActions { get; init; }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/BaseBranchPolicyContract.cs
+++ b/src/IntentSystem.Cli/Commands/BaseBranchPolicyContract.cs
@@ -1,0 +1,63 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G294: canonical mapping between a host's <c>base_branch_policy</c> configuration
+/// and the resulting expected GitHub PR base branch. Two modes are supported:
+///
+/// <list type="bullet">
+/// <item>
+/// <description><c>direct-main</c> (default): every child PR targets <c>main</c>; the
+/// host merges directly to <c>main</c>.</description>
+/// </item>
+/// <item>
+/// <description><c>main-ai</c>: every child PR targets <c>main-ai</c>; the operator
+/// periodically opens a human-reviewed <c>main-ai → main</c> batch PR.</description>
+/// </item>
+/// </list>
+///
+/// The contract is consumed by:
+/// <list type="bullet">
+/// <item><description><c>intent-cli guide prompt-matrix</c> (child-loop and host-loop), which
+/// surfaces the expected base branch to the AI agent so it cannot rely on hidden
+/// human memory.</description></item>
+/// <item><description><c>intent-cli automation base-branch-check</c>, which compares the
+/// observed PR base branch against the configured policy and surfaces a structured
+/// mismatch result.</description></item>
+/// </list>
+/// </summary>
+internal static class BaseBranchPolicyContract
+{
+    public static bool IsKnownPolicy(string policy)
+    {
+        return string.Equals(policy, CliRuntimeContracts.DirectMainBaseBranchPolicy, StringComparison.Ordinal)
+            || string.Equals(policy, CliRuntimeContracts.MainAiBaseBranchPolicy, StringComparison.Ordinal);
+    }
+
+    public static string ResolveExpectedBaseBranch(string policy)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(policy);
+
+        return policy switch
+        {
+            CliRuntimeContracts.DirectMainBaseBranchPolicy => CliRuntimeContracts.DirectMainBaseBranch,
+            CliRuntimeContracts.MainAiBaseBranchPolicy => CliRuntimeContracts.MainAiIntegrationBaseBranch,
+            _ => throw new InvalidOperationException(
+                $"Unknown base branch policy '{policy}'. Expected '{CliRuntimeContracts.DirectMainBaseBranchPolicy}' or '{CliRuntimeContracts.MainAiBaseBranchPolicy}'.")
+        };
+    }
+
+    public static string DescribePolicy(string policy)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(policy);
+
+        return policy switch
+        {
+            CliRuntimeContracts.DirectMainBaseBranchPolicy =>
+                "Child PRs target `main` directly; host merges land on `main`.",
+            CliRuntimeContracts.MainAiBaseBranchPolicy =>
+                "Child PRs target `main-ai` (the AI integration branch); the human operator periodically opens a `main-ai → main` batch PR. Never open a child PR against `main` directly under this policy.",
+            _ => throw new InvalidOperationException(
+                $"Unknown base branch policy '{policy}'.")
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -33,6 +33,7 @@ internal static class CommandRouter
 
     private static readonly IReadOnlyList<string> AutomationCommandHelp =
     [
+        "automation base-branch-check --repo <r> --pr <n> --actual-base <branch> [--policy direct-main|main-ai]",
         "automation check",
         "automation clarification-stop",
         "automation complete",
@@ -145,6 +146,7 @@ internal static class CommandRouter
             },
             ["automation"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
+                ["base-branch-check"] = AutomationBaseBranchCheckCommand.Execute,
                 ["check"] = AutomationCheckCommand.Execute,
                 ["clarification-stop"] = AutomationClarificationStopCommand.Execute,
                 ["complete"] = AutomationCompleteCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -51,7 +51,7 @@ internal static class GuidePromptMatrixCommand
         RegexOptions.Compiled);
 
     private const string UsageLine =
-        "Usage: intent-cli guide prompt-matrix [--mode child-loop|host-loop|child-oneshot|host-oneshot] [--domain <name>] [--target-repo <owner/repo>] [--agent claude|codex|generic] [--frequency <NNm|NNh>] [--format markdown|json]";
+        "Usage: intent-cli guide prompt-matrix [--mode child-loop|host-loop|child-oneshot|host-oneshot] [--domain <name>] [--target-repo <owner/repo>] [--agent claude|codex|generic] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--format markdown|json]";
 
     private static readonly string[] ForbiddenSources =
     [
@@ -72,14 +72,14 @@ internal static class GuidePromptMatrixCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var mode, out var format, out var domain, out var targetRepo, out var agent, out var frequency, out var error))
+        if (!TryParseArguments(args, out var mode, out var format, out var domain, out var targetRepo, out var agent, out var frequency, out var baseBranchPolicy, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
             return 1;
         }
 
-        var entries = BuildEntries(mode, domain, targetRepo, agent, frequency);
+        var entries = BuildEntries(mode, domain, targetRepo, agent, frequency, baseBranchPolicy);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
@@ -107,17 +107,21 @@ internal static class GuidePromptMatrixCommand
         string? domain,
         string? targetRepo,
         string? agent,
-        string? frequency)
+        string? frequency,
+        string? baseBranchPolicy)
     {
         var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
         var targetRepoPlaceholder = string.IsNullOrWhiteSpace(targetRepo) ? "<TARGET-REPO>" : targetRepo;
+        var resolvedPolicy = string.IsNullOrWhiteSpace(baseBranchPolicy)
+            ? CliRuntimeContracts.DefaultBaseBranchPolicy
+            : baseBranchPolicy;
 
         var all = new[]
         {
-            BuildChildLoop(domainPlaceholder, agent, frequency),
-            BuildHostLoop(domainPlaceholder, targetRepoPlaceholder, agent, frequency),
-            BuildChildOneshot(domainPlaceholder),
-            BuildHostOneshot(domainPlaceholder, targetRepoPlaceholder)
+            BuildChildLoop(domainPlaceholder, agent, frequency, resolvedPolicy),
+            BuildHostLoop(domainPlaceholder, targetRepoPlaceholder, agent, frequency, resolvedPolicy),
+            BuildChildOneshot(domainPlaceholder, resolvedPolicy),
+            BuildHostOneshot(domainPlaceholder, targetRepoPlaceholder, resolvedPolicy)
         };
 
         if (mode is null)
@@ -182,14 +186,27 @@ $@"Frequency: {frequency} (operator-resolved). {schedulingHint}
             ? FrequencyGuidanceRecurring
             : $"{frequency} (operator-resolved)";
 
-    private static GuidePromptMatrixEntry BuildChildLoop(string domainPlaceholder, string? agent, string? frequency)
+    private static string RenderBaseBranchPolicyBlock(string baseBranchPolicy, string targetRoleVerb)
+    {
+        var expected = BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy);
+        var description = BaseBranchPolicyContract.DescribePolicy(baseBranchPolicy);
+        return
+$@"Base branch policy: `{baseBranchPolicy}` (expected base branch: `{expected}`).
+- {description}
+- {targetRoleVerb} this policy mechanically: derive the PR base branch from `intent-cli` config (`base_branch_policy`), never from prompt memory. Use `intent-cli automation base-branch-check --repo <r> --pr <n> --policy {baseBranchPolicy} --actual-base $(gh pr view <n> --repo <r> --json baseRefName --jq .baseRefName) --format json` to flag mismatches.";
+    }
+
+    private static GuidePromptMatrixEntry BuildChildLoop(string domainPlaceholder, string? agent, string? frequency, string baseBranchPolicy)
     {
         var resolvedAgent = NormalizeAgent(agent);
         var frequencyBlock = RenderFrequencyBlock(agent, frequency);
+        var basePolicyBlock = RenderBaseBranchPolicyBlock(baseBranchPolicy, "Honor");
         var prompt =
 $@"Set up the child implementation loop for the repo in the current worktree. Run the loop body exactly once per wake; the operator or scheduler drives subsequent wakes.
 
 {frequencyBlock}
+
+{basePolicyBlock}
 
 If the installed CLI surface is stale or any required automation command is missing, abort the wake before any mutation: `intent-cli automation doctor --format json` (or `automation host-review-preflight` reporting `stale-host-cli`) is the canonical signal — refresh the installed CLI; never fall back to raw `gh` label mutation. The installed CLI may come from a global dotnet tool install on `PATH` (e.g. `$HOME/.dotnet/tools/intent-cli`); that is the default local-testing route and the doctor reports `binary_source: path-global-tool` in that case. A cwd-local `.intent-cli/bin/intent-cli` shim still wins when present (`binary_source: cwd-local-shim`) and `INTENT_CLI_INSTALLED_PATH` pins a specific binary for version-specific tests (`binary_source: explicit-override`).
 
@@ -235,17 +252,22 @@ Hard rules:
             Prompt = prompt,
             Agent = resolvedAgent,
             Frequency = string.IsNullOrWhiteSpace(frequency) ? null : frequency,
+            BaseBranchPolicy = baseBranchPolicy,
+            ExpectedBaseBranch = BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy),
         };
     }
 
-    private static GuidePromptMatrixEntry BuildHostLoop(string domainPlaceholder, string targetRepoPlaceholder, string? agent, string? frequency)
+    private static GuidePromptMatrixEntry BuildHostLoop(string domainPlaceholder, string targetRepoPlaceholder, string? agent, string? frequency, string baseBranchPolicy)
     {
         var resolvedAgent = NormalizeAgent(agent);
         var frequencyBlock = RenderFrequencyBlock(agent, frequency);
+        var basePolicyBlock = RenderBaseBranchPolicyBlock(baseBranchPolicy, "Closeout / merge expectation honors");
         var prompt =
 $@"Set up the host review and next-slice loop for domain `{domainPlaceholder}` against `{targetRepoPlaceholder}`. Run the loop body exactly once per wake; the operator or scheduler drives subsequent wakes.
 
 {frequencyBlock}
+
+{basePolicyBlock}
 
 If the installed CLI surface is stale or any required automation command is missing, abort the wake before any mutation: `intent-cli automation doctor --format json` (or `automation host-review-preflight` reporting `stale-host-cli`) is the canonical signal — refresh the installed CLI; never fall back to raw `gh` label mutation. The installed CLI may come from a global dotnet tool install on `PATH` (e.g. `$HOME/.dotnet/tools/intent-cli`); that is the default local-testing route and the doctor reports `binary_source: path-global-tool` in that case. A cwd-local `.intent-cli/bin/intent-cli` shim still wins when present (`binary_source: cwd-local-shim`) and `INTENT_CLI_INSTALLED_PATH` pins a specific binary for version-specific tests (`binary_source: explicit-override`).
 
@@ -321,16 +343,21 @@ Hard rules:
             ],
             Prompt = prompt,
             Agent = resolvedAgent,
-            Frequency = string.IsNullOrWhiteSpace(frequency) ? null : frequency
+            Frequency = string.IsNullOrWhiteSpace(frequency) ? null : frequency,
+            BaseBranchPolicy = baseBranchPolicy,
+            ExpectedBaseBranch = BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy),
         };
     }
 
-    private static GuidePromptMatrixEntry BuildChildOneshot(string domainPlaceholder)
+    private static GuidePromptMatrixEntry BuildChildOneshot(string domainPlaceholder, string baseBranchPolicy)
     {
+        var basePolicyBlock = RenderBaseBranchPolicyBlock(baseBranchPolicy, "Honor");
         var prompt =
 $@"Run one child implementation/update wake exactly once.
 
 Do not create or update any automation, loop, cron, monitor, reminder, or recurring wakeup. This is a one-shot execution. Frequency is forbidden.
+
+{basePolicyBlock}
 
 First-call sequence (read-only; required before any mutation):
 1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
@@ -372,16 +399,21 @@ Hard rules:
                 "intent-cli guide commands list --format json",
                 $"intent-cli automation summary --domain {domainPlaceholder} --format json"
             ],
-            Prompt = prompt
+            Prompt = prompt,
+            BaseBranchPolicy = baseBranchPolicy,
+            ExpectedBaseBranch = BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy),
         };
     }
 
-    private static GuidePromptMatrixEntry BuildHostOneshot(string domainPlaceholder, string targetRepoPlaceholder)
+    private static GuidePromptMatrixEntry BuildHostOneshot(string domainPlaceholder, string targetRepoPlaceholder, string baseBranchPolicy)
     {
+        var basePolicyBlock = RenderBaseBranchPolicyBlock(baseBranchPolicy, "Closeout / merge expectation honors");
         var prompt =
 $@"Run the host review and next-slice for domain `{domainPlaceholder}` against `{targetRepoPlaceholder}` exactly once.
 
 Do not create or update any automation, loop, cron, monitor, reminder, or recurring wakeup. This is a one-shot execution. Frequency is forbidden.
+
+{basePolicyBlock}
 
 First-call sequence (read-only; required before any mutation):
 1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
@@ -447,7 +479,9 @@ Hard rules:
                 $"intent-cli intent status --domain {domainPlaceholder} --format json",
                 $"intent-cli intent next-slice --dry-run --domain {domainPlaceholder} --target-repo {targetRepoPlaceholder} --format json"
             ],
-            Prompt = prompt
+            Prompt = prompt,
+            BaseBranchPolicy = baseBranchPolicy,
+            ExpectedBaseBranch = BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy),
         };
     }
 
@@ -498,6 +532,7 @@ Hard rules:
         out string? targetRepo,
         out string? agent,
         out string? frequency,
+        out string? baseBranchPolicy,
         out string error)
     {
         mode = null;
@@ -506,6 +541,7 @@ Hard rules:
         targetRepo = null;
         agent = null;
         frequency = null;
+        baseBranchPolicy = null;
         error = string.Empty;
 
         for (var index = 0; index < args.Length; index++)
@@ -609,6 +645,22 @@ Hard rules:
                     index++;
                     break;
 
+                case "--base-branch-policy":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = $"--base-branch-policy requires a value ('{CliRuntimeContracts.DirectMainBaseBranchPolicy}' or '{CliRuntimeContracts.MainAiBaseBranchPolicy}').";
+                        return false;
+                    }
+                    var requestedPolicy = args[index + 1].Trim();
+                    if (!BaseBranchPolicyContract.IsKnownPolicy(requestedPolicy))
+                    {
+                        error = $"--base-branch-policy must be '{CliRuntimeContracts.DirectMainBaseBranchPolicy}' or '{CliRuntimeContracts.MainAiBaseBranchPolicy}' (got '{requestedPolicy}').";
+                        return false;
+                    }
+                    baseBranchPolicy = requestedPolicy;
+                    index++;
+                    break;
+
                 default:
                     error = $"Unknown argument '{argument}'.";
                     return false;
@@ -634,6 +686,7 @@ Hard rules:
         writer.WriteLine("--domain, --target-repo, --agent, and --frequency are optional; provide them to render a concrete paste-ready prompt instead of one with placeholders.");
         writer.WriteLine("--agent values: claude (same-thread `/loop`), codex (current-thread heartbeat), generic.");
         writer.WriteLine("--frequency examples: 5m, 20m, 1h. Omit to keep the rendered prompt's ask-the-operator instruction.");
+        writer.WriteLine($"--base-branch-policy values: {CliRuntimeContracts.DirectMainBaseBranchPolicy} (default; child PRs target `{CliRuntimeContracts.DirectMainBaseBranch}`), {CliRuntimeContracts.MainAiBaseBranchPolicy} (child PRs target `{CliRuntimeContracts.MainAiIntegrationBaseBranch}`).");
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -672,4 +725,10 @@ internal sealed record GuidePromptMatrixEntry
 
     [JsonPropertyName("frequency")]
     public string? Frequency { get; init; }
+
+    [JsonPropertyName("base_branch_policy")]
+    public string? BaseBranchPolicy { get; init; }
+
+    [JsonPropertyName("expected_base_branch")]
+    public string? ExpectedBaseBranch { get; init; }
 }

--- a/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
+++ b/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
@@ -56,6 +56,7 @@ internal static class CliConfigLoader
             ?? string.Empty;
         var parentIntentRepoRoot = TryGetOptionalString(rootTable, CliRuntimeContracts.ParentIntentRepoRootKey)
             ?? string.Empty;
+        var baseBranchPolicy = ReadBaseBranchPolicy(rootTable, "CLI config root");
         var roles = ReadRoles(rootTable);
         var supervision = ReadSupervision(rootTable);
         var run = ReadRun(rootTable);
@@ -67,6 +68,7 @@ internal static class CliConfigLoader
             worktreeRoot,
             workRepoPath,
             parentIntentRepoRoot,
+            baseBranchPolicy,
             roles,
             supervision,
             run,
@@ -100,6 +102,7 @@ internal static class CliConfigLoader
             ?? string.Empty;
         var parentIntentRepoRoot = TryGetOptionalString(projectTable, CliRuntimeContracts.ParentIntentRepoRootKey)
             ?? string.Empty;
+        var baseBranchPolicy = ReadBaseBranchPolicy(projectTable, "CLI config [project] section");
         var roles = ReadRoles(rootTable);
         var supervision = ReadSupervision(rootTable);
         var run = ReadRun(rootTable);
@@ -111,6 +114,7 @@ internal static class CliConfigLoader
             worktreeRoot,
             workRepoPath,
             parentIntentRepoRoot,
+            baseBranchPolicy,
             roles,
             supervision,
             run,
@@ -124,6 +128,7 @@ internal static class CliConfigLoader
         string worktreeRoot,
         string workRepoPath,
         string parentIntentRepoRoot,
+        string baseBranchPolicy,
         RoleMappings roles,
         SupervisionConfig supervision,
         RunConfig run,
@@ -137,13 +142,35 @@ internal static class CliConfigLoader
                 ArtifactRoot = artifactRoot,
                 WorktreeRoot = worktreeRoot,
                 WorkRepoPath = workRepoPath,
-                ParentIntentRepoRoot = parentIntentRepoRoot
+                ParentIntentRepoRoot = parentIntentRepoRoot,
+                BaseBranchPolicy = baseBranchPolicy
             },
             Roles = roles,
             Supervision = supervision,
             Run = run,
             DirectRun = directRun
         };
+    }
+
+    private static string ReadBaseBranchPolicy(TomlTable table, string contractName)
+    {
+        ArgumentNullException.ThrowIfNull(table);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contractName);
+
+        var value = TryGetOptionalString(table, CliRuntimeContracts.BaseBranchPolicyKey);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return CliRuntimeContracts.DefaultBaseBranchPolicy;
+        }
+
+        if (!string.Equals(value, CliRuntimeContracts.DirectMainBaseBranchPolicy, StringComparison.Ordinal)
+            && !string.Equals(value, CliRuntimeContracts.MainAiBaseBranchPolicy, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"{contractName} '{CliRuntimeContracts.BaseBranchPolicyKey}' must be '{CliRuntimeContracts.DirectMainBaseBranchPolicy}' or '{CliRuntimeContracts.MainAiBaseBranchPolicy}' (got '{value}').");
+        }
+
+        return value;
     }
 
     private static void RejectObsoleteWorkflowEngineKey(TomlTable table, string contractName)

--- a/src/IntentSystem.Cli/Models/CliConfig.cs
+++ b/src/IntentSystem.Cli/Models/CliConfig.cs
@@ -24,6 +24,8 @@ internal sealed record ProjectConfig
     public string WorkRepoPath { get; init; } = string.Empty;
 
     public string ParentIntentRepoRoot { get; init; } = string.Empty;
+
+    public string BaseBranchPolicy { get; init; } = CliRuntimeContracts.DefaultBaseBranchPolicy;
 }
 
 internal sealed record RoleMappings

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -69,7 +69,8 @@ internal static class Program
     {
         return args.Length >= 2
             && string.Equals(args[0], "automation", StringComparison.Ordinal)
-            && (string.Equals(args[1], "check", StringComparison.Ordinal)
+            && (string.Equals(args[1], "base-branch-check", StringComparison.Ordinal)
+                || string.Equals(args[1], "check", StringComparison.Ordinal)
                 || string.Equals(args[1], "clarification-stop", StringComparison.Ordinal)
                 || string.Equals(args[1], "complete", StringComparison.Ordinal)
                 || string.Equals(args[1], "doctor", StringComparison.Ordinal)

--- a/tests/IntentSystem.Cli.Tests/AutomationBaseBranchCheckCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationBaseBranchCheckCommandTests.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class AutomationBaseBranchCheckCommandTests
+{
+    [Fact]
+    public void Execute_DirectMainPolicyWithMainBase_ReturnsOk()
+    {
+        using var writer = new StringWriter();
+        var exitCode = AutomationBaseBranchCheckCommand.Execute(
+            CreateContext("direct-main"),
+            ["--repo", "owner/repo", "--pr", "12", "--actual-base", "main", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("ok", root.GetProperty("status").GetString());
+        Assert.Equal("direct-main", root.GetProperty("policy").GetString());
+        Assert.Equal("main", root.GetProperty("expected_base").GetString());
+        Assert.Equal("main", root.GetProperty("actual_base").GetString());
+        Assert.Empty(root.GetProperty("recommended_actions").EnumerateArray());
+    }
+
+    [Fact]
+    public void Execute_DirectMainPolicyWithMainAiBase_ReturnsMismatch()
+    {
+        using var writer = new StringWriter();
+        var exitCode = AutomationBaseBranchCheckCommand.Execute(
+            CreateContext("direct-main"),
+            ["--repo", "owner/repo", "--pr", "12", "--actual-base", "main-ai", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("mismatch", root.GetProperty("status").GetString());
+        Assert.Equal("main", root.GetProperty("expected_base").GetString());
+        Assert.Equal("main-ai", root.GetProperty("actual_base").GetString());
+        Assert.Contains("requires `main`", root.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.Equal(2, root.GetProperty("recommended_actions").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_MainAiPolicyWithMainAiBase_ReturnsOk()
+    {
+        using var writer = new StringWriter();
+        var exitCode = AutomationBaseBranchCheckCommand.Execute(
+            CreateContext("main-ai"),
+            ["--repo", "owner/repo", "--pr", "42", "--actual-base", "main-ai", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("ok", document.RootElement.GetProperty("status").GetString());
+        Assert.Equal("main-ai", document.RootElement.GetProperty("expected_base").GetString());
+    }
+
+    [Fact]
+    public void Execute_MainAiPolicyWithMainBase_ReturnsMismatch_AndExitsOne()
+    {
+        using var writer = new StringWriter();
+        var exitCode = AutomationBaseBranchCheckCommand.Execute(
+            CreateContext("main-ai"),
+            ["--repo", "owner/repo", "--pr", "42", "--actual-base", "main", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("mismatch", root.GetProperty("status").GetString());
+        Assert.Equal("main-ai", root.GetProperty("policy").GetString());
+        Assert.Equal("main-ai", root.GetProperty("expected_base").GetString());
+        Assert.Equal("main", root.GetProperty("actual_base").GetString());
+    }
+
+    [Fact]
+    public void Execute_PolicyOverrideWins_OverConfig()
+    {
+        using var writer = new StringWriter();
+        var exitCode = AutomationBaseBranchCheckCommand.Execute(
+            CreateContext("direct-main"),
+            ["--repo", "owner/repo", "--pr", "5", "--actual-base", "main-ai", "--policy", "main-ai", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("ok", document.RootElement.GetProperty("status").GetString());
+        Assert.Equal("main-ai", document.RootElement.GetProperty("policy").GetString());
+    }
+
+    [Fact]
+    public void Execute_RejectsUnknownPolicyFlag()
+    {
+        using var writer = new StringWriter();
+        var exitCode = AutomationBaseBranchCheckCommand.Execute(
+            CreateContext("direct-main"),
+            ["--repo", "owner/repo", "--pr", "5", "--actual-base", "main", "--policy", "main-bogus", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must be 'direct-main' or 'main-ai'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RejectsMissingActualBase()
+    {
+        using var writer = new StringWriter();
+        var exitCode = AutomationBaseBranchCheckCommand.Execute(
+            CreateContext("direct-main"),
+            ["--repo", "owner/repo", "--pr", "5", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--actual-base", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MarkdownFormatRendersHumanReadableSummary()
+    {
+        using var writer = new StringWriter();
+        var exitCode = AutomationBaseBranchCheckCommand.Execute(
+            CreateContext("main-ai"),
+            ["--repo", "owner/repo", "--pr", "42", "--actual-base", "main"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Base branch check — owner/repo PR #42", output, StringComparison.Ordinal);
+        Assert.Contains("- Status: **mismatch**", output, StringComparison.Ordinal);
+        Assert.Contains("Recommended actions", output, StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string baseBranchPolicy)
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                    BaseBranchPolicy = baseBranchPolicy
+                }
+            }
+        };
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
@@ -251,6 +251,62 @@ public sealed class CliConfigLoaderTests
         Assert.Contains("post_fix_worktree_progress_policy", exception.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Load_BaseBranchPolicy_DefaultsToDirectMain_WhenAbsent()
+    {
+        var toml = """
+        default_domain = "intent-cli"
+        artifact_root = ".intent-cli"
+        """;
+
+        var config = CliConfigLoader.Load(toml);
+
+        Assert.Equal("direct-main", config.Project.BaseBranchPolicy);
+    }
+
+    [Fact]
+    public void Load_BaseBranchPolicy_AcceptsMainAi_AtRoot()
+    {
+        var toml = """
+        default_domain = "intent-cli"
+        artifact_root = ".intent-cli"
+        base_branch_policy = "main-ai"
+        """;
+
+        var config = CliConfigLoader.Load(toml);
+
+        Assert.Equal("main-ai", config.Project.BaseBranchPolicy);
+    }
+
+    [Fact]
+    public void Load_BaseBranchPolicy_AcceptsMainAi_InProjectSection()
+    {
+        var toml = """
+        [project]
+        domain = "intent-cli"
+        artifact_root = ".intent-cli"
+        base_branch_policy = "main-ai"
+        """;
+
+        var config = CliConfigLoader.Load(toml);
+
+        Assert.Equal("main-ai", config.Project.BaseBranchPolicy);
+    }
+
+    [Fact]
+    public void Load_BaseBranchPolicy_RejectsUnknownValue()
+    {
+        var toml = """
+        default_domain = "intent-cli"
+        artifact_root = ".intent-cli"
+        base_branch_policy = "trunk"
+        """;
+
+        var exception = Assert.Throws<InvalidOperationException>(() => CliConfigLoader.Load(toml));
+        Assert.Contains("base_branch_policy", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("trunk", exception.Message, StringComparison.Ordinal);
+    }
+
     private sealed class TemporaryDirectory : IDisposable
     {
         private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-tests-").FullName;

--- a/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
@@ -917,6 +917,96 @@ public sealed class GuidePromptMatrixCommandTests
         Assert.Contains("local same-thread/current-thread automation", prompt, StringComparison.Ordinal);
     }
 
+    // ── G294 base branch policy ─────────────────────────────────────────
+
+    [Fact]
+    public void Execute_DefaultBaseBranchPolicy_IsDirectMain()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("direct-main", root.GetProperty("base_branch_policy").GetString());
+        Assert.Equal("main", root.GetProperty("expected_base_branch").GetString());
+        var prompt = root.GetProperty("prompt").GetString()!;
+        Assert.Contains("Base branch policy: `direct-main`", prompt, StringComparison.Ordinal);
+        Assert.Contains("expected base branch: `main`", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildLoopWithMainAiPolicy_RendersMainAiBaseBranch()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--base-branch-policy", "main-ai", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("main-ai", root.GetProperty("base_branch_policy").GetString());
+        Assert.Equal("main-ai", root.GetProperty("expected_base_branch").GetString());
+        var prompt = root.GetProperty("prompt").GetString()!;
+        Assert.Contains("Base branch policy: `main-ai`", prompt, StringComparison.Ordinal);
+        Assert.Contains("Child PRs target `main-ai`", prompt, StringComparison.Ordinal);
+        Assert.Contains("automation base-branch-check", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostLoopWithMainAiPolicy_SurfacesPolicyInPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--base-branch-policy", "main-ai", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("main-ai", root.GetProperty("base_branch_policy").GetString());
+        Assert.Equal("main-ai", root.GetProperty("expected_base_branch").GetString());
+        var prompt = root.GetProperty("prompt").GetString()!;
+        Assert.Contains("Closeout / merge expectation honors", prompt, StringComparison.Ordinal);
+        Assert.Contains("`main-ai → main` batch PR", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RejectsUnknownBaseBranchPolicy()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--base-branch-policy", "trunk"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--base-branch-policy must be 'direct-main' or 'main-ai'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_AllFourModes_CarryBaseBranchPolicy_WhenSet()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--base-branch-policy", "main-ai", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+        foreach (var entry in document.RootElement.EnumerateArray())
+        {
+            Assert.Equal("main-ai", entry.GetProperty("base_branch_policy").GetString());
+            Assert.Equal("main-ai", entry.GetProperty("expected_base_branch").GetString());
+        }
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext


### PR DESCRIPTION
## Summary
- Adds a `base_branch_policy` field to the host `[project]` config (default `direct-main`; `main-ai` opts the project into the AI integration-branch workflow where child PRs target `main-ai` and the operator opens a `main-ai → main` batch PR). Both root-level and `[project]` placements are accepted; unknown values are rejected at load.
- Threads the policy through `intent-cli guide prompt-matrix --base-branch-policy <p>` so the four operational modes carry `base_branch_policy` and `expected_base_branch` in their JSON entries and a "Base branch policy" block in their rendered prompts (child-loop / child-oneshot honor the policy when opening PRs; host-loop / host-oneshot honor it for closeout/merge).
- Adds `intent-cli automation base-branch-check --repo <r> --pr <n> --actual-base <branch> [--policy direct-main|main-ai]` as a deterministic read-only diagnostic. The caller passes `--actual-base` (typically captured via `gh pr view <n> --json baseRefName --jq .baseRefName`) so the command stays unit-testable; it exits non-zero on mismatch and returns recommended actions in JSON.

## Test plan
- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — 2131 passed, 1 skipped, 0 failed.
- [x] `AutomationBaseBranchCheckCommandTests` covers direct-main / main-ai matches, both mismatches (each policy with the wrong actual base), `--policy` override beating config, unknown policy rejection, missing `--actual-base`, and markdown rendering.
- [x] `CliConfigLoaderTests` covers default-when-absent, root-level `main-ai`, `[project]`-section `main-ai`, and unknown-value rejection.
- [x] `GuidePromptMatrixCommandTests` covers default policy on child-loop, main-ai policy on child-loop and host-loop prompt blocks, unknown policy rejection, and propagation across all four modes when `--base-branch-policy` is supplied.
- [x] Smoke-tested the built binary end-to-end: `automation base-branch-check` returns mismatch JSON with exit 1; `guide prompt-matrix --mode child-loop --base-branch-policy main-ai` renders the new policy block including the canonical recovery command.

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)