### PR TITLE
G300: child worker commands runnable from cwd without .intent-cli

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -234,6 +234,7 @@ Hard rules:
 - Never apply `intent-target` from the child loop; it is host-owned.
 - Never apply `intent-pr-created` to a PR; it is an issue-side completion marker.
 - **PR draft state (G296)**: create child implementation/update PRs as **ready-for-review** (non-draft) by default. Do NOT pass `--draft` to `gh pr create` unless the operator explicitly asks for a draft. After opening the PR, pass the actual draft state into `worker result-summary --pr-draft true|false` so the host review loop can detect a draft PR before approval. If you must keep the PR draft (incomplete work, operator hold), do not transition the issue to ready-for-review states; mark the outcome accordingly and document the reason.
+- **Child cwd is GitHub-contract-only (G300)**: the implementation repo must NOT contain its own `.intent-cli/` and the child loop MUST NOT read parent host queue-state, runs.jsonl, packets, or intent metadata. `worker next-action` / `claim` / `complete` / `result-summary` are runnable from a child cwd because they take `--repo <owner/repo>` and use `intent-cli` only for GitHub label transitions. If `worker complete --kind issue --outcome pr-created --pr <n> --write` reports `linked_pr_synced: false` with a queue-state warning (host queue not present in child cwd), that is expected — parent host metadata reconciliation is owned by the host loop, never by the child loop.
 - Process at most one action per wake.";
 
         return new GuidePromptMatrixEntry
@@ -385,6 +386,7 @@ Hard rules:
 - Never apply `intent-target` from the child loop; it is host-owned.
 - Never apply `intent-pr-created` to a PR; it is an issue-side completion marker.
 - **PR draft state (G296)**: create child implementation/update PRs as **ready-for-review** (non-draft) by default. Do NOT pass `--draft` to `gh pr create` unless the operator explicitly asks for a draft. After opening the PR, pass the actual draft state into `worker result-summary --pr-draft true|false` so the host review loop can detect a draft PR before approval. If you must keep the PR draft (incomplete work, operator hold), do not transition the issue to ready-for-review states; mark the outcome accordingly and document the reason.
+- **Child cwd is GitHub-contract-only (G300)**: the implementation repo must NOT contain its own `.intent-cli/` and the child loop MUST NOT read parent host queue-state, runs.jsonl, packets, or intent metadata. `worker next-action` / `claim` / `complete` / `result-summary` are runnable from a child cwd because they take `--repo <owner/repo>` and use `intent-cli` only for GitHub label transitions. If `worker complete --kind issue --outcome pr-created --pr <n> --write` reports `linked_pr_synced: false` with a queue-state warning (host queue not present in child cwd), that is expected — parent host metadata reconciliation is owned by the host loop, never by the child loop.
 - Process at most one action per wake.
 - Do not create a cron, monitor, scheduler, reminder, or new thread after completing this wake.";
 

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -24,7 +24,8 @@ internal static class Program
             if (IsIntakeInitCommand(args)
                 || IsIntentInitCommand(args)
                 || IsAutomationWorktreeCommand(args)
-                || IsGuideOneshotCommand(args))
+                || IsGuideOneshotCommand(args)
+                || IsWorkerCommand(args))
             {
                 return CommandRouter.Execute(args, CreateBootstrapContext(currentDirectory, args), Console.Out);
             }
