### PR TITLE
G302: structured clarification artifact and answer workflow

### DIFF
--- a/src/IntentSystem.Cli/Commands/ClarificationCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClarificationCommand.cs
@@ -1,0 +1,508 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G302: <c>intent-cli clarification status / next / answer</c>. New
+/// structured clarification surface so an AI agent can ask the host
+/// directly which product-owner question to put to the human, record the
+/// answer durably, and have <c>intent status</c> /
+/// <c>intent next-slice</c> reflect the resulting state without
+/// free-form markdown interpretation.
+///
+/// <list type="bullet">
+/// <item><description><c>status</c> — list every clarification under
+/// <c>intents/&lt;domain&gt;/clarifications/*.toml</c> (open + answered).</description></item>
+/// <item><description><c>next</c> — return the first open clarification with
+/// background, options, pros/cons, and recommendation.</description></item>
+/// <item><description><c>answer --id &lt;id&gt; --choice &lt;option-id&gt; [--note &lt;text&gt;] --write</c>
+///   — set <c>status = "answered"</c> and write the
+///   <c>[answer]</c> table.</description></item>
+/// </list>
+/// </summary>
+internal static class ClarificationCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    /// <summary>Test seam — replaces the default UTC timestamp source.</summary>
+    public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never
+    };
+
+    public static int ExecuteStatus(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseDomainAndFormat(args, context, out var domain, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        IReadOnlyList<StructuredClarification> all;
+        try
+        {
+            all = StructuredClarificationsDirectory.ReadAll(context.RepoRoot, domain);
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+
+        var openCount = all.Count(c => c.IsOpen());
+        var result = new ClarificationStatusResult
+        {
+            Domain = domain,
+            DirectoryPath = StructuredClarificationsDirectory.ResolveDirectory(context.RepoRoot, domain),
+            OpenCount = openCount,
+            AnsweredCount = all.Count - openCount,
+            Items = all
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteStatusMarkdown(writer, result);
+        }
+        return 0;
+    }
+
+    public static int ExecuteNext(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseDomainAndFormat(args, context, out var domain, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        IReadOnlyList<StructuredClarification> all;
+        try
+        {
+            all = StructuredClarificationsDirectory.ReadAll(context.RepoRoot, domain);
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+
+        var next = all.FirstOrDefault(c => c.IsOpen());
+        var result = new ClarificationNextResult
+        {
+            Domain = domain,
+            HasOpen = next is not null,
+            Clarification = next
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteNextMarkdown(writer, result);
+        }
+        return 0;
+    }
+
+    public static int ExecuteAnswer(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseAnswerArgs(args, context, out var domain, out var id, out var choice, out var note, out var write, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var path = StructuredClarificationsDirectory.ResolveFile(context.RepoRoot, domain, id);
+        if (!File.Exists(path))
+        {
+            writer.WriteLine($"No structured clarification found at '{path}' for domain '{domain}' id '{id}'.");
+            return 1;
+        }
+
+        StructuredClarification existing;
+        try
+        {
+            existing = StructuredClarificationToml.Deserialize(File.ReadAllText(path), sourcePath: path);
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+
+        if (!existing.Options.Any(o => string.Equals(o.Id, choice, StringComparison.Ordinal)))
+        {
+            writer.WriteLine(
+                $"Choice '{choice}' is not one of the recorded option ids for clarification '{id}': [{string.Join(", ", existing.Options.Select(o => o.Id))}].");
+            return 1;
+        }
+
+        var answeredAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow)
+            .ToUniversalTime()
+            .ToString("yyyy-MM-ddTHH:mm:ssZ", System.Globalization.CultureInfo.InvariantCulture);
+
+        var updated = existing with
+        {
+            Status = StructuredClarificationStatus.Answered,
+            Answer = new StructuredClarificationAnswer
+            {
+                Choice = choice,
+                Note = note,
+                AnsweredAt = answeredAt
+            }
+        };
+
+        if (write)
+        {
+            File.WriteAllText(path, StructuredClarificationToml.Serialize(updated));
+        }
+
+        var result = new ClarificationAnswerResult
+        {
+            Domain = domain,
+            Id = id,
+            Mode = write ? "write" : "dry-run",
+            Path = path,
+            Clarification = updated
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteAnswerMarkdown(writer, result);
+        }
+        return 0;
+    }
+
+    private static void WriteStatusMarkdown(TextWriter writer, ClarificationStatusResult result)
+    {
+        writer.WriteLine($"# Clarification status — `{result.Domain}`");
+        writer.WriteLine();
+        writer.WriteLine($"- Directory: `{result.DirectoryPath}`");
+        writer.WriteLine($"- Open: {result.OpenCount}");
+        writer.WriteLine($"- Answered: {result.AnsweredCount}");
+        writer.WriteLine();
+
+        if (result.Items.Count == 0)
+        {
+            writer.WriteLine("_No structured clarifications found._");
+            return;
+        }
+
+        foreach (var item in result.Items)
+        {
+            writer.WriteLine($"## `{item.Id}` — **{item.Status}**");
+            writer.WriteLine();
+            writer.WriteLine(item.Question);
+            writer.WriteLine();
+            if (item.Blocks.Count > 0)
+            {
+                writer.WriteLine($"- Blocks: {string.Join(", ", item.Blocks.Select(b => "`" + b + "`"))}");
+            }
+            if (item.Answer is { } answer)
+            {
+                writer.WriteLine($"- Answer: `{answer.Choice}` (recorded {answer.AnsweredAt})");
+            }
+            writer.WriteLine();
+        }
+    }
+
+    private static void WriteNextMarkdown(TextWriter writer, ClarificationNextResult result)
+    {
+        writer.WriteLine($"# Clarification next — `{result.Domain}`");
+        writer.WriteLine();
+        if (!result.HasOpen || result.Clarification is null)
+        {
+            writer.WriteLine("_No open structured clarifications._");
+            return;
+        }
+
+        var c = result.Clarification;
+        writer.WriteLine($"## `{c.Id}`");
+        writer.WriteLine();
+        if (!string.IsNullOrEmpty(c.Background))
+        {
+            writer.WriteLine("### Background");
+            writer.WriteLine();
+            writer.WriteLine(c.Background);
+            writer.WriteLine();
+        }
+        writer.WriteLine("### Question");
+        writer.WriteLine();
+        writer.WriteLine(c.Question);
+        writer.WriteLine();
+        if (c.Options.Count > 0)
+        {
+            writer.WriteLine("### Options");
+            writer.WriteLine();
+            foreach (var option in c.Options)
+            {
+                writer.WriteLine($"- **`{option.Id}`** — {option.Label}");
+                if (option.Pros.Count > 0)
+                {
+                    writer.WriteLine($"  - Pros: {string.Join("; ", option.Pros)}");
+                }
+                if (option.Cons.Count > 0)
+                {
+                    writer.WriteLine($"  - Cons: {string.Join("; ", option.Cons)}");
+                }
+            }
+            writer.WriteLine();
+        }
+        if (!string.IsNullOrEmpty(c.Recommendation))
+        {
+            writer.WriteLine($"### Recommendation: `{c.Recommendation}`");
+            writer.WriteLine();
+        }
+        if (c.Blocks.Count > 0)
+        {
+            writer.WriteLine($"Blocks: {string.Join(", ", c.Blocks.Select(b => "`" + b + "`"))}");
+        }
+    }
+
+    private static void WriteAnswerMarkdown(TextWriter writer, ClarificationAnswerResult result)
+    {
+        writer.WriteLine($"# Clarification answer — `{result.Domain}` / `{result.Id}` ({result.Mode})");
+        writer.WriteLine();
+        var c = result.Clarification;
+        if (c.Answer is { } answer)
+        {
+            writer.WriteLine($"- Choice: `{answer.Choice}`");
+            if (!string.IsNullOrEmpty(answer.Note))
+            {
+                writer.WriteLine($"- Note: {answer.Note}");
+            }
+            writer.WriteLine($"- Answered at: {answer.AnsweredAt}");
+            writer.WriteLine($"- Path: `{result.Path}`");
+        }
+    }
+
+    private static bool TryParseDomainAndFormat(
+        string[] args,
+        CliContext context,
+        out string domain,
+        out string format,
+        out string error)
+    {
+        domain = string.Empty;
+        format = FormatMarkdown;
+        error = string.Empty;
+        string? domainOverride = null;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+                    domainOverride = args[++index].Trim();
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var candidate = args[++index].Trim();
+                    if (!string.Equals(candidate, FormatJson, StringComparison.Ordinal)
+                        && !string.Equals(candidate, FormatMarkdown, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{candidate}').";
+                        return false;
+                    }
+                    format = candidate;
+                    break;
+                default:
+                    error = $"Unknown argument '{args[index]}'.";
+                    return false;
+            }
+        }
+
+        domain = string.IsNullOrWhiteSpace(domainOverride) ? context.Config.Project.Domain : domainOverride!;
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            error = "A domain must be specified via --domain or via [project] domain in the host config.";
+            return false;
+        }
+        return true;
+    }
+
+    private static bool TryParseAnswerArgs(
+        string[] args,
+        CliContext context,
+        out string domain,
+        out string id,
+        out string choice,
+        out string? note,
+        out bool write,
+        out string format,
+        out string error)
+    {
+        domain = string.Empty;
+        id = string.Empty;
+        choice = string.Empty;
+        note = null;
+        write = false;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        string? domainOverride = null;
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+                    domainOverride = args[++index].Trim();
+                    break;
+                case "--id":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--id requires a value.";
+                        return false;
+                    }
+                    id = args[++index].Trim();
+                    break;
+                case "--choice":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--choice requires a value.";
+                        return false;
+                    }
+                    choice = args[++index].Trim();
+                    break;
+                case "--note":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--note requires a value.";
+                        return false;
+                    }
+                    note = args[++index];
+                    break;
+                case "--write":
+                    write = true;
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var candidate = args[++index].Trim();
+                    if (!string.Equals(candidate, FormatJson, StringComparison.Ordinal)
+                        && !string.Equals(candidate, FormatMarkdown, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{candidate}').";
+                        return false;
+                    }
+                    format = candidate;
+                    break;
+                default:
+                    error = $"Unknown argument '{args[index]}'.";
+                    return false;
+            }
+        }
+
+        domain = string.IsNullOrWhiteSpace(domainOverride) ? context.Config.Project.Domain : domainOverride!;
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            error = "A domain must be specified via --domain or via [project] domain in the host config.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            error = "Clarification answer requires '--id <id>'.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(choice))
+        {
+            error = "Clarification answer requires '--choice <option-id>'.";
+            return false;
+        }
+        return true;
+    }
+}
+
+internal sealed record ClarificationStatusResult
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("directory_path")]
+    public required string DirectoryPath { get; init; }
+
+    [JsonPropertyName("open_count")]
+    public required int OpenCount { get; init; }
+
+    [JsonPropertyName("answered_count")]
+    public required int AnsweredCount { get; init; }
+
+    [JsonPropertyName("items")]
+    public required IReadOnlyList<StructuredClarification> Items { get; init; }
+}
+
+internal sealed record ClarificationNextResult
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("has_open")]
+    public required bool HasOpen { get; init; }
+
+    [JsonPropertyName("clarification")]
+    public StructuredClarification? Clarification { get; init; }
+}
+
+internal sealed record ClarificationAnswerResult
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("path")]
+    public required string Path { get; init; }
+
+    [JsonPropertyName("clarification")]
+    public required StructuredClarification Clarification { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -16,6 +16,7 @@ internal static class CommandRouter
         "review",
         "interview",
         "clarify",
+        "clarification",
         "intake",
         "status",
         "context",
@@ -95,6 +96,12 @@ internal static class CommandRouter
                 ["answer"] = ClarifyAnswerCommand.Execute,
                 ["draft"] = ClarifyDraftCommand.Execute,
                 ["record"] = ClarifyRecordCommand.Execute
+            },
+            ["clarification"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["status"] = ClarificationCommand.ExecuteStatus,
+                ["next"] = ClarificationCommand.ExecuteNext,
+                ["answer"] = ClarificationCommand.ExecuteAnswer
             },
             ["queue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -161,6 +161,23 @@ internal static class IntentNextSliceCommand
 
         var clarificationOpen = clarificationAnalysis?.HasOpenBlocker ?? false;
         var staleClarificationMetadata = clarificationAnalysis?.StaleClarificationMetadata ?? false;
+
+        // G302: structured clarifications under
+        // `intents/<domain>/clarifications/*.toml` block next-slice the
+        // same way the legacy markdown blocker does.
+        try
+        {
+            if (StructuredClarificationsDirectory.HasOpenBlocker(context.RepoRoot, domain))
+            {
+                clarificationOpen = true;
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Treat parse errors as non-blocking here; the dedicated
+            // `clarification status` surface returns the structured error
+            // when the operator audits it directly.
+        }
         IntentNextSliceCandidate? candidate = null;
         if (Directory.Exists(packetRoot))
         {

--- a/src/IntentSystem.Cli/Commands/IntentStatusCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentStatusCommand.cs
@@ -129,6 +129,22 @@ internal static class IntentStatusCommand
             clarificationOpen = ClarificationOpenDetector.HasOpenBlocker(File.ReadAllText(clarificationPath!));
         }
 
+        // G302: structured clarifications under
+        // `intents/<domain>/clarifications/*.toml` are an additive open
+        // signal. ANY open structured clarification flips
+        // `clarification_open` true regardless of the markdown shape.
+        try
+        {
+            if (StructuredClarificationsDirectory.HasOpenBlocker(context.RepoRoot, domain))
+            {
+                clarificationOpen = true;
+            }
+        }
+        catch (InvalidOperationException exception)
+        {
+            notes.Add($"structured clarification could not be parsed: {exception.Message}");
+        }
+
         return new IntentStatusResult
         {
             Domain = domain,

--- a/src/IntentSystem.Cli/Commands/StructuredClarification.cs
+++ b/src/IntentSystem.Cli/Commands/StructuredClarification.cs
@@ -1,0 +1,84 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G302: structured clarification artifact. One TOML file per clarification
+/// under <c>intents/&lt;domain&gt;/clarifications/&lt;id&gt;.toml</c>. The
+/// shape is product-owner friendly: background, question, options with
+/// pros/cons, recommendation, and a list of execution units the
+/// clarification blocks. The <c>answer</c> table is populated by
+/// <c>intent-cli clarification answer --write</c> and never by free-form
+/// markdown editing.
+///
+/// Coexists with the legacy markdown <c>clarifications/open.md</c>: the
+/// existing <see cref="ClarificationOpenDetector"/> still parses that file,
+/// and <see cref="IntentStatusCommand"/> /
+/// <see cref="IntentNextSliceCommand"/> OR the two sources together so a
+/// domain with EITHER a markdown blocker OR an open structured
+/// clarification reports <c>clarification_open: true</c>.
+/// </summary>
+internal sealed record StructuredClarification
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("background")]
+    public string Background { get; init; } = string.Empty;
+
+    [JsonPropertyName("question")]
+    public required string Question { get; init; }
+
+    [JsonPropertyName("options")]
+    public required IReadOnlyList<StructuredClarificationOption> Options { get; init; }
+
+    [JsonPropertyName("recommendation")]
+    public string? Recommendation { get; init; }
+
+    [JsonPropertyName("blocks")]
+    public required IReadOnlyList<string> Blocks { get; init; }
+
+    [JsonPropertyName("answer")]
+    public StructuredClarificationAnswer? Answer { get; init; }
+
+    [JsonPropertyName("source_path")]
+    public string? SourcePath { get; init; }
+
+    public bool IsOpen() => string.Equals(Status, StructuredClarificationStatus.Open, StringComparison.Ordinal);
+}
+
+internal sealed record StructuredClarificationOption
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("label")]
+    public string Label { get; init; } = string.Empty;
+
+    [JsonPropertyName("pros")]
+    public IReadOnlyList<string> Pros { get; init; } = Array.Empty<string>();
+
+    [JsonPropertyName("cons")]
+    public IReadOnlyList<string> Cons { get; init; } = Array.Empty<string>();
+}
+
+internal sealed record StructuredClarificationAnswer
+{
+    [JsonPropertyName("choice")]
+    public required string Choice { get; init; }
+
+    [JsonPropertyName("note")]
+    public string? Note { get; init; }
+
+    [JsonPropertyName("answered_at")]
+    public required string AnsweredAt { get; init; }
+}
+
+internal static class StructuredClarificationStatus
+{
+    public const string Open = "open";
+    public const string Answered = "answered";
+}

