### PR TITLE
G323: structured prohibitions on every generated guidance contract

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuidanceProhibitions.cs
+++ b/src/IntentSystem.Cli/Commands/GuidanceProhibitions.cs
@@ -1,0 +1,102 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G323: structured prohibition surfaced by every generated guidance
+/// contract (setup contracts and one-shot task planners). Pairs a
+/// stable identifier with a human-readable description so controllers
+/// can dispatch on the <c>id</c> without reading prose, while operators
+/// reading the prompt see the same enforcement.
+/// </summary>
+internal sealed record GuidanceProhibition
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+}
+
+/// <summary>
+/// G323: single source of truth for the prohibitions every generated
+/// guidance contract MUST advertise. Centralizing the catalog means
+/// <see cref="GuideAutomationSetupCommand"/>, <see cref="TaskCommand"/>,
+/// and any future planner produce the same structured prohibition list
+/// with the same canonical IDs — tests can assert the IDs exist on each
+/// output and the lint surface
+/// (<see cref="GuideAutomationContractLinter"/>) can keep its prose
+/// patterns aligned with the structured IDs.
+/// </summary>
+internal static class GuidanceProhibitionCatalog
+{
+    public const string LocalRulesFallbackForbidden = "local-rules-fallback-forbidden";
+    public const string SkillFallbackForbidden = "skill-fallback-forbidden";
+    public const string CopiedPromptForbidden = "copied-prompt-forbidden";
+    public const string StaleCliFallbackForbidden = "stale-cli-fallback-forbidden";
+    public const string MissingCommandSurfaceForbidden = "missing-command-surface-forbidden";
+    public const string DotnetRunFallbackForbidden = "dotnet-run-fallback-forbidden";
+    public const string RawGhLabelMutationForbidden = "raw-gh-label-mutation-forbidden";
+    public const string ProviderLaunchForbidden = "provider-launch-forbidden";
+    public const string IntentCliRunForbidden = "intent-cli-run-forbidden";
+    public const string StaleMemoryFallbackForbidden = "stale-memory-fallback-forbidden";
+
+    /// <summary>
+    /// G323: canonical prohibition list for setup contracts AND task
+    /// planners. Order is the order operators see in markdown rendering;
+    /// JSON output mirrors the same order for stable diffs.
+    /// </summary>
+    public static IReadOnlyList<GuidanceProhibition> All { get; } = new GuidanceProhibition[]
+    {
+        new()
+        {
+            Id = LocalRulesFallbackForbidden,
+            Description = "Do not read `intents/rules/**` for routine collaboration; the installed `intent-cli guide` is the canonical guidance source."
+        },
+        new()
+        {
+            Id = SkillFallbackForbidden,
+            Description = "Do not dispatch local skill files (`gh-issue-to-pr`, `gh-fix-pr-comment`, etc.) for routine work; use `intent-cli` worker / automation commands instead."
+        },
+        new()
+        {
+            Id = CopiedPromptForbidden,
+            Description = "Do not consume copied prompt files for routine operation; regenerate via `intent-cli guide automation setup` to capture current contract text."
+        },
+        new()
+        {
+            Id = StaleMemoryFallbackForbidden,
+            Description = "Do not rely on stale model memory or prior conversation patterns when installed `intent-cli` guidance is available; re-run `guide model` / `guide onboarding` / `automation summary` to refresh the current contract."
+        },
+        new()
+        {
+            Id = StaleCliFallbackForbidden,
+            Description = "If `intent-cli automation doctor` reports `stale-host-cli`, abort the wake before any mutation and refresh the installed CLI; never fall back to direct DLL invocation."
+        },
+        new()
+        {
+            Id = MissingCommandSurfaceForbidden,
+            Description = "If a required automation command surface is missing per `automation doctor`, abort and surface the gap; do not silently fall back to ordinary GitHub review or raw label mutation."
+        },
+        new()
+        {
+            Id = DotnetRunFallbackForbidden,
+            Description = "Do not run `dotnet run` as a fallback for `intent-cli`; the installed CLI on `PATH` (or the cwd-local shim / explicit override) is the only supported invocation surface."
+        },
+        new()
+        {
+            Id = RawGhLabelMutationForbidden,
+            Description = "Do not perform raw `gh ... edit --add-label` / `--remove-label` workflow-label mutations; route every workflow label transition through `intent-cli automation` / `intent-cli worker` commands."
+        },
+        new()
+        {
+            Id = ProviderLaunchForbidden,
+            Description = "Do not ask `intent-cli` to launch Claude/Codex or any AI provider; this CLI is text-only and never spawns model providers."
+        },
+        new()
+        {
+            Id = IntentCliRunForbidden,
+            Description = "Do not call `intent-cli run` from chat-first loops; `run` is advanced runtime (integration smoke / replay / dogfooding) and is not part of the routine collaboration path."
+        }
+    };
+}