@@ -101,6 +102,31 @@ internal static class Program
                 || string.Equals(args[1], "model", StringComparison.Ordinal)
                 || string.Equals(args[1], "commands", StringComparison.Ordinal)
                 || string.Equals(args[1], "onboarding", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// G300: child worker commands (next-action / claim / complete /
+    /// result-summary / *-preflight) are GitHub-contract-only and must be
+    /// runnable from a child implementation repo cwd that has no
+    /// `.intent-cli/` directory. The worker family takes <c>--repo
+    /// &lt;owner/repo&gt;</c> on the command line and uses installed
+    /// `intent-cli` only for GitHub label transitions; parent host queue
+    /// state, runs.jsonl, and intent metadata stay host-only. Bootstrapping
+    /// the context with cwd as RepoRoot lets these commands run; commands
+    /// that incidentally read queue-state already degrade to a warning
+    /// when the file is missing (G205 / G300).
+    /// </summary>
+    private static bool IsWorkerCommand(string[] args)
+    {
+        return args.Length >= 2
+            && string.Equals(args[0], "worker", StringComparison.Ordinal)
+            && (string.Equals(args[1], "next-action", StringComparison.Ordinal)
+                || string.Equals(args[1], "claim", StringComparison.Ordinal)
+                || string.Equals(args[1], "complete", StringComparison.Ordinal)
+                || string.Equals(args[1], "result-summary", StringComparison.Ordinal)
+                || string.Equals(args[1], "issue-preflight", StringComparison.Ordinal)
+                || string.Equals(args[1], "pr-review-preflight", StringComparison.Ordinal)
+                || string.Equals(args[1], "pr-comment-preflight", StringComparison.Ordinal));
     }
 
     private static CliContext CreateBootstrapContext(string currentDirectory, string[] args)

--- a/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
@@ -1079,6 +1079,42 @@ public sealed class GuidePromptMatrixCommandTests
         Assert.Contains("--pr-merged $IS_MERGED", prompt, StringComparison.Ordinal);
     }
 
+    // ── G300 child cwd is GitHub-contract-only ──────────────────────────
+
+    [Fact]
+    public void Execute_ChildLoop_StatesImplementationRepoMustNotContainIntentCli()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("**Child cwd is GitHub-contract-only (G300)**", prompt, StringComparison.Ordinal);
+        Assert.Contains("MUST NOT", prompt, StringComparison.Ordinal);
+        Assert.Contains("queue-state", prompt, StringComparison.Ordinal);
+        // G300 must not couple the child loop to host-only `automation
+        // reconcile` — the child prompt only states that reconciliation is
+        // host-owned, never naming the command.
+        Assert.DoesNotContain("automation reconcile", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildOneshot_StatesImplementationRepoMustNotContainIntentCli()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-oneshot", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("**Child cwd is GitHub-contract-only (G300)**", prompt, StringComparison.Ordinal);
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/ProgramTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ProgramTests.cs
@@ -1,4 +1,5 @@
 using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -88,6 +89,46 @@ public sealed class ProgramTests
                 consoleScope.Error.ToString(),
                 StringComparison.Ordinal);
             Assert.Equal(string.Empty, consoleScope.Out.ToString());
+        }
+    }
+
+    // ── G300 child worker is host-state-free ─────────────────────────────
+
+    [Fact]
+    public void Main_GivenWorkerNextActionFromChildCwdWithoutIntentCli_RunsAgainstGitHubOnly()
+    {
+        // G300: a child implementation cwd has no `.intent-cli/` and must
+        // not be expected to. `worker next-action --repo <r>` should run
+        // through Program.Main using a bootstrap context (cwd = RepoRoot)
+        // and return a GitHub-derived no-action result, NOT the
+        // missing-host-state structured guidance from G299.
+        lock (ProcessStateLock)
+        {
+            using var tempDirectory = new TemporaryDirectory();
+            var childCwd = tempDirectory.CreateDirectory("child-impl");
+            using var consoleScope = new ConsoleScope();
+            using var currentDirectoryScope = new CurrentDirectoryScope(childCwd);
+
+            var lister = new EmptyAutomationCandidateLister();
+            WorkerNextActionCommand.CandidateListerFactory = () => lister;
+            try
+            {
+                var exitCode = Program.Main(
+                    ["worker", "next-action", "--repo", "J-Tech-Japan/intent-system", "--workdir", childCwd, "--format", "json"]);
+
+                Assert.Equal(0, exitCode);
+                var stdout = consoleScope.Out.ToString();
+                // G299 missing-host-state guidance must NOT have fired.
+                Assert.DoesNotContain("missing host state (G299)", stdout, StringComparison.Ordinal);
+                Assert.DoesNotContain("\"status\": \"missing-host-state\"", stdout, StringComparison.Ordinal);
+                // Empty GitHub state → deterministic no-action result.
+                Assert.Contains("\"action\": \"none\"", stdout, StringComparison.Ordinal);
+                Assert.Equal(string.Empty, consoleScope.Error.ToString());
+            }
+            finally
+            {
+                WorkerNextActionCommand.CandidateListerFactory = null;
+            }
         }
     }
 
