### PR TITLE
G318: auto-probe next-slice before host-loop true-idle

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -28,6 +28,16 @@ internal static class AutomationHostLoopNextActionCommand
 
     public static Func<IGitHubAutomationCandidateLister>? CandidateListerFactory { get; set; }
 
+    /// <summary>
+    /// G318: testability seam for the automatic <c>intent next-slice --dry-run</c>
+    /// probe. Production uses <see cref="IntentCliNextSliceDryRunProbe"/>
+    /// (in-process invocation of <see cref="IntentNextSliceCommand"/>) so
+    /// the host loop never reports <c>true-idle</c> when a candidate is
+    /// ready to publish. Tests inject a fake that returns canned outcomes
+    /// without touching the live queue-state.
+    /// </summary>
+    public static Func<CliContext, INextSliceDryRunProbe>? NextSliceDryRunProbeFactory { get; set; }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
@@ -69,6 +79,29 @@ internal static class AutomationHostLoopNextActionCommand
         var openIntentTargetExists = OpenIntentTargetExists(openPrs, openIssues);
         var anyLeaseHeld = AnyChildWorkerLeaseHeld(openPrs, openIssues);
 
+        // G318: automatically probe `intent next-slice --dry-run` when the
+        // operator did not pre-pipe the flag. The host loop must NOT report
+        // `true-idle` while a matching next-slice candidate is ready to
+        // publish, so the command takes ownership of the probe instead of
+        // relying on the caller to wire it. An operator-supplied
+        // `--next-slice-issue-cut-ready` (with `--publish-next-execution-unit`)
+        // still wins so existing pre-pipe flows are byte-identical.
+        var nextSliceIssueCutReady = parsed.NextSliceIssueCutReady;
+        var publishNextSliceExecutionUnit = parsed.PublishNextSliceExecutionUnit;
+        if (!nextSliceIssueCutReady && !string.IsNullOrWhiteSpace(parsed.Domain))
+        {
+            var probe = NextSliceDryRunProbeFactory?.Invoke(context)
+                ?? new IntentCliNextSliceDryRunProbe(context);
+            var probed = probe.Probe(parsed.Repo, parsed.Domain!);
+            if (probed != null
+                && string.Equals(probed.RecommendedOutcome, "issue-cut-ready", StringComparison.Ordinal)
+                && !string.IsNullOrWhiteSpace(probed.ExecutionUnit))
+            {
+                nextSliceIssueCutReady = true;
+                publishNextSliceExecutionUnit = probed.ExecutionUnit;
+            }
+        }
+
         var input = new HostLoopNextActionInput
         {
             Repo = parsed.Repo,
@@ -80,8 +113,8 @@ internal static class AutomationHostLoopNextActionCommand
             ApprovedPrPendingMergeCloseout = approvedPr,
             PublishRecoveryRepairsAvailable = parsed.PublishRecoveryRepairsAvailable,
             PublishLifecycleDriftCount = parsed.PublishLifecycleDriftCount,
-            NextSliceIssueCutReady = parsed.NextSliceIssueCutReady,
-            PublishNextSliceExecutionUnit = parsed.PublishNextSliceExecutionUnit,
+            NextSliceIssueCutReady = nextSliceIssueCutReady,
+            PublishNextSliceExecutionUnit = publishNextSliceExecutionUnit,
             OpenIntentTargetPrOrIssueExists = openIntentTargetExists,
             AnyChildWorkerLeaseHeld = anyLeaseHeld,
             HardClarificationOpen = parsed.HardClarificationOpen

--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -82,23 +82,64 @@ internal static class AutomationHostLoopNextActionCommand
         // G318: automatically probe `intent next-slice --dry-run` when the
         // operator did not pre-pipe the flag. The host loop must NOT report
         // `true-idle` while a matching next-slice candidate is ready to
-        // publish, so the command takes ownership of the probe instead of
-        // relying on the caller to wire it. An operator-supplied
-        // `--next-slice-issue-cut-ready` (with `--publish-next-execution-unit`)
-        // still wins so existing pre-pipe flows are byte-identical.
+        // publish OR a blocked next-slice outcome (clarification-required,
+        // skip-next-slice-due-to-wip) is pending, so the command takes
+        // ownership of the probe instead of relying on the caller to wire
+        // it. An operator-supplied `--next-slice-issue-cut-ready` (with
+        // `--publish-next-execution-unit`) still wins so existing pre-pipe
+        // flows are byte-identical.
         var nextSliceIssueCutReady = parsed.NextSliceIssueCutReady;
         var publishNextSliceExecutionUnit = parsed.PublishNextSliceExecutionUnit;
+        var hardClarificationOpen = parsed.HardClarificationOpen;
+        var openIntentTargetExistsResolved = openIntentTargetExists;
         if (!nextSliceIssueCutReady && !string.IsNullOrWhiteSpace(parsed.Domain))
         {
             var probe = NextSliceDryRunProbeFactory?.Invoke(context)
                 ?? new IntentCliNextSliceDryRunProbe(context);
             var probed = probe.Probe(parsed.Repo, parsed.Domain!);
-            if (probed != null
-                && string.Equals(probed.RecommendedOutcome, "issue-cut-ready", StringComparison.Ordinal)
-                && !string.IsNullOrWhiteSpace(probed.ExecutionUnit))
+            if (probed != null)
             {
-                nextSliceIssueCutReady = true;
-                publishNextSliceExecutionUnit = probed.ExecutionUnit;
+                switch (probed.RecommendedOutcome)
+                {
+                    case "issue-cut-ready":
+                        // Happy path: surface the publish-next-issue lane.
+                        if (!string.IsNullOrWhiteSpace(probed.ExecutionUnit))
+                        {
+                            nextSliceIssueCutReady = true;
+                            publishNextSliceExecutionUnit = probed.ExecutionUnit;
+                        }
+                        break;
+
+                    case "clarification-required":
+                        // G318 review fix: a blocked next-slice with an
+                        // open hard-clarification must NOT fall through to
+                        // true-idle. Force the analyzer's
+                        // `hard-clarification` lane.
+                        hardClarificationOpen = true;
+                        break;
+
+                    case "skip-next-slice-due-to-wip":
+                        // G318 review fix: queue-state authoritatively
+                        // reports a WIP-cap block. Surface the existing
+                        // `wip-cap-blocked` classification vocabulary even
+                        // when the GitHub label listing happens to look
+                        // empty (queue-state and label state can diverge
+                        // transiently). The analyzer's wip-cap-blocked
+                        // lane requires `!AnyChildWorkerLeaseHeld`, which
+                        // matches the next-slice "skip" semantic (the
+                        // skip is about new publication, not about a
+                        // child worker holding a lease).
+                        openIntentTargetExistsResolved = true;
+                        break;
+
+                    case "no-actionable-item":
+                    default:
+                        // Truly idle from next-slice's perspective; let
+                        // the analyzer fall through to existing lanes
+                        // (review-pr / wip-cap-blocked / wait-for-child /
+                        // true-idle).
+                        break;
+                }
             }
         }
 
@@ -115,9 +156,9 @@ internal static class AutomationHostLoopNextActionCommand
             PublishLifecycleDriftCount = parsed.PublishLifecycleDriftCount,
             NextSliceIssueCutReady = nextSliceIssueCutReady,
             PublishNextSliceExecutionUnit = publishNextSliceExecutionUnit,
-            OpenIntentTargetPrOrIssueExists = openIntentTargetExists,
+            OpenIntentTargetPrOrIssueExists = openIntentTargetExistsResolved,
             AnyChildWorkerLeaseHeld = anyLeaseHeld,
-            HardClarificationOpen = parsed.HardClarificationOpen
+            HardClarificationOpen = hardClarificationOpen
         };
 
         var result = HostLoopNextActionAnalyzer.Analyze(input);

