### PR TITLE
G326: role-scoped host ownership model

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -250,7 +250,9 @@ internal static class CommandRouter
                 ["intent-work"] = GuideIntentWorkCommand.Execute,
                 ["worker"] = GuideWorkerCommand.Execute,
                 ["closeout"] = GuideCloseoutCommand.Execute,
-                ["prompt-matrix"] = GuidePromptMatrixCommand.Execute
+                ["prompt-matrix"] = GuidePromptMatrixCommand.Execute,
+                // G326: role-scoped host ownership model.
+                ["host-ownership"] = GuideHostOwnershipCommand.Execute
             },
             ["intent"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
@@ -512,6 +512,16 @@ Frequency policy (applies only when a recurring local loop is explicitly request
         {
             writer.WriteLine($"- cwd role: {result.CwdRole}");
         }
+        if (!string.IsNullOrWhiteSpace(result.HostRole))
+        {
+            // G326 review fix (PR #756): render the resolved host role
+            // (design / review-runtime / child-worker / ambiguous) in
+            // the markdown contract operators paste and follow. JSON
+            // exposes `host_role` separately; this line ensures markdown
+            // does not silently lose the role binding that decides what
+            // the cwd is allowed to mutate.
+            writer.WriteLine($"- host role: {result.HostRole}");
+        }
         if (!string.IsNullOrWhiteSpace(result.CanonicalPurpose)
             && !string.IsNullOrWhiteSpace(result.RawPurpose)
             && !string.Equals(result.CanonicalPurpose, result.RawPurpose, StringComparison.Ordinal))

--- a/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideAutomationSetupCommand.cs
@@ -40,7 +40,8 @@ internal static class GuideAutomationSetupCommand
     private const string UsageLine =
         "Usage: intent-cli guide automation setup --kind|--purpose <child-implement|host-review-next-slice|alias> "
         + "[--repo <owner/repo>] [--domain <name>] [--target-repo <owner/repo>] "
-        + "[--agent claude|codex|claude code|codex-cli|unknown] [--cwd <path>] [--cwd-role host|child] [--frequency <NNm|NNh>] "
+        + "[--agent claude|codex|claude code|codex-cli|unknown] [--cwd <path>] [--cwd-role host|child] "
+        + "[--host-role design|review-runtime|child-worker|ambiguous] [--frequency <NNm|NNh>] "
         + "[--format markdown|json]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
@@ -64,6 +65,7 @@ internal static class GuideAutomationSetupCommand
                 out var rawAgent,
                 out var cwd,
                 out var rawCwdRole,
+                out var rawHostRole,
                 out var frequency,
                 out var format,
                 out var error))
@@ -129,6 +131,38 @@ internal static class GuideAutomationSetupCommand
             return 1;
         }
 
+        // G326: resolve the host role (design / review-runtime /
+        // child-worker / ambiguous). When the operator did not pass
+        // `--host-role`, infer from the canonical cwd-role: child cwd
+        // implies `child-worker`; host cwd cannot be disambiguated
+        // between design and review-runtime without an explicit flag, so
+        // we surface `ambiguous` and let the operator decide. This keeps
+        // the durable-state ownership decision explicit per G326.
+        string hostRoleCanonical;
+        if (!string.IsNullOrWhiteSpace(rawHostRole))
+        {
+            hostRoleCanonical = HostOwnershipModel.ResolveRole(rawHostRole);
+            if (string.Equals(hostRoleCanonical, HostOwnershipModel.RoleAmbiguous, StringComparison.Ordinal)
+                && !string.Equals(rawHostRole, HostOwnershipModel.RoleAmbiguous, StringComparison.OrdinalIgnoreCase))
+            {
+                writer.WriteLine(
+                    $"--host-role '{rawHostRole}' did not resolve to a known role (design / review-runtime / child-worker / ambiguous).");
+                writer.WriteLine(UsageLine);
+                return 1;
+            }
+        }
+        else if (string.Equals(cwdRoleCanonical, GuideAutomationSetupAliasResolver.CanonicalCwdRoleChild, StringComparison.Ordinal))
+        {
+            hostRoleCanonical = HostOwnershipModel.RoleChildWorker;
+        }
+        else
+        {
+            // Host cwd without an explicit --host-role flag: surface
+            // ambiguous so the operator names design vs review-runtime
+            // before any role-scoped mutation guidance is acted on.
+            hostRoleCanonical = HostOwnershipModel.RoleAmbiguous;
+        }
+
         // G320: agent + frequency are coupled. If the operator supplies an
         // agent we know how to handle (claude/codex) we also require a
         // frequency so the generated contract can pin the exact same-thread