--- a/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
@@ -317,7 +317,8 @@ Frequency policy (applies only when a recurring local loop is explicitly request
                 "copied prompt files"
             },
             LabelOwnership = "All label transitions delegated to installed intent-cli automation / worker commands. Manual `gh ... edit --label` fallback is forbidden.",
-            WorktreeFriendly = "The prompt resolves the repo from the child worktree's `gh` / `git remote` and runs the selector from the parent host root with --workdir; no hard-coded paths, and the same prompt works across local worktrees."
+            WorktreeFriendly = "The prompt resolves the repo from the child worktree's `gh` / `git remote` and runs the selector from the parent host root with --workdir; no hard-coded paths, and the same prompt works across local worktrees.",
+            Prohibitions = GuidanceProhibitionCatalog.All
         };
     }
 
@@ -432,7 +433,8 @@ Frequency policy (applies only when a recurring local loop is explicitly request
                 "copied prompt files"
             },
             LabelOwnership = "All review-side and issue-side label transitions delegated to installed `intent-cli automation pr-transition` / `automation issue-publish` / `worker claim` / `worker complete`. Manual `gh ... edit --label` fallback is forbidden.",
-            WorktreeFriendly = "The prompt names the parent host root as cwd but does not hardcode any operator-specific path beyond that; the same prompt works across host-side checkouts."
+            WorktreeFriendly = "The prompt names the parent host root as cwd but does not hardcode any operator-specific path beyond that; the same prompt works across host-side checkouts.",
+            Prohibitions = GuidanceProhibitionCatalog.All
         };
     }
 
@@ -804,4 +806,17 @@ internal sealed record GuideAutomationSetupResult
 
     [JsonPropertyName("worktree_friendly")]
     public required string WorktreeFriendly { get; init; }
+
+    /// <summary>
+    /// G323: structured prohibitions list. Every generated setup
+    /// contract advertises the same canonical safety prohibitions
+    /// (no local rules / skill / copied prompt fallback, no stale
+    /// memory fallback, no `dotnet run`, no raw `gh` label edits, no
+    /// AI provider launch, no `intent-cli run` from chat-first loops,
+    /// abort on stale-cli / missing command surface). Controllers can
+    /// dispatch on the structured <c>id</c> values without parsing
+    /// prose.
+    /// </summary>
+    [JsonPropertyName("prohibitions")]
+    public IReadOnlyList<GuidanceProhibition>? Prohibitions { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/TaskCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskCommand.cs
@@ -159,7 +159,8 @@ internal static class TaskCommand
                 "`task issue-to-pr` is the explicit-target counterpart to `worker next-action` returning `action: issue-to-pr`. The dispatch contract is identical; only the discovery path differs.",
                 "Selector loops remain valid — use `worker next-action` for autonomous polling, this planner for controller-driven dispatch.",
                 "Never launch Claude/Codex/AI providers from `intent-cli`; this planner is text-only."
-            }
+            },
+            Prohibitions = GuidanceProhibitionCatalog.All
         };
 
         WritePlan(plan, parsed.Format, writer);
@@ -251,7 +252,8 @@ internal static class TaskCommand
                 "`task review-pr` is the explicit-target counterpart to autonomous host-review. Selector-driven host-review-preflight remains valid; this is for controllers who already know the PR.",
                 "G316 is non-negotiable: every approval summary must satisfy `guide review` `approval_summary_requirements`.",
                 "Never launch AI providers from intent-cli; this planner only emits text the controller runs."
-            }
+            },
+            Prohibitions = GuidanceProhibitionCatalog.All
         };
 
         WritePlan(plan, parsed.Format, writer);
@@ -332,7 +334,8 @@ internal static class TaskCommand
             {
                 "`task fix-pr-comments` is the explicit-target counterpart to `worker next-action` returning `action: pr-comment-fix`. Process at most one repair per wake.",
                 "Latest-actionable-comment selection is the controller's responsibility; this planner emits the contract once selection is made."
-            }
+            },
+            Prohibitions = GuidanceProhibitionCatalog.All
         };
 
         WritePlan(plan, parsed.Format, writer);
