### PR TITLE
G319: continue approved PR merge/closeout before WIP-cap blocking

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -62,6 +62,10 @@ internal static class AutomationHostLoopNextActionCommand
         }
 
         var actionableReviewPr = FindActionableReviewPr(openPrs);
+        var approvedPr = FindApprovedPrPendingContinuation(
+            openPrs,
+            parsed.ApprovedPrMergeStateStatus,
+            parsed.ApprovedPrMetadataBlocked);
         var openIntentTargetExists = OpenIntentTargetExists(openPrs, openIssues);
         var anyLeaseHeld = AnyChildWorkerLeaseHeld(openPrs, openIssues);
 
@@ -73,6 +77,7 @@ internal static class AutomationHostLoopNextActionCommand
             SyncClassification = parsed.SyncClassification,
             SafeStashRequired = parsed.SafeStashRequired,
             ActionableReviewPr = actionableReviewPr,
+            ApprovedPrPendingMergeCloseout = approvedPr,
             PublishRecoveryRepairsAvailable = parsed.PublishRecoveryRepairsAvailable,
             PublishLifecycleDriftCount = parsed.PublishLifecycleDriftCount,
             NextSliceIssueCutReady = parsed.NextSliceIssueCutReady,
@@ -122,6 +127,67 @@ internal static class AutomationHostLoopNextActionCommand
             {
                 return new ActionableReviewPr { Number = pr.Number, Url = pr.Url };
             }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// G319: find an open PR carrying both <c>intent-target</c> and
+    /// <c>intent-pr-approved</c> that the host loop must continue
+    /// through merge + closeout BEFORE reporting wip-cap-blocked.
+    /// Skips PRs that are simultaneously holding a child-worker lease
+    /// (<c>intent-pr-update-in-progress</c>) or carrying a fresh
+    /// request-update label (<c>intent-pr-request-update</c>) — those
+    /// states mean review hasn't reached a stable approval point and
+    /// the review-pr / request-update lanes own them.
+    /// </summary>
+    private static ApprovedPrContinuation? FindApprovedPrPendingContinuation(
+        IReadOnlyList<GitHubAutomationPrCandidate> openPrs,
+        string? mergeStateStatusOverride,
+        bool hostMetadataBlocked)
+    {
+        foreach (var pr in openPrs)
+        {
+            var labels = (pr.Labels ?? Array.Empty<GitHubAutomationLabel>())
+                .Select(label => label.Name)
+                .ToHashSet(StringComparer.Ordinal);
+            var hasIntentTarget = labels.Contains(WorkerNextActionConstants.Labels.IntentTarget);
+            var hasApproved = labels.Contains(WorkerNextActionConstants.Labels.IntentPrApproved);
+            var hasUpdateInProgress = labels.Contains(WorkerNextActionConstants.Labels.IntentPrUpdateInProgress);
+            var hasRequestUpdate = labels.Contains(WorkerNextActionConstants.Labels.IntentPrRequestUpdate);
+            if (!hasIntentTarget || !hasApproved || hasUpdateInProgress || hasRequestUpdate)
+            {
+                continue;
+            }
+
+            // G289 defensive: skip PRs that aren't actually OPEN (the
+            // lister already filters by --state open, but live data may
+            // race against a recent merge).
+            if (!string.IsNullOrEmpty(pr.State)
+                && !string.Equals(pr.State, "OPEN", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            int? linkedIssueNumber = null;
+            if (pr.ClosingIssuesReferences is { Count: > 0 })
+            {
+                var first = pr.ClosingIssuesReferences[0];
+                if (first.Number > 0)
+                {
+                    linkedIssueNumber = first.Number;
+                }
+            }
+
+            return new ApprovedPrContinuation
+            {
+                Number = pr.Number,
+                Url = pr.Url,
+                IsDraft = pr.IsDraft,
+                MergeStateStatus = mergeStateStatusOverride,
+                HostMetadataBlocked = hostMetadataBlocked,
+                LinkedIssueNumber = linkedIssueNumber
+            };
         }
         return null;
     }
@@ -189,6 +255,8 @@ internal static class AutomationHostLoopNextActionCommand
         var nextSliceIssueCutReady = false;
         string? publishNextSliceExecutionUnit = null;
         var hardClarificationOpen = false;
+        string? approvedPrMergeStateStatus = null;
+        var approvedPrMetadataBlocked = false;
         var format = FormatMarkdown;
 
         for (var index = 0; index < args.Length; index++)
@@ -249,6 +317,24 @@ internal static class AutomationHostLoopNextActionCommand
                 case "--hard-clarification-open":
                     hardClarificationOpen = true;
                     break;
+                case "--approved-pr-merge-state":
+                    // G319: optional override of `gh pr view --json
+                    // mergeStateStatus` for the approved PR continuation
+                    // lane. Pass `CLEAN` (or omit entirely) for the happy
+                    // path; `BLOCKED` / `CONFLICTING` / `DIRTY` / `BEHIND`
+                    // / `UNKNOWN` map to `approved-pr-merge-blocked`.
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--approved-pr-merge-state requires a value (e.g. CLEAN, BLOCKED, CONFLICTING)."; return false;
+                    }
+                    approvedPrMergeStateStatus = args[++index].Trim();
+                    break;
+                case "--approved-pr-metadata-blocked":
+                    // G319: operator/preflight has determined the parent
+                    // host metadata (queue-state linked_pr / linked_issue
+                    // / packet directory) is not ready for closeout.
+                    approvedPrMetadataBlocked = true;
+                    break;
                 case "--format":
                     if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
                     {
@@ -285,6 +371,8 @@ internal static class AutomationHostLoopNextActionCommand
             NextSliceIssueCutReady = nextSliceIssueCutReady,
             PublishNextSliceExecutionUnit = publishNextSliceExecutionUnit,
             HardClarificationOpen = hardClarificationOpen,
+            ApprovedPrMergeStateStatus = approvedPrMergeStateStatus,
+            ApprovedPrMetadataBlocked = approvedPrMetadataBlocked,
             Format = format
         };
         return true;
@@ -302,6 +390,8 @@ internal static class AutomationHostLoopNextActionCommand
         public required bool NextSliceIssueCutReady { get; init; }
         public string? PublishNextSliceExecutionUnit { get; init; }
         public required bool HardClarificationOpen { get; init; }
+        public string? ApprovedPrMergeStateStatus { get; init; }
+        public required bool ApprovedPrMetadataBlocked { get; init; }
         public required string Format { get; init; }
     }
 }

