### PR TITLE
G301: canonical new-host bootstrap and wrong-host guard

### DIFF
--- a/src/IntentSystem.Cli/Commands/IntentInitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentInitCommand.cs
@@ -24,7 +24,7 @@ internal static class IntentInitCommand
     private const string FormatMarkdown = "markdown";
 
     private const string UsageLine =
-        "Usage: intent-cli intent init --domain <name> [--target-repo <owner/repo>] [--write] [--format markdown|json]";
+        "Usage: intent-cli intent init --domain <name> [--target-repo <owner/repo>] [--host-repo <owner/repo>] [--write] [--format markdown|json]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -65,9 +65,16 @@ internal static class IntentInitCommand
 
         EnsureNotChildWorktree(hostRepoRoot);
 
+        // G301: extend the new-host bootstrap to also write the canonical
+        // host policy files (`AGENTS.md`, `CLAUDE.md`) and the host-binding
+        // record so wrong-host operation can be detected later. The
+        // existing four files (G293) are preserved verbatim.
         var planned = new List<string>
         {
             $"{CliRuntimeContracts.IntentCliDirectoryName}/{CliRuntimeContracts.ConfigFileName}",
+            $"{CliRuntimeContracts.IntentCliDirectoryName}/host-binding.toml",
+            "AGENTS.md",
+            "CLAUDE.md",
             $"intents/{request.Domain}/README.md",
             $"intents/{request.Domain}/clarifications/open.md",
             $"intents/{request.Domain}/intent-tree/00-map.md"
@@ -174,6 +181,10 @@ internal static class IntentInitCommand
         {
             var path when path.EndsWith($"/{CliRuntimeContracts.ConfigFileName}", StringComparison.Ordinal)
                 => RenderConfigToml(request),
+            var path when path.EndsWith("/host-binding.toml", StringComparison.Ordinal)
+                => RenderHostBindingToml(request),
+            "AGENTS.md" => RenderAgentsMarkdown(request),
+            "CLAUDE.md" => RenderClaudeMarkdown(request),
             var path when path.EndsWith("/README.md", StringComparison.Ordinal)
                 => RenderDomainReadme(request),
             var path when path.EndsWith("/clarifications/open.md", StringComparison.Ordinal)
@@ -183,6 +194,127 @@ internal static class IntentInitCommand
             _ => throw new InvalidOperationException(
                 $"Intent init has no template for '{relativePath}'.")
         };
+    }
+
+    /// <summary>
+    /// G301: host-binding record so other commands can detect wrong-host
+    /// usage. Captures the canonical owner/repo of the host (the repo that
+    /// owns this `.intent-cli/` package) plus the target child repo and
+    /// the domain. <see cref="WrongHostGuard"/> reads this file and
+    /// compares against the observed git remote.
+    /// </summary>
+    private static string RenderHostBindingToml(IntentInitRequest request)
+    {
+        var hostRepoLine = string.IsNullOrWhiteSpace(request.HostRepo)
+            ? "host_repo = \"\""
+            : $"host_repo = \"{EscapeTomlString(request.HostRepo!)}\"";
+        var targetRepoLine = string.IsNullOrWhiteSpace(request.TargetRepo)
+            ? "target_repo = \"\""
+            : $"target_repo = \"{EscapeTomlString(request.TargetRepo!)}\"";
+
+        return $$"""
+        # G301 host binding record. Other intent-cli commands consult this to
+        # detect wrong-host operation (e.g. publishing a domain from a host
+        # repo whose remote does not match `host_repo`). Empty values are
+        # treated as "not yet bound" and skip the wrong-host check.
+        [host]
+        domain = "{{EscapeTomlString(request.Domain)}}"
+        {{hostRepoLine}}
+        {{targetRepoLine}}
+        """;
+    }
+
+    /// <summary>
+    /// G301: canonical host-side AGENTS.md so a fresh AI agent reading the
+    /// repo immediately sees the host working policy without needing to
+    /// rely on prompt memory. Keep this short and durable; it is not a
+    /// substitute for `intent-cli guide ...`.
+    /// </summary>
+    private static string RenderAgentsMarkdown(IntentInitRequest request)
+    {
+        var targetLine = string.IsNullOrWhiteSpace(request.TargetRepo)
+            ? string.Empty
+            : $"- Target repo (child implementation): `{request.TargetRepo}`" + Environment.NewLine;
+        var hostLine = string.IsNullOrWhiteSpace(request.HostRepo)
+            ? string.Empty
+            : $"- Host repo (this repo): `{request.HostRepo}`" + Environment.NewLine;
+
+        return $$"""
+        # AGENTS.md — host repo working policy
+
+        This is an **intent host repository**. It owns durable parent state for the
+        `{{request.Domain}}` domain under `.intent-cli/` and `intents/{{request.Domain}}/`.
+        Child implementation repos do NOT own this state.
+
+        {{hostLine}}{{targetLine}}- Domain: `{{request.Domain}}`
+        - Bootstrapped by `intent-cli intent init` (G293 / G301).
+
+        ## Host repo working policy
+
+        - Work directly on `main`. Do NOT open a PR for routine host-state updates
+          (queue-state, runs.jsonl, packets, intents/) unless the operator explicitly
+          asks for one.
+        - `git pull --ff-only` before edits. Commit and push to `main` after each
+          coherent change.
+        - All workflow label transitions go through installed `intent-cli automation`
+          / `intent-cli worker` commands. Never edit GitHub labels by hand.
+        - Routine collaboration uses `intent-cli guide ...`. Do NOT read
+          `intents/rules/**`, copied prompt files, or local skill files for routine
+          operation.
+        - Do NOT call `intent-cli run` (advanced runtime) or `dotnet run` as a
+          fallback. Do NOT ask `intent-cli` to launch Claude/Codex.
+
+        ## Wrong-host detection (G301)
+
+        `.intent-cli/host-binding.toml` records the canonical host repo for this
+        domain. If you operate this domain from a different host repo, expect
+        `intent-cli` to surface a structured wrong-host warning with remediation
+        steps; do not silently proceed with parent-state mutation.
+        """;
+    }
+
+    /// <summary>
+    /// G301: companion Claude-readable host policy. Mirrors AGENTS.md so a
+    /// Claude agent reading either file gets the same canonical
+    /// instructions regardless of which the host conventions name.
+    /// </summary>
+    private static string RenderClaudeMarkdown(IntentInitRequest request)
+    {
+        var targetLine = string.IsNullOrWhiteSpace(request.TargetRepo)
+            ? string.Empty
+            : $"- Target repo: `{request.TargetRepo}`" + Environment.NewLine;
+        var hostLine = string.IsNullOrWhiteSpace(request.HostRepo)
+            ? string.Empty
+            : $"- Host repo (this repo): `{request.HostRepo}`" + Environment.NewLine;
+
+        return $$"""
+        # CLAUDE.md — host repo guide for Claude / chat-first agents
+
+        This is an **intent host repository** for the `{{request.Domain}}` domain.
+        See `AGENTS.md` for the canonical host working policy. This file mirrors
+        that policy for Claude-specific tool conventions.
+
+        {{hostLine}}{{targetLine}}
+        ## Reading order
+
+        1. The current GitHub Issue body (when running an automation loop).
+        2. `AGENTS.md` (host policy baseline).
+        3. `intent-cli guide ...` (chat-first canonical guidance — never read
+           `intents/rules/**` or local skills for routine operation).
+
+        ## Hard rules (host repo)
+
+        - Work directly on `main` for host-state updates; pull before edit, commit
+          and push after each coherent change. Open a PR only if the operator
+          explicitly asks.
+        - Workflow label transitions go through `intent-cli automation` /
+          `intent-cli worker`. Never raw `gh ... edit --add-label`.
+        - Do NOT call `intent-cli run`, `dotnet run`, or ask intent-cli to launch
+          an AI provider.
+        - On any `Could not find .intent-cli` failure, follow the structured
+          fail-closed guidance (G299) — do not fall back to ordinary GitHub
+          review or raw PR comments.
+        """;
     }
 
     private static string RenderConfigToml(IntentInitRequest request)
