### PR TITLE
G332: route review closeout-plan and next-slice WIP gate through scoped state

### DIFF
--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -121,7 +121,31 @@ internal static class IntentNextSliceCommand
             ? context.Config.Project.Domain
             : domainOverride!;
 
-        var queueStatePath = context.GetQueueStatePath();
+        // G332: when the caller names a target repo, route the
+        // queue-state read through the runtime-scoped resolver so the
+        // WIP gate sees the scoped state for the (domain, target-repo)
+        // pair rather than unrelated root state. Pre-migration hosts
+        // with only the legacy root file fall through automatically
+        // (StateLocationKind.Legacy). When no target repo is supplied
+        // the read keeps its pre-G332 root behavior byte-identically.
+        string queueStatePath;
+        string? stateLayout = null;
+        if (!string.IsNullOrWhiteSpace(targetRepo))
+        {
+            var location = RuntimeScopedStateResolver.ResolveQueueStatePathForRead(
+                context.RepoRoot, domain, targetRepo!);
+            queueStatePath = location.Path;
+            stateLayout = location.Kind switch
+            {
+                StateLocationKind.Scoped => "scoped",
+                StateLocationKind.Legacy => "legacy-fallback",
+                _ => "scoped"
+            };
+        }
+        else
+        {
+            queueStatePath = context.GetQueueStatePath();
+        }
         QueueState? queueState = null;
         var notes = new List<string>();
 
@@ -290,6 +314,7 @@ internal static class IntentNextSliceCommand
             Candidate = candidate,
             RecommendedOutcome = recommendedOutcome,
             RuntimeCreationAllowed = runtimeCreationAllowed,
+            StateLayout = stateLayout,
             Warnings = warnings,
             Notes = notes
         };
@@ -769,6 +794,18 @@ internal sealed record IntentNextSliceResult
     /// </summary>
     [JsonPropertyName("runtime_creation_allowed")]
     public required bool RuntimeCreationAllowed { get; init; }
+
+    /// <summary>
+    /// G332: which on-disk layout the runtime-scoped resolver chose
+    /// for the queue-state read when the caller supplied
+    /// <c>--target-repo</c>. <c>scoped</c> when
+    /// `.intent-cli/runtime/&lt;domain&gt;/&lt;owner&gt;__&lt;repo&gt;/queue-state.json`
+    /// exists, <c>legacy-fallback</c> when only the legacy root path
+    /// exists (pre-migration), null when no target repo was supplied
+    /// (the read used the pre-G332 root path byte-identically).
+    /// </summary>
+    [JsonPropertyName("state_layout")]
+    public string? StateLayout { get; init; }
 
     [JsonPropertyName("warnings")]
     public required IReadOnlyList<string> Warnings { get; init; }

--- a/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
@@ -125,7 +125,21 @@ internal static class ReviewCloseoutPlanCommand
             ? context.Config.Project.Domain
             : domainOverride!;
 
-        var queueStatePath = context.GetQueueStatePath();
+        // G332: route queue-state read through the runtime-scoped
+        // resolver. When `.intent-cli/runtime/<domain>/<owner>__<repo>/queue-state.json`
+        // exists on disk it wins; only-legacy hosts (pre-migration)
+        // continue to read the root file (fallback explicitly surfaced
+        // via `state_layout`). The packet lookup under
+        // `.intent-cli/issues/<execution-unit>/` is unchanged (G300).
+        var queueStateLocation = RuntimeScopedStateResolver.ResolveQueueStatePathForRead(
+            context.RepoRoot, domain, repo!);
+        var queueStatePath = queueStateLocation.Path;
+        var stateLayout = queueStateLocation.Kind switch
+        {
+            StateLocationKind.Scoped => "scoped",
+            StateLocationKind.Legacy => "legacy-fallback",
+            _ => "scoped"
+        };
         var gaps = new List<ReviewCloseoutPlanGap>();
 
         QueueState? queueState = null;
@@ -377,7 +391,8 @@ internal static class ReviewCloseoutPlanCommand
             RecoveredLinkage = recoveredLinkage,
             AmbiguousLinkage = ambiguousLinkage,
             ClosingIssuesSource = closingIssuesSource,
-            LinkageRecoveryApplied = false
+            LinkageRecoveryApplied = false,
+            StateLayout = stateLayout
         };
 
         // G329 review fix: when --write-recovered-linkage is supplied