--- a/src/IntentSystem.Cli/Commands/HostLoopNextActionAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/HostLoopNextActionAnalyzer.cs
@@ -23,6 +23,12 @@ namespace IntentSystem.Cli.Commands;
 ///    (G306 lane); recommend the begin/end safe-stash flow.
 /// 4. <c>review-pr</c> — there is an actionable review PR; recommend
 ///    closeout-plan and approval/merge.
+/// 4.5 (G319) <c>approved-pr-merge-closeout</c> — an open PR already
+///    carries <c>intent-pr-approved</c> and must be merged + closed out
+///    before any wip-cap-blocked stop. Unsafe variants surface as
+///    <c>approved-pr-draft-blocked</c> (G297), <c>approved-pr-merge-blocked</c>
+///    (mergeStateStatus != CLEAN), or <c>approved-pr-metadata-blocked</c>
+///    (queue/linked_pr/linked_issue inconsistent).
 /// 5. <c>repair-host-metadata</c> — `intent-pr-created` exists on an
 ///    issue but the queue has no `linked_pr` (G303 publish-recovery
 ///    case), or the publish artifact lifecycle has a deterministic
@@ -49,6 +55,13 @@ internal static class HostLoopNextActionAnalyzer
     public const string ClassificationDirtyHostState = "dirty-host-state";
     public const string ClassificationSafeStash = "safe-stash";
     public const string ClassificationReviewPr = "review-pr";
+    // G319: approved-PR continuation lane — fires BEFORE WIP-cap so an
+    // already-approved-but-unmerged PR is completed before the wake stops
+    // for "an open intent-target exists".
+    public const string ClassificationApprovedPrMergeCloseout = "approved-pr-merge-closeout";
+    public const string ClassificationApprovedPrDraftBlocked = "approved-pr-draft-blocked";
+    public const string ClassificationApprovedPrMergeBlocked = "approved-pr-merge-blocked";
+    public const string ClassificationApprovedPrMetadataBlocked = "approved-pr-metadata-blocked";
     public const string ClassificationRepairHostMetadata = "repair-host-metadata";
     public const string ClassificationPublishNextIssue = "publish-next-issue";
     public const string ClassificationHardClarification = "hard-clarification";
@@ -106,6 +119,67 @@ internal static class HostLoopNextActionAnalyzer
                     "Run `review closeout-plan` to confirm host metadata, then `pr-transition --transition approved --write`, merge, then `closeout pr --pr-merged true --write`."
                 },
                 $"Review PR actionable: #{reviewPr.Number}.");
