### PR TITLE
G324: G312-safe closeout durable writes

### DIFF
--- a/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
@@ -135,14 +135,12 @@ internal static class CloseoutPrCommand
         }
 
         var executionUnit = matchedItem.ExecutionUnit;
-        var nowIso = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow)
-            .ToUniversalTime()
-            .ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", System.Globalization.CultureInfo.InvariantCulture);
+        var nowTs = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
 
         var runsEvents = new List<string>
         {
-            BuildRunsEvent(executionUnit, "pr-merged", repo!, pr.Value, nowIso),
-            BuildRunsEvent(executionUnit, "closeout-recorded", repo!, pr.Value, nowIso)
+            BuildRunsEvent(executionUnit, "pr-merged", repo!, pr.Value, nowTs),
+            BuildRunsEvent(executionUnit, "closeout-recorded", repo!, pr.Value, nowTs)
         };
 
         if (write && !alreadyCompleted)
@@ -258,17 +256,26 @@ internal static class CloseoutPrCommand
         };
     }
 
-    private static string BuildRunsEvent(string executionUnit, string kind, string repo, int pr, string timestampIso)
+    /// <summary>
+    /// G324: emit a current-schema <see cref="RunEvent"/> line that the
+    /// supervisor / durable-state preflight stack can deserialize without
+    /// errors. Replaces the legacy <c>timestamp</c> + <c>kind</c> fields
+    /// (which the strict G312 preflight rejects as invalid) with the
+    /// canonical <c>ts</c> / <c>event</c> / <c>by</c> trio plus the new
+    /// optional <c>repo</c> / <c>pr</c> correlation fields.
+    /// </summary>
+    private static string BuildRunsEvent(string executionUnit, string @event, string repo, int pr, DateTimeOffset ts)
     {
-        var payload = new Dictionary<string, object?>
+        var runEvent = new RunEvent
         {
-            ["timestamp"] = timestampIso,
-            ["execution_unit"] = executionUnit,
-            ["kind"] = kind,
-            ["repo"] = repo,
-            ["pr"] = pr
+            Ts = ts,
+            ExecutionUnit = executionUnit,
+            Event = @event,
+            By = "intent-cli closeout pr",
+            Repo = repo,
+            Pr = pr
         };
-        return JsonSerializer.Serialize(payload, RunsEventJsonOptions);
+        return RunLogSerializer.SerializeLine(runEvent);
     }
 
     private static string ClassifyContinuation(QueueState state, string completingUnit)
@@ -572,10 +579,10 @@ internal static class CloseoutPrCommand
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
-    private static readonly JsonSerializerOptions RunsEventJsonOptions = new()
-    {
-        WriteIndented = false
-    };
+    // G324: legacy raw-dictionary serialization options removed —
+    // closeout now emits canonical `RunEvent` lines via
+    // `RunLogSerializer.SerializeLine` so durable-state preflight can
+    // deserialize them.
 }
 
 internal sealed record CloseoutPrResult