@@ -960,6 +975,18 @@ internal sealed record ReviewCloseoutPlanResult
     /// </summary>
     [JsonPropertyName("linkage_recovery_applied")]
     public required bool LinkageRecoveryApplied { get; init; }
+
+    /// <summary>
+    /// G332: which on-disk layout the runtime-scoped resolver chose
+    /// for the queue-state read — <c>scoped</c> when
+    /// `.intent-cli/runtime/&lt;domain&gt;/&lt;owner&gt;__&lt;repo&gt;/queue-state.json`
+    /// is on disk (or selected as the first-write target),
+    /// <c>legacy-fallback</c> when only the legacy root path exists
+    /// (pre-migration hosts). Surfaced so the host loop and operator
+    /// can audit which state source produced the plan.
+    /// </summary>
+    [JsonPropertyName("state_layout")]
+    public string? StateLayout { get; init; }
 }
 
 /// <summary>

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -453,6 +453,214 @@ public sealed class IntentNextSliceCommandTests
                 .GetProperty("created_by_role").GetString());
     }
 
+    // --- G332: runtime-scoped state preference for WIP gate ----------------
+
+    [Fact]
+    public void Execute_G332_TargetRepoWithScopedQueueState_ReadsScopedAndReportsScopedLayout()
+    {
+        // G332 acceptance: when `--target-repo` is supplied AND the
+        // scoped queue-state exists for (domain, target-repo), the
+        // WIP gate reads the scoped file rather than the legacy root.
+        // Result records `state_layout: scoped`.
+        using var workspace = new IntentNextSliceWorkspace();
+        // Legacy root has an UNRELATED active item — would falsely
+        // trigger WIP if the gate read root.
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-12T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "UNRELATED-1",
+                  "title": "unrelated",
+                  "state": "active",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_issue": {"repo": "J-Tech-Japan/SomeOther", "number": 1},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+        // Scoped state is empty (no WIP) — so the gate should NOT
+        // see WIP and the candidate should publish.
+        workspace.WriteFile(
+            ".intent-cli/runtime/intent-cli/J-Tech-Japan__intent-system/queue-state.json",
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-12T00:00:00Z",
+              "items": []
+            }
+            """);
+        workspace.WriteFile(
+            ".intent-cli/issues/G332/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G332/packet.yaml",
+            """
+            implementation_issue_packet:
+              source_execution_unit: G332
+              target_repo: J-Tech-Japan/intent-system
+              clarification_return_path: intents/intent-cli/clarifications/open.md
+            """);
+
+        using var writer = new StringWriter();
+        var exit = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--dry-run",
+                "--domain", "intent-cli",
+                "--target-repo", "J-Tech-Japan/intent-system"
+            },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("scoped", root.GetProperty("state_layout").GetString());
+        // No WIP visible via the scope → candidate is publishable.
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+    }
+
+    [Fact]
+    public void Execute_G332_TargetRepoWithLegacyOnly_FallsBackToLegacyAndReportsFallback()
+    {
+        // G332 transition: when no scoped state exists, the gate falls
+        // back to legacy root and surfaces `state_layout: legacy-fallback`.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-12T00:00:00Z",
+              "items": []
+            }
+            """);
+        workspace.WriteFile(
+            ".intent-cli/issues/G332/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G332/packet.yaml",
+            """
+            implementation_issue_packet:
+              source_execution_unit: G332
+              target_repo: J-Tech-Japan/intent-system
+              clarification_return_path: intents/intent-cli/clarifications/open.md
+            """);
+
+        using var writer = new StringWriter();
+        var exit = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--dry-run",
+                "--domain", "intent-cli",
+                "--target-repo", "J-Tech-Japan/intent-system"
+            },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("legacy-fallback", root.GetProperty("state_layout").GetString());
+    }
+
+    [Fact]
+    public void Execute_G332_WithoutTargetRepo_PreservesPreG332RootRead_NoStateLayoutField()
+    {
+        // G332 invariant: callers that don't pass --target-repo
+        // continue with byte-identical pre-G332 root behavior. The
+        // result does NOT carry a `state_layout` field (null →
+        // omitted by WhenWritingNull).
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-12T00:00:00Z",
+              "items": []
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exit = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            new[] { "--dry-run", "--runtime-creation-allowed" },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.False(doc.RootElement.TryGetProperty("state_layout", out _),
+            "without --target-repo the result must omit state_layout (pre-G332 behavior).");
+    }
+
+    [Fact]
+    public void Execute_G332_ScopedActiveItem_BlocksWipEvenIfLegacyRootEmpty()
+    {
+        // G332 isolation: when scoped state has an Active item, the WIP
+        // gate must fire even if the legacy root file is empty.
+        // Inverse of the previous test — confirms reads come from
+        // scoped state, not legacy.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-12T00:00:00Z",
+              "items": []
+            }
+            """);
+        workspace.WriteFile(
+            ".intent-cli/runtime/intent-cli/J-Tech-Japan__intent-system/queue-state.json",
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-12T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "SCOPED-WIP",
+                  "title": "scoped WIP",
+                  "state": "active",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_issue": {"repo": "J-Tech-Japan/intent-system", "number": 700},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exit = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--dry-run",
+                "--domain", "intent-cli",
+                "--target-repo", "J-Tech-Japan/intent-system"
+            },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("scoped", root.GetProperty("state_layout").GetString());
+        // WIP detected via scoped state.
+        Assert.Equal("skip-next-slice-due-to-wip",
+            root.GetProperty("recommended_outcome").GetString());
+    }
+
     private static string BuildCompleteContractBody()
     {
         return """