@@ -256,6 +388,7 @@ internal static class IntentInitCommand
 
         string? domain = null;
         string? targetRepo = null;
+        string? hostRepo = null;
         var write = false;
         var format = FormatMarkdown;
 
@@ -278,6 +411,14 @@ internal static class IntentInitCommand
                         return false;
                     }
                     targetRepo = args[++index].Trim();
+                    break;
+                case "--host-repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "Missing value for '--host-repo'.";
+                        return false;
+                    }
+                    hostRepo = args[++index].Trim();
                     break;
                 case "--write":
                     write = true;
@@ -319,6 +460,7 @@ internal static class IntentInitCommand
         {
             Domain = domain!,
             TargetRepo = targetRepo,
+            HostRepo = hostRepo,
             Write = write,
             Format = format
         };
@@ -370,6 +512,8 @@ internal static class IntentInitCommand
         public required string Domain { get; init; }
 
         public string? TargetRepo { get; init; }
+
+        public string? HostRepo { get; init; }
 
         public required bool Write { get; init; }
 

--- a/src/IntentSystem.Cli/Commands/WrongHostGuard.cs
+++ b/src/IntentSystem.Cli/Commands/WrongHostGuard.cs
@@ -1,0 +1,196 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G301: pure analyzer for wrong-host detection. Compares the host
+/// repo's recorded binding (from <c>.intent-cli/host-binding.toml</c>,
+/// produced by <c>intent-cli intent init</c>) against the observed git
+/// remote URL of the current cwd. When the bound host repo does not
+/// match the observed remote, the analyzer returns a structured
+/// mismatch result so callers can fail closed and surface remediation
+/// steps to the operator instead of silently mutating parent state in
+/// the wrong host.
+///
+/// The contract is intentionally pure — no `gh` calls, no file I/O.
+/// Callers (`intent init`, `intent next-slice`, `automation
+/// issue-publish`, etc.) capture the binding and the observed remote
+/// and pass them in.
+/// </summary>
+internal static class WrongHostGuard
+{
+    public const string StatusOk = "ok";
+    public const string StatusUnbound = "unbound";
+    public const string StatusMismatch = "wrong-host";
+
+    public static WrongHostGuardResult Check(
+        string domain,
+        string? boundHostRepo,
+        string? observedRemoteUrl)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+
+        var bound = NormalizeRepo(boundHostRepo);
+        var observed = ExtractOwnerRepo(observedRemoteUrl);
+
+        if (string.IsNullOrEmpty(bound))
+        {
+            return new WrongHostGuardResult
+            {
+                Status = StatusUnbound,
+                Domain = domain,
+                BoundHostRepo = null,
+                ObservedHostRepo = observed,
+                ObservedRemoteUrl = observedRemoteUrl,
+                Summary = $"No `host_repo` is recorded in `.intent-cli/host-binding.toml` for domain `{domain}`. Wrong-host detection is disabled until the binding is set.",
+                RemediationSteps = new[]
+                {
+                    $"Re-run `intent-cli intent init --domain {domain} --host-repo <owner/repo> --target-repo <owner/repo> --write` from this host repo to record the canonical binding.",
+                    "If this host is not the canonical host for the domain, stop and clarify with the operator before mutating parent state."
+                }
+            };
+        }
+
+        if (string.IsNullOrEmpty(observed))
+        {
+            return new WrongHostGuardResult
+            {
+                Status = StatusUnbound,
+                Domain = domain,
+                BoundHostRepo = bound,
+                ObservedHostRepo = null,
+                ObservedRemoteUrl = observedRemoteUrl,
+                Summary = $"`host_repo` is bound to `{bound}` but the observed git remote could not be parsed. Cannot prove this is the canonical host; treat as unbound and surface to the operator.",
+                RemediationSteps = new[]
+                {
+                    "Capture the canonical host remote with `git -C <host-repo> remote get-url origin` and pass the parsed `<owner>/<repo>` to `WrongHostGuard.Check`.",
+                    "If the host has no remote (local-only), explicitly disable the wrong-host check via operator policy; do not silently proceed."
+                }
+            };
+        }
+
+        if (string.Equals(bound, observed, StringComparison.OrdinalIgnoreCase))
+        {
+            return new WrongHostGuardResult
+            {
+                Status = StatusOk,
+                Domain = domain,
+                BoundHostRepo = bound,
+                ObservedHostRepo = observed,
+                ObservedRemoteUrl = observedRemoteUrl,
+                Summary = $"Host binding matches: domain `{domain}` is operating from its canonical host `{bound}`.",
+                RemediationSteps = Array.Empty<string>()
+            };
+        }
+
+        return new WrongHostGuardResult
+        {
+            Status = StatusMismatch,
+            Domain = domain,
+            BoundHostRepo = bound,
+            ObservedHostRepo = observed,
+            ObservedRemoteUrl = observedRemoteUrl,
+            Summary = $"Wrong-host operation detected for domain `{domain}` (G301). `.intent-cli/host-binding.toml` records `host_repo = \"{bound}\"`, but the current cwd's git remote points at `{observed}`. Refusing to silently mutate parent state.",
+            RemediationSteps = new[]
+            {
+                $"`cd` to the canonical host repo `{bound}` and re-run the failing command there.",
+                $"If `{observed}` is the new intended host for `{domain}`, the operator must explicitly migrate: re-run `intent-cli intent init --domain {domain} --host-repo {observed} --write` (after copying durable state across hosts) and document the migration.",
+                $"If `{observed}` is the WRONG cwd (e.g. you accidentally cd'd into another host), stop and surface the gap rather than guessing. Do not commit parent state to `{observed}` while the binding still names `{bound}`.",
+                "Never silently rewrite host-binding.toml from a non-canonical host; cross-host migration is operator-driven by design."
+            }
+        };
+    }
+
+    private static string? NormalizeRepo(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+        return value.Trim();
+    }
+
+    /// <summary>
+    /// Extract <c>owner/repo</c> from a git remote URL. Accepts both
+    /// HTTPS (<c>https://github.com/owner/repo[.git]</c>) and SSH
+    /// (<c>git@github.com:owner/repo[.git]</c>) shapes. Returns null
+    /// when the URL cannot be normalized — callers treat null as
+    /// "observed-unknown" rather than mismatch so unbound checks stay
+    /// distinct from wrong-host failures.
+    /// </summary>
+    internal static string? ExtractOwnerRepo(string? remoteUrl)
+    {
+        if (string.IsNullOrWhiteSpace(remoteUrl))
+        {
+            return null;
+        }
+
+        var trimmed = remoteUrl.Trim();
+        if (trimmed.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+        {
+            trimmed = trimmed[..^4];
+        }
+
+        // Accept owner/repo passed verbatim (test seam / explicit binding).
+        if (!trimmed.Contains("://", StringComparison.Ordinal)
+            && !trimmed.Contains('@', StringComparison.Ordinal)
+            && trimmed.Count(c => c == '/') == 1)
+        {
+            var parts = trimmed.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length == 2)
+            {
+                return $"{parts[0]}/{parts[1]}";
+            }
+        }
+
+        // HTTPS: https://github.com/<owner>/<repo>
+        var httpsIndex = trimmed.IndexOf("github.com/", StringComparison.OrdinalIgnoreCase);
+        if (httpsIndex >= 0)
+        {
+            var afterHost = trimmed[(httpsIndex + "github.com/".Length)..];
+            var segments = afterHost.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (segments.Length >= 2)
+            {
+                return $"{segments[0]}/{segments[1]}";
+            }
+        }
+
+        // SSH: git@github.com:<owner>/<repo>
+        var sshIndex = trimmed.IndexOf("github.com:", StringComparison.OrdinalIgnoreCase);
+        if (sshIndex >= 0)
+        {
+            var afterHost = trimmed[(sshIndex + "github.com:".Length)..];
+            var segments = afterHost.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (segments.Length >= 2)
+            {
+                return $"{segments[0]}/{segments[1]}";
+            }
+        }
+
+        return null;
+    }
+}
+
+internal sealed record WrongHostGuardResult
+{
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("bound_host_repo")]
+    public string? BoundHostRepo { get; init; }
+
+    [JsonPropertyName("observed_host_repo")]
+    public string? ObservedHostRepo { get; init; }
+
+    [JsonPropertyName("observed_remote_url")]
+    public string? ObservedRemoteUrl { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("remediation_steps")]
+    public required IReadOnlyList<string> RemediationSteps { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/IntentInitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentInitCommandTests.cs
@@ -70,6 +70,106 @@ public sealed class IntentInitCommandTests
         Assert.Contains("`intents/auth/README.md`", secondOutput, StringComparison.Ordinal);
     }
 