@@ -147,7 +181,7 @@ internal static class GuideAutomationSetupCommand
         switch (kind)
         {
             case KindChildImplement:
-                return EmitResult(writer, format, BuildChildImplement(repo, domain, agent, cwd, frequency, cwdRoleCanonical, rawKind, rawAgent));
+                return EmitResult(writer, format, BuildChildImplement(repo, domain, agent, cwd, frequency, cwdRoleCanonical, rawKind, rawAgent, hostRoleCanonical));
 
             case KindHostReviewNextSlice:
                 if (string.IsNullOrWhiteSpace(domain))
@@ -163,7 +197,7 @@ internal static class GuideAutomationSetupCommand
                     return 1;
                 }
 
-                return EmitResult(writer, format, BuildHostReviewNextSlice(domain!, targetRepo!, agent, cwd, frequency, cwdRoleCanonical, rawKind, rawAgent));
+                return EmitResult(writer, format, BuildHostReviewNextSlice(domain!, targetRepo!, agent, cwd, frequency, cwdRoleCanonical, rawKind, rawAgent, hostRoleCanonical));
 
             default:
                 writer.WriteLine(
@@ -231,7 +265,8 @@ Scheduling mechanism: unknown — ASK the operator which same-thread / local-aut
         string? frequency,
         string? cwdRoleCanonical = null,
         string? rawPurpose = null,
-        string? rawAgent = null)
+        string? rawAgent = null,
+        string? hostRoleCanonical = null)
     {
         var repoLabel = string.IsNullOrWhiteSpace(repo) ? "the repo in the current worktree" : $"`{repo}`";
         var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
@@ -318,7 +353,8 @@ Frequency policy (applies only when a recurring local loop is explicitly request
             },
             LabelOwnership = "All label transitions delegated to installed intent-cli automation / worker commands. Manual `gh ... edit --label` fallback is forbidden.",
             WorktreeFriendly = "The prompt resolves the repo from the child worktree's `gh` / `git remote` and runs the selector from the parent host root with --workdir; no hard-coded paths, and the same prompt works across local worktrees.",
-            Prohibitions = GuidanceProhibitionCatalog.All
+            Prohibitions = GuidanceProhibitionCatalog.All,
+            HostRole = hostRoleCanonical
         };
     }
 
@@ -333,7 +369,8 @@ Frequency policy (applies only when a recurring local loop is explicitly request
         string? frequency,
         string? cwdRoleCanonical = null,
         string? rawPurpose = null,
-        string? rawAgent = null)
+        string? rawAgent = null,
+        string? hostRoleCanonical = null)
     {
         var (schedulingMechanism, schedulingBlock) = ResolveScheduling(agent, frequency);
         var cwdLine = string.IsNullOrWhiteSpace(cwd)
@@ -434,7 +471,8 @@ Frequency policy (applies only when a recurring local loop is explicitly request
             },
             LabelOwnership = "All review-side and issue-side label transitions delegated to installed `intent-cli automation pr-transition` / `automation issue-publish` / `worker claim` / `worker complete`. Manual `gh ... edit --label` fallback is forbidden.",
             WorktreeFriendly = "The prompt names the parent host root as cwd but does not hardcode any operator-specific path beyond that; the same prompt works across host-side checkouts.",
-            Prohibitions = GuidanceProhibitionCatalog.All
+            Prohibitions = GuidanceProhibitionCatalog.All,
+            HostRole = hostRoleCanonical
         };
     }
 
@@ -528,6 +566,7 @@ Frequency policy (applies only when a recurring local loop is explicitly request
         out string? agent,
         out string? cwd,
         out string? cwdRole,
+        out string? hostRole,
         out string? frequency,
         out string format,
         out string error)
@@ -539,6 +578,7 @@ Frequency policy (applies only when a recurring local loop is explicitly request
         agent = null;
         cwd = null;
         cwdRole = null;
+        hostRole = null;
         frequency = null;
         format = FormatMarkdown;
         error = string.Empty;
@@ -627,6 +667,17 @@ Frequency policy (applies only when a recurring local loop is explicitly request
                     }
 
                     cwdRole = args[index + 1];
+                    index++;
+                    break;
+
+                case "--host-role":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--host-role requires a value (design, review-runtime, child-worker, or ambiguous).";
+                        return false;
+                    }
+
+                    hostRole = args[index + 1];
                     index++;
                     break;
 