--- a/src/IntentSystem.Cli/Commands/QueueStateForwardDeltaAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/QueueStateForwardDeltaAnalyzer.cs
@@ -128,20 +128,94 @@ internal static class QueueStateForwardDeltaAnalyzer
 
     private static ItemClassification ClassifyItem(QueueItem head, QueueItem working)
     {
-        // All scalar/metadata fields (other than LinkedIssue / LinkedPr)
-        // must be byte-identical for the delta to be classified as
-        // forward-only. Anything else is operator-review territory.
-        if (!string.Equals(head.Title, working.Title, StringComparison.Ordinal)
-            || head.State != working.State
+        // G324: closeout state transitions (Queued / Active / Review /
+        // Fixing → Completed) are deterministic forward-only mutations.
+        // When the ONLY scalar change is `state` moving along that
+        // pipeline AND every other scalar field stays byte-identical,
+        // surface the new `ClosedOutToCompleted` change kind so the
+        // host's auto-commit lane accepts a wake-after-closeout.
+        var stateChanged = head.State != working.State;
+        var otherScalarsChanged =
+            !string.Equals(head.Title, working.Title, StringComparison.Ordinal)
             || !string.Equals(head.ClarificationReturnPath, working.ClarificationReturnPath, StringComparison.Ordinal)
             || !string.Equals(head.WorkerRole, working.WorkerRole, StringComparison.Ordinal)
             || !string.Equals(head.ReviewRole, working.ReviewRole, StringComparison.Ordinal)
-            || !string.Equals(head.Priority, working.Priority, StringComparison.Ordinal))
+            || !string.Equals(head.Priority, working.Priority, StringComparison.Ordinal);
+        if (otherScalarsChanged)
         {
             return new ItemClassification(
                 ItemVerdict.Reject,
                 null,
-                $"items[execution_unit=`{head.ExecutionUnit}`] has scalar metadata changes (title/state/role/priority/clarification_return_path); refuse forward-only auto-commit.");
+                $"items[execution_unit=`{head.ExecutionUnit}`] has scalar metadata changes (title/role/priority/clarification_return_path); refuse forward-only auto-commit.");
+        }
+        if (stateChanged)
+        {
+            if (working.State == QueueItemState.Completed
+                && (head.State == QueueItemState.Queued
+                    || head.State == QueueItemState.Active
+                    || head.State == QueueItemState.Review
+                    || head.State == QueueItemState.Fixing))
+            {
+                // Capture the closeout transition as a forward-only change.
+                // Dependencies / packet_paths / linked refs must still be
+                // byte-identical (verified below) for the verdict to
+                // hold.
+                if (!SequenceEquals(head.Dependencies, working.Dependencies)
+                    || !SequenceEquals(head.BlockedBy, working.BlockedBy))
+                {
+                    return new ItemClassification(
+                        ItemVerdict.Reject,
+                        null,
+                        $"items[execution_unit=`{head.ExecutionUnit}`] dependencies / blocked_by changed; refuse forward-only auto-commit.");
+                }
+                if (!PacketPathsEqual(head.PacketPaths, working.PacketPaths))
+                {
+                    return new ItemClassification(
+                        ItemVerdict.Reject,
+                        null,
+                        $"items[execution_unit=`{head.ExecutionUnit}`] packet_paths changed; refuse forward-only auto-commit.");
+                }
+                // Refuse if linked refs simultaneously changed; closeout
+                // is purely the state transition.
+                var linkedIssueDeltaForCloseout = ClassifyLinkedIssue(head, working);
+                if (linkedIssueDeltaForCloseout.Verdict == ItemVerdict.Reject)
+                {
+                    return linkedIssueDeltaForCloseout;
+                }
+                if (linkedIssueDeltaForCloseout.Verdict == ItemVerdict.ForwardChange)
+                {
+                    return new ItemClassification(
+                        ItemVerdict.Reject,
+                        null,
+                        $"items[execution_unit=`{head.ExecutionUnit}`] state transitioned to completed AND linked_issue changed simultaneously; refuse forward-only auto-commit (operator review).");
+                }
+                var linkedPrDeltaForCloseout = ClassifyLinkedPr(head, working);
+                if (linkedPrDeltaForCloseout.Verdict == ItemVerdict.Reject)
+                {
+                    return linkedPrDeltaForCloseout;
+                }
+                if (linkedPrDeltaForCloseout.Verdict == ItemVerdict.ForwardChange)
+                {
+                    return new ItemClassification(
+                        ItemVerdict.Reject,
+                        null,
+                        $"items[execution_unit=`{head.ExecutionUnit}`] state transitioned to completed AND linked_pr changed simultaneously; refuse forward-only auto-commit (operator review).");
+                }
+
+                return new ItemClassification(
+                    ItemVerdict.ForwardChange,
+                    new QueueStateForwardChange
+                    {
+                        ExecutionUnit = head.ExecutionUnit,
+                        Kind = QueueStateForwardChangeKind.ClosedOutToCompleted
+                    },
+                    null);
+            }
+
+            return new ItemClassification(
+                ItemVerdict.Reject,
+                null,
+                $"items[execution_unit=`{head.ExecutionUnit}`] state changed from `{head.State}` to `{working.State}`; only queued/active/review/fixing → completed is supported as forward-only (closeout).");
         }
 
         if (!SequenceEquals(head.Dependencies, working.Dependencies)
@@ -330,6 +404,9 @@ internal static class QueueStateForwardDeltaAnalyzer
                 $"added linked_issue (#{change.LinkedIssueNumber}, {change.LinkedIssueRepo}) on `{change.ExecutionUnit}`",
             QueueStateForwardChangeKind.AddedLinkedIssueAndPr =>
                 $"added linked_issue (#{change.LinkedIssueNumber}, {change.LinkedIssueRepo}) and linked_pr=`{change.LinkedPrUrl}` on `{change.ExecutionUnit}`",
+            // G324: closeout state transition.
+            QueueStateForwardChangeKind.ClosedOutToCompleted =>
+                $"closed out `{change.ExecutionUnit}` (state → completed)",
             _ => $"forward delta on `{change.ExecutionUnit}`",
         });
         return $"forward-only queue-state.json delta: {string.Join("; ", pieces)}.";
