### PR TITLE
G328: make NextSlice provenance explicit (design vs review-runtime) and surface design-needed

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -92,6 +92,7 @@ internal static class AutomationHostLoopNextActionCommand
         var publishNextSliceExecutionUnit = parsed.PublishNextSliceExecutionUnit;
         var hardClarificationOpen = parsed.HardClarificationOpen;
         var openIntentTargetExistsResolved = openIntentTargetExists;
+        var designNeeded = false; // G328
         if (!nextSliceIssueCutReady && !string.IsNullOrWhiteSpace(parsed.Domain))
         {
             var probe = NextSliceDryRunProbeFactory?.Invoke(context)
@@ -108,6 +109,16 @@ internal static class AutomationHostLoopNextActionCommand
                             nextSliceIssueCutReady = true;
                             publishNextSliceExecutionUnit = probed.ExecutionUnit;
                         }
+                        break;
+
+                    case "design-needed":
+                        // G328: probe reports no prepared packet and
+                        // runtime creation is not permitted. Route the
+                        // analyzer to the `design-needed` lane so the
+                        // host loop never falls through to `true-idle`
+                        // while a design-side packet draft is the
+                        // actual next move.
+                        designNeeded = true;
                         break;
 
                     case "clarification-required":
@@ -158,7 +169,8 @@ internal static class AutomationHostLoopNextActionCommand
             PublishNextSliceExecutionUnit = publishNextSliceExecutionUnit,
             OpenIntentTargetPrOrIssueExists = openIntentTargetExistsResolved,
             AnyChildWorkerLeaseHeld = anyLeaseHeld,
-            HardClarificationOpen = hardClarificationOpen
+            HardClarificationOpen = hardClarificationOpen,
+            DesignNeeded = designNeeded
         };
 
         var result = HostLoopNextActionAnalyzer.Analyze(input);

--- a/src/IntentSystem.Cli/Commands/HostLoopNextActionAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/HostLoopNextActionAnalyzer.cs
@@ -67,6 +67,15 @@ internal static class HostLoopNextActionAnalyzer
     public const string ClassificationHardClarification = "hard-clarification";
     public const string ClassificationWipCapBlocked = "wip-cap-blocked";
     public const string ClassificationWaitForChild = "wait-for-child";
+    /// <summary>
+    /// G328: emitted when no actionable host signal exists AND the
+    /// next-slice probe reports `design-needed` (no prepared packet
+    /// and runtime creation is not permitted). Surfaces ABOVE
+    /// <c>true-idle</c> so the host loop can call out the missing
+    /// design work instead of reporting genuine idleness.
+    /// </summary>
+    public const string ClassificationDesignNeeded = "design-needed";
+
     public const string ClassificationTrueIdle = "true-idle";
 
     public static HostLoopNextActionResult Analyze(HostLoopNextActionInput input)
@@ -257,7 +266,24 @@ internal static class HostLoopNextActionAnalyzer
                 "Child worker holds the lease — wait, no host mutation needed.");
         }
 
-        // 9. true idle
+        // 9. G328 design-needed: next-slice probe says no prepared
+        //    packet exists and runtime creation is not permitted —
+        //    the next move is a design-side packet draft, NOT
+        //    waiting on a child or sitting idle. Surfaces ABOVE
+        //    true-idle so the host loop reports the gap explicitly.
+        if (input.DesignNeeded)
+        {
+            return Result(ClassificationDesignNeeded, mutationAllowed: false,
+                $"intent-cli intent next-slice --dry-run --domain {input.Domain ?? "<DOMAIN>"} --runtime-creation-allowed --format json",
+                new[]
+                {
+                    "intent next-slice --dry-run reports `design-needed`: no prepared packet exists and runtime creation is not permitted on this host.",
+                    "The next move is a design-side packet draft on the MyIntentHost workspace, not a host-loop wait. Re-run next-slice with `--runtime-creation-allowed` only when this workspace is a review-runtime authorized to author packets."
+                },
+                "Design-needed — no prepared packet; draft one on the design workspace.");
+        }
+
+        // 10. true idle
         return Result(ClassificationTrueIdle, mutationAllowed: false,
             recommendedCommand: null,
             new[] { "No actionable host signal across review/publish/repair/clarification lanes." },
@@ -331,6 +357,15 @@ internal sealed record HostLoopNextActionInput
 
     /// <summary>True when a Hard Clarification (open structured clarification or markdown blocker) is recorded.</summary>
     public bool HardClarificationOpen { get; init; }
+
+    /// <summary>
+    /// G328: true when the `intent next-slice --dry-run` probe
+    /// reports `design-needed` (no prepared packet AND runtime
+    /// creation not permitted). Routes the analyzer to the
+    /// `design-needed` classification before falling through to
+    /// `true-idle`.
+    /// </summary>
+    public bool DesignNeeded { get; init; }
 }
 
 internal sealed record ActionableReviewPr

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -22,6 +22,16 @@ internal static class IntentNextSliceCommand
     private const string OutcomeSkipDueToWip = "skip-next-slice-due-to-wip";
     private const string OutcomeClarificationRequired = "clarification-required";
     private const string OutcomeNoActionableItem = "no-actionable-item";