@@ -819,4 +870,18 @@ internal sealed record GuideAutomationSetupResult
     /// </summary>
     [JsonPropertyName("prohibitions")]
     public IReadOnlyList<GuidanceProhibition>? Prohibitions { get; init; }
+
+    /// <summary>
+    /// G326: structured host role identifier (<c>design</c>,
+    /// <c>review-runtime</c>, <c>child-worker</c>, or <c>ambiguous</c>).
+    /// Inferred from <see cref="CwdRole"/> when the operator did not
+    /// pass <c>--host-role</c> explicitly: a <c>child</c> cwd resolves
+    /// to <c>child-worker</c>; a <c>host</c> cwd surfaces
+    /// <c>ambiguous</c> because design and review-runtime cannot be
+    /// disambiguated without an explicit flag (see
+    /// <see cref="HostOwnershipModel"/> for the may-write /
+    /// must-not-write matrix).
+    /// </summary>
+    [JsonPropertyName("host_role")]
+    public string? HostRole { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/GuideHostOwnershipCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHostOwnershipCommand.cs
@@ -1,0 +1,202 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G326: read-only <c>intent-cli guide host-ownership</c>. Emits the
+/// canonical role-scoped host topology — design / review-runtime /
+/// child-worker / ambiguous — with each role's responsibilities and
+/// the may-write / must-not-write matrix that <see cref="HostOwnershipModel"/>
+/// defines. Operators and downstream tooling (closeout, packet draft,
+/// publish-flow) reference this to decide what the current cwd is
+/// allowed to mutate. Never mutates state. Never launches a provider.
+/// </summary>
+internal static class GuideHostOwnershipCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide host-ownership [--role design|review-runtime|child-worker|ambiguous] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var rawRole, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        string? focusRoleId = null;
+        if (!string.IsNullOrWhiteSpace(rawRole))
+        {
+            focusRoleId = HostOwnershipModel.ResolveRole(rawRole);
+            if (string.Equals(focusRoleId, HostOwnershipModel.RoleAmbiguous, StringComparison.Ordinal)
+                && !string.Equals(rawRole, HostOwnershipModel.RoleAmbiguous, StringComparison.OrdinalIgnoreCase))
+            {
+                writer.WriteLine(
+                    $"--role '{rawRole}' did not resolve to a known role (design / review-runtime / child-worker / ambiguous).");
+                writer.WriteLine(UsageLine);
+                return 1;
+            }
+        }
+
+        var result = new GuideHostOwnershipResult
+        {
+            FocusRole = focusRoleId,
+            Roles = HostOwnershipModel.Roles
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideHostOwnershipResult result)
+    {
+        writer.WriteLine("# Guide host-ownership (G326)");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.FocusRole))
+        {
+            writer.WriteLine($"- focus role: `{result.FocusRole}`");
+            writer.WriteLine();
+        }
+
+        var roles = string.IsNullOrWhiteSpace(result.FocusRole)
+            ? result.Roles
+            : result.Roles.Where(r => string.Equals(r.Id, result.FocusRole, StringComparison.Ordinal)).ToArray();
+
+        foreach (var role in roles)
+        {
+            writer.WriteLine($"## `{role.Id}`");
+            writer.WriteLine();
+            writer.WriteLine(role.Summary);
+            writer.WriteLine();
+            writer.WriteLine("### Responsibilities");
+            foreach (var item in role.Responsibilities)
+            {
+                writer.WriteLine($"- {item}");
+            }
+            writer.WriteLine();
+            writer.WriteLine("### May write");
+            if (role.MayWrite.Count == 0)
+            {
+                writer.WriteLine("- _(nothing — ambiguous role refuses durable writes until a deterministic role binding is supplied)_");
+            }
+            else
+            {
+                foreach (var item in role.MayWrite)
+                {
+                    writer.WriteLine($"- {item}");
+                }
+            }
+            writer.WriteLine();
+            writer.WriteLine("### Must NOT write");
+            foreach (var item in role.MustNotWrite)
+            {
+                writer.WriteLine($"- {item}");
+            }
+            writer.WriteLine();
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? role,
+        out string format,
+        out string error)
+    {
+        role = null;
+        format = FormatJson; // controller-friendly default
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--role":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--role requires a value (design, review-runtime, child-worker, or ambiguous).";
+                        return false;
+                    }
+                    role = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide host-ownership (G326)");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Emit the role-scoped host topology: design / review-runtime / child-worker / ambiguous,");
+        writer.WriteLine("with each role's responsibilities and the may-write / must-not-write matrix.");
+        writer.WriteLine("Default JSON output is controller-friendly; markdown is the operator-facing rendering.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record GuideHostOwnershipResult
+{
+    /// <summary>
+    /// G326: optional focus role (when the caller passed
+    /// <c>--role &lt;x&gt;</c>). Null indicates the caller asked for the
+    /// full matrix.
+    /// </summary>
+    [JsonPropertyName("focus_role")]
+    public string? FocusRole { get; init; }
+
+    [JsonPropertyName("roles")]
+    public required IReadOnlyList<HostOwnershipRole> Roles { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/HostOwnershipModel.cs
+++ b/src/IntentSystem.Cli/Commands/HostOwnershipModel.cs
@@ -1,0 +1,183 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G326: structured ownership model for the role-scoped host topology.
+///
+/// The system intentionally runs from multiple local worktrees against
+/// the same remote — a <em>design</em> workspace (MyIntentHost),
+/// one or more <em>review-runtime</em> workspaces (IntentSystemReview,
+/// SekibanAsAServiceReview), and per-issue <em>child-worker</em>
+/// implementation worktrees. The problem isn't multiple worktrees — it's
+/// that without an explicit ownership boundary the same queue-state /
+/// runs.jsonl / packet files get written from incompatible angles.
+///
+/// This model is the canonical source of truth for which role owns
+/// which write surface; commands that emit ownership-aware guidance
+/// (<see cref="GuideHostOwnershipCommand"/>, the
+/// <c>intent-cli guide automation setup</c> contract surface, the
+/// G324 closeout durable writes) all reference it.
+///
+/// Pure data — no I/O, no Process.Start, no provider launch.
+/// </summary>
+internal static class HostOwnershipModel
+{
+    public const string RoleDesign = "design";
+    public const string RoleReviewRuntime = "review-runtime";
+    public const string RoleChildWorker = "child-worker";
+    public const string RoleAmbiguous = "ambiguous";
+
+    /// <summary>
+    /// G326: canonical list of host roles. Order is the order operators
+    /// see in markdown rendering; JSON output mirrors the same order
+    /// for stable diffs.
+    /// </summary>
+    public static IReadOnlyList<HostOwnershipRole> Roles { get; } = new HostOwnershipRole[]
+    {
+        new()
+        {
+            Id = RoleDesign,
+            Summary = "Intent design / packet backlog workspace (e.g. MyIntentHost).",
+            Responsibilities = new[]
+            {
+                "Shape intents under `intents/<domain>/**`.",
+                "Draft and maintain prepared packets (packet.yaml + implementation.md + review-context.md).",
+                "Author clarification artifacts and chase Hard Clarification answers.",
+                "Prepare NextSlice candidates so review-runtime can publish them as GitHub issues.",
+                "Update host bindings / automation summary intent metadata."
+            },
+            MayWrite = new[]
+            {
+                "intents/<domain>/**",
+                ".intent-cli/issues/<execution-unit>/packet.yaml",
+                ".intent-cli/issues/<execution-unit>/implementation.md",
+                ".intent-cli/issues/<execution-unit>/review-context.md",
+                ".intent-cli/issues/<execution-unit>/github-body.md",
+                "intents/<domain>/clarifications/**"
+            },
+            MustNotWrite = new[]
+            {
+                "Closeout records on `.intent-cli/runs.jsonl` (review-runtime owns the runtime audit trail).",
+                "Submodule pointers from a merge commit (review-runtime owns runtime sync).",
+                "Labels on a merged PR (host review owns transition; child-worker drives child label state)."
+            }
+        },
+        new()
+        {
+            Id = RoleReviewRuntime,
+            Summary = "Review / closeout / runtime workspace (e.g. IntentSystemReview, SekibanAsAServiceReview).",
+            Responsibilities = new[]
+            {
+                "Pull --ff-only continuously; never block on operator design work.",
+                "Run host-review (G316 packet-aware review).",
+                "Mark approval / request-update through `intent-cli automation pr-transition`.",
+                "Run `intent-cli closeout pr --write` for merged PRs; emit current-schema (G324) RunEvent lines.",
+                "Apply submodule pointer updates from the merged commit.",
+                "Publish the next-slice issue from a prepared packet when WIP cap is clear.",
+                "Optionally produce a runtime-created NextSlice packet (record ownership label so design knows)."
+            },
+            MayWrite = new[]
+            {
+                ".intent-cli/queue-state.json (closeout state transition; G324 forward-only delta).",
+                ".intent-cli/runs.jsonl (closeout-recorded / pr-merged / publish events; append-only).",
+                "submodules/<child>/ pointer (`git add submodules/<child>`).",
+                ".intent-cli/issues/<execution-unit>/publish.yaml (publish lifecycle metadata).",
+                "Workflow labels via `intent-cli automation pr-transition` / `intent-cli automation issue-publish`."
+            },
+            MustNotWrite = new[]
+            {
+                "Packet content (`packet.yaml` / `implementation.md` / `review-context.md`) — that is design-owned; runtime-created packets must be authored explicitly via a packet-draft command with a runtime ownership label, not by hand-editing the design surface.",
+                "Local `intents/rules/**` (those are read-only canonical rules).",
+                "Child worker branch contents (the implementer owns the child branch)."
+            }
+        },
+        new()
+        {
+            Id = RoleChildWorker,
+            Summary = "Per-issue child implementation worktree (issue-to-PR or PR-comment-fix).",
+            Responsibilities = new[]
+            {
+                "Implement the GitHub issue contract for a single issue or PR comment scope.",
+                "Open / push a child PR with `Closes #<issue>` (G311) targeting `main` (G294 base policy).",
+                "Run targeted tests; classify outcome; surface stale-cli / missing-command-surface abort gates.",
+                "Mark issue-side and PR-side workflow labels exclusively via `intent-cli worker claim` / `worker complete`."
+            },
+            MayWrite = new[]
+            {
+                "Source / test files inside the child worktree (the implementation repo's working tree).",
+                "Git branch + remote refs for the child PR.",
+                "GitHub PR body / comments via `gh pr` (read-only label edits are forbidden — see MustNotWrite)."
+            },
+            MustNotWrite = new[]
+            {
+                "`.intent-cli/queue-state.json` / `.intent-cli/runs.jsonl` / `.intent-cli/issues/**` in the child cwd — parent durable state is host-owned (G300). The implementation repo MUST NOT contain a `.intent-cli/` directory, and the child loop MUST NOT read parent host queue-state.",
+                "`intent-target` (host-owned) or `intent-pr-created` (issue-side completion) labels via raw `gh` calls — both are routed through `worker complete`.",
+                "Submodule pointer updates — runtime owns the merge-sha sync."
+            }
+        },
+        new()
+        {
+            Id = RoleAmbiguous,
+            Summary = "Role cannot be deterministically inferred from the cwd / bindings — surface the gap to the operator.",
+            Responsibilities = new[]
+            {
+                "Refuse to write parent durable state until the operator (or `--role` flag) names the role.",
+                "Run read-only diagnostics (`automation doctor`, `intent status`, `guide automation setup`) without mutation.",
+                "Surface an explicit ask so the operator can disambiguate."
+            },
+            MayWrite = Array.Empty<string>(),
+            MustNotWrite = new[]
+            {
+                "Anything that requires a deterministic role binding (closeout, publish, packet draft, label transitions)."
+            }
+        }
+    };
+
+    /// <summary>
+    /// G326: deterministic role resolver. Returns the canonical role for
+    /// the supplied <paramref name="raw"/> identifier (case-insensitive,
+    /// hyphen/underscore-tolerant) or <see cref="RoleAmbiguous"/> when
+    /// the value does not match any known role.
+    /// </summary>
+    public static string ResolveRole(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return RoleAmbiguous;
+        }
+
+        var normalized = raw.Trim().ToLowerInvariant().Replace('_', '-');
+        return normalized switch
+        {
+            "design" or "design-host" or "intent-design" => RoleDesign,
+            "review-runtime" or "review" or "runtime" or "review-host" => RoleReviewRuntime,
+            "child-worker" or "child" or "worker" or "implementer" => RoleChildWorker,
+            _ => RoleAmbiguous
+        };
+    }
+}
+
+/// <summary>
+/// G326: one row of the host ownership matrix. <c>Id</c> is the stable
+/// machine-readable role identifier; <c>Summary</c>, <c>Responsibilities</c>,
+/// <c>MayWrite</c>, and <c>MustNotWrite</c> form the operator-facing
+/// contract that downstream tooling renders to JSON or markdown.
+/// </summary>
+internal sealed record HostOwnershipRole
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("responsibilities")]
+    public required IReadOnlyList<string> Responsibilities { get; init; }
+
+    [JsonPropertyName("may_write")]
+    public required IReadOnlyList<string> MayWrite { get; init; }
+
+    [JsonPropertyName("must_not_write")]
+    public required IReadOnlyList<string> MustNotWrite { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideHostOwnershipCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideHostOwnershipCommandTests.cs
@@ -1,0 +1,274 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G326: tests for the read-only `intent-cli guide host-ownership`
+/// surface. Verifies the canonical role list, the may-write /
+/// must-not-write matrix, focus-role filtering, and the
+/// controller-friendly JSON shape.
+/// </summary>
+public sealed class GuideHostOwnershipCommandTests
+{
+    [Fact]
+    public void Execute_DefaultJson_ReturnsAllFourCanonicalRoles()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideHostOwnershipCommand.Execute(CreateContext(), Array.Empty<string>(), writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var roles = doc.RootElement.GetProperty("roles");
+        Assert.Equal(4, roles.GetArrayLength());
+        var ids = roles.EnumerateArray()
+            .Select(r => r.GetProperty("id").GetString()!)
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.Contains("design", ids);
+        Assert.Contains("review-runtime", ids);
+        Assert.Contains("child-worker", ids);
+        Assert.Contains("ambiguous", ids);
+    }
+
+    [Fact]
+    public void Execute_EveryRoleHasMatrixFields()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideHostOwnershipCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        foreach (var role in doc.RootElement.GetProperty("roles").EnumerateArray())
+        {
+            Assert.False(string.IsNullOrWhiteSpace(role.GetProperty("id").GetString()));
+            Assert.False(string.IsNullOrWhiteSpace(role.GetProperty("summary").GetString()));
+            Assert.True(role.GetProperty("responsibilities").GetArrayLength() >= 1);
+            // ambiguous role has empty may_write by design; every other
+            // role has at least one entry.
+            var id = role.GetProperty("id").GetString()!;
+            if (id == "ambiguous")
+            {
+                Assert.Equal(0, role.GetProperty("may_write").GetArrayLength());
+            }
+            else
+            {
+                Assert.True(role.GetProperty("may_write").GetArrayLength() >= 1);
+            }
+            Assert.True(role.GetProperty("must_not_write").GetArrayLength() >= 1);
+        }
+    }
+
+    [Theory]
+    [InlineData("design")]
+    [InlineData("review-runtime")]
+    [InlineData("child-worker")]
+    [InlineData("ambiguous")]
+    public void Execute_FocusRole_ReturnsOnlyThatRole(string role)
+    {
+        using var writer = new StringWriter();
+        var exit = GuideHostOwnershipCommand.Execute(
+            CreateContext(),
+            new[] { "--role", role, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(role, doc.RootElement.GetProperty("focus_role").GetString());
+        // Roles list still carries the full matrix (markdown filters
+        // by focus_role; JSON exposes both the focus pointer and the
+        // matrix so controllers can reason about cross-role
+        // boundaries).
+        Assert.Equal(4, doc.RootElement.GetProperty("roles").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_UnknownRoleValue_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideHostOwnershipCommand.Execute(
+            CreateContext(),
+            new[] { "--role", "garbage", "--format", "json" },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--role 'garbage' did not resolve", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MarkdownDefault_FiltersToFocusRoleSection()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideHostOwnershipCommand.Execute(
+            CreateContext(),
+            new[] { "--role", "child-worker", "--format", "markdown" },
+            writer);
+
+        Assert.Equal(0, exit);
+        var output = writer.ToString();
+        Assert.Contains("## `child-worker`", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("## `design`", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("## `review-runtime`", output, StringComparison.Ordinal);
+        Assert.Contains("Must NOT write", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HostOwnershipModel_ChildWorkerForbidsParentHostStateWrites()
+    {
+        // G326 acceptance: the write matrix MUST forbid child workers
+        // from writing parent host state. This is a direct read on the
+        // pure model so the contract can't drift from intent without
+        // the test failing first.
+        var childWorker = HostOwnershipModel.Roles
+            .Single(r => r.Id == HostOwnershipModel.RoleChildWorker);
+
+        Assert.Contains(childWorker.MustNotWrite,
+            entry => entry.Contains(".intent-cli/queue-state.json", StringComparison.Ordinal));
+        Assert.Contains(childWorker.MustNotWrite,
+            entry => entry.Contains(".intent-cli/runs.jsonl", StringComparison.Ordinal));
+        // The implementation repo MUST NOT contain `.intent-cli/`
+        // (G300 reference).
+        Assert.Contains(childWorker.MustNotWrite,
+            entry => entry.Contains("MUST NOT contain a `.intent-cli/`", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void HostOwnershipModel_DesignAndReviewRuntimeBothOwnNextSliceCreation()
+    {
+        // G326 acceptance: the model explicitly allows design-side AND
+        // review-runtime-side NextSlice creation with different
+        // ownership labels (design produces prepared packets;
+        // review-runtime publishes them and may produce runtime-created
+        // packets recorded as such).
+        var design = HostOwnershipModel.Roles.Single(r => r.Id == HostOwnershipModel.RoleDesign);
+        var review = HostOwnershipModel.Roles.Single(r => r.Id == HostOwnershipModel.RoleReviewRuntime);
+
+        Assert.Contains(design.Responsibilities,
+            r => r.Contains("Prepare NextSlice", StringComparison.OrdinalIgnoreCase)
+                || r.Contains("prepared packet", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(review.Responsibilities,
+            r => r.Contains("Publish the next-slice", StringComparison.OrdinalIgnoreCase)
+                || r.Contains("runtime-created NextSlice", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("design", "design")]
+    [InlineData("Design", "design")]
+    [InlineData("intent-design", "design")]
+    [InlineData("review-runtime", "review-runtime")]
+    [InlineData("review", "review-runtime")]
+    [InlineData("runtime", "review-runtime")]
+    [InlineData("child", "child-worker")]
+    [InlineData("worker", "child-worker")]
+    [InlineData("implementer", "child-worker")]
+    [InlineData("garbage", "ambiguous")]
+    [InlineData("", "ambiguous")]
+    public void ResolveRole_NormalizesAliasToCanonicalIdentifier(string raw, string expected)
+    {
+        Assert.Equal(expected, HostOwnershipModel.ResolveRole(raw));
+    }
+
+    // --- G326: setup contract surfaces host_role -----------------------------
+
+    [Fact]
+    public void GuideAutomationSetup_ChildImplementWithoutFlag_InfersChildWorkerHostRole()
+    {
+        // G326 acceptance: when the operator did not pass --host-role,
+        // a `child-implement` purpose (which implies cwd_role=child)
+        // resolves to host_role=child-worker.
+        using var writer = new StringWriter();
+        var exit = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            new[] { "--purpose", "child-implement", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("child-worker", doc.RootElement.GetProperty("host_role").GetString());
+    }
+
+    [Fact]
+    public void GuideAutomationSetup_HostReviewWithoutFlag_SurfacesAmbiguous()
+    {
+        // G326 acceptance: a host cwd (host-review-next-slice purpose)
+        // cannot be disambiguated between design and review-runtime
+        // without an explicit --host-role flag. The setup contract MUST
+        // say `ambiguous` so the operator names the role before any
+        // role-scoped mutation guidance is acted on.
+        using var writer = new StringWriter();
+        var exit = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            new[]
+            {
+                "--purpose", "host-review-next-slice",
+                "--domain", "intent-cli",
+                "--target-repo", "J-Tech-Japan/intent-system",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("ambiguous", doc.RootElement.GetProperty("host_role").GetString());
+    }
+
+    [Fact]
+    public void GuideAutomationSetup_ExplicitHostRoleFlag_RespectsOperatorChoice()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            new[]
+            {
+                "--purpose", "host-review-next-slice",
+                "--domain", "intent-cli",
+                "--target-repo", "J-Tech-Japan/intent-system",
+                "--host-role", "review-runtime",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("review-runtime", doc.RootElement.GetProperty("host_role").GetString());
+    }
+
+    [Fact]
+    public void GuideAutomationSetup_UnknownHostRoleValue_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            new[]
+            {
+                "--purpose", "child-implement",
+                "--host-role", "garbage",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--host-role 'garbage' did not resolve", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideHostOwnershipCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideHostOwnershipCommandTests.cs
@@ -238,6 +238,52 @@ public sealed class GuideHostOwnershipCommandTests
     }
 
     [Fact]
+    public void GuideAutomationSetup_Markdown_RendersResolvedHostRoleLine()
+    {
+        // G326 review fix (PR #756): the operator-facing markdown
+        // contract MUST render the resolved host role alongside the
+        // cwd role; the JSON-only `host_role` field is invisible to
+        // operators who paste the markdown contract and follow it.
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            new[]
+            {
+                "--purpose", "host-review-next-slice",
+                "--domain", "intent-cli",
+                "--target-repo", "J-Tech-Japan/intent-system",
+                "--host-role", "review-runtime",
+                "--format", "markdown"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("- host role: review-runtime", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideAutomationSetup_Markdown_ChildImplementInfersChildWorkerRoleInMarkdown()
+    {
+        // G326 review fix (PR #756): child-implement purpose without
+        // `--host-role` infers `child-worker`; markdown MUST render
+        // that resolved role so the operator-facing contract reflects
+        // the same binding the JSON exposes via `host_role`.
+        using var writer = new StringWriter();
+        var exitCode = GuideAutomationSetupCommand.Execute(
+            CreateContext(),
+            new[]
+            {
+                "--purpose", "child-implement",
+                "--format", "markdown"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("- host role: child-worker", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void GuideAutomationSetup_UnknownHostRoleValue_ReturnsUsageError()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Defines the canonical role-scoped host topology so the same remote can be operated safely from separate design (MyIntentHost), review-runtime (IntentSystemReview / SekibanAsAServiceReview), and child implementation worktrees. The problem was never multiple worktrees — it was that without an explicit ownership boundary every role could write the same queue-state / runs.jsonl / packet files.

- New `HostOwnershipModel` (pure, no I/O) is the single source of truth for four canonical roles + each role's may-write / must-not-write matrix:
  - `design` — intent shaping, packet backlog, clarification, prepared packet creation.
  - `review-runtime` — git sync, host review, merge, closeout, runtime state, next-issue publish from prepared packets, optional runtime-created NextSlice.
  - `child-worker` — GitHub issue/PR implementation and PR-comment-fix only; no parent `.intent-cli/` writes.
  - `ambiguous` — refuses durable writes until the operator names the role.
  `ResolveRole` normalizes case / hyphens / underscores and known aliases.
- New `intent-cli guide host-ownership [--role <r>] [--format markdown|json]` command emits the matrix. JSON output is controller-friendly (focus_role + full roles array); markdown filters to the focus role for paste-ready operator reports. Wired into the existing `guide` router alongside `automation`, `review`, `commands`, etc.
- `GuideAutomationSetupCommand` gains a `--host-role` flag and a structured `host_role` JSON field. When the operator did not pass the flag, the role is inferred from `cwd-role`: child cwd → `child-worker`; host cwd → `ambiguous` (design vs review-runtime can't be disambiguated without an explicit binding).

## Why

PR #752 (G324) and earlier wakes showed that review closeout / next-slice publish events were entangled with packet design / clarification mutations because no explicit ownership matrix said which role owned which write surface. With G326 every generated guidance contract and every downstream command can dispatch on a stable role identifier and a documented matrix without having to re-infer the boundaries.

## Test plan

- [x] `Execute_DefaultJson_ReturnsAllFourCanonicalRoles` — JSON exposes design, review-runtime, child-worker, ambiguous.
- [x] `Execute_EveryRoleHasMatrixFields` — each role has summary, responsibilities, may_write (empty for ambiguous), must_not_write.
- [x] `Execute_FocusRole_ReturnsOnlyThatRole` (Theory × 4) — `--role` sets `focus_role`; markdown filters to that section.
- [x] `Execute_UnknownRoleValue_ReturnsUsageError`.
- [x] `Execute_MarkdownDefault_FiltersToFocusRoleSection` — markdown rendering for `--role child-worker` excludes other role sections.
- [x] `HostOwnershipModel_ChildWorkerForbidsParentHostStateWrites` — direct read on the pure model asserting `.intent-cli/queue-state.json`, `.intent-cli/runs.jsonl`, and the G300 boundary are in `must_not_write`.
- [x] `HostOwnershipModel_DesignAndReviewRuntimeBothOwnNextSliceCreation` — design has "Prepare NextSlice"; review-runtime has "Publish the next-slice" + "runtime-created NextSlice".
- [x] `ResolveRole_NormalizesAliasToCanonicalIdentifier` (Theory × 11) — alias resolution including the canonical `ambiguous` fallback.
- [x] `GuideAutomationSetup_ChildImplementWithoutFlag_InfersChildWorkerHostRole` — child purpose → `host_role=child-worker`.
- [x] `GuideAutomationSetup_HostReviewWithoutFlag_SurfacesAmbiguous` — host purpose without `--host-role` → `host_role=ambiguous`.
- [x] `GuideAutomationSetup_ExplicitHostRoleFlag_RespectsOperatorChoice` — explicit `--host-role review-runtime` is preserved.
- [x] `GuideAutomationSetup_UnknownHostRoleValue_ReturnsUsageError`.
- [x] All 132 prior GuideAutomation* tests pass byte-identically (new `host_role` field is additive).
- [x] Full CLI suite: 2510 passed, 0 failed.

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)