@@ -341,6 +418,18 @@ internal enum QueueStateForwardChangeKind
     AddedLinkedPr,
     AddedLinkedIssue,
     AddedLinkedIssueAndPr,
+
+    /// <summary>
+    /// G324: state transition recorded by <c>intent-cli closeout pr --write</c>
+    /// — the matched item moved from
+    /// <see cref="IntentSystem.Supervisor.Models.QueueItemState.Queued"/>
+    /// / <c>Active</c> / <c>Review</c> / <c>Fixing</c> to
+    /// <see cref="IntentSystem.Supervisor.Models.QueueItemState.Completed"/>.
+    /// All other scalar metadata for that item AND every other item is
+    /// byte-identical. Auto-commit safe because the transition is the
+    /// deterministic forward-only mutation the closeout command makes.
+    /// </summary>
+    ClosedOutToCompleted,
 }
 
 internal sealed record QueueStateForwardChange

--- a/src/IntentSystem.Supervisor/Models/RunEvent.cs
+++ b/src/IntentSystem.Supervisor/Models/RunEvent.cs
@@ -37,4 +37,20 @@ public sealed record RunEvent
     public string? ReviewContextRef { get; init; }
 
     public string? WorktreePath { get; init; }
+
+    /// <summary>
+    /// G324: GitHub repository the event refers to, in
+    /// <c>owner/repo</c> form. Optional; populated by closeout / PR
+    /// transition events that bind durable bookkeeping to a specific
+    /// GitHub repository.
+    /// </summary>
+    public string? Repo { get; init; }
+
+    /// <summary>
+    /// G324: GitHub PR number the event refers to. Optional; populated
+    /// alongside <see cref="Repo"/> by closeout / PR-merge events so
+    /// downstream consumers can correlate without re-parsing the
+    /// linked_pr URL.
+    /// </summary>
+    public int? Pr { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -15,6 +16,105 @@ public sealed class CloseoutPrCommandTests : IDisposable
     public void Dispose()
     {
         CloseoutPrCommand.UtcNowFactory = null;
+    }
+
+    // --- G324: durable writes use current RunEvent schema + auto-commit safe ---
+
+    [Fact]
+    public void Execute_GivenWrite_AppendsCurrentSchemaRunEventsThatDeserialize()
+    {
+        // G324 acceptance: closeout runs.jsonl lines must use the
+        // canonical `ts` / `execution_unit` / `event` / `by` fields
+        // (plus the new `repo` / `pr` correlation) so the supervisor
+        // and the G312 durable-state preflight can deserialize them.
+        // Legacy `timestamp` / `kind` are gone.
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G324", "review", linkedPr: "595"));
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "595", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var lines = workspace.RunsLines();
+        Assert.Equal(2, lines.Length);
+        foreach (var line in lines)
+        {
+            // New schema fields must be present.
+            Assert.Contains("\"ts\":", line, StringComparison.Ordinal);
+            Assert.Contains("\"event\":", line, StringComparison.Ordinal);
+            Assert.Contains("\"by\":", line, StringComparison.Ordinal);
+            Assert.Contains("\"execution_unit\":\"G324\"", line, StringComparison.Ordinal);
+            // Legacy schema fields must NOT appear in the new line.
+            Assert.DoesNotContain("\"timestamp\":", line, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"kind\":", line, StringComparison.Ordinal);
+            // Every emitted line must round-trip through the supervisor
+            // deserializer with no exception (this is what `RunsJsonlAppendOnlyAnalyzer`
+            // calls to validate appended lines).
+            var deserialized = RunLogSerializer.DeserializeLine(line);
+            Assert.Equal("G324", deserialized.ExecutionUnit);
+            Assert.Equal("intent-cli closeout pr", deserialized.By);
+            Assert.Equal("J-Tech-Japan/intent-system", deserialized.Repo);
+            Assert.Equal(595, deserialized.Pr);
+        }
+        Assert.Equal("pr-merged", RunLogSerializer.DeserializeLine(lines[0]).Event);
+        Assert.Equal("closeout-recorded", RunLogSerializer.DeserializeLine(lines[1]).Event);
+    }
+
+    [Fact]
+    public void Execute_GivenWrite_QueueStateDeltaIsForwardOnlyAutoCommitSafe()
+    {
+        // G324 acceptance: durable-state-preflight (G312) must classify
+        // the closeout-only state change as forward-only / verified so
+        // the host loop's auto-commit lane proceeds without an operator
+        // review stop on the next wake.
+        using var workspace = new CloseoutPrWorkspace();
+        var beforeQueueText = BuildQueueState("G324", "review", linkedPr: "596");
+        workspace.WriteQueueState(beforeQueueText);
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--write", "--format", "json"],
+            writer);
+        Assert.Equal(0, exitCode);
+
+        var afterQueueText = workspace.QueueStateOnDisk();
+        var delta = QueueStateForwardDeltaAnalyzer.Analyze(beforeQueueText, afterQueueText);
+
+        Assert.Equal(QueueStateForwardDeltaAnalyzer.ClassificationForwardOnly, delta.Classification);
+        var change = Assert.Single(delta.Changes);
+        Assert.Equal(QueueStateForwardChangeKind.ClosedOutToCompleted, change.Kind);
+        Assert.Equal("G324", change.ExecutionUnit);
+    }
+
+    [Fact]
+    public void Execute_GivenWrite_RunsLinesAreAppendOnlyAutoCommitSafe()
+    {
+        // G324 acceptance: combined with the queue-state forward delta,
+        // the runs.jsonl append must classify as append-only so the
+        // overall durable-state preflight reports verified-commit-ready.
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G324", "review", linkedPr: "597"));
+        // Seed an empty runs.jsonl as HEAD so the analyzer compares
+        // empty HEAD vs the 2 appended lines.
+        File.WriteAllText(workspace.Context.GetRunLogPath(), string.Empty);
+        var headRuns = File.ReadAllText(workspace.Context.GetRunLogPath());
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "597", "--write", "--format", "json"],
+            writer);
+        Assert.Equal(0, exitCode);
+
+        var workingRuns = File.ReadAllText(workspace.Context.GetRunLogPath());
+        var runsDelta = RunsJsonlAppendOnlyAnalyzer.Analyze(headRuns, workingRuns);
+
+        Assert.Equal(RunsJsonlAppendOnlyAnalyzer.ClassificationAppendOnly, runsDelta.Classification);
+        Assert.Equal(2, runsDelta.AppendedEventCount);
     }
 
     [Fact]