+        }
+
+        // 4.5 (G319) approved-PR continuation — fires BEFORE WIP-cap so an
+        // approved-but-unmerged PR is completed first. Distinguish the
+        // happy path (merge + closeout ready) from specific unsafe
+        // blockers so the operator gets a precise stop instead of generic
+        // wip-cap-blocked.
+        if (input.ApprovedPrPendingMergeCloseout is { } approvedPr)
+        {
+            if (approvedPr.IsDraft)
+            {
+                return Result(ClassificationApprovedPrDraftBlocked, mutationAllowed: false,
+                    $"intent-cli automation pr-transition --transition review-release --repo {input.Repo} --pr {approvedPr.Number} --write --format json",
+                    new[]
+                    {
+                        $"PR #{approvedPr.Number} ({approvedPr.Url}) carries `intent-pr-approved` but is currently a draft (G297 — draft PRs cannot be merged).",
+                        "Drop the lease via `pr-transition --transition review-release --write` and surface the gap; the PR must be readied for review by the implementer or operator before approval/merge can complete."
+                    },
+                    $"Approved PR #{approvedPr.Number} is draft — refusing to merge (G297).");
+            }
+            if (!string.IsNullOrEmpty(approvedPr.MergeStateStatus)
+                && !string.Equals(approvedPr.MergeStateStatus, "CLEAN", StringComparison.OrdinalIgnoreCase))
+            {
+                return Result(ClassificationApprovedPrMergeBlocked, mutationAllowed: false,
+                    $"gh pr view {approvedPr.Number} --repo {input.Repo} --json mergeStateStatus,mergeable,headRefName,baseRefName",
+                    new[]
+                    {
+                        $"PR #{approvedPr.Number} ({approvedPr.Url}) carries `intent-pr-approved` but mergeStateStatus is `{approvedPr.MergeStateStatus}` (expected CLEAN).",
+                        "Surface the gap to the operator: rebase / resolve conflicts / re-run CI before re-attempting merge. Do NOT silently retry."
+                    },
+                    $"Approved PR #{approvedPr.Number} merge blocked — mergeStateStatus={approvedPr.MergeStateStatus}.");
+            }
+            if (approvedPr.HostMetadataBlocked)
+            {
+                return Result(ClassificationApprovedPrMetadataBlocked, mutationAllowed: false,
+                    $"intent-cli review closeout-plan --pr {approvedPr.Number} --repo {input.Repo} --format json",
+                    new[]
+                    {
+                        $"PR #{approvedPr.Number} ({approvedPr.Url}) carries `intent-pr-approved` but host metadata is inconsistent (e.g. queue-state linked_pr missing, linked_issue mismatch, packet directory missing).",
+                        "Run `review closeout-plan` to surface the structured `host-metadata-blocked` reason and the `recommended_recovery_command` (typically `automation publish-recovery --write` for G313/G315 cases). Host metadata blockers MUST NOT become PR repair comments."
+                    },
+                    $"Approved PR #{approvedPr.Number} host-metadata-blocked — run closeout-plan + publish-recovery before merge.");
+            }
+
+            // Happy path: clean approved PR pending merge + closeout.
+            var mergeCommand = $"intent-cli review closeout-plan --pr {approvedPr.Number} --repo {input.Repo} --format json";
+            var evidence = new List<string>
+            {
+                $"PR #{approvedPr.Number} ({approvedPr.Url}) carries `intent-target` + `intent-pr-approved` and is open, non-draft, and not blocked.",
+                "Approved continuation outranks wip-cap-blocked: the open approved PR IS the next host action — merge and closeout before any new next-slice publish.",
+                $"Sequence: `review closeout-plan --pr {approvedPr.Number} --write` → merge via host's existing merge step → capture `IS_MERGED=$(gh pr view {approvedPr.Number} --json merged --jq .merged)` → `closeout pr --pr {approvedPr.Number} --pr-merged $IS_MERGED --write` (G297 gate). Commit + push parent durable state before stopping the wake."
+            };
+            if (approvedPr.LinkedIssueNumber is int linkedIssue)
+            {
+                evidence.Add($"linked source issue #{linkedIssue} — confirm `Closes #{linkedIssue}` is present in the PR body before merge (G311); closeout pr --write validates and refuses on missing/wrong/multiple.");
+            }
+
+            return Result(ClassificationApprovedPrMergeCloseout, mutationAllowed: true,
+                mergeCommand,
+                evidence,
+                $"Approved PR #{approvedPr.Number} pending merge + closeout — continue before WIP-cap.");
         }
 
         // 5. host metadata repair (G303 publish-recovery + G307 lifecycle)
@@ -228,6 +302,15 @@ internal sealed record HostLoopNextActionInput
     /// <summary>An actionable review PR captured by host-review-preflight, or null.</summary>
     public ActionableReviewPr? ActionableReviewPr { get; init; }
 
+    /// <summary>
+    /// G319: an open PR that already carries `intent-pr-approved` and
+    /// is pending the merge + closeout continuation. When set, the
+    /// analyzer surfaces this BEFORE wip-cap-blocked so the host loop
+    /// completes the approved PR before stopping for "an open
+    /// intent-target exists".
+    /// </summary>
+    public ApprovedPrContinuation? ApprovedPrPendingMergeCloseout { get; init; }
+
     /// <summary>G303: count of high-confidence linked-ref repairs available.</summary>
     public int PublishRecoveryRepairsAvailable { get; init; }
 