--- a/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
@@ -881,6 +881,113 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             writer.ToString(), StringComparison.Ordinal);
     }
 
+    // ─── G332 tests: runtime-scoped state preference ────────────────────────
+
+    [Fact]
+    public void Execute_G332_ScopedQueueStatePresent_ReadsScopedAndReportsScopedLayout()
+    {
+        // G332 acceptance: when scoped queue-state exists for
+        // (domain, target-repo), the closeout planner reads from
+        // `.intent-cli/runtime/<domain>/<owner>__<repo>/queue-state.json`
+        // — not the root file. Result records `state_layout: scoped`.
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        // Legacy root carries an UNRELATED execution unit. The planner
+        // must ignore it once a scoped file exists.
+        workspace.WriteQueueState(BuildQueueState("UNRELATED-1", "review",
+            linkedPr: "999",
+            linkedIssue: ("J-Tech-Japan/SomeOther", 1, null)));
+        // Scoped state carries the actual target item.
+        var scopedDir = Path.Combine(workspace.Context.RepoRoot, ".intent-cli",
+            "runtime", "intent-cli", "J-Tech-Japan__intent-system");
+        Directory.CreateDirectory(scopedDir);
+        File.WriteAllText(Path.Combine(scopedDir, "queue-state.json"),
+            BuildQueueState("G332", "review",
+                linkedPr: "770",
+                linkedIssue: ("J-Tech-Japan/intent-system", 767,
+                    "https://github.com/J-Tech-Japan/intent-system/issues/767")));
+        workspace.WriteFile(".intent-cli/issues/G332/github-body.md", BuildContractBody());
+
+        using var writer = new StringWriter();
+        var exit = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "770", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.True(root.GetProperty("ready").GetBoolean());
+        Assert.Equal("scoped", root.GetProperty("state_layout").GetString());
+        Assert.Equal("G332", root.GetProperty("execution_unit").GetString());
+        // queue_state_path points at the scoped file.
+        Assert.Contains("runtime/intent-cli/J-Tech-Japan__intent-system",
+            root.GetProperty("queue_state_path").GetString()!.Replace('\\', '/'),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G332_NoScopedState_FallsBackToLegacyAndReportsLegacyFallbackLayout()
+    {
+        // G332 transition: pre-migration hosts (G331 not yet run) only
+        // have the legacy root queue-state. The planner falls back to
+        // it and surfaces `state_layout: legacy-fallback` explicitly.
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G332", "review",
+            linkedPr: "770",
+            linkedIssue: ("J-Tech-Japan/intent-system", 767,
+                "https://github.com/J-Tech-Japan/intent-system/issues/767")));
+        workspace.WriteFile(".intent-cli/issues/G332/github-body.md", BuildContractBody());
+
+        using var writer = new StringWriter();
+        var exit = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "770", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.True(root.GetProperty("ready").GetBoolean());
+        Assert.Equal("legacy-fallback", root.GetProperty("state_layout").GetString());
+    }
+
+    [Fact]
+    public void Execute_G332_ScopedStatePresent_IgnoresUnrelatedRootDomainWork()
+    {
+        // G332 isolation: root queue-state may contain unrelated
+        // domain/repo work (e.g. Sekiban items). The closeout planner
+        // MUST NOT see them via the intent-cli/J-Tech-Japan/intent-system
+        // scope — that was the false-WIP / dirty-state coupling root cause.
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueStateWithTwoItems(
+            ("G332", "review", "770",
+                ("J-Tech-Japan/intent-system", 767, null)),
+            ("SEKI-1", "active", null,
+                ("J-Tech-Japan/SekibanAsAService", 99, null))));
+        // Scoped state only has the intent-cli item.
+        var scopedDir = Path.Combine(workspace.Context.RepoRoot, ".intent-cli",
+            "runtime", "intent-cli", "J-Tech-Japan__intent-system");
+        Directory.CreateDirectory(scopedDir);
+        File.WriteAllText(Path.Combine(scopedDir, "queue-state.json"),
+            BuildQueueState("G332", "review",
+                linkedPr: "770",
+                linkedIssue: ("J-Tech-Japan/intent-system", 767, null)));
+        workspace.WriteFile(".intent-cli/issues/G332/github-body.md", BuildContractBody());
+
+        using var writer = new StringWriter();
+        var exit = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "770", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.True(root.GetProperty("ready").GetBoolean());
+        Assert.Equal("scoped", root.GetProperty("state_layout").GetString());
+        Assert.Equal("G332", root.GetProperty("execution_unit").GetString());
+    }
+
     private static string BuildContractBody()
     {
         return """


### PR DESCRIPTION
## Summary

Issue #767 / G332 — host review and next-slice runtime commands must read the G327 role-scoped runtime state (populated by G331's \`migrate host-state\`) instead of treating root \`.intent-cli/queue-state.json\` as the active review-runtime source of truth.

\`CloseoutPrCommand\` was already wired in G327 (PR #758). This slice closes the two remaining gaps the AC names:

1. **\`ReviewCloseoutPlanCommand\`** — was reading legacy root \`context.GetQueueStatePath()\` for the host review preflight queue lookup. Now routes through \`ResolveQueueStatePathForRead(context.RepoRoot, domain, repo)\`. Scoped state wins when present; legacy is the explicit fallback. New \`state_layout\` result field surfaces the choice (\`scoped\` / \`legacy-fallback\`).

2. **\`IntentNextSliceCommand\`** — same legacy root read for the WIP gate. Now, when \`--target-repo\` is supplied, routes through the resolver. Without \`--target-repo\` the read stays byte-identical to pre-G332. Result emits \`state_layout\` only in the scoped lane.

Both commands use \`--repo\`/\`--target-repo\` + \`--domain\` (defaulted from context) — same pattern as \`CloseoutPrCommand\`. The resolver guarantees a consistent choice within one command invocation so closeout-plan and any follow-on closeout-pr write target the same state source.

## Out of scope (per packet)

- Re-running the G331 migration.
- Deleting / rewriting legacy root audit history.
- Moving packet directories under scoped runtime state — \`.intent-cli/issues/<execution-unit>/\` lookup unchanged (G300).
- Changing child worker host-state-free behavior.

## Test plan

- [x] \`ReviewCloseoutPlanCommandTests\` (3 new G332 tests):
  - \`Execute_G332_ScopedQueueStatePresent_ReadsScopedAndReportsScopedLayout\` (root has unrelated work; planner sees only scoped)
  - \`Execute_G332_NoScopedState_FallsBackToLegacyAndReportsLegacyFallbackLayout\` (pre-migration; explicit fallback)
  - \`Execute_G332_ScopedStatePresent_IgnoresUnrelatedRootDomainWork\` (Sekiban item in root must not leak into intent-cli scope)
- [x] \`IntentNextSliceCommandTests\` (4 new G332 tests):
  - \`Execute_G332_TargetRepoWithScopedQueueState_ReadsScopedAndReportsScopedLayout\` (root has fake WIP; scoped is empty → publish proceeds)
  - \`Execute_G332_TargetRepoWithLegacyOnly_FallsBackToLegacyAndReportsFallback\`
  - \`Execute_G332_WithoutTargetRepo_PreservesPreG332RootRead_NoStateLayoutField\`
  - \`Execute_G332_ScopedActiveItem_BlocksWipEvenIfLegacyRootEmpty\` (inverse — scoped Active item triggers WIP gate even with empty root)
- [x] Existing 17 ReviewCloseoutPlan + 41 IntentNextSlice tests pass byte-identically.
- [x] Full CLI suite (clean re-run): 2610 passed, 0 failed.

Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)