### PR TITLE
G314: agent-specific local scheduling contract in prompt-matrix

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -166,11 +166,38 @@ $@"IMPORTANT — frequency is unresolved; ask the operator for the desired frequ
             _ => $"Schedule via the agent's local same-thread/current-thread automation at {frequency}; cloud or new-thread schedulers cannot access local paths."
         };
 
+        var schedulingContract = RenderLocalSchedulingContract(resolvedAgent, frequency);
+
         return
 $@"Frequency: {frequency} (operator-resolved). {schedulingHint}
 - High-frequency local loops (active development): 5 minutes.
-- Low-frequency local loops (background / idle polling): ~20 minutes.";
+- Low-frequency local loops (background / idle polling): ~20 minutes.
+
+{schedulingContract}";
     }
+
+    /// <summary>
+    /// G314: agent-specific local scheduling contract surfaced as a
+    /// stand-alone hard rule paragraph in the rendered prompt. The
+    /// substance was previously buried as a single-sentence frequency
+    /// hint, which let Codex spawn a new thread or remote scheduler
+    /// that could not reach the operator's local <c>.intent-cli</c>
+    /// host paths. This block names the wake primitive each agent
+    /// must use, the local-path access requirement, and the explicit
+    /// forbidden list (new thread / remote scheduler / cloud schedule
+    /// / disconnected monitor) so a fresh agent has no path to a
+    /// non-local schedule.
+    /// </summary>
+    private static string RenderLocalSchedulingContract(string resolvedAgent, string frequency) =>
+        resolvedAgent switch
+        {
+            AgentClaude =>
+$@"**Local scheduling contract (G314)**: this loop runs **same-thread** in the active Claude Code session via `/loop {frequency} <prompt>`. Each wake reuses this thread's local filesystem paths (host repo cwd, child worktree, `.intent-cli/` packages); a different thread / new chat / remote process cannot reach those paths. Do NOT create a new Claude Code thread, a separate chat, a remote/cloud scheduler, an external cron, an out-of-process monitor, or any automation that cannot exec the host's local `intent-cli` against the host repo. If `/loop` is unavailable in the current session, surface the gap to the operator instead of substituting a non-local schedule.",
+            AgentCodex =>
+$@"**Local scheduling contract (G314)**: this loop runs **current-thread** in the active Codex session via local-automation / heartbeat at {frequency}. Each wake reuses this thread's local filesystem paths (host repo cwd, child worktree, `.intent-cli/` packages); a different thread / new chat / remote process cannot reach those paths. Do NOT spawn a new Codex thread, a separate chat, a remote/cloud scheduler, an external cron, an out-of-process monitor, or any automation that cannot exec the host's local `intent-cli` against the host repo. If current-thread heartbeat is unavailable in this session, surface the gap to the operator instead of substituting a non-local schedule.",
+            _ =>
+$@"**Local scheduling contract (G314)**: this loop runs in the **agent's current-thread / same-session** automation surface at {frequency}. Each wake reuses this thread's local filesystem paths (host repo cwd, child worktree, `.intent-cli/` packages); a different thread / new chat / remote process cannot reach those paths. Do NOT create a new thread / chat, a remote/cloud scheduler, an external cron, an out-of-process monitor, or any automation that cannot exec the host's local `intent-cli` against the host repo. If the agent has no same-thread loop primitive, surface the gap to the operator instead of substituting a non-local schedule."
+        };
 
     private static string NormalizeAgent(string? agent)
     {

--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -152,11 +152,26 @@ internal static class GuidePromptMatrixCommand
         var resolvedAgent = NormalizeAgent(agent);
         if (string.IsNullOrWhiteSpace(frequency))
         {
+            // G314 review feedback (PR #732): the local scheduling contract
+            // must surface BEFORE the operator resolves `--frequency`. The
+            // typical operator path is to ask the agent to set up a loop
+            // without naming an interval; the agent calls
+            // `prompt-matrix` to learn the contract, then asks the operator
+            // for the interval. If this branch only emits the short
+            // paragraph, the agent never sees the agent-specific
+            // current-thread / `/loop` requirement and may pick a
+            // separate-thread or remote schedule before the interval is
+            // even resolved. So we emit the same per-agent contract here
+            // with `<frequency>` as a placeholder, plus the standard
+            // forbidden list.
+            var unresolvedSchedulingContract = RenderLocalSchedulingContract(resolvedAgent, "<frequency>");
             return
 $@"IMPORTANT — frequency is unresolved; ask the operator for the desired frequency before creating any cron, monitor, or recurring wakeup. Never guess or use a tool-default interval.
 - High-frequency local loops (active development): 5 minutes.
 - Low-frequency local loops (background / idle polling): ~20 minutes.
-- Local same-thread loops are the baseline for workflows that depend on local paths or local `.intent-cli` packages. Cloud or new-thread schedulers cannot access local paths.";
+- Local same-thread loops are the baseline for workflows that depend on local paths or local `.intent-cli` packages. Cloud or new-thread schedulers cannot access local paths.
+
+{unresolvedSchedulingContract}";
         }
 
         var schedulingHint = resolvedAgent switch

--- a/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
@@ -978,6 +978,92 @@ public sealed class GuidePromptMatrixCommandTests
     }
 
     [Fact]
