### PR TITLE
G299: fail-closed structured guidance for missing host state

### DIFF
--- a/src/IntentSystem.Cli/Commands/MissingHostStateGuidance.cs
+++ b/src/IntentSystem.Cli/Commands/MissingHostStateGuidance.cs
@@ -1,0 +1,214 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G299: structured fail-closed guidance for any <c>intent-cli</c> invocation
+/// that could not resolve the parent host repo's <c>.intent-cli/</c> state.
+///
+/// The bare <c>"Could not find .intent-cli directory"</c> error encouraged
+/// agents to fall back to ordinary GitHub review or raw PR comments,
+/// because the message did not name the host vs child distinction or the
+/// canonical re-run path. This helper replaces the bare error with a
+/// structured object (markdown by default, JSON when the caller passed
+/// <c>--format json</c>) covering the four required elements:
+///
+/// <list type="bullet">
+/// <item><description>Names the parent host repo root requirement.</description></item>
+/// <item><description>Distinguishes <c>host repo cwd</c>, <c>child implementation repo cwd</c>, and <c>target GitHub repo</c>.</description></item>
+/// <item><description>Says implementation findings may become PR comments, but host metadata / guidance failures must NOT.</description></item>
+/// <item><description>Gives the canonical re-run instruction (re-run from the parent host repo root that owns <c>.intent-cli/</c>).</description></item>
+/// </list>
+///
+/// Pure data + render: never invokes <c>gh</c>, never writes files, never
+/// launches an AI provider.
+/// </summary>
+internal static class MissingHostStateGuidance
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    public const string StatusKind = "missing-host-state";
+
+    public static int Emit(TextWriter writer, string[] args, string currentDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentException.ThrowIfNullOrWhiteSpace(currentDirectory);
+
+        var format = ParseFormat(args);
+        var targetRepo = ParseTargetRepo(args);
+        var commandName = ParseCommandName(args);
+        var result = Build(currentDirectory, commandName, targetRepo);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 1;
+    }
+
+    internal static MissingHostStateGuidanceResult Build(
+        string currentDirectory,
+        string? commandName,
+        string? targetRepo)
+    {
+        var hardRules = new[]
+        {
+            "Do NOT fall back to ordinary GitHub review or raw PR comments when host state is missing. Implementation findings (real code/contract gaps the implementer can fix on the PR branch) may still become PR comments; host metadata / guidance failures MUST NOT.",
+            "Do NOT apply raw `gh ... edit --add-label` / `--remove-label` for workflow labels. Every workflow label transition goes through installed `intent-cli automation` / `intent-cli worker` commands.",
+            "Do NOT call `intent-cli run` as a fallback. `run` is advanced runtime (integration smoke / replay / dogfooding), not the chat-first review/worker path.",
+            "Do NOT ask `intent-cli` to launch Claude/Codex or any AI provider; the chat-first model has the human agent driving the conversation."
+        };
+
+        var nextSteps = new List<string>
+        {
+            $"Re-run `intent-cli {commandName ?? "<command>"} ...` from the parent host repo root — the directory that owns the `.intent-cli/` package and `intents/<domain>/` data.",
+            "If you are currently inside a child implementation repo (e.g. a submodule checkout), `cd` to the parent host repo before retrying. Child checkouts typically do not carry their own `.intent-cli/`.",
+            "If you do not know the parent host repo root, ask the operator to provide it; do not guess from prompt memory.",
+            "If host state is genuinely required but unavailable, stop and surface the gap to the operator via structured clarification rather than fall back to a non-host action."
+        };
+
+        if (!string.IsNullOrWhiteSpace(targetRepo))
+        {
+            nextSteps.Add($"Note: the target GitHub repo `{targetRepo}` is the workflow target, NOT the host. Host data lives in a separate parent host repo on disk.");
+        }
+
+        return new MissingHostStateGuidanceResult
+        {
+            Status = StatusKind,
+            Command = commandName,
+            Cwd = currentDirectory,
+            Missing = CliRuntimeContracts.IntentCliDirectoryName,
+            HostRepoCwd = null,
+            ChildRepoCwd = currentDirectory,
+            TargetGithubRepo = targetRepo,
+            Summary = $"intent-cli could not resolve the parent host repo's '{CliRuntimeContracts.IntentCliDirectoryName}/' state from '{currentDirectory}'. Fail-closed (G299) — no GitHub mutation, no PR comment, no label transition was performed.",
+            HardRules = hardRules,
+            NextSteps = nextSteps
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, MissingHostStateGuidanceResult result)
+    {
+        writer.WriteLine($"# intent-cli — missing host state (G299)");
+        writer.WriteLine();
+        writer.WriteLine("**Fail-closed**: the parent host repo's `.intent-cli/` state could not be resolved from the current directory. No GitHub mutation, no PR comment, and no label transition were performed.");
+        writer.WriteLine();
+        writer.WriteLine("## Distinguished cwd buckets");
+        writer.WriteLine($"- Host repo cwd: _unresolved_ (intent-cli looks for `{result.Missing}` here).");
+        writer.WriteLine($"- Child implementation repo cwd: `{result.ChildRepoCwd}` (current cwd; child checkouts often do not carry their own `{result.Missing}`).");
+        writer.WriteLine($"- Target GitHub repo: {(string.IsNullOrWhiteSpace(result.TargetGithubRepo) ? "_unspecified_" : "`" + result.TargetGithubRepo + "`")} (workflow target, not the host).");
+        writer.WriteLine();
+        writer.WriteLine("## Hard rules");
+        foreach (var rule in result.HardRules)
+        {
+            writer.WriteLine($"- {rule}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("## Next steps");
+        foreach (var step in result.NextSteps)
+        {
+            writer.WriteLine($"- {step}");
+        }
+    }
+
+    private static string ParseFormat(string[] args)
+    {
+        for (var index = 0; index < args.Length; index++)
+        {
+            if (string.Equals(args[index], "--format", StringComparison.Ordinal)
+                && index + 1 < args.Length
+                && !string.IsNullOrWhiteSpace(args[index + 1]))
+            {
+                var requested = args[index + 1].Trim();
+                if (string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                {
+                    return FormatJson;
+                }
+                if (string.Equals(requested, FormatMarkdown, StringComparison.Ordinal))
+                {
+                    return FormatMarkdown;
+                }
+            }
+        }
+        return FormatMarkdown;
+    }
+
+    private static string? ParseTargetRepo(string[] args)
+    {
+        for (var index = 0; index < args.Length - 1; index++)
+        {
+            if (string.Equals(args[index], "--repo", StringComparison.Ordinal)
+                || string.Equals(args[index], "--target-repo", StringComparison.Ordinal))
+            {
+                var value = args[index + 1].Trim();
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    return value;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static string? ParseCommandName(string[] args)
+    {
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]))
+        {
+            return null;
+        }
+        if (args.Length == 1 || string.IsNullOrWhiteSpace(args[1]) || args[1].StartsWith("-", StringComparison.Ordinal))
+        {
+            return args[0].Trim();
+        }
+        return $"{args[0].Trim()} {args[1].Trim()}";
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never
+    };
+}
+
+internal sealed record MissingHostStateGuidanceResult
+{
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("command")]
+    public string? Command { get; init; }
+
+    [JsonPropertyName("cwd")]
+    public required string Cwd { get; init; }
+
+    [JsonPropertyName("missing")]
+    public required string Missing { get; init; }
+
+    [JsonPropertyName("host_repo_cwd")]
+    public string? HostRepoCwd { get; init; }
+
+    [JsonPropertyName("child_repo_cwd")]
+    public string? ChildRepoCwd { get; init; }
+
+    [JsonPropertyName("target_github_repo")]
+    public string? TargetGithubRepo { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("hard_rules")]
+    public required IReadOnlyList<string> HardRules { get; init; }
+
+    [JsonPropertyName("next_steps")]
+    public required IReadOnlyList<string> NextSteps { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -29,9 +29,16 @@ internal static class Program
                 return CommandRouter.Execute(args, CreateBootstrapContext(currentDirectory, args), Console.Out);
             }
 
-            var repoRoot = RepoRootResolver.Resolve(currentDirectory)
-                ?? throw new InvalidOperationException(
-                    $"Could not find {CliRuntimeContracts.IntentCliDirectoryName} directory from '{currentDirectory}'.");
+            var repoRoot = RepoRootResolver.Resolve(currentDirectory);
+            if (repoRoot is null)
+            {
+                // G299: fail-closed structured guidance instead of the bare
+                // "Could not find .intent-cli directory" error. The bare
+                // error encouraged agents to fall back to ordinary GitHub
+                // review or raw PR comments when invoked from a child
+                // implementation checkout that has no `.intent-cli/`.
+                return MissingHostStateGuidance.Emit(Console.Out, args, currentDirectory);
+            }
 
             var context = new CliContext
             {

--- a/tests/IntentSystem.Cli.Tests/MissingHostStateGuidanceTests.cs
+++ b/tests/IntentSystem.Cli.Tests/MissingHostStateGuidanceTests.cs
@@ -1,0 +1,124 @@
+using System.Text.Json;
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class MissingHostStateGuidanceTests
+{
+    [Fact]
+    public void Emit_DefaultMarkdown_NamesHostRepoVsChildRepoVsTargetRepo()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = MissingHostStateGuidance.Emit(
+            writer,
+            new[] { "guide", "review", "--pr", "4", "--repo", "J-Tech-Japan/TraceForge" },
+            "/Users/dev/TraceForge/submodules/traceforge");
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("missing host state (G299)", output, StringComparison.Ordinal);
+        Assert.Contains("Host repo cwd: _unresolved_", output, StringComparison.Ordinal);
+        Assert.Contains("Child implementation repo cwd: `/Users/dev/TraceForge/submodules/traceforge`", output, StringComparison.Ordinal);
+        Assert.Contains("Target GitHub repo: `J-Tech-Japan/TraceForge`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Emit_JsonFormat_ProducesMachineReadableMissingHostStateRecord()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = MissingHostStateGuidance.Emit(
+            writer,
+            new[] { "guide", "review", "--pr", "4", "--repo", "J-Tech-Japan/TraceForge", "--format", "json" },
+            "/Users/dev/TraceForge/submodules/traceforge");
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("missing-host-state", root.GetProperty("status").GetString());
+        Assert.Equal("guide review", root.GetProperty("command").GetString());
+        Assert.Equal("/Users/dev/TraceForge/submodules/traceforge", root.GetProperty("cwd").GetString());
+        Assert.Equal(".intent-cli", root.GetProperty("missing").GetString());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("host_repo_cwd").ValueKind);
+        Assert.Equal("/Users/dev/TraceForge/submodules/traceforge", root.GetProperty("child_repo_cwd").GetString());
+        Assert.Equal("J-Tech-Japan/TraceForge", root.GetProperty("target_github_repo").GetString());
+        Assert.Equal(4, root.GetProperty("hard_rules").GetArrayLength());
+        Assert.True(root.GetProperty("next_steps").GetArrayLength() >= 4);
+    }
+
+    [Fact]
+    public void Emit_HardRules_ForbidFallbackToOrdinaryGitHubReview()
+    {
+        using var writer = new StringWriter();
+        MissingHostStateGuidance.Emit(
+            writer,
+            new[] { "guide", "review", "--pr", "4", "--format", "json" },
+            "/tmp/child");
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var rules = document.RootElement.GetProperty("hard_rules")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+
+        Assert.Contains(rules, r => r.Contains("Do NOT fall back to ordinary GitHub review", StringComparison.Ordinal));
+        Assert.Contains(rules, r => r.Contains("Implementation findings", StringComparison.Ordinal)
+                                 && r.Contains("may still become PR comments", StringComparison.Ordinal)
+                                 && r.Contains("host metadata", StringComparison.Ordinal));
+        Assert.Contains(rules, r => r.Contains("gh ... edit --add-label", StringComparison.Ordinal));
+        Assert.Contains(rules, r => r.Contains("intent-cli run", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Emit_NextSteps_TellsAgentToReRunFromParentHostRepoRoot()
+    {
+        using var writer = new StringWriter();
+        MissingHostStateGuidance.Emit(
+            writer,
+            new[] { "worker", "next-action", "--repo", "J-Tech-Japan/TraceForge", "--workdir", "/tmp/child", "--format", "json" },
+            "/tmp/child");
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var steps = document.RootElement.GetProperty("next_steps")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+
+        Assert.Contains(steps, s => s.Contains("Re-run", StringComparison.Ordinal)
+                                 && s.Contains("parent host repo root", StringComparison.Ordinal)
+                                 && s.Contains("`.intent-cli/`", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("child implementation repo", StringComparison.Ordinal)
+                                 && s.Contains("submodule", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("structured clarification", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Emit_OmitsTargetRepoNote_WhenRepoFlagAbsent()
+    {
+        using var writer = new StringWriter();
+        MissingHostStateGuidance.Emit(
+            writer,
+            new[] { "guide", "review", "--format", "json" },
+            "/tmp/child");
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(JsonValueKind.Null, document.RootElement.GetProperty("target_github_repo").ValueKind);
+        var steps = document.RootElement.GetProperty("next_steps")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.DoesNotContain(steps, s => s.Contains("workflow target, NOT the host", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("guide", "review", "guide review")]
+    [InlineData("worker", "next-action", "worker next-action")]
+    [InlineData("closeout", "pr", "closeout pr")]
+    [InlineData("review", "run", "review run")]
+    public void Emit_CommandName_Reflects_TheInvocation(string group, string sub, string expected)
+    {
+        using var writer = new StringWriter();
+        MissingHostStateGuidance.Emit(
+            writer,
+            new[] { group, sub, "--format", "json" },
+            "/tmp/child");
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(expected, document.RootElement.GetProperty("command").GetString());
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/ProgramTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ProgramTests.cs
@@ -43,8 +43,13 @@ public sealed class ProgramTests
     }
 
     [Fact]
-    public void Main_GivenDirectoryWithoutIntentCliRoot_ReturnsExitCodeOne()
+    public void Main_GivenDirectoryWithoutIntentCliRoot_ReturnsExitCodeOne_AndEmitsStructuredFailClosed()
     {
+        // G299: a non-bootstrap command (e.g. `project status`) invoked from a
+        // directory that has no `.intent-cli/` no longer prints the bare
+        // "Could not find .intent-cli directory" error to stderr. Instead it
+        // writes a structured fail-closed guidance to stdout naming the host
+        // vs child distinction and the canonical re-run path, then exits 1.
         lock (ProcessStateLock)
         {
             using var tempDirectory = new TemporaryDirectory();
@@ -55,8 +60,11 @@ public sealed class ProgramTests
             var exitCode = Program.Main(["project", "status"]);
 
             Assert.Equal(1, exitCode);
-            Assert.Contains("Could not find .intent-cli directory", consoleScope.Error.ToString(), StringComparison.Ordinal);
-            Assert.Equal(string.Empty, consoleScope.Out.ToString());
+            var stdout = consoleScope.Out.ToString();
+            Assert.Contains("missing host state (G299)", stdout, StringComparison.Ordinal);
+            Assert.Contains("Host repo cwd: _unresolved_", stdout, StringComparison.Ordinal);
+            Assert.Contains("Child implementation repo cwd:", stdout, StringComparison.Ordinal);
+            Assert.Equal(string.Empty, consoleScope.Error.ToString());
         }
     }
 


### PR DESCRIPTION
## Summary
- Replaces the bare `Could not find .intent-cli directory` stderr error with a structured fail-closed guidance object so AI agents do not silently fall back to ordinary GitHub review or raw PR comments when invoked from a directory that cannot resolve the parent host repo's `.intent-cli/` state. Motivated by TraceForge PR #4 / issue #3, where a child cwd produced the bare error and the agent fell through to a normal PR comment without applying `pr-transition --transition request-update`.
- New `MissingHostStateGuidance` helper renders markdown by default and JSON when `--format json` is passed, covering the four acceptance-criteria elements: parent host repo root requirement; host-repo-cwd / child-impl-repo-cwd / target-GitHub-repo distinction; hard rule that implementation findings may still become PR comments but host metadata / guidance failures must NOT; canonical re-run instruction.
- Wired into `Program.Main` after `RepoRootResolver.Resolve` returns `null`. Bootstrap-detected commands (`intake init`, `intent init`, automation worktree commands, the `guide oneshot` family) keep working unchanged because they bypass the resolver entirely. The structured object goes to **stdout** (not stderr) so loop tooling can parse it; exit code remains `1`.

## Test plan
- [x] `dotnet test --filter MissingHostStateGuidanceTests|ProgramTests` — 13 passed (9 new + the 4 pre-existing Program.Main scenarios, including the updated `Main_GivenDirectoryWithoutIntentCliRoot...` assertion).
- [x] Smoke-tested the built CLI in a fresh tmp dir: `intent-cli guide review --pr 4 --repo J-Tech-Japan/TraceForge --format json` returns `status: missing-host-state`, populates `child_repo_cwd` + `target_github_repo`, surfaces the four hard rules and the structured next steps, and exits 1.
- [x] Full Cli test run: 2167 passed, 1 skipped. The 2 process-state-coupled flakes (`AutomationCheckCommandTests.ProgramMain_AutomationCheckDoesNotRequireIntentCliDirectory`, `AutomationCheckCommandTests.Execute_InfersRepoFromSshOriginRemote`) pass in isolation; same pattern as the `RunFixCommandTests` flake noted on PR #700, unrelated to G299.

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)