+    /// <summary>
+    /// G328: emitted when no prepared packet exists and runtime
+    /// creation is NOT permitted (the operator did not pass
+    /// <c>--runtime-creation-allowed</c>). Signals to the host loop
+    /// that the situation is not truly idle — the next move is a
+    /// design-side packet draft, not a wait-and-retry. The
+    /// host-loop-next-action analyzer maps this onto its own
+    /// <c>design-needed</c> classification (G328).
+    /// </summary>
+    internal const string OutcomeDesignNeeded = "design-needed";
 
     // G285: surfaced in `warnings` when the clarification file has stale
     // front-matter (`intent_state: open`) but the body explicitly records no
@@ -29,7 +39,7 @@ internal static class IntentNextSliceCommand
     internal const string WarningStaleClarificationMetadata = "stale-clarification-metadata";
 
     private const string UsageLine =
-        "Usage: intent-cli intent next-slice --dry-run [--domain <name>] [--target-repo <owner/repo>] [--format json|markdown]";
+        "Usage: intent-cli intent next-slice --dry-run [--domain <name>] [--target-repo <owner/repo>] [--runtime-creation-allowed] [--format json|markdown]";
 
     private static readonly IReadOnlyList<string> RequiredContractSections =
         new[]
@@ -58,7 +68,7 @@ internal static class IntentNextSliceCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var dryRun, out var domainOverride, out var targetRepo, out var format, out var error))
+        if (!TryParseArguments(args, out var dryRun, out var domainOverride, out var targetRepo, out var runtimeCreationAllowed, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
@@ -72,7 +82,7 @@ internal static class IntentNextSliceCommand
             return 1;
         }
 
-        var result = Analyze(context, domainOverride, targetRepo);
+        var result = Analyze(context, domainOverride, targetRepo, runtimeCreationAllowed);
 
         if (string.Equals(format, FormatMarkdown, StringComparison.Ordinal))
         {
@@ -88,6 +98,24 @@ internal static class IntentNextSliceCommand
     }
 
     internal static IntentNextSliceResult Analyze(CliContext context, string? domainOverride, string? targetRepo)
+    {
+        return Analyze(context, domainOverride, targetRepo, runtimeCreationAllowed: false);
+    }
+
+    /// <summary>
+    /// G328 overload — accepts an explicit <paramref name="runtimeCreationAllowed"/>
+    /// flag. When false (the safe default), absence of a prepared
+    /// packet causes the recommendation to surface
+    /// <see cref="OutcomeDesignNeeded"/> rather than
+    /// <see cref="OutcomeNoActionableItem"/>, so the host loop can
+    /// tell the difference between "truly idle" and "needs design
+    /// work before any next slice can be cut".
+    /// </summary>
+    internal static IntentNextSliceResult Analyze(
+        CliContext context,
+        string? domainOverride,
+        string? targetRepo,
+        bool runtimeCreationAllowed)
     {
         var domain = string.IsNullOrWhiteSpace(domainOverride)
             ? context.Config.Project.Domain
@@ -233,7 +261,8 @@ internal static class IntentNextSliceCommand
         var recommendedOutcome = ComputeRecommendedOutcome(
             clarificationOpen,
             wip.Count > 0,
-            candidate);
+            candidate,
+            runtimeCreationAllowed);
 
         var warnings = new List<string>();
         if (staleClarificationMetadata)
@@ -260,6 +289,7 @@ internal static class IntentNextSliceCommand
             PacketRoot = packetRoot,
             Candidate = candidate,
             RecommendedOutcome = recommendedOutcome,
+            RuntimeCreationAllowed = runtimeCreationAllowed,
             Warnings = warnings,
             Notes = notes
         };
@@ -287,12 +317,19 @@ internal static class IntentNextSliceCommand
             missing.AddRange(RequiredContractSections);
         }
 
+        // G328: surface packet provenance so downstream tooling (host
+        // loop / packet publish / closeout) can audit which role
+        // authored the packet. Pre-G328 packets fall back to
+        // `default-design` per `NextSlicePacketProvenanceReader`.
+        var provenance = NextSlicePacketProvenanceReader.Read(directory);
+
         return new IntentNextSliceCandidate
         {
             ExecutionUnit = executionUnit,
             PacketDirectory = directory,
             GithubBodyPresent = githubBodyPresent,
-            MissingContractSections = missing
+            MissingContractSections = missing,
+            Provenance = provenance
         };
     }
 