@@ -254,6 +337,53 @@ internal sealed record ActionableReviewPr
 {
     public required int Number { get; init; }
     public required string Url { get; init; }
+}
+
+/// <summary>
+/// G319: open PR carrying `intent-pr-approved` that the host loop must
+/// continue through merge + closeout before any new next-slice publish.
+/// Caller may pre-fetch additional state (draft, merge state, host
+/// metadata readiness) and feed those into the analyzer; when all
+/// blockers are absent, the analyzer selects the happy-path
+/// <c>approved-pr-merge-closeout</c> classification.
+/// </summary>
+internal sealed record ApprovedPrContinuation
+{
+    public required int Number { get; init; }
+    public required string Url { get; init; }
+
+    /// <summary>
+    /// True when the PR is currently a draft. G297 forbids merging a
+    /// draft PR even if approval transitioned earlier; analyzer maps to
+    /// <c>approved-pr-draft-blocked</c>.
+    /// </summary>
+    public bool IsDraft { get; init; }
+
+    /// <summary>
+    /// Optional `gh pr view --json mergeStateStatus` value, e.g.
+    /// `CLEAN` / `BLOCKED` / `CONFLICTING` / `BEHIND` / `DIRTY` /
+    /// `UNKNOWN`. When null, the analyzer treats it as unverified and
+    /// proceeds on the happy path (the merge step itself will refuse if
+    /// the live state is unsafe). When non-null and not `CLEAN`, the
+    /// analyzer maps to <c>approved-pr-merge-blocked</c>.
+    /// </summary>
+    public string? MergeStateStatus { get; init; }
+
+    /// <summary>
+    /// True when the operator/preflight has determined the parent host
+    /// metadata is not ready for closeout (e.g. queue-state linked_pr
+    /// missing / linked_issue mismatch / packet directory missing).
+    /// Maps to <c>approved-pr-metadata-blocked</c>.
+    /// </summary>
+    public bool HostMetadataBlocked { get; init; }
+
+    /// <summary>
+    /// Optional GitHub closing-reference issue number captured from
+    /// `gh pr view --json closingIssuesReferences`. Surfaced in the
+    /// happy-path evidence to remind the operator that
+    /// <c>closeout pr --write</c> validates the G311 closing reference.
+    /// </summary>
+    public int? LinkedIssueNumber { get; init; }
 }
 
 internal sealed record HostLoopNextActionResult

--- a/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
@@ -59,6 +59,16 @@ internal sealed record GitHubAutomationPrCandidate
     /// </summary>
     [JsonPropertyName("state")]
     public string State { get; init; } = string.Empty;
+
+    /// <summary>
+    /// G319: GitHub PR draft flag from <c>gh pr list --json isDraft</c>.
+    /// Defaults to <c>false</c> so existing test fakes that don't seed it
+    /// keep the prior non-draft behavior. Consumed by the host-loop-next-action
+    /// approved-PR continuation lane (G297 forbids merging a draft PR
+    /// even after an approval transition).
+    /// </summary>
+    [JsonPropertyName("isDraft")]
+    public bool IsDraft { get; init; }
 }
 
 /// <summary>
@@ -117,7 +127,10 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
     // fakes) don't pre-apply `--state open`.
     internal const string ListJsonFields = "number,title,url,createdAt,labels,state";
 
-    internal const string PrListJsonFields = "number,title,url,body,createdAt,updatedAt,labels,closingIssuesReferences,state";
+    // G319: also request `isDraft` so the host-loop-next-action analyzer
+    // can map an approved-but-draft PR to `approved-pr-draft-blocked`
+    // (G297) instead of attempting a merge.
+    internal const string PrListJsonFields = "number,title,url,body,createdAt,updatedAt,labels,closingIssuesReferences,state,isDraft";
 
     /// <summary>
     /// G206: builds the <c>gh pr list</c> argument list shared by the live

