### PR TITLE
G325: surface active PR update lease as wait

### DIFF
--- a/src/IntentSystem.Cli/Commands/WorkerNextActionAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerNextActionAnalyzer.cs
@@ -67,6 +67,45 @@ internal static class WorkerNextActionAnalyzer
             };
         }
 
+        // G325: Priority 1.5 — active PR update lease. A PR carrying
+        // `intent-pr-update-in-progress` is in flight under another
+        // worker's lease. The selector previously fell through to
+        // `none`, which masked the real state. Surface an explicit
+        // `wait` action so operators / controllers see the held lease,
+        // its target PR, and the recommended repair workflow without
+        // any silent fallback. Stale-lease recovery remains an
+        // explicit operator action (`intent-cli automation
+        // pr-transition` etc.); this selector never releases a lease
+        // on its own.
+        var activeLease = intentTargetPrs
+            .Where(pr =>
+            {
+                var labels = LabelNames(pr.Labels);
+                return labels.Contains(WorkerNextActionConstants.Labels.IntentPrUpdateInProgress, StringComparer.Ordinal);
+            })
+            .OrderBy(pr => string.IsNullOrEmpty(pr.UpdatedAt) ? pr.CreatedAt : pr.UpdatedAt, StringComparer.Ordinal)
+            .FirstOrDefault();
+        if (activeLease is not null)
+        {
+            var leaseLabels = LabelNames(activeLease.Labels);
+            var requestUpdatePresent = leaseLabels.Contains(
+                WorkerNextActionConstants.Labels.IntentPrRequestUpdate, StringComparer.Ordinal);
+            var reason = requestUpdatePresent
+                ? "active PR update lease (intent-pr-update-in-progress + intent-pr-request-update); another worker is in flight"
+                : "active PR update lease (intent-pr-update-in-progress); another worker is in flight";
+            return new WorkerNextActionResult
+            {
+                Action = WorkerNextActionConstants.Actions.Wait,
+                Repo = repo,
+                Number = activeLease.Number,
+                Url = activeLease.Url,
+                Reason = reason,
+                RecommendedWorkflow = WorkerNextActionConstants.RecommendedWorkflows.PrCommentFix,
+                Warnings = warnings,
+                SourceClassification = WorkerNextActionConstants.SourceClassifications.PrUpdateInProgress,
+            };
+        }
+
         // Priority 2: PR review target — intentionally not implemented for
         // child-side automation. Host-side review/next-slice loop owns
         // review selection per the parent-host contract; an implementation

--- a/src/IntentSystem.Cli/Commands/WorkerNextActionResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerNextActionResult.cs
@@ -63,6 +63,20 @@ internal static class WorkerNextActionConstants
     {
         public const string PrCommentFix = "pr-comment-fix";
         public const string IssueToPr = "issue-to-pr";
+
+        /// <summary>
+        /// G325: emitted when an existing PR update lease is still active
+        /// (<c>intent-pr-update-in-progress</c> present). The selector
+        /// MUST NOT return <c>none</c> in this case because the system
+        /// is not idle — another worker is in flight. The
+        /// <see cref="WorkerNextActionResult.Number"/> /
+        /// <see cref="WorkerNextActionResult.Url"/> fields point at the
+        /// PR holding the lease so an operator or controller knows
+        /// which lease to monitor or — with explicit authorization —
+        /// release.
+        /// </summary>
+        public const string Wait = "wait";
+
         public const string None = "none";
     }
 
@@ -76,6 +90,17 @@ internal static class WorkerNextActionConstants
     {
         public const string RepairRequired = "repair-required";
         public const string ReadyToImplement = "ready-to-implement";
+
+        /// <summary>
+        /// G325: emitted alongside <see cref="Actions.Wait"/> when an
+        /// active PR update lease (<c>intent-pr-update-in-progress</c>)
+        /// is currently held. Surfaced explicitly so operators can
+        /// distinguish "system is idle" from "another worker is
+        /// repairing this PR" — and so stale-lease recovery is an
+        /// explicit operator/intent-cli action rather than a silent
+        /// fallback.
+        /// </summary>
+        public const string PrUpdateInProgress = "pr-update-in-progress";
     }
 
     public static class Labels