--- a/src/IntentSystem.Cli/Commands/INextSliceDryRunProbe.cs
+++ b/src/IntentSystem.Cli/Commands/INextSliceDryRunProbe.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G318: testability seam for <c>intent-cli automation host-loop-next-action</c>.
+/// Production lets the command probe <c>intent next-slice --dry-run</c>
+/// in-process so the host loop never reports <c>true-idle</c> when a
+/// matching next-slice candidate is ready to publish as a GitHub issue.
+/// Tests inject a fake to avoid touching the live queue-state and to
+/// model `issue-cut-ready` / `no-actionable-item` / `clarification-required`
+/// outcomes deterministically.
+/// </summary>
+internal interface INextSliceDryRunProbe
+{
+    NextSliceProbeResult? Probe(string repo, string domain);
+}
+
+/// <summary>
+/// G318: minimal structured projection of <c>intent next-slice --dry-run</c>.
+/// Only the two fields the host-loop-next-action analyzer needs
+/// (<see cref="RecommendedOutcome"/> + <see cref="ExecutionUnit"/>) are
+/// surfaced; richer status / WIP / clarification detail stays in the
+/// full <c>intent next-slice</c> output for operators who run it
+/// directly.
+/// </summary>
+internal sealed record NextSliceProbeResult
+{
+    public required string RecommendedOutcome { get; init; }
+    public string? ExecutionUnit { get; init; }
+}
+
+/// <summary>
+/// G318: in-process invoker of <see cref="IntentNextSliceCommand"/>.
+/// Reuses the host's existing <see cref="CliContext"/> (so queue-state /
+/// packet directories resolve from the parent host root, not a child
+/// worktree) and parses the JSON output for the analyzer.
+/// </summary>
+internal sealed class IntentCliNextSliceDryRunProbe : INextSliceDryRunProbe
+{
+    private readonly CliContext _context;
+
+    public IntentCliNextSliceDryRunProbe(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    public NextSliceProbeResult? Probe(string repo, string domain)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+
+        var args = new[]
+        {
+            "--dry-run",
+            "--domain", domain,
+            "--target-repo", repo,
+            "--format", "json"
+        };
+
+        using var buffer = new StringWriter();
+        int exitCode;
+        try
+        {
+            exitCode = IntentNextSliceCommand.Execute(_context, args, buffer);
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException)
+        {
+            // G318 fail-soft: the host loop must not crash when the
+            // next-slice probe fails (e.g. queue-state missing, packet
+            // root unreadable). Returning null falls through to the
+            // existing true-idle / wip-cap-blocked classification.
+            return null;
+        }
+
+        if (exitCode != 0)
+        {
+            return null;
+        }
+
+        var stdout = buffer.ToString();
+        if (string.IsNullOrWhiteSpace(stdout))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(stdout);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            var outcome = root.TryGetProperty("recommended_outcome", out var outcomeElement)
+                && outcomeElement.ValueKind == JsonValueKind.String
+                ? outcomeElement.GetString()
+                : null;
+            if (string.IsNullOrWhiteSpace(outcome))
+            {
+                return null;
+            }
+
+            string? executionUnit = null;
+            if (root.TryGetProperty("candidate", out var candidateElement)
+                && candidateElement.ValueKind == JsonValueKind.Object
+                && candidateElement.TryGetProperty("execution_unit", out var unitElement)
+                && unitElement.ValueKind == JsonValueKind.String)
+            {
+                executionUnit = unitElement.GetString();
+            }
+
+            return new NextSliceProbeResult
+            {
+                RecommendedOutcome = outcome!,
+                ExecutionUnit = string.IsNullOrWhiteSpace(executionUnit) ? null : executionUnit
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
@@ -335,6 +335,58 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_NextSliceProbeReturnsClarificationRequired_SurfacesHardClarification_NotTrueIdle()
+    {
+        // G318 review fix (PR #744): a blocked next-slice outcome must not
+        // collapse into `true-idle`. `clarification-required` from
+        // `intent next-slice --dry-run` maps to the analyzer's
+        // `hard-clarification` lane so the operator gets a precise stop
+        // and a clarification-next pointer instead of an idle wake.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "clarification-required", ExecutionUnit = null });
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/SekibanAsAService",
+             "--domain", "sekiban-as-a-service", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("hard-clarification", doc.RootElement.GetProperty("classification").GetString());
+    }
+
+    [Fact]
+    public void Execute_NextSliceProbeReturnsSkipDueToWip_SurfacesWipCapBlocked_NotTrueIdle()
+    {
+        // G318 review fix (PR #744): when queue-state authoritatively
+        // reports `skip-next-slice-due-to-wip` (e.g. labels and queue
+        // diverge), the command MUST surface `wip-cap-blocked` instead of
+        // collapsing into `true-idle` because the GitHub label listing
+        // happens to look empty.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "skip-next-slice-due-to-wip", ExecutionUnit = null });
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/SekibanAsAService",
+             "--domain", "sekiban-as-a-service", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("wip-cap-blocked", doc.RootElement.GetProperty("classification").GetString());
+    }
+
+    [Fact]
     public void Execute_NextSliceProbe_IsNotInvoked_WhenDomainMissing()
     {
         // G318 safety rail: `intent next-slice --dry-run` requires a

--- a/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
@@ -17,11 +17,13 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
     public AutomationHostLoopNextActionCommandTests()
     {
         AutomationHostLoopNextActionCommand.CandidateListerFactory = null;
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = null;
     }
 
     public void Dispose()
     {
         AutomationHostLoopNextActionCommand.CandidateListerFactory = null;
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = null;
     }
 
     [Fact]
@@ -220,6 +222,162 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
             Labels = labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
             State = "OPEN"
         };
+
+    // --- G318: automatic intent next-slice --dry-run probe ----------------
+
+    [Fact]
+    public void Execute_NextSliceProbeReturnsIssueCutReady_SelectsPublishNextIssue_NotTrueIdle()
+    {
+        // Mirrors SKS-G224: empty repo (no review PR, no open intent-target,
+        // no host-metadata drift), `intent next-slice --dry-run` reports
+        // `issue-cut-ready`. Before G318 the host loop reported true-idle;
+        // the command now auto-probes next-slice and surfaces the publish
+        // action.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "SKS-G224" });
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/SekibanAsAService",
+             "--domain", "sekiban-as-a-service", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("publish-next-issue", root.GetProperty("classification").GetString());
+        Assert.True(root.GetProperty("mutation_allowed").GetBoolean());
+        var recommended = root.GetProperty("recommended_command").GetString()!;
+        Assert.Contains("--execution-unit SKS-G224", recommended, StringComparison.Ordinal);
+        Assert.Contains("--target-repo J-Tech-Japan/SekibanAsAService", recommended, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NextSliceProbeReturnsNoActionableItem_FallsThroughToTrueIdle()
+    {
+        // G318 acceptance: when next-slice has no candidate AND no other
+        // host signal exists, true-idle remains a valid outcome.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/SekibanAsAService",
+             "--domain", "sekiban-as-a-service", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("true-idle", doc.RootElement.GetProperty("classification").GetString());
+    }
+
+    [Fact]
+    public void Execute_NextSliceProbe_IsNotInvoked_WhenOperatorPrePipesFlag()
+    {
+        // G318 backward-compat: pre-piped `--next-slice-issue-cut-ready`
+        // wins; the probe is not invoked even when --domain is present.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        var probeWasInvoked = false;
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "ignored", ExecutionUnit = "ignored" },
+            onProbe: () => probeWasInvoked = true);
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/SekibanAsAService",
+             "--domain", "sekiban-as-a-service",
+             "--next-slice-issue-cut-ready",
+             "--publish-next-execution-unit", "OPERATOR-PIPED",
+             "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        Assert.False(probeWasInvoked, "operator-supplied next-slice flag must short-circuit the probe");
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("publish-next-issue", doc.RootElement.GetProperty("classification").GetString());
+        Assert.Contains("--execution-unit OPERATOR-PIPED",
+            doc.RootElement.GetProperty("recommended_command").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NextSliceProbeReturnsIssueCutReady_ButWipCapActive_BlocksPublish()
+    {
+        // G318 acceptance: even when next-slice is `issue-cut-ready`, an
+        // open intent-target issue/PR must keep the WIP-cap-blocked
+        // classification (publish-next-issue requires WIP cap empty).
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: new[] { NewIssue(900, labels: new[] { "intent-target" }) });
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "SKS-G225" });
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/SekibanAsAService",
+             "--domain", "sekiban-as-a-service", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        Assert.Equal("wip-cap-blocked",
+            JsonDocument.Parse(writer.ToString()).RootElement.GetProperty("classification").GetString());
+    }
+
+    [Fact]
+    public void Execute_NextSliceProbe_IsNotInvoked_WhenDomainMissing()
+    {
+        // G318 safety rail: `intent next-slice --dry-run` requires a
+        // domain. Without `--domain` the probe is skipped to avoid an
+        // unconditional in-process invocation that the analyzer cannot
+        // use anyway.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        var probeWasInvoked = false;
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "IGNORED" },
+            onProbe: () => probeWasInvoked = true);
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        Assert.False(probeWasInvoked, "probe must not run without --domain");
+        Assert.Equal("true-idle",
+            JsonDocument.Parse(writer.ToString()).RootElement.GetProperty("classification").GetString());
+    }
+
+    private sealed class FakeNextSliceProbe : INextSliceDryRunProbe
+    {
+        private readonly NextSliceProbeResult? _canned;
+        private readonly Action? _onProbe;
+
+        public FakeNextSliceProbe(NextSliceProbeResult? canned, Action? onProbe = null)
+        {
+            _canned = canned;
+            _onProbe = onProbe;
+        }
+
+        public NextSliceProbeResult? Probe(string repo, string domain)
+        {
+            _onProbe?.Invoke();
+            return _canned;
+        }
+    }
 
     private sealed class FakeLister : IGitHubAutomationCandidateLister
     {


### PR DESCRIPTION
## Summary

`intent-cli automation host-loop-next-action` now invokes `intent next-slice --dry-run` in-process when `--domain` is supplied and the operator did not pre-pipe `--next-slice-issue-cut-ready`. When the probe returns `recommended_outcome: issue-cut-ready` with a non-empty execution unit, the analyzer surfaces the existing `publish-next-issue` classification (packet draft → issue publish-flow → automation issue-publish) instead of falling through to `true-idle`.

- New seam `INextSliceDryRunProbe` + production implementation `IntentCliNextSliceDryRunProbe` calls `IntentNextSliceCommand.Execute` in-process — same `CliContext`, same queue-state / packet root resolution, no recursive subprocess, no extra PATH dependency.
- New static `AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory` mirrors the existing `CandidateListerFactory` for test injection.
- Fail-soft: probe `IOException` / `InvalidOperationException` / `JsonException` / non-zero exit / empty stdout all return null so the host loop keeps classifying via the existing lanes (true-idle, wip-cap-blocked, etc.); a transient queue-state issue can never crash the wake.
- Operator pre-pipe (`--next-slice-issue-cut-ready --publish-next-execution-unit <id>`) still wins and short-circuits the probe — existing `HostLoopNextActionAnalyzerTests` continue to pass byte-identically.

## Why

A SekibanAsAService host heartbeat reported `true-idle` while `intent next-slice --dry-run` for the same state returned `recommended_outcome: issue-cut-ready` for `SKS-G224`. The host loop was correctly delegating to `host-loop-next-action`, but the command itself had no probe — so until the operator threaded the next-slice signal in by hand, the host loop reported idle and the next issue was never cut after a review/closeout wake. G318 puts the probe inside the command so that link cannot be skipped.

## Test plan

- [x] Empty repo + probe `issue-cut-ready/SKS-G224` → classification `publish-next-issue`; `recommended_command` contains `--execution-unit SKS-G224 --target-repo J-Tech-Japan/SekibanAsAService`.
- [x] Empty repo + probe `no-actionable-item` → classification `true-idle` (acceptance: idle remains valid when nothing is ready).
- [x] Operator pre-pipes `--next-slice-issue-cut-ready --publish-next-execution-unit OPERATOR-PIPED` → classification `publish-next-issue` with `OPERATOR-PIPED`; FakeNextSliceProbe's hook asserts the probe was not invoked.
- [x] Open `intent-target` issue + probe `issue-cut-ready` → classification `wip-cap-blocked` (acceptance: WIP cap still wins).
- [x] `--domain` omitted → probe is not invoked; classification falls through to existing lanes (`true-idle` in the empty-repo case).
- [x] All prior 6 `AutomationHostLoopNextActionCommand` tests still pass (G319 happy / draft / merge-blocked / metadata-blocked / wip-cap fallback / lease-held).
- [x] All 21 `HostLoopNextActionAnalyzerTests` pass — the pure analyzer is unchanged.
- [x] Full CLI suite: 2425 passed, 0 failed (no flake in this run).

Closes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)