@@ -408,7 +411,8 @@ internal static class TaskCommand
             {
                 "`task publish-next-issue` is the explicit one-shot for the host's Stage 2 publish; selector-driven `intent next-slice` remains valid.",
                 "At most ONE issue is published per wake; this planner intentionally returns no loop or scheduler instruction."
-            }
+            },
+            Prohibitions = GuidanceProhibitionCatalog.All
         };
 
         WritePlan(plan, parsed.Format, writer);
@@ -705,4 +709,15 @@ internal sealed record TaskPlan
 
     [JsonPropertyName("notes")]
     public required IReadOnlyList<string> Notes { get; init; }
+
+    /// <summary>
+    /// G323: structured prohibitions list. Every task planner advertises
+    /// the same canonical safety prohibitions
+    /// (<see cref="GuidanceProhibitionCatalog"/>) so controllers can
+    /// dispatch on the structured <c>id</c> values without parsing
+    /// prose, and tests can assert each planner output carries the
+    /// guardrails.
+    /// </summary>
+    [JsonPropertyName("prohibitions")]
+    public IReadOnlyList<GuidanceProhibition>? Prohibitions { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideAutomationSetupCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideAutomationSetupCommandTests.cs
@@ -1111,6 +1111,50 @@ public sealed class GuideAutomationSetupCommandTests
         Assert.Contains("--cwd-role must be", writer.ToString(), StringComparison.Ordinal);
     }
 