@@ -193,5 +234,24 @@ public sealed class ProgramTests
                 Directory.Delete(rootPath, recursive: true);
             }
         }
+    }
+
+    /// <summary>
+    /// G300: empty GitHub candidate lister for the child-cwd worker test.
+    /// Returns no PRs and no issues so `worker next-action` produces the
+    /// deterministic <c>action: none</c> result without touching the
+    /// network.
+    /// </summary>
+    private sealed class EmptyAutomationCandidateLister : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) =>
+            Array.Empty<GitHubAutomationPrCandidate>();
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo,
+            IReadOnlyCollection<string> requiredLabels) =>
+            Array.Empty<GitHubAutomationIssueCandidate>();
     }
 }


### PR DESCRIPTION
## Summary
Makes the worker command family GitHub-contract-only and bootstrap-friendly so child implementation loops can run from a child checkout that intentionally has no `.intent-cli/` directory. Motivated by TraceForge PR #4: an implementation cwd `/Users/.../TraceForgeHost/submodules/traceforge` correctly had no `.intent-cli`, but `intent-cli worker ...` aborted with the bare "Could not find .intent-cli directory" error (now G299 fail-closed), even though the worker family only uses GitHub state.

Two coupled changes:

1. **`Program.Main` bootstrap detection** adds `IsWorkerCommand(args)` alongside `intake init` / `intent init` / `automation` worktree commands / `guide oneshot` family. `worker next-action` / `claim` / `complete` / `result-summary` / `*-preflight` now route through `CreateBootstrapContext` (cwd = RepoRoot) instead of failing at `RepoRootResolver`. The commands are already GitHub-contract-only:
   - `next-action` and `claim` only read GitHub via `IGitHubAutomationCandidateLister` / `gh`, never read host queue-state.
   - `complete --kind issue --outcome pr-created --pr <n>` already surfaces `linked_pr_synced: false` with a queue-state warning when the host queue is missing (G205) — exactly the intended child-cwd behavior.

2. **`guide prompt-matrix --mode child-loop` and `child-oneshot`** get a new hard rule: "Child cwd is GitHub-contract-only (G300): the implementation repo must NOT contain its own `.intent-cli/` and the child loop MUST NOT read parent host queue-state, runs.jsonl, packets, or intent metadata." The rule names `linked_pr_synced: false` as the expected child-cwd outcome and explains that parent metadata reconciliation is host-owned. The G300 wording deliberately avoids naming `automation reconcile` so the existing host-only constraint stays in force.

## Test plan
- [x] `dotnet test --filter ProgramTests|GuidePromptMatrixCommandTests|AutomationReconcileCommandTests` — 110 passed (incl. the existing `GuidePromptMatrix_ChildLoopDoesNotMentionReconcile` / `ChildOneshotDoesNotMentionReconcile` invariants which still hold).
- [x] New `Main_GivenWorkerNextActionFromChildCwdWithoutIntentCli_RunsAgainstGitHubOnly`: invokes `Program.Main(["worker", "next-action", "--repo", ..., "--workdir", ...])` from a tempdir without `.intent-cli`, asserts no G299 missing-host-state guidance fires and the GitHub-derived `action: none` JSON is returned with empty stderr.
- [x] New `GuidePromptMatrixCommandTests` cover both `child-loop` and `child-oneshot` containing the G300 hard rule and reaffirm the child prompt does NOT name `automation reconcile`.
- [x] Smoke-tested the built binary: from a fresh tempdir without `.intent-cli`, `intent-cli worker next-action --repo J-Tech-Japan/intent-system --workdir <tmp> --format json` returns the deterministic `action: none` GitHub-derived result with exit 0 (no fail-closed guidance).
- [x] Full Cli test suite: 2172 passed, 1 skipped, 0 failed.

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)