### PR TITLE
G309: intent host-check smoke command for canonical hosts

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -244,6 +244,7 @@ internal static class CommandRouter
             },
             ["intent"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
+                ["host-check"] = IntentHostCheckCommand.Execute,
                 ["init"] = IntentInitCommand.Execute,
                 ["status"] = IntentStatusCommand.Execute,
                 ["search"] = IntentSearchCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/IntentHostCheckAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/IntentHostCheckAnalyzer.cs
@@ -1,0 +1,221 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G309: pure analyzer that classifies whether a parent host repo is a
+/// canonical, fully-initialized intent host for a given domain and
+/// target repo. Inputs are deterministic file-presence flags and the
+/// parsed <c>.intent-cli/host-binding.toml</c> values; the analyzer
+/// returns one of six classifications with structured remediation
+/// steps so a fresh agent can decide whether to proceed with
+/// packet/issue work or stop and surface the gap to the operator.
+///
+/// Classifications, in priority order (the analyzer short-circuits on
+/// the first match):
+/// <list type="bullet">
+/// <item><c>uninitialized</c> — no <c>.intent-cli/config.toml</c>; the host has not run <c>intent init</c>.</item>
+/// <item><c>wrong-host</c> — host-binding records a different host repo than the observed git remote.</item>
+/// <item><c>missing-host-binding</c> — config exists but <c>host-binding.toml</c> is absent (G301 record missing).</item>
+/// <item><c>domain-not-bootstrapped</c> — host binding present but no <c>intents/&lt;domain&gt;/</c> directory.</item>
+/// <item><c>partially-initialized</c> — config + binding + intents/&lt;domain&gt;/ exist but one or more
+///   onboarding artifacts is missing (<c>AGENTS.md</c>, <c>CLAUDE.md</c>, <c>queue-state.json</c>, <c>runs.jsonl</c>).</item>
+/// <item><c>ok</c> — all required artifacts present, host binding matches the observed remote.</item>
+/// </list>
+///
+/// Pure data in / pure data out: no file I/O, no `gh` calls, no state
+/// mutation. The command layer captures the inputs.
+/// </summary>
+internal static class IntentHostCheckAnalyzer
+{
+    public const string ClassificationOk = "ok";
+    public const string ClassificationUninitialized = "uninitialized";
+    public const string ClassificationWrongHost = "wrong-host";
+    public const string ClassificationMissingHostBinding = "missing-host-binding";
+    public const string ClassificationDomainNotBootstrapped = "domain-not-bootstrapped";
+    public const string ClassificationPartiallyInitialized = "partially-initialized";
+
+    public static IntentHostCheckResult Analyze(IntentHostCheckInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentException.ThrowIfNullOrWhiteSpace(input.Domain);
+
+        // 1. uninitialized — no `.intent-cli/config.toml`
+        if (!input.ConfigTomlPresent)
+        {
+            return Result(
+                ClassificationUninitialized,
+                ok: false,
+                summary: $"Host repo at '{input.RepoRoot}' has no `.intent-cli/config.toml`. Run `intent-cli intent init` to bootstrap a canonical intent host.",
+                remediation: new[]
+                {
+                    $"Run `intent-cli intent init --domain {input.Domain} --target-repo {input.TargetRepo ?? "<owner/repo>"} --host-repo <owner/host> --write` from this repo to create the canonical baseline (G293/G301).",
+                    "After init, re-run `intent host-check` to confirm the host is ready before any packet/issue work."
+                },
+                input);
+        }
+
+        // 2. wrong-host — host-binding records a different host repo
+        var bindingResult = WrongHostGuard.Check(input.Domain, input.BoundHostRepo, input.ObservedRemoteUrl);
+        if (string.Equals(bindingResult.Status, WrongHostGuard.StatusMismatch, StringComparison.Ordinal))
+        {
+            return Result(
+                ClassificationWrongHost,
+                ok: false,
+                summary: $"Wrong host for domain `{input.Domain}`: bound host is `{bindingResult.BoundHostRepo}` but the observed remote is `{bindingResult.ObservedHostRepo}`. Operate this domain from the canonical host.",
+                remediation: bindingResult.RemediationSteps,
+                input);
+        }
+
+        // 3. missing-host-binding — config exists but binding is absent
+        if (!input.HostBindingPresent)
+        {
+            return Result(
+                ClassificationMissingHostBinding,
+                ok: false,
+                summary: $"Host repo at '{input.RepoRoot}' has `.intent-cli/config.toml` but no `host-binding.toml`. Re-run intent init with `--host-repo <owner/repo>` so wrong-host detection can fire (G301).",
+                remediation: new[]
+                {
+                    $"Re-run `intent-cli intent init --domain {input.Domain} --target-repo {input.TargetRepo ?? "<owner/repo>"} --host-repo <owner/repo> --write` to record the canonical host binding (idempotent — existing files are preserved).",
+                    "After init, the wrong-host guard can detect operation from a non-canonical host."
+                },
+                input);
+        }
+
+        // 4. domain-not-bootstrapped — binding present but no intents/<domain>/
+        if (!input.IntentsDomainDirectoryPresent)
+        {
+            return Result(
+                ClassificationDomainNotBootstrapped,
+                ok: false,
+                summary: $"Host binding is present but `intents/{input.Domain}/` is missing. The domain has not been bootstrapped on this host.",
+                remediation: new[]
+                {
+                    $"Run `intent-cli intent init --domain {input.Domain} --target-repo {input.TargetRepo ?? "<owner/repo>"} --host-repo {input.BoundHostRepo ?? "<owner/host>"} --write` to bootstrap the domain (idempotent).",
+                    $"After init, `intents/{input.Domain}/{{README.md,clarifications/open.md,intent-tree/00-map.md}}` will be present."
+                },
+                input);
+        }
+
+        // 5. partially-initialized — one or more onboarding artifacts missing
+        var missing = CollectMissingArtifacts(input);
+        if (missing.Count > 0)
+        {
+            return Result(
+                ClassificationPartiallyInitialized,
+                ok: false,
+                summary: $"Host repo at '{input.RepoRoot}' is partially initialized; {missing.Count} required artifact(s) missing: {string.Join(", ", missing.Select(m => "`" + m + "`"))}.",
+                remediation: BuildPartialRemediation(missing, input),
+                input);
+        }
+
+        // 6. ok
+        return Result(
+            ClassificationOk,
+            ok: true,
+            summary: BuildOkSummary(input),
+            remediation: Array.Empty<string>(),
+            input);
+    }
+
+    private static IReadOnlyList<string> CollectMissingArtifacts(IntentHostCheckInput input)
+    {
+        var missing = new List<string>();
+        if (!input.AgentsMarkdownPresent) missing.Add("AGENTS.md");
+        if (!input.ClaudeMarkdownPresent) missing.Add("CLAUDE.md");
+        if (!input.QueueStateJsonPresent) missing.Add(".intent-cli/queue-state.json");
+        if (!input.RunsJsonlPresent) missing.Add(".intent-cli/runs.jsonl");
+        return missing;
+    }
+
+    private static IReadOnlyList<string> BuildPartialRemediation(
+        IReadOnlyList<string> missing,
+        IntentHostCheckInput input)
+    {
+        var steps = new List<string>();
+        if (missing.Contains("AGENTS.md") || missing.Contains("CLAUDE.md"))
+        {
+            steps.Add($"Re-run `intent-cli intent init --domain {input.Domain} --target-repo {input.TargetRepo ?? "<owner/repo>"} --host-repo {input.BoundHostRepo ?? "<owner/host>"} --write` to regenerate the missing AGENTS.md / CLAUDE.md (idempotent — existing files are preserved).");
+        }
+        if (missing.Contains(".intent-cli/queue-state.json"))
+        {
+            steps.Add("Run a host loop wake (review/closeout/next-slice) to populate `.intent-cli/queue-state.json`. The first publish will create the file.");
+        }
+        if (missing.Contains(".intent-cli/runs.jsonl"))
+        {
+            steps.Add("Run a host loop wake; `.intent-cli/runs.jsonl` is appended on each closeout / publish.");
+        }
+        return steps;
+    }
+
+    private static string BuildOkSummary(IntentHostCheckInput input)
+    {
+        var parts = new List<string>
+        {
+            $"Host at '{input.RepoRoot}' is canonical for domain `{input.Domain}`."
+        };
+        if (!string.IsNullOrEmpty(input.BoundHostRepo))
+        {
+            parts.Add($"Host binding: `{input.BoundHostRepo}`.");
+        }
+        if (!string.IsNullOrEmpty(input.TargetRepo))
+        {
+            parts.Add($"Target repo: `{input.TargetRepo}`.");
+        }
+        if (!string.IsNullOrEmpty(input.ChildSubmodulePath))
+        {
+            parts.Add($"Child submodule path: `{input.ChildSubmodulePath}`.");
+        }
+        return string.Join(" ", parts);
+    }
+
+    private static IntentHostCheckResult Result(
+        string classification,
+        bool ok,
+        string summary,
+        IReadOnlyList<string> remediation,
+        IntentHostCheckInput input) =>
+        new()
+        {
+            Classification = classification,
+            Ok = ok,
+            Summary = summary,
+            RemediationSteps = remediation,
+            Domain = input.Domain,
+            TargetRepo = input.TargetRepo,
+            HostRepoRoot = input.RepoRoot,
+            BoundHostRepo = input.BoundHostRepo,
+            ObservedRemoteUrl = input.ObservedRemoteUrl,
+            ChildSubmodulePath = input.ChildSubmodulePath
+        };
+}
+
+internal sealed record IntentHostCheckInput
+{
+    public required string RepoRoot { get; init; }
+    public required string Domain { get; init; }
+    public string? TargetRepo { get; init; }
+    public string? ObservedRemoteUrl { get; init; }
+    public string? ChildSubmodulePath { get; init; }
+
+    public required bool ConfigTomlPresent { get; init; }
+    public required bool HostBindingPresent { get; init; }
+    public string? BoundHostRepo { get; init; }
+    public required bool IntentsDomainDirectoryPresent { get; init; }
+    public required bool AgentsMarkdownPresent { get; init; }
+    public required bool ClaudeMarkdownPresent { get; init; }
+    public required bool QueueStateJsonPresent { get; init; }
+    public required bool RunsJsonlPresent { get; init; }
+}
+
+internal sealed record IntentHostCheckResult
+{
+    public required string Classification { get; init; }
+    public required bool Ok { get; init; }
+    public required string Summary { get; init; }
+    public required IReadOnlyList<string> RemediationSteps { get; init; }
+    public required string Domain { get; init; }
+    public required string? TargetRepo { get; init; }
+    public required string HostRepoRoot { get; init; }
+    public required string? BoundHostRepo { get; init; }
+    public required string? ObservedRemoteUrl { get; init; }
+    public required string? ChildSubmodulePath { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IntentHostCheckCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentHostCheckCommand.cs
@@ -1,0 +1,315 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Tomlyn;
+using Tomlyn.Model;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G309: <c>intent-cli intent host-check --domain &lt;d&gt;
+/// [--target-repo &lt;owner/repo&gt;] [--observed-remote &lt;url&gt;]
+/// [--format markdown|json]</c> — read-only smoke check that classifies
+/// whether the current cwd is a canonical, fully-initialized intent
+/// host for the given domain. Wraps
+/// <see cref="IntentHostCheckAnalyzer"/> with the file-presence and
+/// host-binding-parsing I/O.
+///
+/// The command captures the observed git remote via
+/// <c>git remote get-url origin</c> by default; tests inject a fake
+/// observed remote via <c>--observed-remote</c>. No state mutation,
+/// no `gh` calls, no AI provider launch.
+/// </summary>
+internal static class IntentHostCheckCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    /// <summary>Test seam — replaces the default observed remote capture.</summary>
+    public static Func<string, string?>? ObservedRemoteFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, context, out var parsed, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var repoRoot = context.RepoRoot;
+        var configPath = Path.Combine(repoRoot, ".intent-cli", "config.toml");
+        var bindingPath = Path.Combine(repoRoot, ".intent-cli", "host-binding.toml");
+        var domainDir = Path.Combine(repoRoot, "intents", parsed.Domain);
+        var agentsPath = Path.Combine(repoRoot, "AGENTS.md");
+        var claudePath = Path.Combine(repoRoot, "CLAUDE.md");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var runsLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+
+        var bindingPresent = File.Exists(bindingPath);
+        string? boundHostRepo = null;
+        string? bindingTargetRepo = null;
+        if (bindingPresent)
+        {
+            try
+            {
+                (boundHostRepo, bindingTargetRepo) = ParseHostBinding(File.ReadAllText(bindingPath));
+            }
+            catch (Exception exception) when (exception is InvalidOperationException or IOException)
+            {
+                writer.WriteLine($"failed to parse `.intent-cli/host-binding.toml`: {exception.Message}");
+                return 1;
+            }
+        }
+
+        var observedRemote = parsed.ObservedRemoteOverride ?? CaptureObservedRemote(repoRoot);
+        var targetRepo = parsed.TargetRepoOverride ?? bindingTargetRepo;
+
+        var input = new IntentHostCheckInput
+        {
+            RepoRoot = repoRoot,
+            Domain = parsed.Domain,
+            TargetRepo = targetRepo,
+            ObservedRemoteUrl = observedRemote,
+            ChildSubmodulePath = parsed.ChildSubmodulePath,
+            ConfigTomlPresent = File.Exists(configPath),
+            HostBindingPresent = bindingPresent,
+            BoundHostRepo = boundHostRepo,
+            IntentsDomainDirectoryPresent = Directory.Exists(domainDir),
+            AgentsMarkdownPresent = File.Exists(agentsPath),
+            ClaudeMarkdownPresent = File.Exists(claudePath),
+            QueueStateJsonPresent = File.Exists(queueStatePath),
+            RunsJsonlPresent = File.Exists(runsLogPath)
+        };
+
+        var result = IntentHostCheckAnalyzer.Analyze(input);
+        var emitted = new IntentHostCheckEmittedResult
+        {
+            Domain = result.Domain,
+            TargetRepo = result.TargetRepo,
+            HostRepoRoot = result.HostRepoRoot,
+            BoundHostRepo = result.BoundHostRepo,
+            ObservedRemoteUrl = result.ObservedRemoteUrl,
+            ChildSubmodulePath = result.ChildSubmodulePath,
+            Classification = result.Classification,
+            Ok = result.Ok,
+            Summary = result.Summary,
+            RemediationSteps = result.RemediationSteps
+        };
+
+        if (string.Equals(parsed.Format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(emitted, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, emitted);
+        }
+        return result.Ok ? 0 : 1;
+    }
+
+    internal static (string? HostRepo, string? TargetRepo) ParseHostBinding(string toml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(toml);
+
+        var raw = TomlSerializer.Deserialize<TomlTable>(toml);
+        if (raw is not TomlTable model)
+        {
+            throw new InvalidOperationException("host-binding.toml did not deserialize to a TOML table.");
+        }
+        if (!model.TryGetValue("host", out var hostSection) || hostSection is not TomlTable hostTable)
+        {
+            return (null, null);
+        }
+        string? Get(string key) =>
+            hostTable.TryGetValue(key, out var value) && value is string text && !string.IsNullOrWhiteSpace(text)
+                ? text
+                : null;
+        return (Get("host_repo"), Get("target_repo"));
+    }
+
+    private static string? CaptureObservedRemote(string repoRoot)
+    {
+        if (ObservedRemoteFactory is { } factory)
+        {
+            return factory(repoRoot);
+        }
+
+        try
+        {
+            using var process = new Process();
+            process.StartInfo.FileName = "git";
+            process.StartInfo.ArgumentList.Add("remote");
+            process.StartInfo.ArgumentList.Add("get-url");
+            process.StartInfo.ArgumentList.Add("origin");
+            process.StartInfo.WorkingDirectory = repoRoot;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.CreateNoWindow = true;
+            process.Start();
+            var stdout = process.StandardOutput.ReadToEnd().Trim();
+            process.WaitForExit();
+            return process.ExitCode == 0 && !string.IsNullOrWhiteSpace(stdout) ? stdout : null;
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private static void WriteMarkdown(TextWriter writer, IntentHostCheckEmittedResult result)
+    {
+        writer.WriteLine($"# intent host-check (G309) — domain `{result.Domain}`");
+        writer.WriteLine();
+        writer.WriteLine($"- classification: **{result.Classification}**");
+        writer.WriteLine($"- ok: {(result.Ok ? "yes" : "no")}");
+        writer.WriteLine($"- host_repo_root: `{result.HostRepoRoot}`");
+        if (!string.IsNullOrEmpty(result.BoundHostRepo))
+        {
+            writer.WriteLine($"- bound_host_repo: `{result.BoundHostRepo}`");
+        }
+        if (!string.IsNullOrEmpty(result.TargetRepo))
+        {
+            writer.WriteLine($"- target_repo: `{result.TargetRepo}`");
+        }
+        if (!string.IsNullOrEmpty(result.ObservedRemoteUrl))
+        {
+            writer.WriteLine($"- observed_remote_url: `{result.ObservedRemoteUrl}`");
+        }
+        if (!string.IsNullOrEmpty(result.ChildSubmodulePath))
+        {
+            writer.WriteLine($"- child_submodule_path: `{result.ChildSubmodulePath}`");
+        }
+        writer.WriteLine();
+        writer.WriteLine(result.Summary);
+        if (result.RemediationSteps.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Remediation");
+            foreach (var step in result.RemediationSteps)
+            {
+                writer.WriteLine($"- {step}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, CliContext context, out ParsedArgs parsed, out string error)
+    {
+        parsed = default!;
+        error = string.Empty;
+
+        string? domain = null;
+        string? targetRepo = null;
+        string? observedRemote = null;
+        string? childSubmodulePath = null;
+        var format = FormatMarkdown;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value."; return false;
+                    }
+                    domain = args[++index].Trim();
+                    break;
+                case "--target-repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--target-repo requires a value (owner/repo)."; return false;
+                    }
+                    targetRepo = args[++index].Trim();
+                    break;
+                case "--observed-remote":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--observed-remote requires a value."; return false;
+                    }
+                    observedRemote = args[++index].Trim();
+                    break;
+                case "--child-submodule-path":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--child-submodule-path requires a value."; return false;
+                    }
+                    childSubmodulePath = args[++index].Trim();
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json)."; return false;
+                    }
+                    var requested = args[++index].Trim();
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}')."; return false;
+                    }
+                    format = requested;
+                    break;
+                default:
+                    error = $"Unknown argument '{args[index]}'."; return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            // Fall back to the host config domain when --domain is omitted.
+            domain = string.IsNullOrWhiteSpace(context.Config.Project.Domain)
+                ? null
+                : context.Config.Project.Domain;
+        }
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            error = "intent host-check requires '--domain <name>'.";
+            return false;
+        }
+
+        parsed = new ParsedArgs
+        {
+            Domain = domain!,
+            TargetRepoOverride = targetRepo,
+            ObservedRemoteOverride = observedRemote,
+            ChildSubmodulePath = childSubmodulePath,
+            Format = format
+        };
+        return true;
+    }
+
+    private sealed record ParsedArgs
+    {
+        public required string Domain { get; init; }
+        public string? TargetRepoOverride { get; init; }
+        public string? ObservedRemoteOverride { get; init; }
+        public string? ChildSubmodulePath { get; init; }
+        public required string Format { get; init; }
+    }
+}
+
+internal sealed record IntentHostCheckEmittedResult
+{
+    [JsonPropertyName("domain")] public required string Domain { get; init; }
+    [JsonPropertyName("target_repo")] public required string? TargetRepo { get; init; }
+    [JsonPropertyName("host_repo_root")] public required string HostRepoRoot { get; init; }
+    [JsonPropertyName("bound_host_repo")] public required string? BoundHostRepo { get; init; }
+    [JsonPropertyName("observed_remote_url")] public required string? ObservedRemoteUrl { get; init; }
+    [JsonPropertyName("child_submodule_path")] public required string? ChildSubmodulePath { get; init; }
+    [JsonPropertyName("classification")] public required string Classification { get; init; }
+    [JsonPropertyName("ok")] public required bool Ok { get; init; }
+    [JsonPropertyName("summary")] public required string Summary { get; init; }
+    [JsonPropertyName("remediation_steps")] public required IReadOnlyList<string> RemediationSteps { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -70,7 +70,8 @@ internal static class Program
     {
         return args.Length >= 2
             && string.Equals(args[0], "intent", StringComparison.Ordinal)
-            && string.Equals(args[1], "init", StringComparison.Ordinal);
+            && (string.Equals(args[1], "init", StringComparison.Ordinal)
+                || string.Equals(args[1], "host-check", StringComparison.Ordinal));
     }
 
     private static bool IsAutomationWorktreeCommand(string[] args)

--- a/tests/IntentSystem.Cli.Tests/IntentHostCheckAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentHostCheckAnalyzerTests.cs
@@ -1,0 +1,197 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class IntentHostCheckAnalyzerTests
+{
+    [Fact]
+    public void Analyze_FullyInitializedHost_WithMatchingBinding_ReturnsOk()
+    {
+        var input = NewInput() with
+        {
+            ConfigTomlPresent = true,
+            HostBindingPresent = true,
+            BoundHostRepo = "J-Tech-Japan/MyIntentHost",
+            ObservedRemoteUrl = "https://github.com/J-Tech-Japan/MyIntentHost.git",
+            IntentsDomainDirectoryPresent = true,
+            AgentsMarkdownPresent = true,
+            ClaudeMarkdownPresent = true,
+            QueueStateJsonPresent = true,
+            RunsJsonlPresent = true,
+            TargetRepo = "J-Tech-Japan/intent-system",
+            ChildSubmodulePath = "submodules/intent-system"
+        };
+
+        var result = IntentHostCheckAnalyzer.Analyze(input);
+
+        Assert.Equal("ok", result.Classification);
+        Assert.True(result.Ok);
+        Assert.Empty(result.RemediationSteps);
+        Assert.Contains("canonical for domain `intent-cli`", result.Summary, StringComparison.Ordinal);
+        Assert.Contains("J-Tech-Japan/MyIntentHost", result.Summary, StringComparison.Ordinal);
+        Assert.Contains("submodules/intent-system", result.Summary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Analyze_NoConfigToml_ReturnsUninitialized_WithIntentInitRemediation()
+    {
+        var input = NewInput() with { ConfigTomlPresent = false };
+
+        var result = IntentHostCheckAnalyzer.Analyze(input);
+
+        Assert.Equal("uninitialized", result.Classification);
+        Assert.False(result.Ok);
+        Assert.Contains(result.RemediationSteps, s => s.Contains("intent-cli intent init", StringComparison.Ordinal));
+        Assert.Contains(result.RemediationSteps, s => s.Contains("re-run `intent host-check`", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Analyze_BindingMismatchesObservedRemote_ReturnsWrongHost()
+    {
+        var input = NewInput() with
+        {
+            ConfigTomlPresent = true,
+            HostBindingPresent = true,
+            BoundHostRepo = "J-Tech-Japan/CanonicalHost",
+            ObservedRemoteUrl = "https://github.com/J-Tech-Japan/MyIntentHost.git"
+        };
+
+        var result = IntentHostCheckAnalyzer.Analyze(input);
+
+        Assert.Equal("wrong-host", result.Classification);
+        Assert.False(result.Ok);
+        Assert.Contains("CanonicalHost", result.Summary, StringComparison.Ordinal);
+        Assert.Contains("MyIntentHost", result.Summary, StringComparison.Ordinal);
+        // Reuses WrongHostGuard remediation steps
+        Assert.Contains(result.RemediationSteps, s => s.Contains("`cd` to the canonical host repo", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Analyze_ConfigPresentButBindingAbsent_ReturnsMissingHostBinding()
+    {
+        var input = NewInput() with
+        {
+            ConfigTomlPresent = true,
+            HostBindingPresent = false
+        };
+
+        var result = IntentHostCheckAnalyzer.Analyze(input);
+
+        Assert.Equal("missing-host-binding", result.Classification);
+        Assert.False(result.Ok);
+        Assert.Contains(result.RemediationSteps, s => s.Contains("--host-repo", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Analyze_BindingPresentButNoIntentsDomainDir_ReturnsDomainNotBootstrapped()
+    {
+        var input = NewInput() with
+        {
+            ConfigTomlPresent = true,
+            HostBindingPresent = true,
+            BoundHostRepo = "J-Tech-Japan/MyIntentHost",
+            ObservedRemoteUrl = "https://github.com/J-Tech-Japan/MyIntentHost.git",
+            IntentsDomainDirectoryPresent = false
+        };
+
+        var result = IntentHostCheckAnalyzer.Analyze(input);
+
+        Assert.Equal("domain-not-bootstrapped", result.Classification);
+        Assert.False(result.Ok);
+        Assert.Contains(result.RemediationSteps, s => s.Contains("intents/intent-cli/", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Analyze_DomainBootstrappedButAgentsMissing_ReturnsPartiallyInitialized_WithExactRemediation()
+    {
+        var input = NewInput() with
+        {
+            ConfigTomlPresent = true,
+            HostBindingPresent = true,
+            BoundHostRepo = "J-Tech-Japan/MyIntentHost",
+            ObservedRemoteUrl = "https://github.com/J-Tech-Japan/MyIntentHost.git",
+            IntentsDomainDirectoryPresent = true,
+            AgentsMarkdownPresent = false,
+            ClaudeMarkdownPresent = false,
+            QueueStateJsonPresent = true,
+            RunsJsonlPresent = true,
+            TargetRepo = "J-Tech-Japan/intent-system"
+        };
+
+        var result = IntentHostCheckAnalyzer.Analyze(input);
+
+        Assert.Equal("partially-initialized", result.Classification);
+        Assert.False(result.Ok);
+        Assert.Contains("AGENTS.md", result.Summary, StringComparison.Ordinal);
+        Assert.Contains("CLAUDE.md", result.Summary, StringComparison.Ordinal);
+        Assert.Contains(result.RemediationSteps, s => s.Contains("intent init", StringComparison.Ordinal) && s.Contains("--write", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Analyze_QueueStateMissing_ReturnsPartiallyInitialized_RecommendsHostLoopWake()
+    {
+        var input = NewInput() with
+        {
+            ConfigTomlPresent = true,
+            HostBindingPresent = true,
+            BoundHostRepo = "J-Tech-Japan/MyIntentHost",
+            ObservedRemoteUrl = "https://github.com/J-Tech-Japan/MyIntentHost.git",
+            IntentsDomainDirectoryPresent = true,
+            AgentsMarkdownPresent = true,
+            ClaudeMarkdownPresent = true,
+            QueueStateJsonPresent = false,
+            RunsJsonlPresent = false
+        };
+
+        var result = IntentHostCheckAnalyzer.Analyze(input);
+
+        Assert.Equal("partially-initialized", result.Classification);
+        Assert.Contains(result.RemediationSteps, s => s.Contains("queue-state.json", StringComparison.Ordinal));
+        Assert.Contains(result.RemediationSteps, s => s.Contains("runs.jsonl", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Analyze_WrongHost_BeatsMissingDomain()
+    {
+        // Wrong-host should fire BEFORE checking domain-not-bootstrapped, so
+        // the operator sees the host-mismatch first.
+        var input = NewInput() with
+        {
+            ConfigTomlPresent = true,
+            HostBindingPresent = true,
+            BoundHostRepo = "J-Tech-Japan/CanonicalHost",
+            ObservedRemoteUrl = "https://github.com/J-Tech-Japan/WrongHost.git",
+            IntentsDomainDirectoryPresent = false
+        };
+
+        var result = IntentHostCheckAnalyzer.Analyze(input);
+
+        Assert.Equal("wrong-host", result.Classification);
+    }
+
+    [Fact]
+    public void Analyze_RequiresDomain()
+    {
+        var input = NewInput() with { Domain = "" };
+
+        Assert.Throws<ArgumentException>(() => IntentHostCheckAnalyzer.Analyze(input));
+    }
+
+    private static IntentHostCheckInput NewInput() =>
+        new()
+        {
+            RepoRoot = "/tmp/host",
+            Domain = "intent-cli",
+            TargetRepo = null,
+            ObservedRemoteUrl = null,
+            ChildSubmodulePath = null,
+            ConfigTomlPresent = false,
+            HostBindingPresent = false,
+            BoundHostRepo = null,
+            IntentsDomainDirectoryPresent = false,
+            AgentsMarkdownPresent = false,
+            ClaudeMarkdownPresent = false,
+            QueueStateJsonPresent = false,
+            RunsJsonlPresent = false
+        };
+}


### PR DESCRIPTION
## Summary
Adds a read-only smoke check so a chat agent can verify a parent host repo is a canonical, fully-initialized intent host BEFORE relying on it for packet/issue/review/next-slice work. Classifies the host into one of six terminal states with structured remediation steps that quote exact commands.

**Pure analyzer `IntentHostCheckAnalyzer`** (no I/O, no `gh` calls):
- `uninitialized` — no `.intent-cli/config.toml`; recommend `intent-cli intent init` (G293/G301) and re-run host-check.
- `wrong-host` — `host-binding.toml` records a different host repo than the observed git remote; reuses `WrongHostGuard` (G301) remediation steps so the operator either `cd`s back to the canonical host or runs an explicit cross-host migration.
- `missing-host-binding` — `config.toml` exists but `host-binding.toml` is absent (pre-G301 host); recommend re-running `intent init` with `--host-repo`.
- `domain-not-bootstrapped` — host binding present but no `intents/<domain>/` directory; recommend running `intent init` for that specific domain.
- `partially-initialized` — required onboarding artifacts missing (`AGENTS.md`, `CLAUDE.md`, `.intent-cli/queue-state.json`, `.intent-cli/runs.jsonl`); remediation lists exact files and recommends idempotent `intent init` re-run for AGENTS/CLAUDE while pointing host-loop wakes at queue-state/runs.
- `ok` — all required artifacts present, host binding matches observed remote; summary names the bound host, target repo, and optional child submodule path.

Priority order: `uninitialized` → `wrong-host` → `missing-host-binding` → `domain-not-bootstrapped` → `partially-initialized` → `ok`. The analyzer short-circuits on the first match so the operator sees the most actionable signal first.

**`intent-cli intent host-check --domain <name> [--target-repo <owner/repo>] [--observed-remote <url>] [--child-submodule-path <path>] [--format markdown|json]`**:
- captures `.intent-cli/config.toml`, `host-binding.toml`, `intents/<domain>/`, `AGENTS.md`, `CLAUDE.md`, `.intent-cli/queue-state.json`, `.intent-cli/runs.jsonl` presence,
- parses `host-binding.toml` via Tomlyn to extract `host_repo` / `target_repo`,
- captures the observed git remote via `git remote get-url origin` (test seam: `--observed-remote` flag overrides),
- feeds the analyzer and emits markdown / JSON,
- exit 0 when `ok: true`; exit 1 otherwise so loop callers can short-circuit on a non-ok host.

**Bootstrap-friendly**: `Program.Main` recognizes `intent host-check` alongside `intent init` so the command runs cleanly from a fresh host with no `.intent-cli/` directory yet (returns the `uninitialized` classification with the canonical `intent init` command in remediation, not the G299 missing-host-state guidance).

## Test plan
- [x] `dotnet test --filter IntentHostCheckAnalyzerTests` — 9 passed.
- [x] Cases cover every classification: fully initialized + matching binding → `ok` with summary naming the bound host / target repo / child submodule path; no config → `uninitialized` recommending `intent-cli intent init`; bound host vs observed remote mismatch → `wrong-host` reusing `WrongHostGuard` remediation; config but no binding → `missing-host-binding`; binding but no `intents/<domain>/` → `domain-not-bootstrapped`; missing AGENTS/CLAUDE → `partially-initialized` with idempotent `intent init` re-run; missing queue/runs → `partially-initialized` recommending host-loop wake; wrong-host beats `domain-not-bootstrapped` (priority); missing `--domain` rejected.
- [x] Smoke-tested the built binary from `/Users/tomohisa/dev/GitHub/MyIntentHost`: returns `classification: missing-host-binding` (the host predates G301), correctly identifies the observed remote URL, and emits the canonical re-run command in remediation.
- [x] Full Cli test suite: 2276 passed, 1 skipped, 0 failed.

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)