+    // --- G323: structured prohibitions on every generated contract --------
+
+    [Theory]
+    [InlineData("child-implement", null)]
+    [InlineData("host-review-next-slice", "J-Tech-Japan/intent-system")]
+    public void Execute_AllPurposes_EmitStructuredProhibitionsJson(string purpose, string? targetRepo)
+    {
+        // G323 acceptance: both setup contracts expose the canonical
+        // structured prohibitions list (id + description) so controllers
+        // dispatch on stable ids without parsing prose. The catalog
+        // (`GuidanceProhibitionCatalog`) is the single source of truth
+        // for setup contracts AND task planners (see TaskCommandTests).
+        var args = new List<string>
+        {
+            "--purpose", purpose,
+            "--domain", "intent-cli",
+            "--format", "json"
+        };
+        if (targetRepo is not null)
+        {
+            args.AddRange(new[] { "--target-repo", targetRepo });
+        }
+
+        using var writer = new StringWriter();
+        var exit = GuideAutomationSetupCommand.Execute(CreateContext(), args.ToArray(), writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var prohibitions = doc.RootElement.GetProperty("prohibitions");
+        Assert.True(prohibitions.GetArrayLength() >= 8);
+        var ids = prohibitions.EnumerateArray()
+            .Select(e => e.GetProperty("id").GetString()!)
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.Contains("local-rules-fallback-forbidden", ids);
+        Assert.Contains("skill-fallback-forbidden", ids);
+        Assert.Contains("copied-prompt-forbidden", ids);
+        Assert.Contains("stale-memory-fallback-forbidden", ids);
+        Assert.Contains("stale-cli-fallback-forbidden", ids);
+        Assert.Contains("dotnet-run-fallback-forbidden", ids);
+        Assert.Contains("raw-gh-label-mutation-forbidden", ids);
+        Assert.Contains("provider-launch-forbidden", ids);
+        Assert.Contains("intent-cli-run-forbidden", ids);
+    }
+
     [Fact]
     public void AliasResolver_InferCwdRoleMatchesCanonicalPurpose()
     {

--- a/tests/IntentSystem.Cli.Tests/TaskCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskCommandTests.cs
@@ -362,6 +362,55 @@ public sealed class TaskCommandTests
         Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
     }
 
+    // --- G323: structured prohibitions on every task planner ---------------
+
+    [Theory]
+    [InlineData("issue-to-pr")]
+    [InlineData("review-pr")]
+    [InlineData("fix-pr-comments")]
+    [InlineData("publish-next-issue")]
+    public void Execute_AllTaskPlanners_EmitStructuredProhibitionsJson(string subcommand)
+    {
+        // G323 acceptance: every task planner JSON output exposes the
+        // canonical structured `prohibitions` list (id + description)
+        // so controllers can dispatch on stable ids without parsing
+        // prose. The catalog (`GuidanceProhibitionCatalog`) is the
+        // single source of truth for setup contracts AND task planners.
+        using var writer = new StringWriter();
+        var args = subcommand switch
+        {
+            "issue-to-pr" => new[] { "issue-to-pr", "--repo", "x/y", "--issue", "1", "--workdir", "/tmp/c", "--format", "json" },
+            "review-pr" => new[] { "review-pr", "--repo", "x/y", "--pr", "1", "--workdir", "/tmp/c", "--domain", "d", "--format", "json" },
+            "fix-pr-comments" => new[] { "fix-pr-comments", "--repo", "x/y", "--pr", "1", "--workdir", "/tmp/c", "--format", "json" },
+            "publish-next-issue" => new[] { "publish-next-issue", "--repo", "x/y", "--workdir", "/tmp/h", "--domain", "d", "--target-repo", "x/y", "--format", "json" },
+            _ => throw new ArgumentOutOfRangeException(nameof(subcommand))
+        };
+
+        var exit = TaskCommand.Execute(CreateContext(), args, writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var prohibitions = doc.RootElement.GetProperty("prohibitions");
+        Assert.True(prohibitions.GetArrayLength() >= 8);
+        var ids = prohibitions.EnumerateArray()
+            .Select(e => e.GetProperty("id").GetString()!)
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.Contains("local-rules-fallback-forbidden", ids);
+        Assert.Contains("skill-fallback-forbidden", ids);
+        Assert.Contains("copied-prompt-forbidden", ids);
+        Assert.Contains("stale-memory-fallback-forbidden", ids);
+        Assert.Contains("stale-cli-fallback-forbidden", ids);
+        Assert.Contains("dotnet-run-fallback-forbidden", ids);
+        Assert.Contains("raw-gh-label-mutation-forbidden", ids);
+        Assert.Contains("provider-launch-forbidden", ids);
+        Assert.Contains("intent-cli-run-forbidden", ids);
+        // Each entry must carry a non-empty description.
+        foreach (var entry in prohibitions.EnumerateArray())
+        {
+            Assert.False(string.IsNullOrWhiteSpace(entry.GetProperty("description").GetString()));
+        }
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext


### PR DESCRIPTION
## Summary

Adds a canonical `prohibitions` list (id + description) to every generated guidance output — setup contracts AND one-shot task planners — so controllers can dispatch on stable identifiers without parsing prose, and tests can assert each producer carries the guardrails.

- New `src/IntentSystem.Cli/Commands/GuidanceProhibitions.cs`: `GuidanceProhibition` record + `GuidanceProhibitionCatalog.All` — single source of truth for the canonical 10-entry prohibition list:
  - `local-rules-fallback-forbidden`
  - `skill-fallback-forbidden`
  - `copied-prompt-forbidden`
  - `stale-memory-fallback-forbidden`
  - `stale-cli-fallback-forbidden`
  - `missing-command-surface-forbidden`
  - `dotnet-run-fallback-forbidden`
  - `raw-gh-label-mutation-forbidden`
  - `provider-launch-forbidden`
  - `intent-cli-run-forbidden`
- `GuideAutomationSetupResult`: new optional `prohibitions` JSON field. Both `child-implement` and `host-review-next-slice` contracts populate it from `GuidanceProhibitionCatalog.All`. Markdown rendering unchanged (the prose already carries the equivalent text under `Forbidden rule sources` + `Hard rules`).
- `TaskPlan` (G317): new optional `prohibitions` JSON field on every task planner — `issue-to-pr`, `review-pr`, `fix-pr-comments`, `publish-next-issue` all populate it from the same catalog so the explicit-target one-shots advertise the same guardrails as the autonomous setup contracts.

## Why

G320 + G321 + G322 already moved the routine collaboration contract into `intent-cli` so operators stop pasting fixed conditions and so a lint catches missing prose-level prohibitions. G323 closes the controller-side gap: a downstream agent or CI gate that wants to enforce "this contract MUST forbid raw `gh` label mutation" should not have to grep the prompt — it should dispatch on a stable `id`. Centralizing the catalog in `GuidanceProhibitionCatalog` keeps the setup contracts and task planners aligned forever.

## Test plan

- [x] `Execute_AllPurposes_EmitStructuredProhibitionsJson` (Theory × 2: child-implement, host-review-next-slice) — JSON has `prohibitions[]` with the full canonical id set, non-empty descriptions, length ≥ 8.
- [x] `Execute_AllTaskPlanners_EmitStructuredProhibitionsJson` (Theory × 4: issue-to-pr, review-pr, fix-pr-comments, publish-next-issue) — same assertions for every planner subcommand.
- [x] All 51 G320 + 21 G321 + 11 G322 + prior `GuideAutomationSetup` / `GuideAutomationLint` / `TaskCommand` tests pass byte-identically (additive field is ignored by prior assertions).
- [x] G322 lint continues to catch absence of these guardrails in prose — negative-form-only patterns were locked in by the PR #748 review fix.
- [x] Full CLI suite: 2473 passed, 0 failed.

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)