--- a/tests/IntentSystem.Cli.Tests/WorkerNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerNextActionCommandTests.cs
@@ -63,14 +63,19 @@ public sealed class WorkerNextActionCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_GivenPrInUpdateInProgress_FallsThroughToIssueToPr()
+    public void Execute_GivenPrInUpdateInProgress_SurfacesWaitLease()
     {
+        // G325 replaces the previous "fall through to issue-to-pr"
+        // behavior with an explicit `wait` action so the active update
+        // lease (intent-pr-update-in-progress) is visible to operators
+        // and controllers instead of being masked as generic `none`
+        // (or, as previously, leaking past the held PR to issue-to-pr,
+        // which would let a second worker race the lease holder).
         using var workspace = new WorkerNextActionWorkspace();
         var lister = new FakeLister
         {
             Prs = new[]
             {
-                // PR already claimed by a worker — must be excluded.
                 BuildPr(514, "Already-claimed PR", "https://github.com/J-Tech-Japan/intent-system/pull/514",
                     createdAt: "2026-04-30T00:00:00Z",
                     labels: new[] { "intent-target", "intent-pr-request-update", "intent-pr-update-in-progress" }),
@@ -92,9 +97,14 @@ public sealed class WorkerNextActionCommandTests : IDisposable
 
         Assert.Equal(0, exitCode);
         var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
-        Assert.Equal(WorkerNextActionConstants.Actions.IssueToPr, result.Action);
-        Assert.Equal(515, result.Number);
-        Assert.Equal(WorkerNextActionConstants.RecommendedWorkflows.GhIssueToPr, result.RecommendedWorkflow);
+        Assert.Equal(WorkerNextActionConstants.Actions.Wait, result.Action);
+        Assert.Equal(514, result.Number);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/514", result.Url);
+        Assert.Equal(WorkerNextActionConstants.SourceClassifications.PrUpdateInProgress, result.SourceClassification);
+        Assert.Equal(WorkerNextActionConstants.RecommendedWorkflows.PrCommentFix, result.RecommendedWorkflow);
+        Assert.Contains("active PR update lease", result.Reason, StringComparison.Ordinal);
+        // Issue-to-pr must NOT be surfaced while the lease is held.
+        Assert.NotEqual(515, result.Number);
     }
 
     [Fact]
@@ -686,6 +696,99 @@ public sealed class WorkerNextActionCommandTests : IDisposable
             noBlockComments, @"//.*?$", string.Empty,
             System.Text.RegularExpressions.RegexOptions.Multiline);
         return noLineComments;
+    }
+
+    // --- G325: active PR update lease surfacing -------------------------
+
+    [Fact]
+    public void Execute_GivenPrWithUpdateInProgressOnly_SurfacesWaitLease()
+    {
+        // G325: a PR carrying only `intent-pr-update-in-progress`
+        // (request-update label dropped or never present) is still an
+        // active worker lease; the selector must surface `wait` and
+        // identify the PR, not collapse to `none`.
+        using var workspace = new WorkerNextActionWorkspace();
+        var lister = new FakeLister
+        {
+            Prs = new[]
+            {
+                BuildPr(801, "Active lease (no request-update)",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/801",
+                    createdAt: "2026-05-01T00:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-update-in-progress" }),
+            },
+            Issues = Array.Empty<GitHubAutomationIssueCandidate>(),
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer));
+
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal(WorkerNextActionConstants.Actions.Wait, result.Action);
+        Assert.Equal(801, result.Number);
+        Assert.Equal(WorkerNextActionConstants.SourceClassifications.PrUpdateInProgress, result.SourceClassification);
+    }
+
+    [Fact]
+    public void Execute_GivenRequestUpdateWithoutLease_StillReturnsPrCommentFix()
+    {
+        // G325 regression guard: the new wait lane must not regress the
+        // canonical actionable-repair path. A PR with
+        // `intent-pr-request-update` and NO `intent-pr-update-in-progress`
+        // must still surface as `pr-comment-fix`.
+        using var workspace = new WorkerNextActionWorkspace();
+        var lister = new FakeLister
+        {
+            Prs = new[]
+            {
+                BuildPr(802, "Repair feedback waiting",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/802",
+                    createdAt: "2026-05-01T00:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-request-update" }),
+            },
+            Issues = Array.Empty<GitHubAutomationIssueCandidate>(),
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer));
+
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal(WorkerNextActionConstants.Actions.PrCommentFix, result.Action);
+        Assert.Equal(802, result.Number);
+        Assert.Equal(WorkerNextActionConstants.SourceClassifications.RepairRequired, result.SourceClassification);
+    }
+
+    [Fact]
+    public void Execute_GivenNoPrOrIssue_StillReturnsTrueNone()
+    {
+        // G325 regression guard: when there is no PR at all, `wait`
+        // does NOT fire — the selector still returns true `none` so
+        // the host loop can declare idle.
+        using var workspace = new WorkerNextActionWorkspace();
+        var lister = new FakeLister
+        {
+            Prs = Array.Empty<GitHubAutomationPrCandidate>(),
+            Issues = Array.Empty<GitHubAutomationIssueCandidate>(),
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer));
+
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal(WorkerNextActionConstants.Actions.None, result.Action);
+        Assert.Null(result.Number);
     }
 
     private static GitHubAutomationPrCandidate BuildPr(


### PR DESCRIPTION
## Summary

`worker next-action` previously returned `{ "action": "none", "reason": "no actionable coding automation target" }` when the only candidate PR carried an active `intent-pr-update-in-progress` lease. The system is not idle in that case — another worker is repairing the PR — and operators / controllers had no signal that work was in flight. G325 surfaces an explicit `wait` action with the lease metadata so the lease is visible while existing claim protection stays intact.

- New `Actions.Wait` (`"wait"`) + `SourceClassifications.PrUpdateInProgress` (`"pr-update-in-progress"`) constants.
- `WorkerNextActionAnalyzer` gains a Priority 1.5 lane: when an open intent-target PR carries `intent-pr-update-in-progress`, return `wait` with PR `number` + `url`, `source_classification: pr-update-in-progress`, `recommended_workflow: pr-comment-fix`, and a reason that names whether the lease is paired with `intent-pr-request-update` or held alone.
- Stale-lease recovery remains an explicit operator action through `intent-cli automation pr-transition` / `worker complete`; this selector never releases a lease on its own.
- Priority is now:
  1. PR comment-fix repair (request-update without lease) → `pr-comment-fix`
  2. Active PR update lease (update-in-progress present) → `wait`
  3. Issue-to-PR (open intent-target issue) → `issue-to-pr`
  4. No actionable target → `none`

This means `issue-to-pr` no longer races past a held PR lease, and `none` is reserved for true idle.

## Why

PR #744 (G318) sat with `intent-pr-request-update` + `intent-pr-update-in-progress` while host review correctly waited. The child selector returned generic `none`, masking the real state. Without `wait`, an operator couldn't tell idle from in-flight, and there was no structured pointer to the lease holder for monitoring or — with explicit operator authorization — stale-lease release.

## Test plan

- [x] `Execute_GivenPrInUpdateInProgress_SurfacesWaitLease` — request-update + update-in-progress → `wait`, PR #514, classification `pr-update-in-progress`, URL embedded, reason mentions "active PR update lease"; issue #515 NOT surfaced while lease is held.
- [x] `Execute_GivenPrWithUpdateInProgressOnly_SurfacesWaitLease` — lease without companion request-update label still classifies as `wait`.
- [x] `Execute_GivenRequestUpdateWithoutLease_StillReturnsPrCommentFix` — regression guard for the canonical Priority 1 path.
- [x] `Execute_GivenNoPrOrIssue_StillReturnsTrueNone` — regression guard that `none` is reserved for true idle.
- [x] All prior 19 `WorkerNextActionCommand` tests pass (one renamed from `FallsThroughToIssueToPr` to `SurfacesWaitLease` to reflect new semantic).
- [x] Full CLI suite: 2485 passed, 0 failed.

Closes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)