--- a/src/IntentSystem.Cli/Commands/StructuredClarificationToml.cs
+++ b/src/IntentSystem.Cli/Commands/StructuredClarificationToml.cs
@@ -1,0 +1,217 @@
+using Tomlyn;
+using Tomlyn.Model;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G302: TOML serializer / deserializer for
+/// <see cref="StructuredClarification"/> artifacts. Uses the existing
+/// Tomlyn dependency so the format stays consistent with
+/// <c>.intent-cli/config.toml</c> and <c>host-binding.toml</c>.
+///
+/// Round-trip is intentionally lossy on whitespace and comments so the
+/// writer produces a canonical layout: scalars, then options as
+/// <c>[[options]]</c> tables, then the optional <c>[answer]</c> table.
+/// </summary>
+internal static class StructuredClarificationToml
+{
+    public static StructuredClarification Deserialize(string toml, string? sourcePath = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(toml);
+
+        var raw = TomlSerializer.Deserialize<TomlTable>(toml);
+        if (raw is not TomlTable model)
+        {
+            throw new InvalidOperationException("Structured clarification payload did not deserialize to a TOML table.");
+        }
+        var id = RequireScalar(model, "id");
+        var status = RequireScalar(model, "status");
+        if (!string.Equals(status, StructuredClarificationStatus.Open, StringComparison.Ordinal)
+            && !string.Equals(status, StructuredClarificationStatus.Answered, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Structured clarification '{id}' has unsupported status '{status}'. Expected '{StructuredClarificationStatus.Open}' or '{StructuredClarificationStatus.Answered}'.");
+        }
+
+        var question = RequireScalar(model, "question");
+        var background = OptionalScalar(model, "background") ?? string.Empty;
+        var recommendation = OptionalScalar(model, "recommendation");
+        var blocks = ReadStringArray(model, "blocks");
+        var options = ReadOptions(model);
+        var answer = ReadAnswer(model);
+
+        if (string.Equals(status, StructuredClarificationStatus.Answered, StringComparison.Ordinal)
+            && answer is null)
+        {
+            throw new InvalidOperationException(
+                $"Structured clarification '{id}' is marked answered but has no [answer] table.");
+        }
+
+        return new StructuredClarification
+        {
+            Id = id,
+            Status = status,
+            Background = background,
+            Question = question,
+            Options = options,
+            Recommendation = recommendation,
+            Blocks = blocks,
+            Answer = answer,
+            SourcePath = sourcePath
+        };
+    }
+
+    public static string Serialize(StructuredClarification clarification)
+    {
+        ArgumentNullException.ThrowIfNull(clarification);
+
+        var lines = new List<string>
+        {
+            $"id = \"{Escape(clarification.Id)}\"",
+            $"status = \"{Escape(clarification.Status)}\"",
+            $"question = \"{Escape(clarification.Question)}\""
+        };
+
+        if (!string.IsNullOrEmpty(clarification.Background))
+        {
+            lines.Add($"background = \"\"\"{Environment.NewLine}{clarification.Background}{Environment.NewLine}\"\"\"");
+        }
+
+        if (!string.IsNullOrEmpty(clarification.Recommendation))
+        {
+            lines.Add($"recommendation = \"{Escape(clarification.Recommendation!)}\"");
+        }
+
+        lines.Add($"blocks = [{string.Join(", ", clarification.Blocks.Select(b => $"\"{Escape(b)}\""))}]");
+
+        foreach (var option in clarification.Options)
+        {
+            lines.Add(string.Empty);
+            lines.Add("[[options]]");
+            lines.Add($"id = \"{Escape(option.Id)}\"");
+            if (!string.IsNullOrEmpty(option.Label))
+            {
+                lines.Add($"label = \"{Escape(option.Label)}\"");
+            }
+            lines.Add($"pros = [{string.Join(", ", option.Pros.Select(p => $"\"{Escape(p)}\""))}]");
+            lines.Add($"cons = [{string.Join(", ", option.Cons.Select(c => $"\"{Escape(c)}\""))}]");
+        }
+
+        if (clarification.Answer is { } answer)
+        {
+            lines.Add(string.Empty);
+            lines.Add("[answer]");
+            lines.Add($"choice = \"{Escape(answer.Choice)}\"");
+            if (!string.IsNullOrEmpty(answer.Note))
+            {
+                lines.Add($"note = \"{Escape(answer.Note!)}\"");
+            }
+            lines.Add($"answered_at = \"{Escape(answer.AnsweredAt)}\"");
+        }
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    private static string RequireScalar(TomlTable model, string key)
+    {
+        if (!model.TryGetValue(key, out var raw) || raw is not string value || string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"Structured clarification is missing required scalar '{key}'.");
+        }
+        return value;
+    }
+
+    private static string? OptionalScalar(TomlTable model, string key)
+    {
+        if (!model.TryGetValue(key, out var raw) || raw is not string value)
+        {
+            return null;
+        }
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    private static IReadOnlyList<string> ReadStringArray(TomlTable model, string key)
+    {
+        if (!model.TryGetValue(key, out var raw))
+        {
+            return Array.Empty<string>();
+        }
+
+        if (raw is not TomlArray array)
+        {
+            throw new InvalidOperationException($"Structured clarification key '{key}' must be an array of strings.");
+        }
+
+        var result = new List<string>(array.Count);
+        foreach (var item in array)
+        {
+            if (item is not string scalar)
+            {
+                throw new InvalidOperationException($"Structured clarification key '{key}' must contain string entries only.");
+            }
+            result.Add(scalar);
+        }
+        return result;
+    }
+
+    private static IReadOnlyList<StructuredClarificationOption> ReadOptions(TomlTable model)
+    {
+        if (!model.TryGetValue("options", out var raw))
+        {
+            return Array.Empty<StructuredClarificationOption>();
+        }
+
+        if (raw is not TomlTableArray tableArray)
+        {
+            throw new InvalidOperationException("Structured clarification key 'options' must be a [[options]] array of tables.");
+        }
+
+        var result = new List<StructuredClarificationOption>(tableArray.Count);
+        foreach (var entry in tableArray)
+        {
+            var id = RequireScalar(entry, "id");
+            var label = OptionalScalar(entry, "label") ?? string.Empty;
+            var pros = ReadStringArray(entry, "pros");
+            var cons = ReadStringArray(entry, "cons");
+            result.Add(new StructuredClarificationOption
+            {
+                Id = id,
+                Label = label,
+                Pros = pros,
+                Cons = cons
+            });
+        }
+        return result;
+    }
+
+    private static StructuredClarificationAnswer? ReadAnswer(TomlTable model)
+    {
+        if (!model.TryGetValue("answer", out var raw))
+        {
+            return null;
+        }
+
+        if (raw is not TomlTable table)
+        {
+            throw new InvalidOperationException("Structured clarification key 'answer' must be a [answer] table.");
+        }
+
+        var choice = RequireScalar(table, "choice");
+        var answeredAt = RequireScalar(table, "answered_at");
+        var note = OptionalScalar(table, "note");
+
+        return new StructuredClarificationAnswer
+        {
+            Choice = choice,
+            AnsweredAt = answeredAt,
+            Note = note
+        };
+    }
+
+    private static string Escape(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/StructuredClarificationsDirectory.cs
+++ b/src/IntentSystem.Cli/Commands/StructuredClarificationsDirectory.cs
@@ -1,0 +1,59 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G302: scans <c>intents/&lt;domain&gt;/clarifications/*.toml</c> and returns
+/// the parsed <see cref="StructuredClarification"/> records. The legacy
+/// <c>open.md</c> markdown file is intentionally ignored — that path is
+/// handled by <see cref="ClarificationOpenDetector"/> and the structured
+/// directory adds an additive source of truth.
+/// </summary>
+internal static class StructuredClarificationsDirectory
+{
+    public static string ResolveDirectory(string repoRoot, string domain)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+
+        return Path.Combine(repoRoot, "intents", domain, "clarifications");
+    }
+
+    public static string ResolveFile(string repoRoot, string domain, string id)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+
+        return Path.Combine(ResolveDirectory(repoRoot, domain), $"{id}.toml");
+    }
+
+    public static IReadOnlyList<StructuredClarification> ReadAll(string repoRoot, string domain)
+    {
+        var directory = ResolveDirectory(repoRoot, domain);
+        if (!Directory.Exists(directory))
+        {
+            return Array.Empty<StructuredClarification>();
+        }
+
+        var results = new List<StructuredClarification>();
+        foreach (var path in Directory.EnumerateFiles(directory, "*.toml")
+            .OrderBy(p => p, StringComparer.Ordinal))
+        {
+            var toml = File.ReadAllText(path);
+            try
+            {
+                var clarification = StructuredClarificationToml.Deserialize(toml, sourcePath: path);
+                results.Add(clarification);
+            }
+            catch (InvalidOperationException exception)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to parse structured clarification at '{path}': {exception.Message}", exception);
+            }
+        }
+
+        return results;
+    }
+
+    public static bool HasOpenBlocker(string repoRoot, string domain)
+    {
+        return ReadAll(repoRoot, domain).Any(c => c.IsOpen());
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/ClarificationCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClarificationCommandTests.cs
@@ -1,0 +1,280 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ClarificationCommandTests : IDisposable
+{
+    public ClarificationCommandTests()
+    {
+        ClarificationCommand.UtcNowFactory = null;
+    }
+
+    public void Dispose()
+    {
+        ClarificationCommand.UtcNowFactory = null;
+    }
+
+    [Fact]
+    public void Status_NoDirectory_ReturnsZeroCounts()
+    {
+        using var workspace = new ClarificationWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = ClarificationCommand.ExecuteStatus(
+            workspace.Context,
+            ["--domain", "demo", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("open_count").GetInt32());
+        Assert.Equal(0, doc.RootElement.GetProperty("answered_count").GetInt32());
+        Assert.Empty(doc.RootElement.GetProperty("items").EnumerateArray());
+    }
+
+    [Fact]
+    public void Status_OneOpenAndOneAnswered_ReportsCounts()
+    {
+        using var workspace = new ClarificationWorkspace();
+        workspace.WriteClarification("demo", "open-q", BuildOpenToml("open-q", "Question A?"));
+        workspace.WriteClarification("demo", "answered-q", BuildAnsweredToml("answered-q", "Question B?", "yes"));
+        using var writer = new StringWriter();
+
+        ClarificationCommand.ExecuteStatus(
+            workspace.Context,
+            ["--domain", "demo", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(1, doc.RootElement.GetProperty("open_count").GetInt32());
+        Assert.Equal(1, doc.RootElement.GetProperty("answered_count").GetInt32());
+        Assert.Equal(2, doc.RootElement.GetProperty("items").GetArrayLength());
+    }
+
+    [Fact]
+    public void Next_ReturnsFirstOpenWithStructuredFields()
+    {
+        using var workspace = new ClarificationWorkspace();
+        workspace.WriteClarification("demo", "storage", BuildOpenToml("storage", "Which backend?"));
+        using var writer = new StringWriter();
+
+        var exitCode = ClarificationCommand.ExecuteNext(
+            workspace.Context,
+            ["--domain", "demo", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.True(doc.RootElement.GetProperty("has_open").GetBoolean());
+        var c = doc.RootElement.GetProperty("clarification");
+        Assert.Equal("storage", c.GetProperty("id").GetString());
+        Assert.Equal("Which backend?", c.GetProperty("question").GetString());
+        Assert.Equal(2, c.GetProperty("options").GetArrayLength());
+        Assert.Equal("yes", c.GetProperty("recommendation").GetString());
+        Assert.Contains(
+            c.GetProperty("blocks").EnumerateArray(),
+            e => e.GetString() == "TF-G3");
+    }
+
+    [Fact]
+    public void Next_NoOpenClarification_ReturnsHasOpenFalse()
+    {
+        using var workspace = new ClarificationWorkspace();
+        workspace.WriteClarification("demo", "answered-q", BuildAnsweredToml("answered-q", "Q?", "yes"));
+        using var writer = new StringWriter();
+
+        ClarificationCommand.ExecuteNext(
+            workspace.Context,
+            ["--domain", "demo", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.False(doc.RootElement.GetProperty("has_open").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("clarification").ValueKind);
+    }
+
+    [Fact]
+    public void Answer_WriteRecordsChoiceNoteAndTimestamp_AndMarksAnswered()
+    {
+        using var workspace = new ClarificationWorkspace();
+        workspace.WriteClarification("demo", "storage", BuildOpenToml("storage", "Which backend?"));
+        ClarificationCommand.UtcNowFactory = () => new DateTimeOffset(2026, 5, 8, 12, 34, 56, TimeSpan.Zero);
+
+        using var writer = new StringWriter();
+        var exitCode = ClarificationCommand.ExecuteAnswer(
+            workspace.Context,
+            ["--domain", "demo", "--id", "storage", "--choice", "yes", "--note", "Approved 2026-05-08", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("write", doc.RootElement.GetProperty("mode").GetString());
+        var c = doc.RootElement.GetProperty("clarification");
+        Assert.Equal("answered", c.GetProperty("status").GetString());
+        var ans = c.GetProperty("answer");
+        Assert.Equal("yes", ans.GetProperty("choice").GetString());
+        Assert.Equal("Approved 2026-05-08", ans.GetProperty("note").GetString());
+        Assert.Equal("2026-05-08T12:34:56Z", ans.GetProperty("answered_at").GetString());
+
+        // File on disk reflects the change.
+        var path = StructuredClarificationsDirectory.ResolveFile(workspace.RepoRoot, "demo", "storage");
+        var roundTrip = StructuredClarificationToml.Deserialize(File.ReadAllText(path), sourcePath: path);
+        Assert.False(roundTrip.IsOpen());
+        Assert.Equal("yes", roundTrip.Answer!.Choice);
+    }
+
+    [Fact]
+    public void Answer_DryRunByDefault_DoesNotMutateFile()
+    {
+        using var workspace = new ClarificationWorkspace();
+        workspace.WriteClarification("demo", "storage", BuildOpenToml("storage", "Which backend?"));
+        var path = StructuredClarificationsDirectory.ResolveFile(workspace.RepoRoot, "demo", "storage");
+        var before = File.ReadAllText(path);
+
+        using var writer = new StringWriter();
+        ClarificationCommand.ExecuteAnswer(
+            workspace.Context,
+            ["--domain", "demo", "--id", "storage", "--choice", "yes", "--format", "json"],
+            writer);
+
+        Assert.Equal(before, File.ReadAllText(path));
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("dry-run", doc.RootElement.GetProperty("mode").GetString());
+    }
+
+    [Fact]
+    public void Answer_RejectsUnknownChoice()
+    {
+        using var workspace = new ClarificationWorkspace();
+        workspace.WriteClarification("demo", "storage", BuildOpenToml("storage", "Which backend?"));
+        using var writer = new StringWriter();
+
+        var exitCode = ClarificationCommand.ExecuteAnswer(
+            workspace.Context,
+            ["--domain", "demo", "--id", "storage", "--choice", "azure-blob", "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("not one of the recorded option ids", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Answer_MissingId_ReturnsExitCodeOne()
+    {
+        using var workspace = new ClarificationWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = ClarificationCommand.ExecuteAnswer(
+            workspace.Context,
+            ["--domain", "demo", "--choice", "yes", "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--id", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IntentStatus_Reports_ClarificationOpen_WhenStructuredOpen()
+    {
+        using var workspace = new ClarificationWorkspace();
+        workspace.WriteClarification("demo", "storage", BuildOpenToml("storage", "Which backend?"));
+
+        var result = IntentStatusCommand.Analyze(workspace.Context, "demo");
+
+        Assert.True(result.ClarificationOpen);
+    }
+
+    [Fact]
+    public void IntentStatus_Reports_ClarificationClosed_WhenAllAnswered()
+    {
+        using var workspace = new ClarificationWorkspace();
+        workspace.WriteClarification("demo", "storage", BuildAnsweredToml("storage", "Which backend?", "yes"));
+
+        var result = IntentStatusCommand.Analyze(workspace.Context, "demo");
+
+        Assert.False(result.ClarificationOpen);
+    }
+
+    private static string BuildOpenToml(string id, string question) =>
+        $$"""
+        id = "{{id}}"
+        status = "open"
+        question = "{{question}}"
+        recommendation = "yes"
+        blocks = ["TF-G3"]
+
+        [[options]]
+        id = "yes"
+        label = "Yes"
+        pros = ["Simple"]
+        cons = []
+
+        [[options]]
+        id = "no"
+        label = "No"
+        pros = ["Defer"]
+        cons = ["Blocks"]
+        """;
+
+    private static string BuildAnsweredToml(string id, string question, string choice) =>
+        $$"""
+        id = "{{id}}"
+        status = "answered"
+        question = "{{question}}"
+        recommendation = "yes"
+        blocks = ["TF-G3"]
+
+        [[options]]
+        id = "yes"
+        label = "Yes"
+        pros = ["Simple"]
+        cons = []
+
+        [answer]
+        choice = "{{choice}}"
+        answered_at = "2026-05-08T00:00:00Z"
+        """;
+
+    private sealed class ClarificationWorkspace : IDisposable
+    {
+        public ClarificationWorkspace()
+        {
+            RepoRoot = Directory.CreateTempSubdirectory("clarification-tests-").FullName;
+            Context = new CliContext
+            {
+                RepoRoot = RepoRoot,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "demo",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees"
+                    }
+                }
+            };
+        }
+
+        public string RepoRoot { get; }
+
+        public CliContext Context { get; }
+
+        public void WriteClarification(string domain, string id, string toml)
+        {
+            var dir = Path.Combine(RepoRoot, "intents", domain, "clarifications");
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, id + ".toml"), toml);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RepoRoot))
+            {
+                Directory.Delete(RepoRoot, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a structured clarification surface so an AI agent can ask intent-cli directly which product-owner question to put to the human, record the answer durably, and have `intent status` / `intent next-slice` reflect open clarification blockers without ad-hoc markdown interpretation. Motivated by TraceForgeHost: `open.md` held real product-owner questions but `intent-cli intent status` reported `clarification_open: false`, forcing the agent to read open.md by hand.

**Artifact format** — one TOML file per clarification under `intents/<domain>/clarifications/<id>.toml`, parsed via the existing Tomlyn dependency:

```toml
id = "storage"
status = "open"           # or "answered"
question = "Which storage backend should TF-G3 use?"
background = "..."
recommendation = "postgres"
blocks = ["TF-G3"]

[[options]]
id = "postgres"
label = "PostgreSQL"
pros = ["Reliable", "Mature"]
cons = ["Operational overhead"]

[[options]]
id = "sqlite"
label = "SQLite"
pros = ["Simple"]
cons = ["Single-node"]

[answer]                  # written by `clarification answer --write`
choice = "postgres"
note = "..."
answered_at = "2026-05-08T12:34:56Z"
```

**New `clarification` command group**:

- `clarification status --domain <d> [--format markdown|json]` — list every clarification with open/answered counts.
- `clarification next --domain <d> [--format markdown|json]` — return the first open clarification with background, options, pros/cons, and recommendation as a structured object.
- `clarification answer --domain <d> --id <id> --choice <option-id> [--note <text>] [--write] [--format markdown|json]` — set `status="answered"` and write the `[answer]` table; dry-run by default. Rejects unknown choice ids; resolves `--domain` via `[project] domain` when omitted.

**Integrates with the existing surfaces**:

- `intent status --domain <d>` now ORs the structured directory's open-blocker signal into `clarification_open`. A domain with an open `*.toml` clarification reports `clarification_open: true` even if `open.md` does not.
- `intent next-slice --dry-run` does the same so a candidate is blocked while any structured clarification is still open.

**Coexists with the legacy markdown** `clarifications/open.md`: the existing `ClarificationOpenDetector` still parses that file, so this slice is purely additive — domains with no structured directory are unchanged.

## Test plan
- [x] `dotnet test --filter ClarificationCommandTests` — 10 passed (status x2, next x2, answer x4 incl. write/dry-run/unknown-choice/missing-id, intent-status integration x2).
- [x] Full Cli test suite: 2202 passed, 1 skipped, 0 failed.
- [x] Smoke-tested the built binary in a fresh tmp host: `intent init --domain demo --write` → write a `storage.toml` clarification → `clarification next --domain demo` returns full structured options → `clarification answer --id storage --choice postgres --note "..." --write` mutates file with timestamped `[answer]` → `clarification status` flips `open_count: 1 → 0`.

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)