### PR TITLE
G298: prefix execution unit on published GitHub issue titles

### DIFF
--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -122,11 +122,17 @@ internal static class IssuePublishFlowCommand
         // Body H1 remains a fallback for older packets / Sekiban-style
         // bodies that start at `## Goal`. Title source is reported on the
         // result so the operator can audit which path resolved the title.
+        // G298: format the resolved title as `<execution-unit> <title>` when
+        // the title doesn't already begin with the execution-unit token, so
+        // `gh issue create` always carries a scan-friendly identifier in the
+        // GitHub issue list. Already-prefixed titles (and the deterministic
+        // `<id> (untitled)` fallback) stay verbatim.
         string? title = null;
         string? titleSource = null;
         if (githubBodyPresent)
         {
             (title, titleSource) = ResolveTitleWithSource(executionUnit!, packetDirectory, githubBodyPath);
+            title = FormatIssueTitle(executionUnit!, title);
         }
 
         if (!githubBodyPresent || missing.Count > 0)
@@ -838,6 +844,36 @@ internal static class IssuePublishFlowCommand
     }
 
     /// <summary>
+    /// G298: prepend the execution-unit token to the resolved title when the
+    /// title does not already start with it. The operator scans the GitHub
+    /// issue list by execution unit (G294, SKS-G190, etc.), so a title like
+    /// <c>Add host branch policy ...</c> stored without the token would hide
+    /// the issue's correlation key. Already-prefixed titles and the
+    /// deterministic <c>&lt;id&gt; (untitled)</c> fallback are returned
+    /// verbatim — we only insert the prefix when missing. The check is
+    /// case-sensitive because execution units are uppercase identifiers.
+    /// </summary>
+    internal static string FormatIssueTitle(string executionUnit, string? resolvedTitle)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+
+        if (string.IsNullOrWhiteSpace(resolvedTitle))
+        {
+            return $"{executionUnit} (untitled)";
+        }
+
+        var trimmed = resolvedTitle.Trim();
+        if (trimmed.StartsWith(executionUnit + " ", StringComparison.Ordinal)
+            || string.Equals(trimmed, executionUnit, StringComparison.Ordinal)
+            || trimmed.StartsWith(executionUnit + ":", StringComparison.Ordinal))
+        {
+            return trimmed;
+        }
+
+        return $"{executionUnit} {trimmed}";
+    }
+
+    /// <summary>
     /// G290: reads the top-level <c>title:</c> scalar from packet.yaml. The
     /// packet schema places the field at the root (older packets) or under
     /// `implementation_issue_packet:` (Sekiban-style); we accept either by
@@ -1082,6 +1118,16 @@ internal sealed record IssuePublishFlowResult
 
     [JsonPropertyName("title")]
     public string? Title { get; init; }
+
+    /// <summary>
+    /// G298: explicit alias for <see cref="Title"/> emphasizing that this
+    /// is the final title sent to <c>gh issue create</c>. Same value; the
+    /// distinct field name lets operators and downstream tooling read
+    /// "issue_title" without re-inferring it from <c>title</c> when audit
+    /// trails care about the exact GitHub-side string.
+    /// </summary>
+    [JsonPropertyName("issue_title")]
+    public string? IssueTitle => Title;
 
     /// <summary>
     /// G290: which path resolved <see cref="Title"/>. One of

--- a/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
@@ -594,6 +594,151 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
         Assert.Contains("issue publish-flow", writer.ToString(), StringComparison.Ordinal);
     }
 
