### PR TITLE
G317: explicit one-shot task planners for controller-driven dispatch

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -24,6 +24,7 @@ internal static class CommandRouter
         "automation",
         "safety",
         "tasking",
+        "task",
         "worker",
         "metadata",
         "guide",
@@ -195,6 +196,13 @@ internal static class CommandRouter
             {
                 ["validate"] = MetadataValidateCommand.Execute,
                 ["update"] = MetadataUpdateCommand.Execute
+            },
+            ["task"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["issue-to-pr"] = (ctx, args, w) => TaskCommand.Execute(ctx, ["issue-to-pr", .. args], w),
+                ["review-pr"] = (ctx, args, w) => TaskCommand.Execute(ctx, ["review-pr", .. args], w),
+                ["fix-pr-comments"] = (ctx, args, w) => TaskCommand.Execute(ctx, ["fix-pr-comments", .. args], w),
+                ["publish-next-issue"] = (ctx, args, w) => TaskCommand.Execute(ctx, ["publish-next-issue", .. args], w)
             },
             ["tasking"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -295,6 +295,20 @@ internal static class CommandRouter
             return RunCommand.Execute(context, [], writer);
         }
 
+        // G317 review-fix: `intent-cli task` (no subcommand) and
+        // `intent-cli task --help` must reach the task help surface.
+        // Without this special-case, `task` falls through to the
+        // "group and subcommand required" branch and `task --help`
+        // looks up "--help" in the per-group dictionary and fails as
+        // "not yet implemented", which makes the task surface
+        // undiscoverable from the installed CLI entry path.
+        if (string.Equals(args[0], "task", StringComparison.Ordinal)
+            && (args.Length == 1
+                || (args.Length == 2 && string.Equals(args[1], "--help", StringComparison.Ordinal))))
+        {
+            return TaskCommand.Execute(context, args[1..], writer);
+        }
+
         if (args.Length < 2)
         {
             writer.WriteLine("A command group and subcommand are required.");

--- a/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
@@ -166,6 +166,14 @@ internal static class GuideCommandsListCommand
         },
         new CommandGroupEntry
         {
+            Name = "task",
+            Classification = ClassificationSupport,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerOperator,
+            Purpose = "G317 explicit one-shot task planners (issue-to-pr / review-pr / fix-pr-comments / publish-next-issue). Returns a bounded executable contract — preconditions, steps, label transitions, abort conditions — for controllers that already know the target. Read-only: never calls gh, never mutates state, never launches AI providers."
+        },
+        new CommandGroupEntry
+        {
             Name = "intake",
             Classification = ClassificationExperimental,
             Mutability = MutabilityMixed,

--- a/src/IntentSystem.Cli/Commands/TaskCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskCommand.cs
@@ -1,0 +1,708 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G317: Explicit one-shot task planner surface. A controller thread or
+/// operator who already knows the target (issue #N, PR #N, or "publish
+/// the next issue") can ask intent-cli for a bounded executable contract
+/// instead of starting from a selector loop. Four subcommands:
+/// <list type="bullet">
+///   <item><c>task issue-to-pr --repo &lt;r&gt; --issue &lt;n&gt; --workdir &lt;path&gt;</c></item>
+///   <item><c>task review-pr --repo &lt;r&gt; --pr &lt;n&gt; --domain &lt;d&gt;</c></item>
+///   <item><c>task fix-pr-comments --repo &lt;r&gt; --pr &lt;n&gt; --workdir &lt;path&gt;</c></item>
+///   <item><c>task publish-next-issue --domain &lt;d&gt; --target-repo &lt;r&gt;</c></item>
+/// </list>
+///
+/// Each planner is read-only: it validates the explicit numbers/paths,
+/// builds the exact CLI step sequence the controller should run, and
+/// names the label transitions and abort conditions. It does not call
+/// <c>gh</c>, does not mutate state, and never launches an AI provider —
+/// the steps it returns DO mutate state when the controller chooses to
+/// run them. Selector-driven loops (`worker next-action`,
+/// `host-review-preflight`, `intent next-slice`) remain valid and
+/// unchanged; this surface is the controller-dispatch alternative.
+/// </summary>
+internal static class TaskCommand
+{
+    private const string KindIssueToPr = "issue-to-pr";
+    private const string KindReviewPr = "review-pr";
+    private const string KindFixPrComments = "fix-pr-comments";
+    private const string KindPublishNextIssue = "publish-next-issue";
+
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli task <issue-to-pr|review-pr|fix-pr-comments|publish-next-issue> [--repo <r>] "
+        + "[--issue <n>] [--pr <n>] [--workdir <path>] [--domain <d>] [--target-repo <r>] "
+        + "[--format markdown|json]";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 0
+            || (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal)))
+        {
+            WriteHelp(writer);
+            return args.Length == 0 ? 1 : 0;
+        }
+
+        var kind = args[0];
+        var rest = args[1..];
+
+        return kind switch
+        {
+            KindIssueToPr => PlanIssueToPr(rest, writer),
+            KindReviewPr => PlanReviewPr(rest, writer),
+            KindFixPrComments => PlanFixPrComments(rest, writer),
+            KindPublishNextIssue => PlanPublishNextIssue(rest, writer),
+            _ => UnknownKind(kind, writer)
+        };
+    }
+
+    private static int UnknownKind(string kind, TextWriter writer)
+    {
+        writer.WriteLine($"Unknown task kind '{kind}'.");
+        writer.WriteLine(UsageLine);
+        return 1;
+    }
+
+    // ---- task issue-to-pr ---------------------------------------------------
+
+    private static int PlanIssueToPr(string[] args, TextWriter writer)
+    {
+        if (!TryParse(args, out var parsed, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var refusals = new List<string>();
+        if (string.IsNullOrWhiteSpace(parsed.Repo))
+        {
+            refusals.Add("--repo <owner/repo> is required for task issue-to-pr.");
+        }
+        if (parsed.Issue is null)
+        {
+            refusals.Add("--issue <n> is required for task issue-to-pr.");
+        }
+        if (string.IsNullOrWhiteSpace(parsed.Workdir))
+        {
+            refusals.Add("--workdir <path> is required for task issue-to-pr (the child implementation worktree).");
+        }
+
+        if (refusals.Count > 0)
+        {
+            return EmitRefusal(KindIssueToPr, parsed, refusals, writer);
+        }
+
+        var plan = new TaskPlan
+        {
+            Task = KindIssueToPr,
+            Repo = parsed.Repo,
+            Issue = parsed.Issue,
+            Pr = null,
+            Workdir = parsed.Workdir,
+            Domain = parsed.Domain,
+            TargetRepo = parsed.TargetRepo,
+            Summary = $"Implement {parsed.Repo}#{parsed.Issue}: claim the issue, branch off main in {parsed.Workdir}, run the issue-to-PR workflow on the source URL ONLY, open a PR with `Closes #{parsed.Issue}` (G311), then summarize and complete via `worker complete`.",
+            Preconditions = new[]
+            {
+                "Operator/controller has authoritatively selected this issue number — no selector lookup is performed by this planner.",
+                $"Workdir `{parsed.Workdir}` is the child-cwd implementation repo (no `.intent-cli/` per G300; presence is fine but child loop must NOT read it).",
+                "`gh auth status` is clean and `intent-cli` resolves on PATH (G305 abort gates).",
+                "`intent-cli automation doctor --format json` reports `status: ok` (no `stale-host-cli`).",
+                "If parent host workdir is dirty, host-side has already run `automation host-sync-preflight` + `automation durable-state-preflight` per G304/G306/G312 — child loop never repairs parent metadata."
+            },
+            Steps = new[]
+            {
+                $"intent-cli worker claim --kind issue --repo {parsed.Repo} --number {parsed.Issue} --write --format json",
+                $"cd {parsed.Workdir} && git checkout main && git pull --ff-only && git checkout -b claude/g-issue-{parsed.Issue}",
+                $"# Read GitHub issue body (gh issue view {parsed.Issue} --repo {parsed.Repo} --json title,body,labels) — it IS the implementation contract; do not read repo skill files for routine work.",
+                "# Implement the narrow scope; tests + build green.",
+                $"git push -u origin claude/g-issue-{parsed.Issue}",
+                $"# Open PR via `gh pr create --repo {parsed.Repo} --base main --title \"...\" --body \"... Closes #{parsed.Issue}\"` (G311 — body MUST contain Closes/Fixes/Resolves #{parsed.Issue}; `worker complete` validates and refuses on missing/wrong/multiple).",
+                $"intent-cli automation base-branch-check --repo {parsed.Repo} --pr <new-pr-n> --policy direct-main --actual-base $(gh pr view <new-pr-n> --repo {parsed.Repo} --json baseRefName --jq .baseRefName) --format json",
+                $"IS_DRAFT=$(gh pr view <new-pr-n> --repo {parsed.Repo} --json isDraft --jq .isDraft)",
+                $"intent-cli worker result-summary --kind issue-to-pr --repo {parsed.Repo} --outcome pr-created --issue {parsed.Issue} --pr <new-pr-n> --pr-draft $IS_DRAFT --format json",
+                $"intent-cli worker complete --kind issue --repo {parsed.Repo} --number {parsed.Issue} --outcome pr-created --pr <new-pr-n> --write --format json"
+            },
+            LabelTransitions = new[]
+            {
+                "claim → add `intent-issue-in-progress` (issue side); the host owns `intent-target` and never the child.",
+                "complete pr-created → swap `intent-issue-in-progress` → `intent-pr-created` on the source ISSUE (NEVER on the PR — G287/G317).",
+                "Child loop NEVER applies `intent-target` and NEVER applies `intent-pr-created` directly to a PR."
+            },
+            AbortConditions = new[]
+            {
+                "Wrong repo: `gh pr view` reports a different `repository.nameWithOwner` than --repo → stop, do not push, surface the gap.",
+                "Active lease conflict: `worker claim` returns errors other than the expected linked_pr_synced warning → stop, do not re-claim without operator authorization.",
+                "Missing closing reference: `worker complete` refuses because PR body lacks `Closes #" + parsed.Issue + "` → repair PR body and retry; never approve without the reference (G311).",
+                "Base branch policy mismatch: `automation base-branch-check` reports a non-`main` base → stop, surface the gap.",
+                "`linked_pr_synced: false` from `worker complete` is the EXPECTED child-cwd warning (G300); not an abort."
+            },
+            Notes = new[]
+            {
+                "`task issue-to-pr` is the explicit-target counterpart to `worker next-action` returning `action: issue-to-pr`. The dispatch contract is identical; only the discovery path differs.",
+                "Selector loops remain valid — use `worker next-action` for autonomous polling, this planner for controller-driven dispatch.",
+                "Never launch Claude/Codex/AI providers from `intent-cli`; this planner is text-only."
+            }
+        };
+
+        WritePlan(plan, parsed.Format, writer);
+        return 0;
+    }
+
+    // ---- task review-pr -----------------------------------------------------
+
+    private static int PlanReviewPr(string[] args, TextWriter writer)
+    {
+        if (!TryParse(args, out var parsed, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var refusals = new List<string>();
+        if (string.IsNullOrWhiteSpace(parsed.Repo))
+        {
+            refusals.Add("--repo <owner/repo> is required for task review-pr.");
+        }
+        if (parsed.Pr is null)
+        {
+            refusals.Add("--pr <n> is required for task review-pr.");
+        }
+        if (string.IsNullOrWhiteSpace(parsed.Domain))
+        {
+            refusals.Add("--domain <name> is required for task review-pr (G316 packet/intent-aware review).");
+        }
+
+        if (refusals.Count > 0)
+        {
+            return EmitRefusal(KindReviewPr, parsed, refusals, writer);
+        }
+
+        var plan = new TaskPlan
+        {
+            Task = KindReviewPr,
+            Repo = parsed.Repo,
+            Issue = null,
+            Pr = parsed.Pr,
+            Workdir = parsed.Workdir,
+            Domain = parsed.Domain,
+            TargetRepo = parsed.TargetRepo,
+            Summary = $"Host-review {parsed.Repo}#{parsed.Pr} for domain `{parsed.Domain}`. Decision branches: pass → approve+merge+closeout (G297 — `--pr-merged` gate); fail → actionable comment + request-update (G316 classification); host-metadata blockers → recovery via `automation publish-recovery` / `automation reconcile`, never PR comments (G287/G313/G315).",
+            Preconditions = new[]
+            {
+                "Operator/controller has authoritatively selected this PR number — no `host-review-preflight` selector pass is performed by this planner.",
+                $"PR is non-draft (G297): `IS_DRAFT=$(gh pr view {parsed.Pr} --repo {parsed.Repo} --json isDraft --jq .isDraft)` → if `true`, classify `draft-merge-blocked`, run `pr-transition --transition review-release --write` to drop `intent-pr-reviewing` cleanly, surface gap. Never apply final approval to a draft PR.",
+                "Pre-wake host sync (G304): host has run `automation host-sync-preflight` and either `clean` or `verified-commit-ready` via `durable-state-preflight`; refuse to mutate parent durable state from this planner's contract until that gate is clean.",
+                "G316 intent-and-packet-aware review is REQUIRED — passing tests is necessary but NEVER sufficient for approval."
+            },
+            Steps = new[]
+            {
+                $"intent-cli automation base-branch-check --repo {parsed.Repo} --pr {parsed.Pr} --policy direct-main --actual-base $(gh pr view {parsed.Pr} --repo {parsed.Repo} --json baseRefName --jq .baseRefName) --format json",
+                $"intent-cli review closeout-plan --pr {parsed.Pr} --repo {parsed.Repo} --domain {parsed.Domain} --format json",
+                $"intent-cli guide review --pr {parsed.Pr} --repo {parsed.Repo} --domain {parsed.Domain} --format json",
+                $"# Read packet_paths (packet.yaml/implementation.md/review-context.md/github-body.md) and intent_reference_paths (PR-specific paths from packet only — never broad domain dirs); cite each in the approval summary.",
+                "# Decision A: review passes — emit approval summary satisfying `approval_summary_requirements` (packet contract, AC, OOS, intent reference, tests-pass-paired-with-evidence, G311 Closes ref). Then:",
+                $"  intent-cli automation pr-transition --transition approved --repo {parsed.Repo} --pr {parsed.Pr} --write --format json",
+                "  # merge via host's existing merge step",
+                $"  IS_MERGED=$(gh pr view {parsed.Pr} --repo {parsed.Repo} --json merged --jq .merged)",
+                $"  intent-cli closeout pr --pr {parsed.Pr} --repo {parsed.Repo} --pr-merged $IS_MERGED --write --format json",
+                "# Decision B: review needs implementation repair (`blocker_classification: implementation-review-finding`) — leave actionable PR comment satisfying `request_update_requirements` (classify each finding implementation-finding | host-metadata-blocked | intent-ambiguity; tie to packet/intent clause). Then:",
+                $"  intent-cli automation pr-transition --transition request-update --repo {parsed.Repo} --pr {parsed.Pr} --write --format json",
+                "# Decision C: host-metadata-blocked (no queue item, missing linked_issue/linked_pr, etc.) — DO NOT post PR comment (G287). Run recovery:",
+                $"  intent-cli automation publish-recovery --repo {parsed.Repo} --format json   # G313/G315 lane",
+                $"  intent-cli automation reconcile --lane host-review --repo {parsed.Repo} --format json   # fallback after publish-recovery",
+                "  # If reconcile reports unsafe stops, surface a structured operator stop. Release the lease cleanly with `pr-transition --transition review-release --write`."
+            },
+            LabelTransitions = new[]
+            {
+                "review-start → add `intent-pr-reviewing` (recommended via host-review-preflight; not part of this explicit planner unless the controller asks).",
+                "approved → swap `intent-pr-reviewing` → `intent-pr-approved` on the PR.",
+                "request-update → swap `intent-pr-reviewing` → `intent-pr-request-update` on the PR.",
+                "review-release (used on draft-merge-blocked or host-metadata-blocked stops) → remove `intent-pr-reviewing` without adding `intent-pr-request-update`."
+            },
+            AbortConditions = new[]
+            {
+                "Wrong repo: `closeout-plan` or `guide review` returns a queue item targeting a different repo → stop, surface the gap.",
+                "Wrong domain: `guide review` returns an execution unit whose packet does not belong to --domain → stop with structured clarification.",
+                "Missing closing reference: PR body lacks `Closes #<source-issue>` → fail review with implementation-finding (G311), never approve.",
+                "Unsafe metadata: publish-recovery / reconcile report `unsafe_stops` → surface a structured operator stop, never write parent state.",
+                "Tests-only evidence: approval summary has only `tests passed` and no packet/intent citations → request-update, never approve (G316)."
+            },
+            Notes = new[]
+            {
+                "`task review-pr` is the explicit-target counterpart to autonomous host-review. Selector-driven host-review-preflight remains valid; this is for controllers who already know the PR.",
+                "G316 is non-negotiable: every approval summary must satisfy `guide review` `approval_summary_requirements`.",
+                "Never launch AI providers from intent-cli; this planner only emits text the controller runs."
+            }
+        };
+
+        WritePlan(plan, parsed.Format, writer);
+        return 0;
+    }
+
+    // ---- task fix-pr-comments ----------------------------------------------
+
+    private static int PlanFixPrComments(string[] args, TextWriter writer)
+    {
+        if (!TryParse(args, out var parsed, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var refusals = new List<string>();
+        if (string.IsNullOrWhiteSpace(parsed.Repo))
+        {
+            refusals.Add("--repo <owner/repo> is required for task fix-pr-comments.");
+        }
+        if (parsed.Pr is null)
+        {
+            refusals.Add("--pr <n> is required for task fix-pr-comments.");
+        }
+        if (string.IsNullOrWhiteSpace(parsed.Workdir))
+        {
+            refusals.Add("--workdir <path> is required for task fix-pr-comments (the child implementation worktree).");
+        }
+
+        if (refusals.Count > 0)
+        {
+            return EmitRefusal(KindFixPrComments, parsed, refusals, writer);
+        }
+
+        var plan = new TaskPlan
+        {
+            Task = KindFixPrComments,
+            Repo = parsed.Repo,
+            Issue = null,
+            Pr = parsed.Pr,
+            Workdir = parsed.Workdir,
+            Domain = parsed.Domain,
+            TargetRepo = parsed.TargetRepo,
+            Summary = $"Repair {parsed.Repo}#{parsed.Pr} from the latest actionable review/comment ONLY. Checkout the existing PR head in {parsed.Workdir}, apply the narrow requested change, push to the same branch, then `worker result-summary --kind pr-comment-fix --outcome repair-pushed` and `worker complete --kind pr --outcome repair-pushed --write` to swap labels into rereview-ready.",
+            Preconditions = new[]
+            {
+                "Operator/controller has authoritatively selected this PR number; the latest actionable review/comment on this PR is the ONLY source of repair scope.",
+                "Do NOT rediscover unrelated work via `worker next-action` while a `pr-comment-fix` claim is active.",
+                "PR has `intent-pr-request-update` (or equivalent rereview-blocking label) so a claim transitions cleanly into `intent-pr-update-in-progress`.",
+                "`gh auth status` is clean; `intent-cli automation doctor` reports `status: ok`."
+            },
+            Steps = new[]
+            {
+                $"intent-cli worker claim --kind pr --repo {parsed.Repo} --number {parsed.Pr} --write --format json",
+                $"cd {parsed.Workdir} && git fetch origin && git checkout $(gh pr view {parsed.Pr} --repo {parsed.Repo} --json headRefName --jq .headRefName) && git pull --ff-only",
+                $"# Read latest actionable review/comment via `gh pr view {parsed.Pr} --repo {parsed.Repo} --json comments,reviews` — apply ONLY the narrow requested change.",
+                "# Tests + build green; do NOT broaden scope, do NOT rebase onto unrelated work.",
+                $"git push origin $(gh pr view {parsed.Pr} --repo {parsed.Repo} --json headRefName --jq .headRefName)",
+                $"intent-cli worker result-summary --kind pr-comment-fix --repo {parsed.Repo} --outcome repair-pushed --pr {parsed.Pr} --format json",
+                $"intent-cli worker complete --kind pr --repo {parsed.Repo} --number {parsed.Pr} --outcome repair-pushed --write --format json"
+            },
+            LabelTransitions = new[]
+            {
+                "claim → add `intent-pr-update-in-progress` to the PR (already has `intent-pr-request-update`).",
+                "complete repair-pushed → swap `intent-pr-update-in-progress` → `intent-pr-rereview-ready` and remove `intent-pr-request-update` from the PR.",
+                "Child loop NEVER applies `intent-target` or `intent-pr-created` from this lane."
+            },
+            AbortConditions = new[]
+            {
+                "Wrong PR head: `gh pr view` reports a head SHA different from the local checkout after `git pull` → stop, do not push.",
+                "Scope drift: the diff touches files not referenced by the actionable comment → stop, narrow the change before push.",
+                "Active lease held by another worker without operator re-claim → stop, surface the gap (G305 abort condition).",
+                "`worker complete` returns errors other than the expected linked_pr_synced warning → stop, do not retry blindly."
+            },
+            Notes = new[]
+            {
+                "`task fix-pr-comments` is the explicit-target counterpart to `worker next-action` returning `action: pr-comment-fix`. Process at most one repair per wake.",
+                "Latest-actionable-comment selection is the controller's responsibility; this planner emits the contract once selection is made."
+            }
+        };
+
+        WritePlan(plan, parsed.Format, writer);
+        return 0;
+    }
+
+    // ---- task publish-next-issue -------------------------------------------
+
+    private static int PlanPublishNextIssue(string[] args, TextWriter writer)
+    {
+        if (!TryParse(args, out var parsed, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var refusals = new List<string>();
+        if (string.IsNullOrWhiteSpace(parsed.Domain))
+        {
+            refusals.Add("--domain <name> is required for task publish-next-issue.");
+        }
+        if (string.IsNullOrWhiteSpace(parsed.TargetRepo))
+        {
+            refusals.Add("--target-repo <owner/repo> is required for task publish-next-issue.");
+        }
+
+        if (refusals.Count > 0)
+        {
+            return EmitRefusal(KindPublishNextIssue, parsed, refusals, writer);
+        }
+
+        var plan = new TaskPlan
+        {
+            Task = KindPublishNextIssue,
+            Repo = parsed.Repo,
+            Issue = null,
+            Pr = null,
+            Workdir = parsed.Workdir,
+            Domain = parsed.Domain,
+            TargetRepo = parsed.TargetRepo,
+            Summary = $"Publish ONE next-slice issue for domain `{parsed.Domain}` against `{parsed.TargetRepo}`. Bounded one-shot: `intent next-slice --dry-run` must return `issue-cut-ready`, no Hard Clarification open, candidate Child Issue Contract complete; then `packet draft --write` → `issue publish-flow --write` → `automation issue-publish --write`. WIP cap is honored unless the operator explicitly requested `--allow-wip-cap-override`.",
+            Preconditions = new[]
+            {
+                "Pre-wake host sync (G304): `automation host-sync-preflight` is `clean` (or has been advanced through `durable-state-preflight` and committed).",
+                "Post-merge fresh-state reload (G289): if Stage 1 just merged a PR, `git pull --ff-only` on the host repo BEFORE running `intent next-slice --dry-run`.",
+                "WIP cap honored: no open `intent-target` issue/PR remains, OR operator explicitly approved `--allow-wip-cap-override` for queue warming (G288).",
+                "No Hard Clarification open for the candidate (`recommended_outcome != clarification-required`); stale-clarification-metadata warnings (G285) are NOT a stop."
+            },
+            Steps = new[]
+            {
+                $"intent-cli intent next-slice --dry-run --domain {parsed.Domain} --target-repo {parsed.TargetRepo} --format json",
+                "# Confirm `recommended_outcome: issue-cut-ready` (or `wip-cap-overridden` warning when --allow-wip-cap-override is approved).",
+                $"intent-cli packet draft --execution-unit <id> --target-repo {parsed.TargetRepo} --dry-run --format markdown",
+                $"intent-cli packet draft --execution-unit <id> --target-repo {parsed.TargetRepo} --format json",
+                $"intent-cli issue publish-flow <id> --repo {parsed.TargetRepo} --write --format json",
+                "# After parent durable state is pushed, apply the published label:",
+                $"intent-cli automation issue-publish --repo {parsed.TargetRepo} --issue <new-issue-n> --write --format json"
+            },
+            LabelTransitions = new[]
+            {
+                "`automation issue-publish --write` adds `intent-target` to the newly created issue. The host owns this label; child loops never apply it.",
+                "No PR-side label transitions — this is an issue-publish task."
+            },
+            AbortConditions = new[]
+            {
+                "`intent next-slice --dry-run` returns `clarification-required` with substantive blocker text → run `clarification next` for the structured product-owner question (G310); do not silently publish.",
+                "WIP cap blocks: an open `intent-target` issue/PR remains AND the operator did NOT approve queue warming → stop.",
+                "Child Issue Contract incomplete (missing AC / OOS / Verification) → repair the contract first; do not publish.",
+                "`automation host-sync-preflight` reports `dirty-host-durable-state` without `durable-state-preflight` having converged on `verified-commit-ready` → stop, do not publish on top of a dirty host."
+            },
+            Notes = new[]
+            {
+                "`task publish-next-issue` is the explicit one-shot for the host's Stage 2 publish; selector-driven `intent next-slice` remains valid.",
+                "At most ONE issue is published per wake; this planner intentionally returns no loop or scheduler instruction."
+            }
+        };
+
+        WritePlan(plan, parsed.Format, writer);
+        return 0;
+    }
+
+    // ---- shared planner emission -------------------------------------------
+
+    private static int EmitRefusal(string task, ParsedArgs parsed, IReadOnlyList<string> refusals, TextWriter writer)
+    {
+        var plan = new TaskPlan
+        {
+            Task = task,
+            Repo = parsed.Repo,
+            Issue = parsed.Issue,
+            Pr = parsed.Pr,
+            Workdir = parsed.Workdir,
+            Domain = parsed.Domain,
+            TargetRepo = parsed.TargetRepo,
+            Summary = "structured-refusal: required arguments missing or invalid",
+            Refusals = refusals,
+            Preconditions = Array.Empty<string>(),
+            Steps = Array.Empty<string>(),
+            LabelTransitions = Array.Empty<string>(),
+            AbortConditions = Array.Empty<string>(),
+            Notes = new[]
+            {
+                "Explicit-target planners never guess missing identifiers. Re-run with the required flags supplied.",
+                UsageLine
+            }
+        };
+        WritePlan(plan, parsed.Format, writer);
+        return 1;
+    }
+
+    private static void WritePlan(TaskPlan plan, string format, TextWriter writer)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(plan, JsonOptions));
+            writer.WriteLine();
+            return;
+        }
+
+        WriteMarkdown(plan, writer);
+    }
+
+    private static void WriteMarkdown(TaskPlan plan, TextWriter writer)
+    {
+        writer.WriteLine($"# task {plan.Task}");
+        writer.WriteLine();
+        if (!string.IsNullOrEmpty(plan.Repo))
+        {
+            writer.WriteLine($"- repo: `{plan.Repo}`");
+        }
+        if (plan.Issue is not null)
+        {
+            writer.WriteLine($"- issue: #{plan.Issue}");
+        }
+        if (plan.Pr is not null)
+        {
+            writer.WriteLine($"- pr: #{plan.Pr}");
+        }
+        if (!string.IsNullOrEmpty(plan.Workdir))
+        {
+            writer.WriteLine($"- workdir: `{plan.Workdir}`");
+        }
+        if (!string.IsNullOrEmpty(plan.Domain))
+        {
+            writer.WriteLine($"- domain: `{plan.Domain}`");
+        }
+        if (!string.IsNullOrEmpty(plan.TargetRepo))
+        {
+            writer.WriteLine($"- target-repo: `{plan.TargetRepo}`");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"_Summary:_ {plan.Summary}");
+        writer.WriteLine();
+
+        if (plan.Refusals is { Count: > 0 } refusals)
+        {
+            writer.WriteLine("## Refusals");
+            foreach (var refusal in refusals)
+            {
+                writer.WriteLine($"- {refusal}");
+            }
+            writer.WriteLine();
+        }
+
+        WriteSection(writer, "Preconditions", plan.Preconditions);
+        WriteSection(writer, "Steps", plan.Steps);
+        WriteSection(writer, "Label transitions", plan.LabelTransitions);
+        WriteSection(writer, "Abort conditions", plan.AbortConditions);
+        WriteSection(writer, "Notes", plan.Notes);
+    }
+
+    private static void WriteSection(TextWriter writer, string title, IReadOnlyList<string> entries)
+    {
+        if (entries.Count == 0)
+        {
+            return;
+        }
+        writer.WriteLine($"## {title}");
+        foreach (var entry in entries)
+        {
+            writer.WriteLine($"- {entry}");
+        }
+        writer.WriteLine();
+    }
+
+    // ---- parsing -----------------------------------------------------------
+
+    private readonly record struct ParsedArgs(
+        string? Repo,
+        int? Issue,
+        int? Pr,
+        string? Workdir,
+        string? Domain,
+        string? TargetRepo,
+        string Format);
+
+    private static bool TryParse(string[] args, out ParsedArgs parsed, out string error)
+    {
+        string? repo = null;
+        int? issue = null;
+        int? pr = null;
+        string? workdir = null;
+        string? domain = null;
+        string? targetRepo = null;
+        var format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--repo":
+                    if (!Next(args, ref i, "--repo", out repo, out error))
+                    {
+                        parsed = default;
+                        return false;
+                    }
+                    break;
+                case "--issue":
+                    if (!NextInt(args, ref i, "--issue", out var issueValue, out error))
+                    {
+                        parsed = default;
+                        return false;
+                    }
+                    issue = issueValue;
+                    break;
+                case "--pr":
+                    if (!NextInt(args, ref i, "--pr", out var prValue, out error))
+                    {
+                        parsed = default;
+                        return false;
+                    }
+                    pr = prValue;
+                    break;
+                case "--workdir":
+                    if (!Next(args, ref i, "--workdir", out workdir, out error))
+                    {
+                        parsed = default;
+                        return false;
+                    }
+                    break;
+                case "--domain":
+                    if (!Next(args, ref i, "--domain", out domain, out error))
+                    {
+                        parsed = default;
+                        return false;
+                    }
+                    break;
+                case "--target-repo":
+                    if (!Next(args, ref i, "--target-repo", out targetRepo, out error))
+                    {
+                        parsed = default;
+                        return false;
+                    }
+                    break;
+                case "--format":
+                    if (!Next(args, ref i, "--format", out var requested, out error))
+                    {
+                        parsed = default;
+                        return false;
+                    }
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        parsed = default;
+                        return false;
+                    }
+                    format = requested!;
+                    break;
+                default:
+                    error = $"Unknown argument '{args[i]}'.";
+                    parsed = default;
+                    return false;
+            }
+        }
+
+        parsed = new ParsedArgs(repo, issue, pr, workdir, domain, targetRepo, format);
+        return true;
+    }
+
+    private static bool Next(string[] args, ref int i, string flag, out string? value, out string error)
+    {
+        if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+        {
+            value = null;
+            error = $"{flag} requires a value.";
+            return false;
+        }
+        value = args[++i].Trim();
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool NextInt(string[] args, ref int i, string flag, out int value, out string error)
+    {
+        if (!Next(args, ref i, flag, out var raw, out error))
+        {
+            value = 0;
+            return false;
+        }
+        if (!int.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out value)
+            || value <= 0)
+        {
+            error = $"{flag} must be a positive integer (got '{raw}').";
+            return false;
+        }
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("task — explicit one-shot planners for controller-driven dispatch (G317).");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine();
+        writer.WriteLine("Subcommands:");
+        writer.WriteLine($"- {KindIssueToPr} --repo <r> --issue <n> --workdir <path> [--format markdown|json]");
+        writer.WriteLine($"- {KindReviewPr} --repo <r> --pr <n> --domain <d> [--format markdown|json]");
+        writer.WriteLine($"- {KindFixPrComments} --repo <r> --pr <n> --workdir <path> [--format markdown|json]");
+        writer.WriteLine($"- {KindPublishNextIssue} --domain <d> --target-repo <r> [--format markdown|json]");
+        writer.WriteLine();
+        writer.WriteLine("Each subcommand returns a bounded executable contract: preconditions, steps, label transitions, abort conditions, and notes. The planner is read-only — it does not call gh, does not mutate state, and never launches an AI provider.");
+    }
+}
+
+/// <summary>
+/// G317: structured planner output for a `task &lt;kind&gt;` invocation.
+/// </summary>
+internal sealed record TaskPlan
+{
+    [JsonPropertyName("task")]
+    public required string Task { get; init; }
+
+    [JsonPropertyName("repo")]
+    public string? Repo { get; init; }
+
+    [JsonPropertyName("issue")]
+    public int? Issue { get; init; }
+
+    [JsonPropertyName("pr")]
+    public int? Pr { get; init; }
+
+    [JsonPropertyName("workdir")]
+    public string? Workdir { get; init; }
+
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
+
+    [JsonPropertyName("target_repo")]
+    public string? TargetRepo { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("refusals")]
+    public IReadOnlyList<string>? Refusals { get; init; }
+
+    [JsonPropertyName("preconditions")]
+    public required IReadOnlyList<string> Preconditions { get; init; }
+
+    [JsonPropertyName("steps")]
+    public required IReadOnlyList<string> Steps { get; init; }
+
+    [JsonPropertyName("label_transitions")]
+    public required IReadOnlyList<string> LabelTransitions { get; init; }
+
+    [JsonPropertyName("abort_conditions")]
+    public required IReadOnlyList<string> AbortConditions { get; init; }
+
+    [JsonPropertyName("notes")]
+    public required IReadOnlyList<string> Notes { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -79,6 +79,72 @@ public sealed class CommandRouterTests
         Assert.Contains("not yet implemented", writer.ToString(), StringComparison.OrdinalIgnoreCase);
     }
 
+    // G317 review-fix: `intent-cli task --help` and `intent-cli task`
+    // must reach TaskCommand's help surface through the real router
+    // entry path, not only through direct `TaskCommand.Execute` calls.
+    [Fact]
+    public void Execute_GivenTaskHelpFlag_DispatchesToTaskHelp_ExitZero()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(
+            ["task", "--help"],
+            CreateContext("/tmp/intent-system"),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Usage: intent-cli task", output, StringComparison.Ordinal);
+        Assert.Contains("issue-to-pr", output, StringComparison.Ordinal);
+        Assert.Contains("review-pr", output, StringComparison.Ordinal);
+        Assert.Contains("fix-pr-comments", output, StringComparison.Ordinal);
+        Assert.Contains("publish-next-issue", output, StringComparison.Ordinal);
+        // Must NOT regress to the old "not yet implemented" surface.
+        Assert.DoesNotContain("not yet implemented", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_GivenTaskGroupNoSubcommand_DispatchesToTaskUsage_ExitOne()
+    {
+        // `intent-cli task` (no subcommand) shows usage and returns 1
+        // — same contract as direct `TaskCommand.Execute(args=[])`.
+        // Critically, it must NOT fall through to the router's
+        // "command group and subcommand are required" message.
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(
+            ["task"],
+            CreateContext("/tmp/intent-system"),
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Usage: intent-cli task", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("A command group and subcommand are required", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenTaskIssueToPr_DispatchesToTaskCommandViaRouter()
+    {
+        // The four subcommand kinds dispatch through the router's
+        // dictionary entries — verify with a happy-path issue-to-pr
+        // call that the kind threads through and returns a valid
+        // executable contract.
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(
+            ["task", "issue-to-pr", "--repo", "J-Tech-Japan/intent-system",
+             "--issue", "5000", "--workdir", "/tmp/child", "--format", "json"],
+            CreateContext("/tmp/intent-system"),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("\"task\":", output, StringComparison.Ordinal);
+        Assert.Contains("\"issue-to-pr\"", output, StringComparison.Ordinal);
+        Assert.Contains("--number 5000", output, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void Execute_GivenProjectStatusCommand_DispatchesToProjectStatusRenderer()
     {

--- a/tests/IntentSystem.Cli.Tests/TaskCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskCommandTests.cs
@@ -1,0 +1,381 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G317: explicit one-shot task planner surface — verifies each
+/// subcommand returns a bounded executable contract, validates inputs
+/// before mutation guidance is emitted, and never crosses the read-only
+/// boundary (no gh call, no state mutation in the planner itself).
+/// </summary>
+public sealed class TaskCommandTests
+{
+    // ---- task issue-to-pr ---------------------------------------------------
+
+    [Fact]
+    public void IssueToPr_HappyPath_JsonContractContainsClaimWorkdirCloseAndComplete()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(
+            CreateContext(),
+            ["issue-to-pr", "--repo", "J-Tech-Japan/intent-system", "--issue", "5000",
+             "--workdir", "/tmp/child", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("issue-to-pr", root.GetProperty("task").GetString());
+        Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("repo").GetString());
+        Assert.Equal(5000, root.GetProperty("issue").GetInt32());
+        Assert.Equal("/tmp/child", root.GetProperty("workdir").GetString());
+        Assert.False(root.TryGetProperty("refusals", out _),
+            "happy-path plan must not include refusals.");
+
+        var steps = root.GetProperty("steps").EnumerateArray().Select(e => e.GetString()!).ToArray();
+        // Concrete contract: claim, branch, push, base-branch-check, result-summary, complete.
+        Assert.Contains(steps, s => s.Contains("worker claim --kind issue", StringComparison.Ordinal)
+            && s.Contains("--number 5000", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("git checkout -b claude/g-issue-5000", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("git push -u origin claude/g-issue-5000", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("automation base-branch-check", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("worker result-summary --kind issue-to-pr", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("worker complete --kind issue", StringComparison.Ordinal)
+            && s.Contains("--number 5000", StringComparison.Ordinal)
+            && s.Contains("--outcome pr-created", StringComparison.Ordinal)
+            && s.Contains("--write", StringComparison.Ordinal));
+
+        // G311: Closes #<source-issue> must be named in the steps so the
+        // controller does not forget the closing reference.
+        Assert.Contains(steps, s => s.Contains("Closes #5000", StringComparison.Ordinal));
+
+        // Abort conditions name G300 linked_pr_synced expected warning,
+        // G311 missing closing reference, and base-branch policy mismatch.
+        var aborts = root.GetProperty("abort_conditions")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(aborts, a => a.Contains("linked_pr_synced: false", StringComparison.Ordinal));
+        Assert.Contains(aborts, a => a.Contains("Closes #5000", StringComparison.Ordinal));
+        Assert.Contains(aborts, a => a.Contains("base-branch-check", StringComparison.Ordinal));
+
+        // Label transitions never apply intent-target / intent-pr-created
+        // from the child loop.
+        var labels = root.GetProperty("label_transitions")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(labels, l => l.Contains("intent-issue-in-progress", StringComparison.Ordinal));
+        Assert.Contains(labels, l => l.Contains("intent-pr-created", StringComparison.Ordinal));
+        Assert.Contains(labels, l => l.Contains("NEVER applies `intent-target`", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void IssueToPr_MissingIssue_EmitsStructuredRefusal_NoSteps_ExitOne()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(
+            CreateContext(),
+            ["issue-to-pr", "--repo", "J-Tech-Japan/intent-system",
+             "--workdir", "/tmp/child", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("issue-to-pr", root.GetProperty("task").GetString());
+        var refusals = root.GetProperty("refusals").EnumerateArray()
+            .Select(e => e.GetString()!).ToArray();
+        Assert.Contains(refusals, r => r.Contains("--issue", StringComparison.Ordinal));
+        // Refusal plans never emit steps — the controller must repair its
+        // input before any mutation guidance appears.
+        Assert.Empty(root.GetProperty("steps").EnumerateArray());
+    }
+
+    [Fact]
+    public void IssueToPr_NegativeIssue_RejectsBeforeBuildingPlan()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(
+            CreateContext(),
+            ["issue-to-pr", "--repo", "x/y", "--issue", "-1", "--workdir", "/tmp/c"],
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--issue must be a positive integer", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    // ---- task review-pr -----------------------------------------------------
+
+    [Fact]
+    public void ReviewPr_HappyPath_JsonContractContainsThreeDecisionBranchesAndG316Hooks()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(
+            CreateContext(),
+            ["review-pr", "--repo", "J-Tech-Japan/intent-system", "--pr", "501",
+             "--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("review-pr", root.GetProperty("task").GetString());
+        Assert.Equal(501, root.GetProperty("pr").GetInt32());
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+
+        var steps = root.GetProperty("steps").EnumerateArray().Select(e => e.GetString()!).ToArray();
+        // Decision A (approve), Decision B (request-update), Decision C
+        // (host-metadata-blocked → publish-recovery / reconcile, never PR
+        // comment) all appear in the contract.
+        Assert.Contains(steps, s => s.Contains("review closeout-plan --pr 501", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("guide review --pr 501", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("pr-transition --transition approved", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("closeout pr --pr 501", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("pr-transition --transition request-update", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("automation publish-recovery", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("automation reconcile --lane host-review", StringComparison.Ordinal));
+        // base-branch-check is the FIRST validation step.
+        Assert.Contains(steps, s => s.Contains("base-branch-check", StringComparison.Ordinal)
+            && s.Contains("--pr 501", StringComparison.Ordinal));
+
+        // G316 packet/intent-aware: approval_summary_requirements text is
+        // surfaced via approval-summary cite + tests-pass evidence.
+        Assert.Contains(steps, s => s.Contains("approval_summary_requirements", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("request_update_requirements", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("intent_reference_paths", StringComparison.Ordinal));
+
+        var aborts = root.GetProperty("abort_conditions")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(aborts, a => a.Contains("Tests-only evidence", StringComparison.Ordinal)
+            || a.Contains("only `tests passed`", StringComparison.Ordinal));
+        Assert.Contains(aborts, a => a.Contains("Closes #<source-issue>", StringComparison.Ordinal)
+            || a.Contains("G311", StringComparison.Ordinal));
+
+        // Draft-aware approval (G297) is in the preconditions.
+        var preconds = root.GetProperty("preconditions")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(preconds, p => p.Contains("isDraft", StringComparison.Ordinal)
+            || p.Contains("G297", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ReviewPr_MissingDomain_RefusesBeforeAnyApprovalSteps()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(
+            CreateContext(),
+            ["review-pr", "--repo", "J-Tech-Japan/intent-system", "--pr", "501", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var refusals = doc.RootElement.GetProperty("refusals")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(refusals, r => r.Contains("--domain", StringComparison.Ordinal));
+        Assert.Empty(doc.RootElement.GetProperty("steps").EnumerateArray());
+    }
+
+    // ---- task fix-pr-comments ----------------------------------------------
+
+    [Fact]
+    public void FixPrComments_HappyPath_NarrowsToLatestActionableCommentOnly()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(
+            CreateContext(),
+            ["fix-pr-comments", "--repo", "J-Tech-Japan/intent-system", "--pr", "501",
+             "--workdir", "/tmp/child", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var steps = doc.RootElement.GetProperty("steps")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(steps, s => s.Contains("worker claim --kind pr", StringComparison.Ordinal)
+            && s.Contains("--number 501", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("gh pr view 501", StringComparison.Ordinal)
+            && s.Contains("headRefName", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("worker result-summary --kind pr-comment-fix", StringComparison.Ordinal)
+            && s.Contains("--outcome repair-pushed", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("worker complete --kind pr", StringComparison.Ordinal)
+            && s.Contains("--outcome repair-pushed", StringComparison.Ordinal)
+            && s.Contains("--write", StringComparison.Ordinal));
+
+        // Preconditions explicitly forbid rediscovery via worker next-action
+        // while a pr-comment-fix claim is active.
+        var preconds = doc.RootElement.GetProperty("preconditions")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(preconds, p => p.Contains("Do NOT rediscover", StringComparison.Ordinal)
+            || p.Contains("worker next-action", StringComparison.Ordinal));
+
+        // Abort conditions name scope-drift.
+        var aborts = doc.RootElement.GetProperty("abort_conditions")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(aborts, a => a.Contains("Scope drift", StringComparison.Ordinal));
+
+        // Labels: intent-pr-update-in-progress → intent-pr-rereview-ready.
+        var labels = doc.RootElement.GetProperty("label_transitions")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(labels, l => l.Contains("intent-pr-update-in-progress", StringComparison.Ordinal));
+        Assert.Contains(labels, l => l.Contains("intent-pr-rereview-ready", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FixPrComments_MissingWorkdir_StructuredRefusal()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(
+            CreateContext(),
+            ["fix-pr-comments", "--repo", "x/y", "--pr", "1", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var refusals = doc.RootElement.GetProperty("refusals")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(refusals, r => r.Contains("--workdir", StringComparison.Ordinal));
+    }
+
+    // ---- task publish-next-issue -------------------------------------------
+
+    [Fact]
+    public void PublishNextIssue_HappyPath_BoundedToSingleIssuePerWake()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(
+            CreateContext(),
+            ["publish-next-issue", "--domain", "intent-cli",
+             "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("publish-next-issue", root.GetProperty("task").GetString());
+
+        var steps = root.GetProperty("steps")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(steps, s => s.Contains("intent next-slice --dry-run", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("packet draft", StringComparison.Ordinal)
+            && s.Contains("--dry-run", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("issue publish-flow", StringComparison.Ordinal)
+            && s.Contains("--write", StringComparison.Ordinal));
+        Assert.Contains(steps, s => s.Contains("automation issue-publish", StringComparison.Ordinal)
+            && s.Contains("--write", StringComparison.Ordinal));
+
+        var preconds = root.GetProperty("preconditions")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(preconds, p => p.Contains("WIP cap", StringComparison.Ordinal));
+        Assert.Contains(preconds, p => p.Contains("host-sync-preflight", StringComparison.Ordinal));
+
+        var aborts = root.GetProperty("abort_conditions")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(aborts, a => a.Contains("clarification-required", StringComparison.Ordinal));
+        Assert.Contains(aborts, a => a.Contains("WIP cap", StringComparison.Ordinal));
+
+        var notes = root.GetProperty("notes")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(notes, n => n.Contains("at most ONE issue is published per wake", StringComparison.OrdinalIgnoreCase)
+            || n.Contains("ONE issue", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void PublishNextIssue_MissingTargetRepo_StructuredRefusal()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(
+            CreateContext(),
+            ["publish-next-issue", "--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var refusals = doc.RootElement.GetProperty("refusals")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(refusals, r => r.Contains("--target-repo", StringComparison.Ordinal));
+    }
+
+    // ---- shared surface ----------------------------------------------------
+
+    [Fact]
+    public void Markdown_DefaultFormat_RendersNumberedSectionsAndPathsAsCode()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(
+            CreateContext(),
+            ["issue-to-pr", "--repo", "J-Tech-Japan/intent-system", "--issue", "5000",
+             "--workdir", "/tmp/child"],
+            writer);
+
+        Assert.Equal(0, exit);
+        var output = writer.ToString();
+        Assert.Contains("# task issue-to-pr", output, StringComparison.Ordinal);
+        Assert.Contains("- repo: `J-Tech-Japan/intent-system`", output, StringComparison.Ordinal);
+        Assert.Contains("- issue: #5000", output, StringComparison.Ordinal);
+        Assert.Contains("- workdir: `/tmp/child`", output, StringComparison.Ordinal);
+        Assert.Contains("## Preconditions", output, StringComparison.Ordinal);
+        Assert.Contains("## Steps", output, StringComparison.Ordinal);
+        Assert.Contains("## Label transitions", output, StringComparison.Ordinal);
+        Assert.Contains("## Abort conditions", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnknownKind_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(CreateContext(), ["unknown-kind"], writer);
+        Assert.Equal(1, exit);
+        Assert.Contains("Unknown task kind 'unknown-kind'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NoArgs_PrintsUsage_ExitOne()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(CreateContext(), Array.Empty<string>(), writer);
+        Assert.Equal(1, exit);
+        Assert.Contains("Usage: intent-cli task", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HelpFlag_PrintsUsage_ExitZero()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(CreateContext(), ["--help"], writer);
+        Assert.Equal(0, exit);
+        var output = writer.ToString();
+        Assert.Contains("issue-to-pr", output, StringComparison.Ordinal);
+        Assert.Contains("review-pr", output, StringComparison.Ordinal);
+        Assert.Contains("fix-pr-comments", output, StringComparison.Ordinal);
+        Assert.Contains("publish-next-issue", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnknownFormat_RejectedByParser()
+    {
+        using var writer = new StringWriter();
+        var exit = TaskCommand.Execute(
+            CreateContext(),
+            ["issue-to-pr", "--repo", "x/y", "--issue", "1", "--workdir", "/tmp/c", "--format", "yaml"],
+            writer);
+        Assert.Equal(1, exit);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- New `intent-cli task <kind>` surface: read-only planners that return a bounded executable contract for explicit-target dispatch. Four subcommands cover the common controller flows.
- `task issue-to-pr --repo <r> --issue <n> --workdir <path>` — implement issue #N (claim → branch → push → PR with `Closes #N` (G311) → result-summary → complete pr-created).
- `task review-pr --repo <r> --pr <n> --domain <d>` — host-review PR #N with three decision branches (pass → approve+merge+closeout / fail → request-update with G316 classification / host-metadata-blocked → publish-recovery / reconcile, never PR comments per G287).
- `task fix-pr-comments --repo <r> --pr <n> --workdir <path>` — repair PR #N from the latest actionable comment ONLY, narrow scope, swap labels into rereview-ready.
- `task publish-next-issue --domain <d> --target-repo <r>` — bounded ONE-shot publish (next-slice → packet draft → publish-flow → issue-publish; WIP cap and clarification gates enforced).

All four planners are pure: validate inputs, build the contract, emit JSON or markdown. No `gh` calls, no state mutation, no AI provider launch. Missing/invalid required arguments produce a structured-refusal plan (refusals[] populated, steps[] empty, exit 1) so the controller must repair input before any mutation guidance is emitted.

## Why

Selector loops (`worker next-action`, `host-review-preflight`, `intent next-slice`) are correct for autonomous polling but indirect when the controller already knows the target. `task <kind>` keeps the same dispatch contract (claim / lease / label transitions / G311 closing reference / G316 packet/intent-aware review / G287 host-metadata-blocked routing) without requiring a selector pass.

## Test plan

- [x] `task issue-to-pr` JSON contract threads `--issue 5000` and `--workdir /tmp/child` into the steps (claim --number 5000, branch claude/g-issue-5000, base-branch-check, result-summary, complete --number 5000 --outcome pr-created --write); abort conditions name G300 `linked_pr_synced: false` and G311 `Closes #5000`.
- [x] `task review-pr` JSON contract has all three decision branches (approved+merge+closeout, request-update, publish-recovery → reconcile fallback) and surfaces G316 fields (`approval_summary_requirements`, `request_update_requirements`, `intent_reference_paths`); preconditions cite G297 draft-aware approval.
- [x] `task fix-pr-comments` JSON contract uses `gh pr view <n> --json headRefName` for branch checkout, names the latest-actionable-comment scope, forbids `worker next-action` rediscovery while a claim is active, and swaps `intent-pr-update-in-progress` → `intent-pr-rereview-ready`.
- [x] `task publish-next-issue` JSON contract is bounded to one issue per wake (notes mention "ONE issue"), preconditions cite WIP cap + host-sync-preflight, abort conditions cover clarification-required and WIP cap.
- [x] Missing required flags for each subcommand produce structured-refusal plans (steps[] empty, refusals[] populated, exit 1).
- [x] Markdown default format renders code-fenced paths (`- repo: \`...\``), all five sections (Preconditions / Steps / Label transitions / Abort conditions / Notes).
- [x] Unknown kind / unknown format / no-args / --help return helpful messages.
- [x] CommandRouter registers the new `task` group; `guide commands list` advertises classification=support, mutability=read-only.
- [x] Full test suite green: 2403 CLI + 290 supporting, 0 failures.

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)