+    public void Execute_HostLoopPrompt_AgentCodex_NoFrequency_StillEmitsSchedulingContract_G314()
+    {
+        // G314 review feedback on PR #732: the operator's typical setup
+        // request omits `--frequency`; the agent calls `prompt-matrix`,
+        // learns the contract, then asks the operator for the interval.
+        // The unresolved-frequency branch must therefore still emit the
+        // per-agent G314 contract so the agent knows BEFORE the interval
+        // is resolved that it must use current-thread heartbeat / `/loop`
+        // and never a remote scheduler.
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--domain", "intent-system", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "codex", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Local scheduling contract (G314)", prompt, StringComparison.Ordinal);
+        Assert.Contains("current-thread", prompt, StringComparison.Ordinal);
+        Assert.Contains("heartbeat", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do NOT spawn a new Codex thread", prompt, StringComparison.Ordinal);
+        Assert.Contains("remote/cloud scheduler", prompt, StringComparison.Ordinal);
+        Assert.Contains("external cron", prompt, StringComparison.Ordinal);
+        Assert.Contains("out-of-process monitor", prompt, StringComparison.Ordinal);
+        // Frequency is still unresolved — the IMPORTANT preamble must
+        // still tell the agent to ask the operator before scheduling.
+        Assert.Contains("frequency is unresolved", prompt, StringComparison.Ordinal);
+        // The placeholder `<frequency>` should appear in the contract so
+        // the agent has language to reuse once the operator answers.
+        Assert.Contains("at <frequency>", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostLoopPrompt_AgentClaude_NoFrequency_StillEmitsSchedulingContract_G314()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--domain", "intent-system", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Local scheduling contract (G314)", prompt, StringComparison.Ordinal);
+        Assert.Contains("same-thread", prompt, StringComparison.Ordinal);
+        // Claude's wake primitive uses `/loop <frequency> <prompt>` — when
+        // the operator hasn't picked an interval yet the placeholder should
+        // be `<frequency>` so the agent can substitute later.
+        Assert.Contains("/loop <frequency> <prompt>", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do NOT create a new Claude Code thread", prompt, StringComparison.Ordinal);
+        Assert.Contains("frequency is unresolved", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildLoopPrompt_AgentCodex_NoFrequency_StillEmitsSchedulingContract_G314()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--domain", "intent-system", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "codex", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Local scheduling contract (G314)", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do NOT spawn a new Codex thread", prompt, StringComparison.Ordinal);
+        Assert.Contains("frequency is unresolved", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildLoopPrompt_AgentClaude_NoFrequency_StillEmitsSchedulingContract_G314()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--domain", "intent-system", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Local scheduling contract (G314)", prompt, StringComparison.Ordinal);
+        Assert.Contains("/loop <frequency> <prompt>", prompt, StringComparison.Ordinal);
+        Assert.Contains("frequency is unresolved", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_HostLoopPrompt_DocumentsDoctorBinarySourceAcceptance_G314()
     {
         // G314 acceptance: doctor `status: ok` accepts both

--- a/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
@@ -881,6 +881,121 @@ public sealed class GuidePromptMatrixCommandTests
     }
 
     [Fact]
+    public void Execute_HostLoopPrompt_AgentCodex_NamesCurrentThreadHeartbeatAndForbidsNewThread_G314()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--domain", "intent-system", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "codex", "--frequency", "5m", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        // The G314 hard rule must appear with its name + agent-specific content.
+        Assert.Contains("Local scheduling contract (G314)", prompt, StringComparison.Ordinal);
+        Assert.Contains("current-thread", prompt, StringComparison.Ordinal);
+        Assert.Contains("heartbeat", prompt, StringComparison.Ordinal);
+        // The forbidden list must explicitly reject every common non-local
+        // surface so Codex has no path to a separate-thread schedule.
+        Assert.Contains("Do NOT spawn a new Codex thread", prompt, StringComparison.Ordinal);
+        Assert.Contains("remote/cloud scheduler", prompt, StringComparison.Ordinal);
+        Assert.Contains("external cron", prompt, StringComparison.Ordinal);
+        Assert.Contains("out-of-process monitor", prompt, StringComparison.Ordinal);
+        // The operator-supplied frequency must appear in the contract so the
+        // agent is reminded which interval to wake at.
+        Assert.Contains("at 5m", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostLoopPrompt_AgentClaude_NamesSameThreadLoopPrimitive_G314()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--domain", "intent-system", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude", "--frequency", "5m", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Local scheduling contract (G314)", prompt, StringComparison.Ordinal);
+        Assert.Contains("same-thread", prompt, StringComparison.Ordinal);
+        // The Claude rule names `/loop <frequency> <prompt>` as the
+        // canonical wake primitive.
+        Assert.Contains("/loop 5m <prompt>", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do NOT create a new Claude Code thread", prompt, StringComparison.Ordinal);
+        Assert.Contains("remote/cloud scheduler", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildLoopPrompt_AgentCodex_IncludesLocalSchedulingContract_G314()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--domain", "intent-system", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "codex", "--frequency", "5m", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Local scheduling contract (G314)", prompt, StringComparison.Ordinal);
+        Assert.Contains("current-thread", prompt, StringComparison.Ordinal);
+        Assert.Contains("Do NOT spawn a new Codex thread", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildLoopPrompt_AgentClaude_IncludesLocalSchedulingContract_G314()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--domain", "intent-system", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude", "--frequency", "5m", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Local scheduling contract (G314)", prompt, StringComparison.Ordinal);
+        Assert.Contains("/loop 5m <prompt>", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostLoopPrompt_AgentGeneric_StillIncludesContractWithoutAgentSpecificPrimitive_G314()
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--domain", "intent-system", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "generic", "--frequency", "5m", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Local scheduling contract (G314)", prompt, StringComparison.Ordinal);
+        // Generic agent must still name same-thread / current-thread, must
+        // still forbid remote/cloud schedules, but must NOT name `/loop` or
+        // `Codex` as the primitive (those are agent-specific).
+        Assert.Contains("current-thread", prompt, StringComparison.Ordinal);
+        Assert.Contains("remote/cloud scheduler", prompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("/loop 5m <prompt>", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HostLoopPrompt_DocumentsDoctorBinarySourceAcceptance_G314()
+    {
+        // G314 acceptance: doctor `status: ok` accepts both
+        // `path-global-tool` and `cwd-local-shim`. The prompt already
+        // surfaces this — lock it down so a regression cannot drop it.
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--domain", "intent-system", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude", "--frequency", "5m", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("path-global-tool", prompt, StringComparison.Ordinal);
+        Assert.Contains("cwd-local-shim", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_HostLoopPrompt_OrdersPublishRecoveryBeforeReconcile_G313()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary
- Promotes the agent-specific scheduling rule from a single-sentence frequency hint to a stand-alone `**Local scheduling contract (G314)**` paragraph rendered directly under the frequency block in every recurring prompt (host-loop + child-loop, both `host-` and `child-` modes).
- Three agent-specific variants:
  - **Codex** — name *current-thread local automation / heartbeat* at the resolved frequency; forbid spawning a new Codex thread / separate chat / remote-cloud scheduler / external cron / out-of-process monitor / any automation that cannot exec the host's local `intent-cli`.
  - **Claude** — name same-thread `/loop <frequency> <prompt>` as the canonical wake primitive with the same forbidden list.
  - **Generic** — same-thread / current-thread automation generically; same forbidden list; no agent-specific primitive named.
- When the agent surface lacks a same-thread loop primitive, the rule tells the agent to surface the gap to the operator rather than substitute a non-local schedule.

## Why
Incident: Codex review automation for SekibanAsAService ran in a separate thread instead of the current thread because the existing scheduling hint was a single line buried inside the frequency block; Codex chose a separate chat that could not access local paths. G314 makes the agent-specific contract a top-level hard rule with an explicit forbidden list, so a fresh agent has no path to a non-local schedule.

## Test plan
- [x] `dotnet test` (full suite, 2365 passed / 1 skipped)
- [x] `GuidePromptMatrixCommandTests` — 6 new G314 tests:
  - host-loop --agent codex: contains contract header + `current-thread` + `heartbeat` + `Do NOT spawn a new Codex thread` + remote/cloud/cron/monitor forbidden list + frequency interpolation
  - host-loop --agent claude: contains `same-thread` + `/loop 5m <prompt>` + `Do NOT create a new Claude Code thread`
  - child-loop --agent codex / claude: same contract appears under child-loop too
  - host-loop --agent generic: contract appears with generic wording but does NOT name `/loop` or `Codex` as the primitive
  - host-loop --agent claude: locks in doctor `binary_source` acceptance for both `path-global-tool` and `cwd-local-shim`
- [ ] Manual: `intent-cli guide prompt-matrix --mode host-loop --agent codex --frequency 5m --format markdown` — confirm the contract paragraph is visible and unambiguous
- [ ] Manual: `intent-cli guide prompt-matrix --mode host-loop --agent claude --frequency 5m --format markdown` — same

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)