+    // ── G301 host bootstrap (AGENTS.md / CLAUDE.md / host-binding.toml) ──
+
+    [Fact]
+    public void Execute_WithWrite_AlsoBootstrapsAgentsClaudeAndHostBinding()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var hostRoot = tempDirectory.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "trace-forge-poc", "--target-repo", "J-Tech-Japan/TraceForge", "--host-repo", "J-Tech-Japan/TraceForgeHost", "--write"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var agents = Path.Combine(hostRoot, "AGENTS.md");
+        var claude = Path.Combine(hostRoot, "CLAUDE.md");
+        var binding = Path.Combine(hostRoot, ".intent-cli", "host-binding.toml");
+        Assert.True(File.Exists(agents));
+        Assert.True(File.Exists(claude));
+        Assert.True(File.Exists(binding));
+
+        var agentsText = File.ReadAllText(agents);
+        Assert.Contains("intent host repository", agentsText, StringComparison.Ordinal);
+        Assert.Contains("Work directly on `main`", agentsText, StringComparison.Ordinal);
+        Assert.Contains("Wrong-host detection (G301)", agentsText, StringComparison.Ordinal);
+        Assert.Contains("J-Tech-Japan/TraceForgeHost", agentsText, StringComparison.Ordinal);
+        Assert.Contains("J-Tech-Japan/TraceForge", agentsText, StringComparison.Ordinal);
+        Assert.Contains("trace-forge-poc", agentsText, StringComparison.Ordinal);
+
+        var claudeText = File.ReadAllText(claude);
+        Assert.Contains("CLAUDE.md", claudeText, StringComparison.Ordinal);
+        Assert.Contains("trace-forge-poc", claudeText, StringComparison.Ordinal);
+        Assert.Contains("Hard rules (host repo)", claudeText, StringComparison.Ordinal);
+        Assert.Contains("G299", claudeText, StringComparison.Ordinal);
+
+        var bindingText = File.ReadAllText(binding);
+        Assert.Contains("[host]", bindingText, StringComparison.Ordinal);
+        Assert.Contains("domain = \"trace-forge-poc\"", bindingText, StringComparison.Ordinal);
+        Assert.Contains("host_repo = \"J-Tech-Japan/TraceForgeHost\"", bindingText, StringComparison.Ordinal);
+        Assert.Contains("target_repo = \"J-Tech-Japan/TraceForge\"", bindingText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithWrite_HostBindingHasEmptyValuesWhenFlagsOmitted()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var hostRoot = tempDirectory.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var binding = File.ReadAllText(Path.Combine(hostRoot, ".intent-cli", "host-binding.toml"));
+        Assert.Contains("domain = \"auth\"", binding, StringComparison.Ordinal);
+        Assert.Contains("host_repo = \"\"", binding, StringComparison.Ordinal);
+        Assert.Contains("target_repo = \"\"", binding, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_DryRun_ReportsAgentsClaudeAndHostBindingAsPlanned()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var hostRoot = tempDirectory.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        IntentInitCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--target-repo", "owner/repo", "--host-repo", "owner/host", "--format", "json"],
+            writer);
+
+        var json = writer.ToString();
+        Assert.Contains("\"AGENTS.md\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"CLAUDE.md\"", json, StringComparison.Ordinal);
+        Assert.Contains("\".intent-cli/host-binding.toml\"", json, StringComparison.Ordinal);
+        // No write applied → none of those files should exist on disk.
+        Assert.False(File.Exists(Path.Combine(hostRoot, "AGENTS.md")));
+        Assert.False(File.Exists(Path.Combine(hostRoot, "CLAUDE.md")));
+        Assert.False(File.Exists(Path.Combine(hostRoot, ".intent-cli", "host-binding.toml")));
+    }
+
+    [Fact]
+    public void Execute_RejectsMissingHostRepoValue()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var hostRoot = tempDirectory.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--host-repo"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--host-repo", writer.ToString(), StringComparison.Ordinal);
+    }
+
     [Fact]
     public void Execute_FromChildWorktree_ReturnsExitCodeOne_WithGuidance()
     {

--- a/tests/IntentSystem.Cli.Tests/WrongHostGuardTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WrongHostGuardTests.cs
@@ -1,0 +1,113 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class WrongHostGuardTests
+{
+    [Fact]
+    public void Check_BoundHostMatchesHttpsRemote_ReturnsOk()
+    {
+        var result = WrongHostGuard.Check(
+            "trace-forge-poc",
+            "J-Tech-Japan/TraceForgeHost",
+            "https://github.com/J-Tech-Japan/TraceForgeHost.git");
+
+        Assert.Equal("ok", result.Status);
+        Assert.Equal("J-Tech-Japan/TraceForgeHost", result.BoundHostRepo);
+        Assert.Equal("J-Tech-Japan/TraceForgeHost", result.ObservedHostRepo);
+        Assert.Empty(result.RemediationSteps);
+    }
+
+    [Fact]
+    public void Check_BoundHostMatchesSshRemote_ReturnsOk()
+    {
+        var result = WrongHostGuard.Check(
+            "trace-forge-poc",
+            "J-Tech-Japan/TraceForgeHost",
+            "git@github.com:J-Tech-Japan/TraceForgeHost.git");
+
+        Assert.Equal("ok", result.Status);
+        Assert.Equal("J-Tech-Japan/TraceForgeHost", result.ObservedHostRepo);
+    }
+
+    [Fact]
+    public void Check_BoundHostDiffersFromObservedRemote_ReturnsWrongHostMismatch()
+    {
+        var result = WrongHostGuard.Check(
+            "trace-forge-poc",
+            "J-Tech-Japan/TraceForgeHost",
+            "https://github.com/J-Tech-Japan/MyIntentHost.git");
+
+        Assert.Equal("wrong-host", result.Status);
+        Assert.Equal("J-Tech-Japan/TraceForgeHost", result.BoundHostRepo);
+        Assert.Equal("J-Tech-Japan/MyIntentHost", result.ObservedHostRepo);
+        Assert.Contains("Wrong-host operation detected", result.Summary, StringComparison.Ordinal);
+        Assert.Contains("trace-forge-poc", result.Summary, StringComparison.Ordinal);
+        Assert.Contains(result.RemediationSteps, s => s.Contains("`cd` to the canonical host repo", StringComparison.Ordinal));
+        Assert.Contains(result.RemediationSteps, s => s.Contains("operator must explicitly migrate", StringComparison.Ordinal));
+        Assert.Contains(result.RemediationSteps, s => s.Contains("Never silently rewrite host-binding.toml", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Check_NoBoundHost_ReturnsUnboundWithBootstrapHint()
+    {
+        var result = WrongHostGuard.Check(
+            "trace-forge-poc",
+            null,
+            "https://github.com/J-Tech-Japan/TraceForgeHost.git");
+
+        Assert.Equal("unbound", result.Status);
+        Assert.Null(result.BoundHostRepo);
+        Assert.Contains("intent init", result.RemediationSteps[0], StringComparison.Ordinal);
+        Assert.Contains("--host-repo", result.RemediationSteps[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Check_BoundHostButObservedRemoteUnparseable_ReturnsUnboundWithCaptureHint()
+    {
+        var result = WrongHostGuard.Check(
+            "trace-forge-poc",
+            "J-Tech-Japan/TraceForgeHost",
+            "/local/only/path");
+
+        Assert.Equal("unbound", result.Status);
+        Assert.Equal("J-Tech-Japan/TraceForgeHost", result.BoundHostRepo);
+        Assert.Null(result.ObservedHostRepo);
+        Assert.Contains(result.RemediationSteps, s => s.Contains("git -C", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Check_BothEmpty_ReturnsUnbound()
+    {
+        var result = WrongHostGuard.Check("trace-forge-poc", string.Empty, string.Empty);
+
+        Assert.Equal("unbound", result.Status);
+        Assert.Null(result.BoundHostRepo);
+    }
+
+    [Fact]
+    public void Check_CaseInsensitiveOwnerRepoMatch()
+    {
+        var result = WrongHostGuard.Check(
+            "trace-forge-poc",
+            "J-Tech-Japan/TraceForgeHost",
+            "https://github.com/j-tech-japan/traceforgehost");
+
+        Assert.Equal("ok", result.Status);
+    }
+
+    [Theory]
+    [InlineData("https://github.com/owner/repo.git", "owner/repo")]
+    [InlineData("https://github.com/owner/repo", "owner/repo")]
+    [InlineData("git@github.com:owner/repo.git", "owner/repo")]
+    [InlineData("git@github.com:owner/repo", "owner/repo")]
+    [InlineData("owner/repo", "owner/repo")]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("not a url", null)]
+    [InlineData("/local/only/path", null)]
+    public void ExtractOwnerRepo_HandlesCommonShapes(string? input, string? expected)
+    {
+        Assert.Equal(expected, WrongHostGuard.ExtractOwnerRepo(input));
+    }
+}


### PR DESCRIPTION
## Summary
Extends `intent-cli intent init` (G293) so a single command turns an empty repo into a usable intent host with canonical policy and binding records, and adds a pure analyzer for wrong-host detection. Motivated by TraceForge / TraceForgeHost: TraceForge intent state was accidentally created in `MyIntentHost` because the active cwd happened to be there, while the intended host (`TraceForgeHost`) stayed empty.

`intent init --domain <d> [--target-repo <owner/repo>] [--host-repo <owner/repo>] [--write]` now plans / writes seven files instead of four:

- `.intent-cli/config.toml` — unchanged (G293).
- `.intent-cli/host-binding.toml` (**NEW**) — records the canonical host repo, target child repo, and domain so other commands can detect wrong-host operation.
- `AGENTS.md` (**NEW**) — host repo working policy: work directly on `main`, pull before edit, no PRs for routine host-state updates, label transitions through installed `intent-cli` only, no `run` / `dotnet run` / AI-launch fallbacks, wrong-host detection notice.
- `CLAUDE.md` (**NEW**) — Claude-readable mirror of AGENTS.md plus the reading order (issue body → AGENTS.md → `intent-cli guide ...`) and the G299 fail-closed reminder.
- `intents/<domain>/{README.md, clarifications/open.md, intent-tree/00-map.md}` — unchanged.

Idempotent: existing files are preserved (reported under `existing`), missing files are created on `--write`. Empty `--target-repo` / `--host-repo` flags produce empty values in `host-binding.toml` so the binding can be filled in later without breaking the schema.

`WrongHostGuard.Check(domain, boundHostRepo, observedRemoteUrl)` is a pure analyzer that returns one of three statuses: `ok`, `unbound`, or `wrong-host`. The mismatch result carries a structured remediation list (cd back to canonical host; operator-driven migration; never silently rewrite the binding) so loop callers can fail closed with actionable guidance instead of mutating parent state in the wrong host. Both HTTPS and SSH GitHub URL shapes are accepted; case-insensitive `owner/repo` match.

**Out of scope (follow-up)**: domain-level filtering of `intent status` / `intent next-slice` is not in this PR — `QueueItem` currently does not carry a domain field, so a shared queue mixes domains. That deserves its own slice with a schema migration plan.

## Test plan
- [x] `dotnet test --filter IntentInitCommandTests|WrongHostGuardTests` — 26 passed (10 existing + new G301 cases).
- [x] New `IntentInitCommand` cases cover: full bootstrap with `--target-repo` and `--host-repo` (asserts AGENTS.md / CLAUDE.md / host-binding.toml content + binding fields); flagless bootstrap (empty values in binding); dry-run plan list; rejection of missing `--host-repo` value.
- [x] New `WrongHostGuardTests` cover all three statuses across HTTPS / SSH / verbatim `owner/repo` inputs, case-insensitive match, unparseable observed URL → unbound, and an `ExtractOwnerRepo` `[Theory]` over common URL shapes.
- [x] Full Cli test suite: 2189 passed, 1 skipped, 0 failed.
- [x] Smoke-tested the built binary end-to-end in a fresh tmp host directory: `intent init --domain trace-forge-poc --target-repo J-Tech-Japan/TraceForge --host-repo J-Tech-Japan/TraceForgeHost --write` writes all 7 files and reports `Initialized: domain 'trace-forge-poc' (written: 7, existing: 0)`.

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)