@@ -320,7 +357,8 @@ internal static class IntentNextSliceCommand
     private static string ComputeRecommendedOutcome(
         bool clarificationOpen,
         bool wipPresent,
-        IntentNextSliceCandidate? candidate)
+        IntentNextSliceCandidate? candidate,
+        bool runtimeCreationAllowed)
     {
         if (clarificationOpen)
         {
@@ -334,7 +372,18 @@ internal static class IntentNextSliceCommand
 
         if (candidate is null)
         {
-            return OutcomeNoActionableItem;
+            // G328: when no prepared packet exists, the recommendation
+            // splits on whether runtime creation is permitted. The
+            // safe default (runtime creation NOT allowed) surfaces
+            // `design-needed` so the host loop never reports
+            // true-idle while a design-side packet draft is the
+            // actual next move. Operators / review-runtime workspaces
+            // that have been granted runtime-creation authority can
+            // pass `--runtime-creation-allowed` to fall through to
+            // the pre-G328 `no-actionable-item` semantics.
+            return runtimeCreationAllowed
+                ? OutcomeNoActionableItem
+                : OutcomeDesignNeeded;
         }
 
         if (candidate.MissingContractSections.Count > 0)
@@ -582,12 +631,14 @@ internal static class IntentNextSliceCommand
         out bool dryRun,
         out string? domainOverride,
         out string? targetRepo,
+        out bool runtimeCreationAllowed,
         out string format,
         out string error)
     {
         dryRun = false;
         domainOverride = null;
         targetRepo = null;
+        runtimeCreationAllowed = false;
         format = FormatJson;
         error = string.Empty;
 
@@ -598,6 +649,10 @@ internal static class IntentNextSliceCommand
             {
                 case "--dry-run":
                     dryRun = true;
+                    break;
+
+                case "--runtime-creation-allowed":
+                    runtimeCreationAllowed = true;
                     break;
 
                 case "--domain":
@@ -706,6 +761,15 @@ internal sealed record IntentNextSliceResult
     [JsonPropertyName("recommended_outcome")]
     public required string RecommendedOutcome { get; init; }
 
+    /// <summary>
+    /// G328: did the caller pass <c>--runtime-creation-allowed</c>?
+    /// Surfaced in the result so downstream tooling (host-loop-next-action)
+    /// can verify the policy gate that produced the recommendation
+    /// without re-parsing the original CLI argv.
+    /// </summary>
+    [JsonPropertyName("runtime_creation_allowed")]
+    public required bool RuntimeCreationAllowed { get; init; }
+
     [JsonPropertyName("warnings")]
     public required IReadOnlyList<string> Warnings { get; init; }
 
@@ -726,4 +790,14 @@ internal sealed record IntentNextSliceCandidate
 
     [JsonPropertyName("missing_contract_sections")]
     public required IReadOnlyList<string> MissingContractSections { get; init; }
+
+    /// <summary>
+    /// G328: packet provenance — which role authored the packet
+    /// (<c>design</c> vs <c>review-runtime</c>), which host workspace
+    /// produced it, and (for runtime-created packets) the source PR.
+    /// Pre-G328 packets fall back to the default-design record so
+    /// the field is never null.
+    /// </summary>
+    [JsonPropertyName("provenance")]
+    public required NextSlicePacketProvenance Provenance { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/NextSlicePacketProvenance.cs
+++ b/src/IntentSystem.Cli/Commands/NextSlicePacketProvenance.cs
@@ -1,0 +1,228 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G328: provenance recorded on a next-slice packet — which role
+/// authored the packet (<c>design</c> vs <c>review-runtime</c>),
+/// which host workspace produced it, and (for runtime-created packets
+/// generated after a closeout) the source PR. Packets that pre-date
+/// G328 do not record provenance; the resolver treats absent
+/// provenance as <c>design</c> with <c>provenance_source =
+/// default-design</c> so existing design-side packets continue to
+/// publish unchanged.
+///
+/// Pure data — no I/O. The reader in
+/// <see cref="NextSlicePacketProvenanceReader"/> performs the file
+/// reads; this record is the analyzer-facing model.
+/// </summary>
+internal sealed record NextSlicePacketProvenance
+{
+    /// <summary><c>design</c> or <c>review-runtime</c>.</summary>
+    [JsonPropertyName("created_by_role")]
+    public required string CreatedByRole { get; init; }
+
+    /// <summary>
+    /// Optional workspace identity (repo / worktree label) that
+    /// authored the packet. Useful when multiple review-runtime
+    /// workspaces (e.g. IntentSystemReview, SekibanAsAServiceReview)
+    /// can both create runtime packets — the host string tells the
+    /// operator which one did.
+    /// </summary>
+    [JsonPropertyName("created_by_host")]
+    public string? CreatedByHost { get; init; }
+
+    /// <summary>
+    /// Optional PR number of the closeout that triggered the
+    /// runtime-created packet. Only meaningful when
+    /// <see cref="CreatedByRole"/> is <c>review-runtime</c>.
+    /// </summary>
+    [JsonPropertyName("source_closeout_pr")]
+    public int? SourceCloseoutPr { get; init; }
+
+    /// <summary>
+    /// Which artifact recorded the provenance:
+    /// <c>packet.yaml</c> when read from the packet manifest, or
+    /// <c>default-design</c> when no provenance block exists and the
+    /// resolver assumed design ownership for legacy packets.
+    /// </summary>
+    [JsonPropertyName("provenance_source")]
+    public required string ProvenanceSource { get; init; }
+}
+
+/// <summary>
+/// G328: canonical role + provenance-source vocabulary.
+/// </summary>
+internal static class NextSlicePacketProvenanceConstants
+{
+    public const string RoleDesign = "design";
+    public const string RoleReviewRuntime = "review-runtime";
+
+    public const string ProvenanceSourcePacketYaml = "packet.yaml";
+    public const string ProvenanceSourceDefaultDesign = "default-design";
+}
+
+/// <summary>
+/// G328: read provenance from a packet directory. Looks for a
+/// top-level <c>provenance:</c> block in <c>packet.yaml</c>:
+///
+/// <code>
+/// provenance:
+///   created_by_role: review-runtime
+///   created_by_host: review-runtime-intent-system
+///   source_closeout_pr: 758
+/// </code>
+///
+/// When <c>packet.yaml</c> is absent, unreadable, or has no
+/// <c>provenance</c> block, the reader returns the default-design
+/// fallback so pre-G328 packets continue to work. Bad role values
+/// (anything other than <c>design</c> / <c>review-runtime</c>) also
+/// fall back to default-design — the resolver never throws.
+/// </summary>
+internal static class NextSlicePacketProvenanceReader
+{
+    /// <summary>
+    /// Read the provenance for the packet at <paramref name="packetDirectory"/>.
+    /// </summary>
+    public static NextSlicePacketProvenance Read(string packetDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packetDirectory);
+        var packetYamlPath = Path.Combine(packetDirectory, "packet.yaml");
+        return ReadFromText(File.Exists(packetYamlPath) ? File.ReadAllText(packetYamlPath) : null);
+    }
+
+    /// <summary>
+    /// Read the provenance from the supplied <c>packet.yaml</c>
+    /// text. Pure — does not touch the filesystem.
+    /// </summary>
+    public static NextSlicePacketProvenance ReadFromText(string? packetYamlText)
+    {
+        if (string.IsNullOrWhiteSpace(packetYamlText))
+        {
+            return DefaultDesign();
+        }
+
+        var (role, host, sourcePr) = ParseProvenanceBlock(packetYamlText);
+        if (role is null)
+        {
+            return DefaultDesign();
+        }
+
+        if (!string.Equals(role, NextSlicePacketProvenanceConstants.RoleDesign, StringComparison.Ordinal)
+            && !string.Equals(role, NextSlicePacketProvenanceConstants.RoleReviewRuntime, StringComparison.Ordinal))
+        {
+            // Unknown role; treat as design fallback (we never want
+            // bad data on a packet to break next-slice planning).
+            return DefaultDesign();
+        }
+
+        return new NextSlicePacketProvenance
+        {
+            CreatedByRole = role,
+            CreatedByHost = host,
+            SourceCloseoutPr = sourcePr,
+            ProvenanceSource = NextSlicePacketProvenanceConstants.ProvenanceSourcePacketYaml
+        };
+    }
+
+    private static NextSlicePacketProvenance DefaultDesign() =>
+        new()
+        {
+            CreatedByRole = NextSlicePacketProvenanceConstants.RoleDesign,
+            CreatedByHost = null,
+            SourceCloseoutPr = null,
+            ProvenanceSource = NextSlicePacketProvenanceConstants.ProvenanceSourceDefaultDesign
+        };
+
+    /// <summary>
+    /// Minimal indentation-aware parser for the <c>provenance:</c>
+    /// block. The packet.yaml schema is small and tightly controlled
+    /// (it's a human-authored design artifact, not a free-form
+    /// document), so a hand-rolled parser is preferable to pulling
+    /// in a full YAML dependency just for one nested block.
+    /// </summary>
+    private static (string? Role, string? Host, int? SourcePr) ParseProvenanceBlock(string text)
+    {
+        var normalized = text.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var lines = normalized.Split('\n');
+
+        // Find the top-level `provenance:` line. A top-level line has
+        // zero leading whitespace.
+        int provenanceLineIndex = -1;
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (line.Length == 0 || char.IsWhiteSpace(line[0]))
+            {
+                continue;
+            }
+            var trimmed = line.Trim();
+            if (string.Equals(trimmed, "provenance:", StringComparison.Ordinal))
+            {
+                provenanceLineIndex = i;
+                break;
+            }
+        }
+
+        if (provenanceLineIndex < 0)
+        {
+            return (null, null, null);
+        }
+
+        string? role = null;
+        string? host = null;
+        int? sourcePr = null;
+
+        // Walk subsequent indented lines until we hit a line that
+        // dedents back to top level.
+        for (var i = provenanceLineIndex + 1; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+            if (!char.IsWhiteSpace(line[0]))
+            {
+                // Hit a new top-level key — provenance block is over.
+                break;
+            }
+
+            var content = line.Trim();
+            var colonIndex = content.IndexOf(':');
+            if (colonIndex <= 0)
+            {
+                continue;
+            }
+            var key = content[..colonIndex].Trim();
+            var value = content[(colonIndex + 1)..].Trim();
+            // Strip optional surrounding quotes.
+            if (value.Length >= 2
+                && ((value[0] == '"' && value[^1] == '"')
+                    || (value[0] == '\'' && value[^1] == '\'')))
+            {
+                value = value[1..^1];
+            }
+
+            switch (key)
+            {
+                case "created_by_role":
+                    role = value;
+                    break;
+                case "created_by_host":
+                    host = string.IsNullOrWhiteSpace(value) ? null : value;
+                    break;
+                case "source_closeout_pr":
+                    if (int.TryParse(value, System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture, out var parsed)
+                        && parsed > 0)
+                    {
+                        sourcePr = parsed;
+                    }
+                    break;
+            }
+        }
+
+        return (role, host, sourcePr);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/HostLoopNextActionAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/HostLoopNextActionAnalyzerTests.cs
@@ -179,6 +179,49 @@ public sealed class HostLoopNextActionAnalyzerTests
     }
 
     [Fact]
+    public void DesignNeeded_WhenProbeReportsDesignNeeded_AndNoOtherSignal()
+    {
+        // G328 acceptance: when the next-slice probe reports
+        // `design-needed` (no prepared packet AND runtime creation is
+        // not permitted), the analyzer surfaces `design-needed`
+        // ABOVE true-idle so the host loop calls out the missing
+        // design work explicitly.
+        var input = NewInput() with
+        {
+            DesignNeeded = true
+        };
+
+        var result = HostLoopNextActionAnalyzer.Analyze(input);
+
+        Assert.Equal("design-needed", result.Classification);
+        Assert.False(result.MutationAllowed);
+        Assert.Contains("intent next-slice", result.RecommendedCommand!, StringComparison.Ordinal);
+        Assert.Contains("--runtime-creation-allowed", result.RecommendedCommand!, StringComparison.Ordinal);
+        Assert.Contains("design-side packet draft",
+            string.Join('\n', result.Evidence),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DesignNeeded_DoesNotOverride_HigherPrioritySignals()
+    {
+        // G328: design-needed sits between wait-for-child and
+        // true-idle. Higher-priority lanes (review-pr, hard
+        // clarification, wip-cap, wait-for-child) must still win
+        // when present.
+        var input = NewInput() with
+        {
+            DesignNeeded = true,
+            HardClarificationOpen = true,
+            Domain = "intent-cli"
+        };
+
+        var result = HostLoopNextActionAnalyzer.Analyze(input);
+
+        Assert.Equal("hard-clarification", result.Classification);
+    }
+
+    [Fact]
     public void WipCapBlocked_WhenOpenIntentTargetButNoLease()
     {
         var input = NewInput() with

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -73,14 +73,20 @@ public sealed class IntentNextSliceCommandTests
     }
 
     [Fact]
-    public void Execute_GivenNoCandidate_RecommendsNoActionableItem()
+    public void Execute_GivenNoCandidate_AndRuntimeCreationAllowed_RecommendsNoActionableItem()
     {
+        // G328: the pre-G328 "no actionable item" semantic is now
+        // gated on the operator passing `--runtime-creation-allowed`
+        // (the review-runtime authorization that lets the runtime
+        // create packets on its own). Hosts that aren't review
+        // runtimes hit the new `design-needed` default — exercised
+        // in Execute_GivenNoCandidate_AndRuntimeCreationDisabled_RecommendsDesignNeeded.
         using var workspace = new IntentNextSliceWorkspace();
 
         using var writer = new StringWriter();
         var exitCode = IntentNextSliceCommand.Execute(
             workspace.Context,
-            ["--dry-run"],
+            ["--dry-run", "--runtime-creation-allowed"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -192,12 +198,16 @@ public sealed class IntentNextSliceCommandTests
     [Fact]
     public void Execute_GivenMarkdownFormat_EmitsHumanReadableOutput()
     {
+        // G328: pass --runtime-creation-allowed so the recommendation
+        // mirrors the pre-G328 markdown rendering for "empty workspace,
+        // truly idle". Without the flag the new default outcome is
+        // `design-needed`, which is asserted separately.
         using var workspace = new IntentNextSliceWorkspace();
         using var writer = new StringWriter();
 
         var exitCode = IntentNextSliceCommand.Execute(
             workspace.Context,
-            ["--dry-run", "--format", "markdown"],
+            ["--dry-run", "--runtime-creation-allowed", "--format", "markdown"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -254,6 +264,193 @@ public sealed class IntentNextSliceCommandTests
         var output = writer.ToString();
         Assert.Contains("intent next-slice", output, StringComparison.Ordinal);
         Assert.Contains("--dry-run", output, StringComparison.Ordinal);
+    }
+
+    // --- G328: provenance + design-needed ----------------------------------
+
+    [Fact]
+    public void Execute_GivenNoCandidate_AndRuntimeCreationDisabled_RecommendsDesignNeeded()
+    {
+        // G328 acceptance: when no prepared packet exists and the
+        // operator has NOT passed --runtime-creation-allowed, the
+        // recommendation is `design-needed` (not `no-actionable-item`).
+        // The host loop maps this onto the design-needed classification
+        // so it never reports true-idle while a design-side packet
+        // draft is the actual next move.
+        using var workspace = new IntentNextSliceWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("design-needed", root.GetProperty("recommended_outcome").GetString());
+        Assert.False(root.GetProperty("runtime_creation_allowed").GetBoolean());
+        Assert.False(root.TryGetProperty("candidate", out _));
+    }
+
+    [Fact]
+    public void Execute_GivenDesignProvenancePacket_CandidateExposesDesignProvenance()
+    {
+        // G328 acceptance: a packet authored on the design workspace
+        // (MyIntentHost) records `created_by_role: design` in
+        // packet.yaml. The next-slice candidate JSON surfaces it so
+        // review-runtime publish consumers can audit provenance.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G328/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G328/packet.yaml",
+            """
+            implementation_issue_packet:
+              source_execution_unit: G328
+              target_repo: J-Tech-Japan/intent-system
+              clarification_return_path: intents/intent-cli/clarifications/open.md
+            provenance:
+              created_by_role: design
+              created_by_host: MyIntentHost
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        var provenance = root.GetProperty("candidate").GetProperty("provenance");
+        Assert.Equal("design", provenance.GetProperty("created_by_role").GetString());
+        Assert.Equal("MyIntentHost", provenance.GetProperty("created_by_host").GetString());
+        Assert.Equal("packet.yaml", provenance.GetProperty("provenance_source").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenReviewRuntimeProvenancePacket_CandidateExposesRuntimeProvenance()
+    {
+        // G328 acceptance: a packet drafted by a review-runtime
+        // workspace after a closeout records the runtime role,
+        // workspace identity, and source PR. The next-slice
+        // candidate JSON surfaces all three.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G329/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G329/packet.yaml",
+            """
+            implementation_issue_packet:
+              source_execution_unit: G329
+              target_repo: J-Tech-Japan/intent-system
+              clarification_return_path: intents/intent-cli/clarifications/open.md
+            provenance:
+              created_by_role: review-runtime
+              created_by_host: review-runtime-intent-system
+              source_closeout_pr: 758
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        var provenance = root.GetProperty("candidate").GetProperty("provenance");
+        Assert.Equal("review-runtime", provenance.GetProperty("created_by_role").GetString());
+        Assert.Equal("review-runtime-intent-system",
+            provenance.GetProperty("created_by_host").GetString());
+        Assert.Equal(758, provenance.GetProperty("source_closeout_pr").GetInt32());
+        Assert.Equal("packet.yaml", provenance.GetProperty("provenance_source").GetString());
+    }
+
+    [Fact]
+    public void Execute_GivenLegacyPacketWithoutProvenance_DefaultsToDesignProvenance()
+    {
+        // G328 backward-compatibility: pre-G328 packets do not record
+        // provenance. They are treated as design-authored so they
+        // continue to be publishable; the `provenance_source` field
+        // is `default-design` so consumers know the binding is
+        // implicit, not explicitly recorded.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/github-body.md",
+            BuildCompleteContractBody());
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        var provenance = root.GetProperty("candidate").GetProperty("provenance");
+        Assert.Equal("design", provenance.GetProperty("created_by_role").GetString());
+        Assert.Equal("default-design",
+            provenance.GetProperty("provenance_source").GetString());
+        Assert.False(provenance.TryGetProperty("created_by_host", out _),
+            "default-design provenance must not invent a host string.");
+    }
+
+    [Fact]
+    public void Execute_PreparedDesignPacket_CanBePublishedByReviewRuntime()
+    {
+        // G328 acceptance: a prepared design-side packet must remain
+        // publishable from a review-runtime workspace — the
+        // `runtime-creation-allowed` flag controls whether the
+        // runtime may CREATE packets, not whether it can publish
+        // packets the design workspace already prepared. Verified
+        // by asserting `issue-cut-ready` regardless of the flag,
+        // with provenance still recorded as `design`.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G330/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G330/packet.yaml",
+            """
+            implementation_issue_packet:
+              source_execution_unit: G330
+              target_repo: J-Tech-Japan/intent-system
+              clarification_return_path: intents/intent-cli/clarifications/open.md
+            provenance:
+              created_by_role: design
+              created_by_host: MyIntentHost
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            // Review-runtime caller does NOT pass --runtime-creation-allowed
+            // because they aren't authoring; they're publishing the
+            // prepared packet.
+            ["--dry-run", "--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        // Issue-cut-ready wins because the prepared packet has the
+        // contract; design-needed is only emitted when there is NO
+        // candidate at all.
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("design",
+            root.GetProperty("candidate")
+                .GetProperty("provenance")
+                .GetProperty("created_by_role").GetString());
     }
 
     private static string BuildCompleteContractBody()
@@ -371,13 +568,16 @@ public sealed class IntentNextSliceCommandTests
         using var writer = new StringWriter();
         var exitCode = IntentNextSliceCommand.Execute(
             workspace.Context,
-            ["--dry-run", "--domain", "intent-cli"],
+            ["--dry-run", "--domain", "intent-cli", "--runtime-creation-allowed"],
             writer);
 
         Assert.Equal(0, exitCode);
         using var document = JsonDocument.Parse(writer.ToString());
         var root = document.RootElement;
-        // SKS packet was excluded, so no candidate and no-actionable-item.
+        // G328: with runtime creation allowed, the no-candidate result
+        // recommends `no-actionable-item` rather than the new default
+        // `design-needed`. This test exercises the cross-domain
+        // exclusion regardless of the G328 default flip.
         Assert.Equal("no-actionable-item", root.GetProperty("recommended_outcome").GetString());
         Assert.False(root.TryGetProperty("candidate", out _));
     }
@@ -555,13 +755,16 @@ public sealed class IntentNextSliceCommandTests
         using var writer = new StringWriter();
         var exitCode = IntentNextSliceCommand.Execute(
             workspace.Context,
-            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system"],
+            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system",
+                "--runtime-creation-allowed"],
             writer);
 
         Assert.Equal(0, exitCode);
         using var document = JsonDocument.Parse(writer.ToString());
         var root = document.RootElement;
-        // Packet excluded because target_repo doesn't match.
+        // G328: with runtime creation allowed, the no-candidate result
+        // remains `no-actionable-item`. This test exercises target-repo
+        // filtering regardless of the G328 default flip.
         Assert.Equal("no-actionable-item", root.GetProperty("recommended_outcome").GetString());
     }
 

--- a/tests/IntentSystem.Cli.Tests/NextSlicePacketProvenanceTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NextSlicePacketProvenanceTests.cs
@@ -1,0 +1,188 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G328: tests for the pure <see cref="NextSlicePacketProvenanceReader"/>.
+/// Covers the role / host / source-pr parse, the default-design
+/// fallback for pre-G328 packets, and the silent-recovery behavior
+/// when the role value is unknown or the block is malformed.
+/// </summary>
+public sealed class NextSlicePacketProvenanceTests
+{
+    [Fact]
+    public void ReadFromText_GivenDesignProvenance_ReturnsDesignRoleAndHost()
+    {
+        var provenance = NextSlicePacketProvenanceReader.ReadFromText(
+            """
+            implementation_issue_packet:
+              source_execution_unit: G328
+            provenance:
+              created_by_role: design
+              created_by_host: MyIntentHost
+            """);
+
+        Assert.Equal("design", provenance.CreatedByRole);
+        Assert.Equal("MyIntentHost", provenance.CreatedByHost);
+        Assert.Null(provenance.SourceCloseoutPr);
+        Assert.Equal("packet.yaml", provenance.ProvenanceSource);
+    }
+
+    [Fact]
+    public void ReadFromText_GivenReviewRuntimeProvenance_ReturnsRoleAndSourcePr()
+    {
+        var provenance = NextSlicePacketProvenanceReader.ReadFromText(
+            """
+            provenance:
+              created_by_role: review-runtime
+              created_by_host: review-runtime-intent-system
+              source_closeout_pr: 758
+            """);
+
+        Assert.Equal("review-runtime", provenance.CreatedByRole);
+        Assert.Equal("review-runtime-intent-system", provenance.CreatedByHost);
+        Assert.Equal(758, provenance.SourceCloseoutPr);
+        Assert.Equal("packet.yaml", provenance.ProvenanceSource);
+    }
+
+    [Fact]
+    public void ReadFromText_GivenNoProvenanceBlock_ReturnsDefaultDesignFallback()
+    {
+        // G328: pre-G328 packets do not record provenance. The reader
+        // returns a `default-design` record so the candidate JSON
+        // is never null and existing publish lanes keep working.
+        var provenance = NextSlicePacketProvenanceReader.ReadFromText(
+            """
+            implementation_issue_packet:
+              source_execution_unit: G244
+              target_repo: J-Tech-Japan/intent-system
+            """);
+
+        Assert.Equal("design", provenance.CreatedByRole);
+        Assert.Null(provenance.CreatedByHost);
+        Assert.Null(provenance.SourceCloseoutPr);
+        Assert.Equal("default-design", provenance.ProvenanceSource);
+    }
+
+    [Fact]
+    public void ReadFromText_GivenNullOrWhitespace_ReturnsDefaultDesign()
+    {
+        var fromNull = NextSlicePacketProvenanceReader.ReadFromText(null);
+        var fromBlank = NextSlicePacketProvenanceReader.ReadFromText("   \n\t");
+
+        Assert.Equal("design", fromNull.CreatedByRole);
+        Assert.Equal("default-design", fromNull.ProvenanceSource);
+        Assert.Equal("design", fromBlank.CreatedByRole);
+        Assert.Equal("default-design", fromBlank.ProvenanceSource);
+    }
+
+    [Theory]
+    [InlineData("robot")]
+    [InlineData("Design")] // case-sensitive — we don't accept aliases
+    [InlineData("")]
+    public void ReadFromText_GivenUnknownRoleValue_FallsBackToDefaultDesign(string role)
+    {
+        // G328: the reader never throws on bad data; an unrecognised
+        // role triggers the default-design fallback so a malformed
+        // packet doesn't take next-slice planning offline.
+        var provenance = NextSlicePacketProvenanceReader.ReadFromText(
+            $"""
+            provenance:
+              created_by_role: {role}
+              created_by_host: x
+            """);
+
+        Assert.Equal("design", provenance.CreatedByRole);
+        Assert.Equal("default-design", provenance.ProvenanceSource);
+    }
+
+    [Fact]
+    public void ReadFromText_GivenQuotedValues_StripsQuotes()
+    {
+        var provenance = NextSlicePacketProvenanceReader.ReadFromText(
+            """
+            provenance:
+              created_by_role: "review-runtime"
+              created_by_host: 'review-runtime-intent-system'
+              source_closeout_pr: 758
+            """);
+
+        Assert.Equal("review-runtime", provenance.CreatedByRole);
+        Assert.Equal("review-runtime-intent-system", provenance.CreatedByHost);
+        Assert.Equal(758, provenance.SourceCloseoutPr);
+    }
+
+    [Fact]
+    public void ReadFromText_GivenInvalidSourcePrNumber_LeavesPrFieldNull()
+    {
+        var provenance = NextSlicePacketProvenanceReader.ReadFromText(
+            """
+            provenance:
+              created_by_role: review-runtime
+              source_closeout_pr: not-a-number
+            """);
+
+        Assert.Equal("review-runtime", provenance.CreatedByRole);
+        Assert.Null(provenance.SourceCloseoutPr);
+    }
+
+    [Fact]
+    public void ReadFromText_StopsAtNextTopLevelKey()
+    {
+        // G328: the provenance parser must stop walking the file when
+        // it dedents back to a top-level key so it doesn't pick up
+        // keys from a sibling block as part of provenance.
+        var provenance = NextSlicePacketProvenanceReader.ReadFromText(
+            """
+            provenance:
+              created_by_role: review-runtime
+              created_by_host: x
+            implementation_issue_packet:
+              source_closeout_pr: 999
+            """);
+
+        Assert.Equal("review-runtime", provenance.CreatedByRole);
+        Assert.Equal("x", provenance.CreatedByHost);
+        // The `source_closeout_pr` inside `implementation_issue_packet`
+        // must NOT be picked up.
+        Assert.Null(provenance.SourceCloseoutPr);
+    }
+
+    [Fact]
+    public void Read_GivenDirectoryWithoutPacketYaml_ReturnsDefaultDesign()
+    {
+        using var temp = new TempDirectory();
+        var provenance = NextSlicePacketProvenanceReader.Read(temp.Path);
+        Assert.Equal("design", provenance.CreatedByRole);
+        Assert.Equal("default-design", provenance.ProvenanceSource);
+    }
+
+    [Fact]
+    public void Read_GivenDirectoryWithPacketYaml_ReadsProvenance()
+    {
+        using var temp = new TempDirectory();
+        File.WriteAllText(Path.Combine(temp.Path, "packet.yaml"),
+            """
+            provenance:
+              created_by_role: review-runtime
+              created_by_host: x
+            """);
+        var provenance = NextSlicePacketProvenanceReader.Read(temp.Path);
+        Assert.Equal("review-runtime", provenance.CreatedByRole);
+        Assert.Equal("x", provenance.CreatedByHost);
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; } =
+            Directory.CreateTempSubdirectory("g328-provenance-tests-").FullName;
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Issue #759 / G328 — support NextSlice creation from either the design workspace OR the review runtime, while making provenance and write scope explicit.

Three pieces:

### 1. Pure provenance reader

New `NextSlicePacketProvenance` record + `NextSlicePacketProvenanceReader`. Parses a top-level \`provenance:\` block from \`packet.yaml\`:

\`\`\`yaml
provenance:
  created_by_role: review-runtime
  created_by_host: review-runtime-intent-system
  source_closeout_pr: 758
\`\`\`

Fields: \`created_by_role\` (\`design\` | \`review-runtime\`), optional \`created_by_host\`, optional \`source_closeout_pr\`, and a \`provenance_source\` discriminator (\`packet.yaml\` vs \`default-design\` for pre-G328 packets). Pre-G328 packets that lack the block silently fall back to default-design so existing publish lanes keep working. Unknown role / malformed PR number also fall back — the reader never throws.

### 2. Candidate surfaces provenance

\`IntentNextSliceCandidate\` now carries a required \`provenance\` field. \`intent next-slice --dry-run\` exposes it in JSON so host loop / publish / closeout consumers can audit which role authored each packet.

### 3. \`design-needed\` recommendation + host-loop classification

- \`intent-cli intent next-slice --dry-run\` accepts a new \`--runtime-creation-allowed\` flag. Without it, the no-candidate case recommends \`design-needed\` (not \`no-actionable-item\`) so non-runtime workspaces don't accidentally report idle while a design packet draft is the actual next move.
- \`HostLoopNextActionAnalyzer\` gains a \`DesignNeeded\` input flag and a \`design-needed\` classification lane sitting ABOVE \`true-idle\`.
- \`AutomationHostLoopNextActionCommand\` routes the probe's \`design-needed\` outcome onto the new lane.

### Out of scope (per packet)

- Packet directories are NOT moved.
- Child workers cannot create packets — no API surface added.
- The existing publish path treats design-authored and runtime-authored packets identically. Provenance is recorded for audit, not as a publish gate, so a prepared design-side packet is still publishable by review runtime.

## Test plan

- [x] \`NextSlicePacketProvenanceTests\` (10 tests): design/review-runtime parses, default-design fallback, null/blank input, unknown role theory, quoted values, malformed PR number, top-level dedent stop, filesystem read paths.
- [x] \`IntentNextSliceCommandTests\` (5 new tests):
  - \`Execute_GivenNoCandidate_AndRuntimeCreationDisabled_RecommendsDesignNeeded\`
  - \`Execute_GivenDesignProvenancePacket_CandidateExposesDesignProvenance\`
  - \`Execute_GivenReviewRuntimeProvenancePacket_CandidateExposesRuntimeProvenance\`
  - \`Execute_GivenLegacyPacketWithoutProvenance_DefaultsToDesignProvenance\`
  - \`Execute_PreparedDesignPacket_CanBePublishedByReviewRuntime\` (design-side prepared packet stays publishable by review runtime)
- [x] \`HostLoopNextActionAnalyzerTests\` (2 new tests):
  - \`DesignNeeded_WhenProbeReportsDesignNeeded_AndNoOtherSignal\`
  - \`DesignNeeded_DoesNotOverride_HigherPrioritySignals\` (higher lanes — review-pr, hard-clarification, wip-cap, wait-for-child — still win)
- [x] Backward-compat: existing IntentNextSliceCommand tests that asserted \`no-actionable-item\` for an empty workspace are updated to pass \`--runtime-creation-allowed\` (preserving original test intent unrelated to G328) or to assert the new \`design-needed\` outcome.
- [x] Full CLI suite: 2564 passed, 0 failed.

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)