### PR TITLE
G295: add guide intent-work audit final-report template

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideIntentWorkAuditCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideIntentWorkAuditCommand.cs
@@ -1,0 +1,332 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G295: Read-only <c>intent-cli guide intent-work audit</c>. Emits a
+/// concise audit/report template that an AI agent (Codex / Claude / Copilot)
+/// must include in its final summary for an intent-organize / clarification /
+/// packet-preload / intent-shape session, so the operator can confirm the
+/// session was driven through <c>intent-cli</c> surfaces — not through
+/// copied prompt files, <c>intents/rules/**</c>, or local skills.
+///
+/// The template explicitly distinguishes read-only guidance/status/search
+/// calls (noisy by default and not tracked in <c>runs.jsonl</c>) from
+/// mutation calls (which DO produce durable state). Skipped commands are
+/// expected to come with a one-line reason (e.g. "no clarification
+/// required"), so a missing call is auditable rather than silent.
+///
+/// Pure read of static template data. Never mutates state. Never launches
+/// an AI provider.
+/// </summary>
+internal static class GuideIntentWorkAuditCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide intent-work audit [--domain <name>] [--target-repo <owner/repo>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine(UsageLine);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var domain, out var targetRepo, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = BuildResult(domain, targetRepo);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static GuideIntentWorkAuditResult BuildResult(string? domain, string? targetRepo)
+    {
+        var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain!;
+        var targetRepoPlaceholder = string.IsNullOrWhiteSpace(targetRepo) ? "<TARGET-REPO>" : targetRepo!;
+
+        return new GuideIntentWorkAuditResult
+        {
+            Summary =
+                "Audit template for an intent-work session. Include this trace in your final operator summary so the operator can verify the session ran through intent-cli surfaces (and not through copied prompt files, intents/rules/**, or local skills).",
+            Domain = domainPlaceholder,
+            TargetRepo = targetRepoPlaceholder,
+            ReadOnlyCallExpectations =
+            [
+                new GuideIntentWorkAuditExpectation
+                {
+                    Order = 1,
+                    Command = "intent-cli guide model --format json",
+                    Purpose = "Confirm chat-first / CLI-internal collaboration model.",
+                    NoMutation = "Pure read; no durable state."
+                },
+                new GuideIntentWorkAuditExpectation
+                {
+                    Order = 2,
+                    Command = "intent-cli guide onboarding --format json",
+                    Purpose = "First-call sequence for a fresh agent.",
+                    NoMutation = "Pure read; no durable state."
+                },
+                new GuideIntentWorkAuditExpectation
+                {
+                    Order = 3,
+                    Command = "intent-cli guide commands list --format json",
+                    Purpose = "Distinguish primary / support / advanced / experimental command groups.",
+                    NoMutation = "Pure read; no durable state."
+                },
+                new GuideIntentWorkAuditExpectation
+                {
+                    Order = 4,
+                    Command = $"intent-cli intent status --domain {domainPlaceholder} --format json",
+                    Purpose = "Current baseline / WIP / queued packets / open clarifications for the domain.",
+                    NoMutation = "Pure read; no durable state."
+                },
+                new GuideIntentWorkAuditExpectation
+                {
+                    Order = 5,
+                    Command = $"intent-cli intent search --domain {domainPlaceholder} <query> --format json",
+                    Purpose = "Locate relevant intent-tree / clarification / packet artifacts before mutating.",
+                    NoMutation = "Pure read; no durable state."
+                },
+                new GuideIntentWorkAuditExpectation
+                {
+                    Order = 6,
+                    Command = $"intent-cli intent next-slice --dry-run --domain {domainPlaceholder} --target-repo {targetRepoPlaceholder} --format json",
+                    Purpose = "Preview the recommended next slice and verify WIP cap / clarification gates.",
+                    NoMutation = "Dry-run; --write is the mutation boundary."
+                }
+            ],
+            MutationCallBoundaries =
+            [
+                new GuideIntentWorkAuditExpectation
+                {
+                    Order = 1,
+                    Command = $"intent-cli interview record-answer --domain {domainPlaceholder} --question <id> --answer <text> --write",
+                    Purpose = "Durably record an operator-accepted answer to a clarification question.",
+                    NoMutation = "Mutation: writes the interview artifact only after operator acceptance."
+                },
+                new GuideIntentWorkAuditExpectation
+                {
+                    Order = 2,
+                    Command = $"intent-cli intent draft-from-interview --domain {domainPlaceholder} --write",
+                    Purpose = "Promote interview answers into the durable intent shape draft.",
+                    NoMutation = "Mutation: writes the intent draft."
+                },
+                new GuideIntentWorkAuditExpectation
+                {
+                    Order = 3,
+                    Command = $"intent-cli packet draft --execution-unit <id> --target-repo {targetRepoPlaceholder} --write",
+                    Purpose = "Materialize the canonical packet directory for a publishable slice.",
+                    NoMutation = "Mutation: writes packet.yaml / implementation.md / review-context.md / github-body.md."
+                },
+                new GuideIntentWorkAuditExpectation
+                {
+                    Order = 4,
+                    Command = $"intent-cli issue publish-flow <id> --repo {targetRepoPlaceholder} --write",
+                    Purpose = "Publish the prepared packet as a GitHub issue and update durable state.",
+                    NoMutation = "Mutation: validates packet → creates GitHub issue → updates queue-state."
+                }
+            ],
+            FinalReportSections =
+            [
+                "Read-only commands invoked (with arguments)",
+                "Mutation commands invoked (with arguments and resulting artifact paths or URLs)",
+                "Files changed (paths + 1-line summary)",
+                "Issue URLs created or updated",
+                "Clarification questions opened, answered, or deferred",
+                "Skipped commands with a one-line reason (e.g. 'no clarification required', 'WIP cap blocked')",
+                "Forbidden sources NOT consulted: intents/rules/**, local skill files, copied prompt files"
+            ],
+            ForbiddenSources =
+            [
+                "intents/rules/**",
+                "local skill files (gh-issue-to-pr, gh-fix-pr-comment, etc.)",
+                "copied prompt files"
+            ],
+            HardRules =
+            [
+                "intent-cli must not launch Codex/Claude or any AI provider during intent work.",
+                "Mutation calls (--write) require explicit operator acceptance; never silent.",
+                "Read-only guidance/status/search calls do NOT need to be queued through `runs.jsonl`; the audit trace in the final summary is the operator's verification surface.",
+                "Skipped commands must come with a one-line reason; a silent omission is a failure of the audit, not an acceptable shortcut.",
+                "Final summary must include this audit template — copy it, fill it in, and surface it to the operator at the end of the session."
+            ]
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideIntentWorkAuditResult result)
+    {
+        writer.WriteLine("# Intent-work audit — final-report template");
+        writer.WriteLine();
+        writer.WriteLine(result.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"- Domain: `{result.Domain}`");
+        writer.WriteLine($"- Target repo: `{result.TargetRepo}`");
+        writer.WriteLine();
+
+        writer.WriteLine("## Read-only call expectations (no durable state)");
+        foreach (var expectation in result.ReadOnlyCallExpectations)
+        {
+            writer.WriteLine($"{expectation.Order}. `{expectation.Command}`");
+            writer.WriteLine($"   - Purpose: {expectation.Purpose}");
+            writer.WriteLine($"   - {expectation.NoMutation}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Mutation call boundaries (require operator acceptance)");
+        foreach (var expectation in result.MutationCallBoundaries)
+        {
+            writer.WriteLine($"{expectation.Order}. `{expectation.Command}`");
+            writer.WriteLine($"   - Purpose: {expectation.Purpose}");
+            writer.WriteLine($"   - {expectation.NoMutation}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Final-report sections to fill in");
+        foreach (var section in result.FinalReportSections)
+        {
+            writer.WriteLine($"- {section}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Forbidden sources (must NOT be consulted as routine source of truth)");
+        foreach (var src in result.ForbiddenSources)
+        {
+            writer.WriteLine($"- {src}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Hard rules");
+        foreach (var rule in result.HardRules)
+        {
+            writer.WriteLine($"- {rule}");
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? domain,
+        out string? targetRepo,
+        out string format,
+        out string error)
+    {
+        domain = null;
+        targetRepo = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+                    domain = args[++index].Trim();
+                    break;
+                case "--target-repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--target-repo requires a value.";
+                        return false;
+                    }
+                    targetRepo = args[++index].Trim();
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[++index].Trim();
+                    if (!string.Equals(requestedFormat, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    break;
+                default:
+                    error = $"Unknown argument '{args[index]}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never
+    };
+}
+
+internal sealed record GuideIntentWorkAuditResult
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("target_repo")]
+    public required string TargetRepo { get; init; }
+
+    [JsonPropertyName("read_only_call_expectations")]
+    public required IReadOnlyList<GuideIntentWorkAuditExpectation> ReadOnlyCallExpectations { get; init; }
+
+    [JsonPropertyName("mutation_call_boundaries")]
+    public required IReadOnlyList<GuideIntentWorkAuditExpectation> MutationCallBoundaries { get; init; }
+
+    [JsonPropertyName("final_report_sections")]
+    public required IReadOnlyList<string> FinalReportSections { get; init; }
+
+    [JsonPropertyName("forbidden_sources")]
+    public required IReadOnlyList<string> ForbiddenSources { get; init; }
+
+    [JsonPropertyName("hard_rules")]
+    public required IReadOnlyList<string> HardRules { get; init; }
+}
+
+internal sealed record GuideIntentWorkAuditExpectation
+{
+    [JsonPropertyName("order")]
+    public required int Order { get; init; }
+
+    [JsonPropertyName("command")]
+    public required string Command { get; init; }
+
+    [JsonPropertyName("purpose")]
+    public required string Purpose { get; init; }
+
+    [JsonPropertyName("no_mutation")]
+    public required string NoMutation { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GuideIntentWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideIntentWorkCommand.cs
@@ -10,7 +10,7 @@ namespace IntentSystem.Cli.Commands;
 internal static class GuideIntentWorkCommand
 {
     private const string UsageLine =
-        "Usage: intent-cli guide intent-work <setup|next-slice-execution> [options]";
+        "Usage: intent-cli guide intent-work <setup|next-slice-execution|audit> [options]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -28,6 +28,11 @@ internal static class GuideIntentWorkCommand
             return GuideIntentWorkNextSliceExecutionCommand.Execute(context, args[1..], writer);
         }
 
+        if (args.Length >= 1 && string.Equals(args[0], "audit", StringComparison.Ordinal))
+        {
+            return GuideIntentWorkAuditCommand.Execute(context, args[1..], writer);
+        }
+
         if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
         {
             WriteHelp(writer);
@@ -43,6 +48,6 @@ internal static class GuideIntentWorkCommand
     {
         writer.WriteLine("guide intent-work");
         writer.WriteLine(UsageLine);
-        writer.WriteLine("Subcommands: setup, next-slice-execution");
+        writer.WriteLine("Subcommands: setup, next-slice-execution, audit");
     }
 }

--- a/src/IntentSystem.Cli/Commands/GuideIntentWorkSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideIntentWorkSetupCommand.cs
@@ -467,6 +467,11 @@ Hard rules:
         writer.WriteLine(result.WorktreeFriendly);
         writer.WriteLine();
 
+        writer.WriteLine("## Final-report audit (G295)");
+        writer.WriteLine();
+        writer.WriteLine(result.FinalReportAudit);
+        writer.WriteLine();
+
         writer.WriteLine("## Prompt");
         writer.WriteLine();
         writer.WriteLine("```text");
@@ -610,4 +615,13 @@ internal sealed record GuideIntentWorkSetupResult
 
     [JsonPropertyName("worktree_friendly")]
     public required string WorktreeFriendly { get; init; }
+
+    /// <summary>
+    /// G295: every intent-work setup result reminds the agent to emit the
+    /// canonical audit trace at the end of the session. The actual template
+    /// lives in <c>intent-cli guide intent-work audit</c>.
+    /// </summary>
+    [JsonPropertyName("final_report_audit")]
+    public string FinalReportAudit { get; init; } =
+        "Final operator summary must include the audit trace from `intent-cli guide intent-work audit --domain <name> --target-repo <owner/repo>`. The audit template distinguishes read-only guidance/status/search calls from mutation calls and lists the forbidden sources that were not consulted (intents/rules/**, local skill files, copied prompt files), so the operator can verify the session ran through intent-cli surfaces.";
 }

--- a/tests/IntentSystem.Cli.Tests/GuideIntentWorkAuditCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideIntentWorkAuditCommandTests.cs
@@ -1,0 +1,157 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideIntentWorkAuditCommandTests
+{
+    [Fact]
+    public void Execute_NoArgs_RendersMarkdownTemplate_WithPlaceholders()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideIntentWorkAuditCommand.Execute(CreateContext(), [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Intent-work audit — final-report template", output, StringComparison.Ordinal);
+        Assert.Contains("## Read-only call expectations", output, StringComparison.Ordinal);
+        Assert.Contains("## Mutation call boundaries", output, StringComparison.Ordinal);
+        Assert.Contains("## Final-report sections to fill in", output, StringComparison.Ordinal);
+        Assert.Contains("## Forbidden sources", output, StringComparison.Ordinal);
+        Assert.Contains("intents/rules/**", output, StringComparison.Ordinal);
+        Assert.Contains("local skill files", output, StringComparison.Ordinal);
+        Assert.Contains("`<DOMAIN>`", output, StringComparison.Ordinal);
+        Assert.Contains("`<TARGET-REPO>`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithDomainAndTargetRepo_SubstitutesPlaceholders()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideIntentWorkAuditCommand.Execute(
+            CreateContext(),
+            ["--domain", "auth", "--target-repo", "owner/repo"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("`auth`", output, StringComparison.Ordinal);
+        Assert.Contains("`owner/repo`", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("`<DOMAIN>`", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("`<TARGET-REPO>`", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli intent status --domain auth", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli packet draft --execution-unit <id> --target-repo owner/repo --write", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_ProducesParseableShape()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideIntentWorkAuditCommand.Execute(
+            CreateContext(),
+            ["--domain", "auth", "--target-repo", "owner/repo", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("auth", root.GetProperty("domain").GetString());
+        Assert.Equal("owner/repo", root.GetProperty("target_repo").GetString());
+
+        var readOnly = root.GetProperty("read_only_call_expectations");
+        Assert.True(readOnly.GetArrayLength() >= 4, "read-only expectations should include onboarding, status, and search");
+        var firstReadOnly = readOnly[0];
+        Assert.Contains("guide model", firstReadOnly.GetProperty("command").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("Pure read", firstReadOnly.GetProperty("no_mutation").GetString()!, StringComparison.Ordinal);
+
+        var mutations = root.GetProperty("mutation_call_boundaries");
+        Assert.True(mutations.GetArrayLength() >= 2, "mutation boundaries should include record-answer and packet draft");
+        Assert.Contains("Mutation:", mutations[0].GetProperty("no_mutation").GetString()!, StringComparison.Ordinal);
+
+        var sections = root.GetProperty("final_report_sections")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(sections, s => s!.Contains("Read-only commands invoked", StringComparison.Ordinal));
+        Assert.Contains(sections, s => s!.Contains("Mutation commands invoked", StringComparison.Ordinal));
+        Assert.Contains(sections, s => s!.Contains("Skipped commands", StringComparison.Ordinal));
+        Assert.Contains(sections, s => s!.Contains("Forbidden sources NOT consulted", StringComparison.Ordinal));
+
+        var forbidden = root.GetProperty("forbidden_sources")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains("intents/rules/**", forbidden);
+
+        var rules = root.GetProperty("hard_rules")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(rules, r => r!.Contains("must not launch", StringComparison.Ordinal));
+        Assert.Contains(rules, r => r!.Contains("audit template", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_RejectsUnknownArgument()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideIntentWorkAuditCommand.Execute(
+            CreateContext(),
+            ["--bogus"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Usage: intent-cli guide intent-work audit", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideIntentWorkRouter_DispatchesAuditSubcommand()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideIntentWorkCommand.Execute(
+            CreateContext(),
+            ["audit", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("<DOMAIN>", document.RootElement.GetProperty("domain").GetString());
+    }
+
+    [Fact]
+    public void GuideIntentWorkSetup_MarkdownAndJson_PointAtAuditCommand()
+    {
+        using var markdownWriter = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "domain-organize", "--domain", "auth", "--target-repo", "owner/repo"],
+            markdownWriter);
+        var markdown = markdownWriter.ToString();
+        Assert.Contains("## Final-report audit (G295)", markdown, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide intent-work audit", markdown, StringComparison.Ordinal);
+
+        using var jsonWriter = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "domain-organize", "--domain", "auth", "--target-repo", "owner/repo", "--format", "json"],
+            jsonWriter);
+        using var document = JsonDocument.Parse(jsonWriter.ToString());
+        var auditField = document.RootElement.GetProperty("final_report_audit").GetString()!;
+        Assert.Contains("intent-cli guide intent-work audit", auditField, StringComparison.Ordinal);
+        Assert.Contains("intents/rules/**", auditField, StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `intent-cli guide intent-work audit [--domain <name>] [--target-repo <owner/repo>] [--format markdown|json]` — a read-only audit/report template the chat agent must surface at the end of an intent-work session so operators can verify the session ran through `intent-cli` and did not silently fall back to `intents/rules/**`, copied prompt files, or local skills.
- Template explicitly separates read-only guidance/status/search calls (`Pure read; no durable state.`) from mutation calls (`Mutation: writes ...`), enumerates the final-report sections to fill in (commands invoked, files changed, issue URLs, clarifications, skipped commands with one-line reasons, forbidden sources NOT consulted), and re-states the hard rules.
- Wires the new sub-token into `guide intent-work` (`Subcommands: setup, next-slice-execution, audit`) and adds a `final_report_audit` field on every `guide intent-work setup` result so the existing setup prompts mechanically point at the audit template instead of relying on memory.
- Pure read of static template data — never mutates state, never launches an AI provider.

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~GuideIntentWorkAuditCommandTests` — 6 passed (markdown placeholder rendering, domain/target-repo substitution, JSON shape, unknown-arg rejection, router dispatch, setup → audit cross-reference in markdown + JSON).
- [x] Smoke-tested the built binary end-to-end: `guide intent-work audit --domain auth --target-repo owner/repo` renders the full template with read-only / mutation / final-report sections and the explicit forbidden-sources list.
- [x] Full Cli test run is green except for one pre-existing flake (`AutomationCheckCommandTests.Execute_InfersRepoFromHttpsOriginRemote`, depends on cwd/git remote ordering); confirmed it passes when run in isolation, and the failure is unrelated to this change.

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)