### PR TITLE
G322: automation setup contract lint

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideAutomationCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationCommand.cs
@@ -49,6 +49,13 @@ internal static class GuideAutomationCommand
             return GuideAutomationLocalLoopCommand.Execute(context, args[1..], writer);
         }
 
+        // G322: nested `guide automation lint ...` validates a generated
+        // contract against the required safety clauses.
+        if (args.Length >= 1 && string.Equals(args[0], "lint", StringComparison.Ordinal))
+        {
+            return GuideAutomationLintCommand.Execute(context, args[1..], writer);
+        }
+
         if (!TryParseArguments(args, out var kind, out var domain, out var repo, out var format, out var error))
         {
             writer.WriteLine(error);

--- a/src/IntentSystem.Cli/Commands/GuideAutomationLintCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationLintCommand.cs
@@ -1,0 +1,429 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G322: read-only <c>intent-cli guide automation lint</c>. Validates a
+/// generated automation setup contract (markdown or plain text) against
+/// the safety clauses the rest of the system relies on
+/// (<see cref="GuideAutomationContractLinter"/>). Mutates nothing;
+/// never launches a provider; never reads queue-state. Tests inject
+/// inline text; production callers read the contract from a file.
+/// </summary>
+internal static class GuideAutomationLintCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide automation lint [--from-file <path> | --text <inline>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var fromFile, out var inlineText, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (string.IsNullOrEmpty(fromFile) && inlineText is null)
+        {
+            writer.WriteLine("guide automation lint requires either --from-file <path> or --text <inline>.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+        if (!string.IsNullOrEmpty(fromFile) && inlineText is not null)
+        {
+            writer.WriteLine("guide automation lint accepts --from-file or --text, not both.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        string contract;
+        if (!string.IsNullOrEmpty(fromFile))
+        {
+            try
+            {
+                contract = File.ReadAllText(fromFile!);
+            }
+            catch (Exception exception) when (
+                exception is FileNotFoundException
+                or DirectoryNotFoundException
+                or UnauthorizedAccessException
+                or IOException)
+            {
+                writer.WriteLine($"failed to read --from-file '{fromFile}': {exception.Message}");
+                return 1;
+            }
+        }
+        else
+        {
+            contract = inlineText!;
+        }
+
+        var result = GuideAutomationContractLinter.Lint(contract);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        // G322: command exit is 0 even when status==fail so callers can
+        // pipe / inspect structured output. CI / scripts looking for a
+        // gate should test the `status` field, not the exit code.
+        return 0;
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideAutomationLintResult result)
+    {
+        writer.WriteLine($"# guide automation lint — {result.Status}");
+        writer.WriteLine();
+        if (result.MissingClauses.Count == 0)
+        {
+            writer.WriteLine("All required safety clauses present.");
+        }
+        else
+        {
+            writer.WriteLine("## Missing clauses");
+            foreach (var miss in result.MissingClauses)
+            {
+                writer.WriteLine($"- `{miss.Id}` — {miss.Description}");
+                if (miss.RequiredAny.Count > 0)
+                {
+                    writer.WriteLine($"  expected ANY of: {string.Join(" | ", miss.RequiredAny.Select(p => $"\"{p}\""))}");
+                }
+            }
+        }
+        if (result.FoundClauses.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Found clauses");
+            foreach (var found in result.FoundClauses)
+            {
+                writer.WriteLine($"- `{found}`");
+            }
+        }
+        if (!string.IsNullOrEmpty(result.RecommendedRegenerationCommand))
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Recommended regeneration");
+            writer.WriteLine();
+            writer.WriteLine($"```");
+            writer.WriteLine(result.RecommendedRegenerationCommand);
+            writer.WriteLine($"```");
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? fromFile,
+        out string? inlineText,
+        out string format,
+        out string error)
+    {
+        fromFile = null;
+        inlineText = null;
+        format = FormatJson; // G322: default controller-friendly
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--from-file":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-file requires a path.";
+                        return false;
+                    }
+                    fromFile = args[index + 1];
+                    index++;
+                    break;
+
+                case "--text":
+                    if (index + 1 >= args.Length)
+                    {
+                        error = "--text requires a value.";
+                        return false;
+                    }
+                    inlineText = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide automation lint");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Validates a generated automation setup contract against the required safety clauses.");
+        writer.WriteLine("Pass --from-file to read a saved contract (paste-ready markdown), or --text for inline content.");
+        writer.WriteLine("Exit code is always 0; gate on the `status` field of the JSON output.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+/// <summary>
+/// G322: pure contract linter. Each clause has a stable identifier and
+/// a list of substring patterns. ANY substring match (case-insensitive)
+/// counts as a clause hit; missing all patterns surfaces the clause as a
+/// failure with the full required-any list so the caller knows what to
+/// add. Splitting the safety surface into small clauses keeps failures
+/// precise — "missing same-thread scheduling" is actionable, "contract
+/// looks wrong" is not.
+/// </summary>
+internal static class GuideAutomationContractLinter
+{
+    public static GuideAutomationLintResult Lint(string contract)
+    {
+        ArgumentNullException.ThrowIfNull(contract);
+
+        var found = new List<string>();
+        var missing = new List<GuideAutomationLintMiss>();
+        foreach (var clause in Clauses)
+        {
+            var hit = false;
+            foreach (var pattern in clause.Patterns)
+            {
+                if (contract.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    hit = true;
+                    break;
+                }
+            }
+
+            if (hit)
+            {
+                found.Add(clause.Id);
+            }
+            else
+            {
+                missing.Add(new GuideAutomationLintMiss
+                {
+                    Id = clause.Id,
+                    Description = clause.Description,
+                    RequiredAny = clause.Patterns
+                });
+            }
+        }
+
+        return new GuideAutomationLintResult
+        {
+            Status = missing.Count == 0 ? "pass" : "fail",
+            FoundClauses = found,
+            MissingClauses = missing,
+            RecommendedRegenerationCommand = missing.Count == 0
+                ? null
+                : "intent-cli guide automation setup --purpose <child-implement|host-review-next-slice> --agent <claude|codex> --domain <DOMAIN> --target-repo <owner/repo> --frequency <NNm> --format markdown"
+        };
+    }
+
+    private sealed record Clause(string Id, string Description, IReadOnlyList<string> Patterns);
+
+    // Required safety clauses. Each clause's Patterns list is OR-matched
+    // (case-insensitive substring); contracts must contain at least one
+    // pattern from each list.
+    private static readonly IReadOnlyList<Clause> Clauses = new[]
+    {
+        new Clause(
+            "same-thread-scheduling",
+            "Contract names a same-thread / local-automation scheduling mechanism (G314).",
+            new[]
+            {
+                "same-thread",
+                "same thread",
+                "current-thread",
+                "current thread",
+                "local automation",
+                "heartbeat",
+                "/loop"
+            }),
+        new Clause(
+            "installed-cli-doctor-check",
+            "Contract references `intent-cli automation doctor` / installed CLI surface checks.",
+            new[]
+            {
+                "automation doctor",
+                "installed CLI",
+                "installed-cli",
+                "stale-host-cli"
+            }),
+        new Clause(
+            "stale-cli-abort",
+            "Contract requires aborting the wake on stale CLI rather than falling back.",
+            new[]
+            {
+                "stale-host-cli",
+                "stale CLI",
+                "abort the wake",
+                "refresh the installed CLI",
+                "refresh or reinstall"
+            }),
+        new Clause(
+            "no-local-rules-or-skills",
+            "Contract forbids reading intents/rules/** and copied local skill prompts.",
+            new[]
+            {
+                "intents/rules/**",
+                "local skill files",
+                "copied prompt"
+            }),
+        new Clause(
+            "no-dotnet-run-fallback",
+            "Contract explicitly forbids falling back to `dotnet run` instead of the installed `intent-cli`.",
+            new[]
+            {
+                // G322: only the explicit negative-form prohibition counts.
+                // A bare `dotnet run` mention is NOT a safety guarantee —
+                // a contract that says "use dotnet run instead" must fail
+                // this clause, not silently pass.
+                "Do not run `dotnet run`",
+                "do not run dotnet run",
+                "do NOT fall back to direct DLL",
+                "do not fall back to direct dll",
+                "never `dotnet run`",
+                "never dotnet run"
+            }),
+        new Clause(
+            "no-raw-label-mutation",
+            "Contract explicitly forbids raw `gh label` / manual workflow label edits.",
+            new[]
+            {
+                // G322: negative-form prohibition only.
+                "no manual `gh ... edit",
+                "no manual gh ... edit",
+                "no raw `gh` label",
+                "no raw gh label",
+                "manual `gh ... edit --add-label` / `--remove-label` fallback",
+                "no manual gh.*edit.*label"
+            }),
+        new Clause(
+            "no-intent-cli-run",
+            "Contract explicitly forbids `intent-cli run` from the chat-first loop (advanced-only).",
+            new[]
+            {
+                // G322: only negative-form prohibition counts. A contract
+                // that says "you may use `intent-cli run`" must fail.
+                "do not call `intent-cli run`",
+                "do not call intent-cli run",
+                "never `intent-cli run`",
+                "never intent-cli run",
+                "advanced runtime"
+            }),
+        new Clause(
+            "no-provider-launch",
+            "Contract explicitly forbids `intent-cli` launching Claude/Codex or any AI provider.",
+            new[]
+            {
+                // G322: negative-form prohibition only.
+                "do not ask `intent-cli` to launch",
+                "do not ask intent-cli to launch",
+                "never launch claude",
+                "never launch codex",
+                "do not launch AI provider"
+            }),
+        new Clause(
+            "canonical-worker-commands",
+            "Contract references canonical worker commands (next-action / claim / complete).",
+            new[]
+            {
+                "worker next-action",
+                "worker claim",
+                "worker complete"
+            }),
+        new Clause(
+            "wip-cap-and-idle-handling",
+            "Contract addresses WIP cap / Hard Clarification (host) or `action: none → idle` (child).",
+            new[]
+            {
+                // Host-loop vocabulary.
+                "WIP cap",
+                "wip-cap",
+                "wip cap",
+                "Hard Clarification",
+                "hard-clarification",
+                "true-idle",
+                "true idle",
+                "no-actionable-item",
+                // Child-loop idle vocabulary: `worker next-action` returns
+                // `action: none` and the loop stops with idle.
+                "stop with `idle`",
+                "stop with idle"
+            })
+    };
+}
+
+internal sealed record GuideAutomationLintResult
+{
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("found_clauses")]
+    public required IReadOnlyList<string> FoundClauses { get; init; }
+
+    [JsonPropertyName("missing_clauses")]
+    public required IReadOnlyList<GuideAutomationLintMiss> MissingClauses { get; init; }
+
+    [JsonPropertyName("recommended_regeneration_command")]
+    public string? RecommendedRegenerationCommand { get; init; }
+}
+
+internal sealed record GuideAutomationLintMiss
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    [JsonPropertyName("required_any")]
+    public required IReadOnlyList<string> RequiredAny { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GuideAutomationLintCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationLintCommand.cs
@@ -350,13 +350,15 @@ internal static class GuideAutomationContractLinter
             "Contract explicitly forbids `intent-cli run` from the chat-first loop (advanced-only).",
             new[]
             {
-                // G322: only negative-form prohibition counts. A contract
-                // that says "you may use `intent-cli run`" must fail.
+                // G322 review fix (PR #748): only negative-form
+                // prohibition counts. A contract that says "you may use
+                // `intent-cli run` — it is the advanced runtime path"
+                // must FAIL this clause, so the bare "advanced runtime"
+                // descriptor is intentionally excluded.
                 "do not call `intent-cli run`",
                 "do not call intent-cli run",
                 "never `intent-cli run`",
-                "never intent-cli run",
-                "advanced runtime"
+                "never intent-cli run"
             }),
         new Clause(
             "no-provider-launch",

--- a/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
@@ -264,6 +264,7 @@ Loop body (single wake; the operator drives subsequent wakes if any):
 Hard rules:
 - Do not read `intents/rules/**`, local skill files (`gh-issue-to-pr`, `gh-fix-pr-comment`, etc.), or copied prompt files for routine collaboration. Use `intent-cli guide ...` instead.
 - Do not call `intent-cli run` from this loop. `run` is advanced runtime (integration smoke / replay / dogfooding), not the chat-first path.
+- If `intent-cli automation doctor` reports `stale-host-cli` or a missing required surface, **abort the wake** before any mutation and refresh the installed CLI. Never fall back to direct DLL invocation or `dotnet run`.
 - Do not run `dotnet run` as a fallback for `intent-cli`.
 - Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
 - All label transitions go through installed `intent-cli automation` / `intent-cli worker` commands. No manual `gh ... edit --add-label` / `--remove-label` fallback for workflow labels.

--- a/tests/IntentSystem.Cli.Tests/GuideAutomationLintCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideAutomationLintCommandTests.cs
@@ -89,6 +89,35 @@ Some automation setup that says:
     }
 
     [Fact]
+    public void Lint_ContractThatDescribesIntentCliRunWithoutProhibition_FailsClause()
+    {
+        // G322 review fix (PR #748): a contract that merely describes
+        // `intent-cli run` as "the advanced runtime path" (or otherwise
+        // permissively mentions it) MUST fail the `no-intent-cli-run`
+        // clause. Only an explicit negative prohibition counts as
+        // satisfying the safety clause. Mirrors the
+        // `Lint_ContractThatAllowsDotnetRunFallback_FailsClause`
+        // permissive-contract test for the `intent-cli run` surface.
+        const string contract = @"
+Some automation setup that says:
+- You may use `intent-cli run` if you want the advanced runtime path.
+- Same-thread `/loop 5m` is the scheduling mechanism.
+- automation doctor is OK; stale-host-cli would abort the wake.
+- Do not run `dotnet run` as a fallback.
+- No manual `gh ... edit --add-label` / `--remove-label` fallback.
+- Do not ask `intent-cli` to launch Claude/Codex.
+- worker next-action / worker claim / worker complete drive dispatch.
+- stop with `idle` when next-action returns none.
+- Do not read `intents/rules/**` or copied prompt files.
+";
+
+        var result = GuideAutomationContractLinter.Lint(contract);
+
+        Assert.Equal("fail", result.Status);
+        Assert.Contains(result.MissingClauses, m => m.Id == "no-intent-cli-run");
+    }
+
+    [Fact]
     public void Lint_JsonOutput_HasControllerFriendlyShape()
     {
         // G322 acceptance: JSON output exposes status / found_clauses /

--- a/tests/IntentSystem.Cli.Tests/GuideAutomationLintCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideAutomationLintCommandTests.cs
@@ -1,0 +1,222 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G322: tests for the read-only `intent-cli guide automation lint`
+/// surface. Verifies that G320 generated contracts pass, that
+/// intentionally-incomplete contracts fail with precise missing-clause
+/// identifiers, and that the JSON output is controller-friendly.
+/// </summary>
+public sealed class GuideAutomationLintCommandTests
+{
+    [Fact]
+    public void Lint_G320ChildLoopContract_Passes()
+    {
+        // G322 acceptance: a generated G320 child-loop contract MUST pass
+        // lint out of the box. Regenerate it inline from
+        // GuideAutomationSetupCommand so the test breaks if either the
+        // contract content drifts or the lint clauses tighten.
+        var contract = GenerateChildContract();
+
+        var result = GuideAutomationContractLinter.Lint(contract);
+
+        Assert.Equal("pass", result.Status);
+        Assert.Empty(result.MissingClauses);
+    }
+
+    [Fact]
+    public void Lint_G320HostLoopContract_Passes()
+    {
+        var contract = GenerateHostContract();
+
+        var result = GuideAutomationContractLinter.Lint(contract);
+
+        Assert.Equal("pass", result.Status);
+        Assert.Empty(result.MissingClauses);
+    }
+
+    [Fact]
+    public void Lint_ContractMissingNoRawLabelMutation_FailsWithPreciseClause()
+    {
+        // G322 acceptance: a contract that omits the "no raw `gh` label
+        // mutation" prohibition fails lint with `no-raw-label-mutation`
+        // in `missing_clauses`.
+        var contract = GenerateChildContract().Replace(
+            "No manual `gh ... edit --add-label` / `--remove-label` fallback for workflow labels.",
+            "",
+            StringComparison.Ordinal);
+
+        var result = GuideAutomationContractLinter.Lint(contract);
+
+        Assert.Equal("fail", result.Status);
+        Assert.Contains(result.MissingClauses, m => m.Id == "no-raw-label-mutation");
+    }
+
+    [Fact]
+    public void Lint_ContractMissingSameThreadScheduling_FailsWithPreciseClause()
+    {
+        // G322 acceptance: a contract that does not name a same-thread /
+        // local-automation scheduling mechanism fails lint.
+        var contract = "Some unrelated automation setup text without any scheduling guidance.";
+
+        var result = GuideAutomationContractLinter.Lint(contract);
+
+        Assert.Equal("fail", result.Status);
+        Assert.Contains(result.MissingClauses, m => m.Id == "same-thread-scheduling");
+    }
+
+    [Fact]
+    public void Lint_ContractThatAllowsDotnetRunFallback_FailsClause()
+    {
+        // G322 acceptance: a contract that does NOT include the explicit
+        // "Do not run `dotnet run`" prohibition fails the
+        // `no-dotnet-run-fallback` clause — a bare `dotnet run` mention
+        // in a permissive context must NOT silently pass.
+        const string contract = @"
+Some automation setup that says:
+- You may use `dotnet run` to invoke the CLI if `intent-cli` is unavailable.
+- Same-thread `/loop 5m` is the scheduling mechanism.
+- automation doctor is OK; stale-host-cli would abort.
+";
+
+        var result = GuideAutomationContractLinter.Lint(contract);
+
+        Assert.Contains(result.MissingClauses, m => m.Id == "no-dotnet-run-fallback");
+    }
+
+    [Fact]
+    public void Lint_JsonOutput_HasControllerFriendlyShape()
+    {
+        // G322 acceptance: JSON output exposes status / found_clauses /
+        // missing_clauses / recommended_regeneration_command so a
+        // controller can gate on `status` without parsing markdown.
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLintCommand.Execute(
+            CreateContext(),
+            ["--text", "broken contract with nothing in it", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode); // exit is always 0; gate on status field
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("fail", root.GetProperty("status").GetString());
+        Assert.True(root.GetProperty("missing_clauses").GetArrayLength() > 0);
+        Assert.NotNull(root.GetProperty("recommended_regeneration_command").GetString());
+        // Each missing clause has id + description + required_any.
+        var firstMiss = root.GetProperty("missing_clauses")[0];
+        Assert.False(string.IsNullOrEmpty(firstMiss.GetProperty("id").GetString()));
+        Assert.False(string.IsNullOrEmpty(firstMiss.GetProperty("description").GetString()));
+        Assert.True(firstMiss.GetProperty("required_any").GetArrayLength() > 0);
+    }
+
+    [Fact]
+    public void Execute_MissingFromFileAndText_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLintCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--from-file", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--text", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_BothFromFileAndText_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLintCommand.Execute(
+            CreateContext(),
+            ["--from-file", "/tmp/whatever", "--text", "inline", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("not both", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_FromFileMissing_ReportsReadError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationLintCommand.Execute(
+            CreateContext(),
+            ["--from-file", "/does/not/exist/whatever.md", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("failed to read", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideAutomationCommand_LintSubcommand_IsRouted()
+    {
+        // G322: `intent-cli guide automation lint ...` must reach the
+        // lint command via the existing guide-automation router so the
+        // CLI surface is discoverable.
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationCommand.Execute(
+            CreateContext(),
+            ["lint", "--text", "broken", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("fail", doc.RootElement.GetProperty("status").GetString());
+    }
+
+    private static string GenerateChildContract()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            [
+                "--purpose", "child-implement",
+                "--agent", "claude",
+                "--domain", "intent-cli",
+                "--frequency", "5m",
+                "--format", "markdown"
+            ],
+            writer);
+        Assert.Equal(0, exitCode);
+        return writer.ToString();
+    }
+
+    private static string GenerateHostContract()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            [
+                "--purpose", "host-review-next-slice",
+                "--agent", "claude",
+                "--domain", "intent-cli",
+                "--target-repo", "J-Tech-Japan/intent-system",
+                "--frequency", "5m",
+                "--format", "markdown"
+            ],
+            writer);
+        Assert.Equal(0, exitCode);
+        return writer.ToString();
+    }
+
+    private static CliContext CreateContext() =>
+        new()
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+}


### PR DESCRIPTION
## Summary

Adds `intent-cli guide automation lint --from-file <path> | --text <inline>` so generated automation setup contracts can be checked deterministically — in tests and from automation agents — before a loop is scheduled. Pure linter (`GuideAutomationContractLinter`) validates ten safety clauses; each clause is an OR-list of case-insensitive substring patterns; failure surfaces precise missing-clause identifiers plus a regeneration hint.

- New file `GuideAutomationLintCommand.cs` (command + linter + result records). Pure: no I/O beyond reading the operator-supplied `--from-file` path; never mutates state; never launches a provider.
- Wired into the existing `GuideAutomationCommand` router as a `lint` subcommand alongside `setup` and `local-loop`.
- JSON output (default) is controller-friendly: `status` / `found_clauses` / `missing_clauses[{id, description, required_any}]` / `recommended_regeneration_command`. Markdown output mirrors the JSON shape for paste-ready reports. The command always exits 0; gate on the `status` field, not on exit code.

### Safety clauses

| id | what it checks |
|----|----------------|
| `same-thread-scheduling` | Same-thread / local-automation mechanism named (G314) |
| `installed-cli-doctor-check` | References `automation doctor` / installed CLI |
| `stale-cli-abort` | Aborts on stale-host-cli rather than falling back |
| `no-local-rules-or-skills` | Forbids `intents/rules/**` and copied local skills |
| `no-dotnet-run-fallback` | Explicit negative form ("Do not run \`dotnet run\`"); permissive contracts fail |
| `no-raw-label-mutation` | Explicit negative form for manual `gh ... edit` label edits |
| `no-intent-cli-run` | Explicit negative form for advanced runtime path |
| `no-provider-launch` | Explicit negative form for launching Claude / Codex / any AI provider |
| `canonical-worker-commands` | References worker next-action / claim / complete |
| `wip-cap-and-idle-handling` | WIP cap / Hard Clarification / true-idle (host) or `stop with \`idle\`` (child) |

Negative-form-only patterns for `no-dotnet-run-fallback` / `no-intent-cli-run` / `no-provider-launch` / `no-raw-label-mutation` mean a contract that says "you may use \`dotnet run\`" or "label edits via \`gh\` are fine" fails the lint — a bare mention is not a safety guarantee.

### Side effect — G320 child-implement contract addendum

Added one Hard rule to the G320 child-implement prompt so the existing generator passes lint:

> If `intent-cli automation doctor` reports `stale-host-cli` or a missing required surface, abort the wake before any mutation and refresh the installed CLI. Never fall back to direct DLL invocation or `dotnet run`.

The host-review-next-slice contract already passes (Stage 1 action dispatch covers `stale-host-cli → Abort the wake immediately`). The child contract previously omitted the doctor check; the addendum closes the gap. No other contract content changed.

## Why

G320 + G321 make `intent-cli` own the automation setup contract. Once that contract is generated rather than handwritten, regressions in the text become high-impact: silently losing "no raw label mutation" or "same-thread local automation" recreates exactly the failure modes the earlier G-issues closed. A read-only lint gives both tests and automation agents a deterministic safety gate before any wake is scheduled.

## Test plan

- [x] `Lint_G320ChildLoopContract_Passes` — generates contract via `GuideAutomationSetupCommand`, asserts `status=pass`, `missing_clauses=[]`.
- [x] `Lint_G320HostLoopContract_Passes` — same for host.
- [x] `Lint_ContractMissingNoRawLabelMutation_FailsWithPreciseClause` — strip the "No manual `gh ... edit`" line, assert `no-raw-label-mutation` in `missing_clauses`.
- [x] `Lint_ContractMissingSameThreadScheduling_FailsWithPreciseClause` — irrelevant text, assert `same-thread-scheduling` in `missing_clauses`.
- [x] `Lint_ContractThatAllowsDotnetRunFallback_FailsClause` — permissive contract with "You may use `dotnet run`" but no negative prohibition fails the `no-dotnet-run-fallback` clause.
- [x] `Lint_JsonOutput_HasControllerFriendlyShape` — assert status / missing_clauses / recommended_regeneration_command / per-miss fields exist.
- [x] `Execute_MissingFromFileAndText_ReturnsUsageError`.
- [x] `Execute_BothFromFileAndText_ReturnsUsageError`.
- [x] `Execute_FromFileMissing_ReportsReadError`.
- [x] `GuideAutomationCommand_LintSubcommand_IsRouted` — `intent-cli guide automation lint --text ... --format json` reaches the lint command via the existing router.
- [x] All 129 `GuideAutomation*` tests pass (51 G320 + 21 G321 + prior + 10 new G322).
- [x] Full CLI suite: 2466 passed, 0 failed.

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)