+    // ── G298 execution-unit prefix in published title ────────────────────
+
+    [Fact]
+    public void Execute_G298_PacketYamlTitleWithoutPrefix_PrependsExecutionUnitInIssueTitle()
+    {
+        // packet.yaml carries a meaningful title that does NOT begin with the
+        // execution unit (the canonical G294 case). The publish-flow result
+        // must show the execution unit as a prefix in the GitHub issue title.
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WritePacketYaml("G294", "Add host branch policy for main versus main-ai operation");
+        workspace.WriteGithubBody("G294", BuildContractBodyWithoutH1());
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G294", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal(
+            "G294 Add host branch policy for main versus main-ai operation",
+            root.GetProperty("title").GetString());
+        Assert.Equal(
+            "G294 Add host branch policy for main versus main-ai operation",
+            root.GetProperty("issue_title").GetString());
+        Assert.Equal("packet-yaml", root.GetProperty("title_source").GetString());
+    }
+
+    [Fact]
+    public void Execute_G298_PacketYamlTitleAlreadyPrefixed_DoesNotDuplicate()
+    {
+        // Already-prefixed packet titles must not get the prefix added a second
+        // time (SKS-G190 case continues to publish verbatim).
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WritePacketYaml("SKS-G190",
+            "SKS-G190 Approval-Gated Production Credential Issuance And Rotation Lifecycle Baseline");
+        workspace.WriteGithubBody("SKS-G190", BuildContractBodyWithoutH1());
+
+        using var writer = new StringWriter();
+        IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["SKS-G190", "--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal(
+            "SKS-G190 Approval-Gated Production Credential Issuance And Rotation Lifecycle Baseline",
+            root.GetProperty("title").GetString());
+        Assert.Equal(
+            "SKS-G190 Approval-Gated Production Credential Issuance And Rotation Lifecycle Baseline",
+            root.GetProperty("issue_title").GetString());
+    }
+
+    [Fact]
+    public void Execute_G298_BodyH1AlreadyPrefixed_DoesNotDuplicate()
+    {
+        // Older packets (no packet.yaml) fall back to body H1; the H1 already
+        // contains the prefix and must not be duplicated.
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G245",
+            BuildCompleteContractBody("G245 Add intent-cli issue publish-flow command"));
+
+        using var writer = new StringWriter();
+        IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G245", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("G245 Add intent-cli issue publish-flow command", root.GetProperty("title").GetString());
+        Assert.Equal("G245 Add intent-cli issue publish-flow command", root.GetProperty("issue_title").GetString());
+        Assert.Equal("github-body-h1", root.GetProperty("title_source").GetString());
+    }
+
+    [Fact]
+    public void Execute_G298_BodyH1WithoutPrefix_PrependsExecutionUnit()
+    {
+        // Synthetic case: body H1 without execution-unit prefix should still
+        // get prefixed at publish time so the GitHub issue list correlates.
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G298",
+            BuildCompleteContractBody("Implement issue title prefix formatter"));
+
+        using var writer = new StringWriter();
+        IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G298", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("G298 Implement issue title prefix formatter", root.GetProperty("title").GetString());
+        Assert.Equal("github-body-h1", root.GetProperty("title_source").GetString());
+    }
+
+    [Fact]
+    public void Execute_G298_FallbackUntitled_RemainsVerbatim()
+    {
+        // The deterministic <id> (untitled) fallback already starts with the
+        // execution unit; the formatter must not double-prefix it.
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G900", BuildContractBodyWithoutH1());
+
+        using var writer = new StringWriter();
+        IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G900", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("G900 (untitled)", root.GetProperty("title").GetString());
+        Assert.Equal("G900 (untitled)", root.GetProperty("issue_title").GetString());
+    }
+
+    [Fact]
+    public void FormatIssueTitle_PrependsWhenMissing_KeepsWhenPresent()
+    {
+        Assert.Equal(
+            "G294 Add host branch policy",
+            IssuePublishFlowCommand.FormatIssueTitle("G294", "Add host branch policy"));
+
+        Assert.Equal(
+            "G294 Add host branch policy",
+            IssuePublishFlowCommand.FormatIssueTitle("G294", "G294 Add host branch policy"));
+
+        // Token must match exactly — `G2940 ...` should NOT be treated as already
+        // prefixed for execution unit `G294`.
+        Assert.Equal(
+            "G294 G2940 Other unit",
+            IssuePublishFlowCommand.FormatIssueTitle("G294", "G2940 Other unit"));
+
+        Assert.Equal(
+            "G294 (untitled)",
+            IssuePublishFlowCommand.FormatIssueTitle("G294", null));
+
+        Assert.Equal(
+            "G294 (untitled)",
+            IssuePublishFlowCommand.FormatIssueTitle("G294", "   "));
+    }
+
     private static string BuildCompleteContractBody(string title)
     {
         return $"""


### PR DESCRIPTION
## Summary
- Adds an `<execution-unit> ` prefix step to `intent-cli issue publish-flow` title resolution. A packet whose `packet.yaml` title is stored without the execution-unit token (the canonical G294 case — `title: Add host branch policy for main versus main-ai operation`) now publishes the GitHub issue with `G294 Add host branch policy ...` so the issue list correlates to packet directories without scanning bodies.
- Already-prefixed titles (e.g. SKS-G190), titles starting with `<id>:`, and the deterministic `<id> (untitled)` fallback are returned verbatim — the new `FormatIssueTitle(executionUnit, resolvedTitle)` helper inserts the prefix only when missing, with token-boundary matching so `G2940` is not treated as already-prefixed for `G294`.
- Result schema gains an explicit `issue_title` JSON field (alias of `title`) so audit consumers and downstream tooling can read the final GitHub-side string without re-inferring it. `title_source` reporting from G290 is preserved unchanged.

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~IssuePublishFlowCommandTests` — 27 passed (21 existing + 6 new).
- [x] New `Execute_G298_*` cases cover: packet-yaml title without prefix → prefixed; already-prefixed packet title (SKS-G190) → unchanged; body-H1 already prefixed → unchanged; body-H1 without prefix → prefixed; `<id> (untitled)` fallback → unchanged.
- [x] New unit test for `FormatIssueTitle` covers token-boundary safety (`G2940` ≠ `G294`-prefixed) and null/whitespace input.
- [x] Full Cli test run is otherwise green; two pre-existing `RunFixCommandTests` flakes around dead session lifecycle pass in isolation and are unrelated to this change.

Closes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)