@@ -672,6 +772,12 @@ public sealed class CloseoutPrCommandTests : IDisposable
         {
             File.WriteAllText(Context.GetQueueStatePath(), content);
         }
+
+        public string QueueStateOnDisk() => File.ReadAllText(Context.GetQueueStatePath());
+
+        public string[] RunsLines() => File.Exists(Context.GetRunLogPath())
+            ? File.ReadAllLines(Context.GetRunLogPath())
+            : Array.Empty<string>();
 
         public void Dispose()
         {

--- a/tests/IntentSystem.Cli.Tests/QueueStateForwardDeltaAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueStateForwardDeltaAnalyzerTests.cs
@@ -223,6 +223,77 @@ public sealed class QueueStateForwardDeltaAnalyzerTests
         };
     }
 
+    // --- G324: closeout state-transition is forward-only auto-commit safe ---
+
+    [Theory]
+    [InlineData(QueueItemState.Queued)]
+    [InlineData(QueueItemState.Active)]
+    [InlineData(QueueItemState.Review)]
+    [InlineData(QueueItemState.Fixing)]
+    public void Analyze_ClosedOutToCompleted_FromAnyValidStartState_ReturnsForwardOnly(QueueItemState startState)
+    {
+        // G324 acceptance: closeout PR durable writes that only change
+        // the matched item's state to Completed (with no other scalar /
+        // dependency / packet / linked-ref changes) MUST classify as
+        // forward-only so the host's auto-commit lane proceeds without
+        // an operator-review stop.
+        var head = BuildState(item => item with { State = startState });
+        var working = BuildState(item => item with { State = QueueItemState.Completed });
+
+        var result = QueueStateForwardDeltaAnalyzer.Analyze(
+            QueueStateSerializer.Serialize(head),
+            QueueStateSerializer.Serialize(working));
+
+        Assert.Equal(QueueStateForwardDeltaAnalyzer.ClassificationForwardOnly, result.Classification);
+        var change = Assert.Single(result.Changes);
+        Assert.Equal(QueueStateForwardChangeKind.ClosedOutToCompleted, change.Kind);
+        Assert.Equal("SKS-G215", change.ExecutionUnit);
+        Assert.Contains("closed out", result.Summary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Analyze_StateTransitionToUnsupportedTarget_StillNeedsOperatorReview()
+    {
+        // G324 safety rail: forward-only is closeout-shaped. A state
+        // transition Queued → Active (or any other non-Completed
+        // target) must still drop into operator review so we don't
+        // accidentally widen the auto-commit lane beyond the closeout
+        // shape.
+        var head = BuildState(item => item with { State = QueueItemState.Queued });
+        var working = BuildState(item => item with { State = QueueItemState.Active });
+
+        var result = QueueStateForwardDeltaAnalyzer.Analyze(
+            QueueStateSerializer.Serialize(head),
+            QueueStateSerializer.Serialize(working));
+
+        Assert.Equal(QueueStateForwardDeltaAnalyzer.ClassificationNeedsOperatorReview, result.Classification);
+    }
+
+    [Fact]
+    public void Analyze_ClosedOutPlusLinkedPrChange_NeedsOperatorReview()
+    {
+        // G324: the closeout forward-only delta is purely the state
+        // transition. A simultaneous linked_pr addition (or any other
+        // forward-change) requires operator review so the auto-commit
+        // lane doesn't bundle multiple distinct mutations.
+        var head = BuildState(item => item with
+        {
+            State = QueueItemState.Review,
+            LinkedPr = null,
+        });
+        var working = BuildState(item => item with
+        {
+            State = QueueItemState.Completed,
+            LinkedPr = "https://github.com/o/r/pull/9",
+        });
+
+        var result = QueueStateForwardDeltaAnalyzer.Analyze(
+            QueueStateSerializer.Serialize(head),
+            QueueStateSerializer.Serialize(working));
+
+        Assert.Equal(QueueStateForwardDeltaAnalyzer.ClassificationNeedsOperatorReview, result.Classification);
+    }
+
     private static QueueItem BuildExtraItem() => new()
     {
         ExecutionUnit = "EXTRA-1",


### PR DESCRIPTION
## Summary

After PR #742 (G320) closeout, the next PR #744 (G318) review wake stopped before review because the parent durable state was dirty AND unsafe under G312: `runs.jsonl` used legacy `timestamp` / `kind` fields the strict `RunEvent` deserializer rejects, and the `queue-state.json` state transition was refused by the forward-only auto-commit lane because any scalar change was previously classified as operator-review territory. A successful closeout blocked the next review wake.

G324 fixes both halves while keeping G312 strict:

- `RunEvent` gains two optional fields — `Repo` (string?) + `Pr` (int?). Snake_case serialization (`repo`, `pr`) with `WhenWritingNull`; existing emitters that don't set them are byte-identical.
- `CloseoutPrCommand.BuildRunsEvent` rewritten to construct a real `RunEvent` and emit it via `RunLogSerializer.SerializeLine`. Lines now carry canonical `ts` / `execution_unit` / `event` / `by` plus `repo` / `pr`; legacy `timestamp` / `kind` and the bespoke `RunsEventJsonOptions` are gone. `By` is pinned to `"intent-cli closeout pr"` for audit attribution.
- `QueueStateForwardDeltaAnalyzer` gains a `ClosedOutToCompleted` forward-only change kind. `ClassifyItem` accepts a state transition from {Queued, Active, Review, Fixing} → Completed when every other scalar / dependency / packet / linked-ref field is byte-identical. Any other state transition (e.g. Queued → Active), or closeout + linked-ref change in the same diff, still falls into operator-review.

## Why

G312 introduced strict durable-state preflight to refuse silent overwrites. G324 makes the closeout command emit deterministic, schema-valid durable state so the next host wake's preflight lands on `verified-commit-ready` without manual repair. The fix is contained to the closeout durable writer + a narrow analyzer extension; review semantics and unsafe-rollback rejection are unchanged.

## Test plan

- [x] `Execute_GivenWrite_AppendsCurrentSchemaRunEventsThatDeserialize` — every appended runs.jsonl line contains `ts` / `event` / `by` (no `timestamp` / `kind`), round-trips through `RunLogSerializer.DeserializeLine` with `ExecutionUnit`, `By="intent-cli closeout pr"`, `Repo`, `Pr` correctly populated, and emits `pr-merged` + `closeout-recorded` events in order.
- [x] `Execute_GivenWrite_QueueStateDeltaIsForwardOnlyAutoCommitSafe` — feeds the before/after queue-state into `QueueStateForwardDeltaAnalyzer` and asserts `forward-only` + a single `ClosedOutToCompleted` change.
- [x] `Execute_GivenWrite_RunsLinesAreAppendOnlyAutoCommitSafe` — feeds the runs.jsonl HEAD vs working content into `RunsJsonlAppendOnlyAnalyzer` and asserts `append-only` with `AppendedEventCount == 2`.
- [x] `Analyze_ClosedOutToCompleted_FromAnyValidStartState_ReturnsForwardOnly` (Theory × 4: Queued, Active, Review, Fixing) — every supported start state classifies as forward-only with the new change kind.
- [x] `Analyze_StateTransitionToUnsupportedTarget_StillNeedsOperatorReview` — a Queued → Active transition (not closeout-shaped) still drops into operator review so the auto-commit lane stays tight.
- [x] `Analyze_ClosedOutPlusLinkedPrChange_NeedsOperatorReview` — a simultaneous closeout + linked_pr addition refuses the auto-commit lane so we don't bundle distinct mutations.
- [x] All 63 prior CloseoutPr / QueueStateForwardDelta / DurableStatePreflight / RunsJsonl tests pass byte-identically.
- [x] Full CLI suite: 2482 passed, 0 failed.

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)