--- a/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
@@ -1,0 +1,255 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G319: command-level regression tests for the approved-PR
+/// continuation lane. Verifies the end-to-end path — the command layer
+/// detects an approved PR from GitHub labels, plumbs it into the
+/// analyzer with the correct `is_draft` + merge-state + metadata flags,
+/// and the analyzer surfaces it BEFORE the wip-cap-blocked stop.
+/// </summary>
+public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
+{
+    public AutomationHostLoopNextActionCommandTests()
+    {
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = null;
+    }
+
+    public void Dispose()
+    {
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = null;
+    }
+
+    [Fact]
+    public void Execute_ApprovedPrOpenAndNonDraft_SelectsApprovedContinuation_NotWipCapBlocked()
+    {
+        // Mirrors SKS PR #571: open, non-draft, carries
+        // intent-target + intent-pr-approved; the host loop previously
+        // stopped at wip-cap-blocked for the open intent-target.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: new[]
+            {
+                NewPr(571, isDraft: false, state: "OPEN", labels: new[] { "intent-target", "intent-pr-approved" },
+                      closingIssue: 570)
+            },
+            issues: new[] { NewIssue(570, labels: new[] { "intent-target", "intent-pr-created" }) });
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("approved-pr-merge-closeout", root.GetProperty("classification").GetString());
+        Assert.True(root.GetProperty("mutation_allowed").GetBoolean());
+        Assert.Contains("--pr 571", root.GetProperty("recommended_command").GetString()!, StringComparison.Ordinal);
+        var evidence = root.GetProperty("evidence").EnumerateArray()
+            .Select(e => e.GetString()!).ToArray();
+        Assert.Contains(evidence, e => e.Contains("#571", StringComparison.Ordinal));
+        Assert.Contains(evidence, e => e.Contains("Closes #570", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_ApprovedPrIsDraft_MapsToApprovedPrDraftBlocked()
+    {
+        // G297: an approved PR that is currently a draft cannot be
+        // merged; the analyzer must classify draft-blocked, not the
+        // happy path or generic wip-cap-blocked.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: new[]
+            {
+                NewPr(571, isDraft: true, state: "OPEN", labels: new[] { "intent-target", "intent-pr-approved" })
+            },
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("approved-pr-draft-blocked", doc.RootElement.GetProperty("classification").GetString());
+        Assert.False(doc.RootElement.GetProperty("mutation_allowed").GetBoolean());
+    }
+
+    [Fact]
+    public void Execute_ApprovedPrMergeStateOverride_MapsToApprovedPrMergeBlocked()
+    {
+        // The command exposes `--approved-pr-merge-state <state>` so
+        // host-loop guidance can pre-fetch `gh pr view --json
+        // mergeStateStatus` once and pipe it in. CONFLICTING → blocked.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: new[]
+            {
+                NewPr(571, isDraft: false, state: "OPEN", labels: new[] { "intent-target", "intent-pr-approved" })
+            },
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/SekibanAsAService",
+             "--approved-pr-merge-state", "CONFLICTING", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("approved-pr-merge-blocked", doc.RootElement.GetProperty("classification").GetString());
+        Assert.False(doc.RootElement.GetProperty("mutation_allowed").GetBoolean());
+        Assert.Contains("CONFLICTING", doc.RootElement.GetProperty("summary").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ApprovedPrMetadataBlockedFlag_MapsToApprovedPrMetadataBlocked()
+    {
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: new[]
+            {
+                NewPr(571, isDraft: false, state: "OPEN", labels: new[] { "intent-target", "intent-pr-approved" })
+            },
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/SekibanAsAService",
+             "--approved-pr-metadata-blocked", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("approved-pr-metadata-blocked", doc.RootElement.GetProperty("classification").GetString());
+    }
+
+    [Fact]
+    public void Execute_OpenIntentTargetPrWithoutApproved_FallsThroughToWipCapBlocked()
+    {
+        // Acceptance: when there is open intent-target work but NO
+        // approved continuation pending, the existing wip-cap-blocked
+        // classification is unchanged.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: new[] { NewIssue(700, labels: new[] { "intent-target" }) });
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("wip-cap-blocked", doc.RootElement.GetProperty("classification").GetString());
+    }
+
+    [Fact]
+    public void Execute_ApprovedPrWithUpdateInProgress_NotSelectedForContinuation()
+    {
+        // An approved PR that is also `intent-pr-update-in-progress`
+        // means a child worker is repairing it. The continuation lane
+        // skips it; the existing wip-cap / wait-for-child lanes handle
+        // the in-flight state.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: new[]
+            {
+                NewPr(571, isDraft: false, state: "OPEN",
+                    labels: new[] { "intent-target", "intent-pr-approved", "intent-pr-update-in-progress" })
+            },
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var classification = doc.RootElement.GetProperty("classification").GetString();
+        Assert.NotEqual("approved-pr-merge-closeout", classification);
+        // Open intent-target + lease held → wait-for-child.
+        Assert.Equal("wait-for-child", classification);
+    }
+
+    // --- helpers --------------------------------------------------------------
+
+    private static GitHubAutomationPrCandidate NewPr(
+        int number,
+        bool isDraft,
+        string state,
+        IReadOnlyList<string> labels,
+        int? closingIssue = null)
+    {
+        var refs = closingIssue is int issueNumber
+            ? new[]
+            {
+                new GitHubPrClosingIssueReference { Number = issueNumber }
+            }
+            : Array.Empty<GitHubPrClosingIssueReference>();
+        return new GitHubAutomationPrCandidate
+        {
+            Number = number,
+            Title = $"PR {number}",
+            Url = $"https://github.com/J-Tech-Japan/SekibanAsAService/pull/{number}",
+            Body = "stub",
+            CreatedAt = "2026-05-10T00:00:00Z",
+            UpdatedAt = "2026-05-10T00:00:00Z",
+            Labels = labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
+            ClosingIssuesReferences = refs,
+            State = state,
+            IsDraft = isDraft
+        };
+    }
+
+    private static GitHubAutomationIssueCandidate NewIssue(int number, IReadOnlyList<string> labels) =>
+        new()
+        {
+            Number = number,
+            Title = $"issue {number}",
+            Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{number}",
+            CreatedAt = "2026-05-10T00:00:00Z",
+            Labels = labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
+            State = "OPEN"
+        };
+
+    private sealed class FakeLister : IGitHubAutomationCandidateLister
+    {
+        private readonly IReadOnlyList<GitHubAutomationPrCandidate> prs;
+        private readonly IReadOnlyList<GitHubAutomationIssueCandidate> issues;
+
+        public FakeLister(
+            IReadOnlyList<GitHubAutomationPrCandidate> prs,
+            IReadOnlyList<GitHubAutomationIssueCandidate> issues)
+        {
+            this.prs = prs;
+            this.issues = issues;
+        }
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => prs;
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) => issues;
+    }
+
+    private static CliContext CreateContext() =>
+        new()
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+}

--- a/tests/IntentSystem.Cli.Tests/HostLoopNextActionAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/HostLoopNextActionAnalyzerTests.cs
@@ -194,6 +194,228 @@ public sealed class HostLoopNextActionAnalyzerTests
         Assert.Contains("host-review-diagnostics", result.RecommendedCommand!, StringComparison.Ordinal);
     }
 
+    // --- G319: approved-PR continuation lane ---------------------------------
+
+    [Fact]
+    public void ApprovedPr_OutranksWipCapBlocked_AndRecommendsMergeCloseout()
+    {
+        // Mirrors the SKS-G219 incident: PR #571 is OPEN, non-draft,
+        // mergeStateStatus=CLEAN, carries intent-target + intent-pr-approved;
+        // host loop previously stopped at wip-cap-blocked. With G319 the
+        // open approved PR is the next host action.
+        var input = NewInput() with
+        {
+            OpenIntentTargetPrOrIssueExists = true,
+            AnyChildWorkerLeaseHeld = false,
+            ApprovedPrPendingMergeCloseout = new ApprovedPrContinuation
+            {
+                Number = 571,
+                Url = "https://github.com/J-Tech-Japan/SekibanAsAService/pull/571",
+                IsDraft = false,
+                MergeStateStatus = "CLEAN",
+                HostMetadataBlocked = false,
+                LinkedIssueNumber = 570
+            }
+        };
+
+        var result = HostLoopNextActionAnalyzer.Analyze(input);
+
+        Assert.Equal("approved-pr-merge-closeout", result.Classification);
+        Assert.NotEqual("wip-cap-blocked", result.Classification);
+        Assert.True(result.MutationAllowed);
+        Assert.Contains("--pr 571", result.RecommendedCommand!, StringComparison.Ordinal);
+        Assert.Contains("review closeout-plan", result.RecommendedCommand!, StringComparison.Ordinal);
+        // Evidence cites both the PR identity and the G311 closing reference reminder.
+        Assert.Contains(result.Evidence, e => e.Contains("#571", StringComparison.Ordinal));
+        Assert.Contains(result.Evidence, e => e.Contains("Closes #570", StringComparison.Ordinal));
+        Assert.Contains(result.Evidence, e =>
+            e.Contains("Approved continuation outranks wip-cap-blocked", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ApprovedPr_WithoutLinkedIssue_StillSelectsMergeCloseout_NoG311Evidence()
+    {
+        var input = NewInput() with
+        {
+            OpenIntentTargetPrOrIssueExists = true,
+            ApprovedPrPendingMergeCloseout = new ApprovedPrContinuation
+            {
+                Number = 700,
+                Url = "https://github.com/owner/repo/pull/700",
+                IsDraft = false,
+                MergeStateStatus = null, // operator didn't pre-check; analyzer treats as CLEAN
+                HostMetadataBlocked = false,
+                LinkedIssueNumber = null
+            }
+        };
+
+        var result = HostLoopNextActionAnalyzer.Analyze(input);
+
+        Assert.Equal("approved-pr-merge-closeout", result.Classification);
+        Assert.DoesNotContain(result.Evidence, e => e.Contains("Closes #", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ApprovedPr_Draft_MapsToApprovedPrDraftBlocked_NotGenericWipCap()
+    {
+        var input = NewInput() with
+        {
+            OpenIntentTargetPrOrIssueExists = true,
+            ApprovedPrPendingMergeCloseout = new ApprovedPrContinuation
+            {
+                Number = 571,
+                Url = "https://github.com/J-Tech-Japan/SekibanAsAService/pull/571",
+                IsDraft = true,
+                MergeStateStatus = "CLEAN",
+                HostMetadataBlocked = false
+            }
+        };
+
+        var result = HostLoopNextActionAnalyzer.Analyze(input);
+
+        Assert.Equal("approved-pr-draft-blocked", result.Classification);
+        Assert.False(result.MutationAllowed);
+        // Recommended command releases the review lease (G292) cleanly.
+        Assert.Contains("pr-transition --transition review-release", result.RecommendedCommand!, StringComparison.Ordinal);
+        Assert.Contains(result.Evidence, e => e.Contains("G297", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ApprovedPr_DirtyMergeState_MapsToApprovedPrMergeBlocked()
+    {
+        var input = NewInput() with
+        {
+            OpenIntentTargetPrOrIssueExists = true,
+            ApprovedPrPendingMergeCloseout = new ApprovedPrContinuation
+            {
+                Number = 571,
+                Url = "https://github.com/J-Tech-Japan/SekibanAsAService/pull/571",
+                IsDraft = false,
+                MergeStateStatus = "CONFLICTING",
+                HostMetadataBlocked = false
+            }
+        };
+
+        var result = HostLoopNextActionAnalyzer.Analyze(input);
+
+        Assert.Equal("approved-pr-merge-blocked", result.Classification);
+        Assert.False(result.MutationAllowed);
+        Assert.Contains("CONFLICTING", result.Summary, StringComparison.Ordinal);
+        Assert.Contains(result.Evidence, e => e.Contains("CONFLICTING", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ApprovedPr_HostMetadataBlocked_MapsToApprovedPrMetadataBlocked()
+    {
+        var input = NewInput() with
+        {
+            OpenIntentTargetPrOrIssueExists = true,
+            ApprovedPrPendingMergeCloseout = new ApprovedPrContinuation
+            {
+                Number = 571,
+                Url = "https://github.com/J-Tech-Japan/SekibanAsAService/pull/571",
+                IsDraft = false,
+                MergeStateStatus = "CLEAN",
+                HostMetadataBlocked = true
+            }
+        };
+
+        var result = HostLoopNextActionAnalyzer.Analyze(input);
+
+        Assert.Equal("approved-pr-metadata-blocked", result.Classification);
+        Assert.False(result.MutationAllowed);
+        Assert.Contains("closeout-plan", result.RecommendedCommand!, StringComparison.Ordinal);
+        Assert.Contains(result.Evidence, e =>
+            e.Contains("MUST NOT become PR repair comments", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ApprovedPr_BlockerPrecedence_DraftBeatsMergeBeatsMetadata()
+    {
+        // If multiple blockers are reported simultaneously, the analyzer
+        // picks the most specific one in a stable order: draft > merge >
+        // metadata. This keeps the operator-facing classification
+        // deterministic.
+        var input = NewInput() with
+        {
+            OpenIntentTargetPrOrIssueExists = true,
+            ApprovedPrPendingMergeCloseout = new ApprovedPrContinuation
+            {
+                Number = 571,
+                Url = "https://github.com/owner/repo/pull/571",
+                IsDraft = true,
+                MergeStateStatus = "CONFLICTING",
+                HostMetadataBlocked = true
+            }
+        };
+
+        Assert.Equal("approved-pr-draft-blocked",
+            HostLoopNextActionAnalyzer.Analyze(input).Classification);
+
+        var mergeOnly = input with
+        {
+            ApprovedPrPendingMergeCloseout = input.ApprovedPrPendingMergeCloseout! with { IsDraft = false }
+        };
+        Assert.Equal("approved-pr-merge-blocked",
+            HostLoopNextActionAnalyzer.Analyze(mergeOnly).Classification);
+
+        var metadataOnly = mergeOnly with
+        {
+            ApprovedPrPendingMergeCloseout = mergeOnly.ApprovedPrPendingMergeCloseout! with { MergeStateStatus = "CLEAN" }
+        };
+        Assert.Equal("approved-pr-metadata-blocked",
+            HostLoopNextActionAnalyzer.Analyze(metadataOnly).Classification);
+    }
+
+    [Fact]
+    public void WipCapBlocked_StillFires_WhenNoApprovedPrContinuation()
+    {
+        // Acceptance: "Given only an in-flight issue/PR without approved
+        // closeout work, WIP-cap blocking remains unchanged." Open
+        // intent-target exists but no approved PR is pending → fall
+        // through to the existing wip-cap-blocked classification.
+        var input = NewInput() with
+        {
+            OpenIntentTargetPrOrIssueExists = true,
+            AnyChildWorkerLeaseHeld = false,
+            ApprovedPrPendingMergeCloseout = null
+        };
+
+        var result = HostLoopNextActionAnalyzer.Analyze(input);
+
+        Assert.Equal("wip-cap-blocked", result.Classification);
+        Assert.False(result.MutationAllowed);
+    }
+
+    [Fact]
+    public void ApprovedPr_DoesNotOverride_HigherPriorityBlockers()
+    {
+        // stale-cli, dirty-host-state, safe-stash, and review-pr all
+        // outrank the approved-PR continuation lane — those signals
+        // represent unsafe states / earlier review work that must be
+        // resolved first.
+        var approved = new ApprovedPrContinuation
+        {
+            Number = 571,
+            Url = "https://github.com/owner/repo/pull/571",
+            IsDraft = false,
+            MergeStateStatus = "CLEAN"
+        };
+
+        Assert.Equal("stale-cli", HostLoopNextActionAnalyzer.Analyze(
+            NewInput() with { StaleCli = true, ApprovedPrPendingMergeCloseout = approved }).Classification);
+
+        Assert.Equal("dirty-host-state", HostLoopNextActionAnalyzer.Analyze(
+            NewInput() with { SyncClassification = "dirty-host-durable-state", ApprovedPrPendingMergeCloseout = approved }).Classification);
+
+        Assert.Equal("review-pr", HostLoopNextActionAnalyzer.Analyze(
+            NewInput() with
+            {
+                ActionableReviewPr = new ActionableReviewPr { Number = 700, Url = "https://github.com/owner/repo/pull/700" },
+                ApprovedPrPendingMergeCloseout = approved
+            }).Classification);
+    }
+
     private static HostLoopNextActionInput NewInput() =>
         new()
         {


### PR DESCRIPTION
## Summary

- `automation host-loop-next-action` now selects an `approved-pr-merge-closeout` action when an open PR already carries `intent-target` + `intent-pr-approved`, instead of stopping at `wip-cap-blocked`. An approved-but-unmerged PR IS the next host action — merge and closeout complete the in-flight work before the wake stops.
- Unsafe variants surface as specific structured blockers: `approved-pr-draft-blocked` (G297 — cannot merge a draft), `approved-pr-merge-blocked` (mergeStateStatus != CLEAN), `approved-pr-metadata-blocked` (queue-state linked_pr / linked_issue / packet inconsistent — recommend G287/G313/G315 recovery, NOT PR comments).
- Higher-priority lanes (stale-cli, dirty-host-state, safe-stash, review-pr) still outrank the new lane. When NO approved continuation is pending, the existing `wip-cap-blocked` behavior is unchanged.

## Why

SekibanAsAService PR #559/#571 incident: a review wake approved a PR but did not merge/closeout in the same wake; the next host wake reported `wip-cap-blocked` for that approved PR and performed no mutation, leaving the PR open indefinitely. WIP cap should block new next-slice publishing, not block completion of an already in-flight approved PR.

## Test plan

- [x] Analyzer happy path: approved PR + open intent-target → `approved-pr-merge-closeout` (not `wip-cap-blocked`); evidence cites the PR url, the "Approved continuation outranks wip-cap-blocked" rationale, and the `Closes #<linked-issue>` G311 reminder when a closing reference is present.
- [x] Analyzer happy path without linked issue: still selects merge-closeout; no spurious G311 reminder.
- [x] Analyzer draft-blocked: `is_draft: true` → `approved-pr-draft-blocked`, recommends `pr-transition --transition review-release --write` (G292/G297 lease drop).
- [x] Analyzer merge-blocked: `mergeStateStatus: CONFLICTING` → `approved-pr-merge-blocked`; summary cites the live state.
- [x] Analyzer metadata-blocked: `host_metadata_blocked: true` → `approved-pr-metadata-blocked`, evidence reminds operator host metadata MUST NOT become PR repair comments.
- [x] Blocker precedence: draft > merge > metadata (stable, deterministic).
- [x] WIP-cap-fallback: open intent-target without approved continuation → `wip-cap-blocked` unchanged.
- [x] Higher-priority outranking: stale-cli / dirty-host-state / review-pr all beat the approved-PR lane.
- [x] Command end-to-end with fake lister: detects approved PR from labels (`gh pr list --json` adds `isDraft`); plumbs `--approved-pr-merge-state` and `--approved-pr-metadata-blocked` overrides; correctly maps each variant; lease-held PR drops out of the lane (goes to `wait-for-child` as before).
- [x] Full test suite green: 2420 CLI + 290 supporting tests, 0 failures.

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)