### PR TITLE
G335: guided host init workflow for new projects

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -509,7 +509,7 @@ internal static class CommandRouter
     /// </summary>
     internal static readonly IReadOnlyList<string> WorkflowGuidePointersHelp = new[]
     {
-        "init — `intent-cli intent init --domain <name> --target-repo <r> --write` (bootstrap host domain).",
+        "init — `intent-cli guide workflow task init-host --format json` (pick design / review-runtime / child-implementation role + scaffold plan, G335) then `intent-cli intent init --domain <name> --target-repo <r> --write` for host roles.",
         "interview — `intent-cli interview next-question --domain <d> --format json` (durable Q/A artifact).",
         "packet — `intent-cli packet draft --execution-unit <id> --target-repo <r> --format markdown` (canonical packet scaffold).",
         "issue — `intent-cli issue publish-flow <id> --repo <r> --write --format json` (publish next-slice issue).",

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -46,9 +46,9 @@ internal static class GuideHelpCommand
         new WorkflowGuidePointer
         {
             Phase = "init",
-            Command = "intent-cli intent init --domain <name> [--target-repo <owner/repo>] --write",
-            Purpose = "Bootstrap a host intent domain. Read-only without --write; --write provisions `.intent-cli/`, queue-state, and packet/runs scaffolding.",
-            SeeAlso = new[] { "intent-cli intake init", "intent-cli guide model --format json" }
+            Command = "intent-cli guide workflow task init-host --format json",
+            Purpose = "Pick a role for a NEW project (design / review-runtime / child-implementation) and get a scaffold plan + the exact `intent-cli intent init` incantation. Refuses to scaffold a child cwd that already carries `.intent-cli/` unless --force-host (G335).",
+            SeeAlso = new[] { "intent-cli intent init --domain <name> --target-repo <owner/repo> --write", "intent-cli intake init", "intent-cli guide model --format json" }
         },
         new WorkflowGuidePointer
         {
@@ -128,8 +128,8 @@ internal static class GuideHelpCommand
         new GuideSubcommandEntry
         {
             Name = "workflow",
-            Purpose = "Workflow suggestion: pick the right intent-cli entry for the operator's described intent.",
-            Example = "intent-cli guide workflow suggest --intent \"publish next issue\" --format json"
+            Purpose = "Workflow suggestion / scaffold plans. Subcommands: suggest (pick the right intent-cli entry for an operator goal); task <name> (bounded scaffold/init plan — today: `task init-host` for new-project role bootstrap, G335).",
+            Example = "intent-cli guide workflow task init-host --format json"
         },
         new GuideSubcommandEntry
         {

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowCommand.cs
@@ -22,7 +22,7 @@ internal static class GuideWorkflowCommand
 
         if (args.Length == 0)
         {
-            writer.WriteLine("guide workflow requires a subcommand. Supported: suggest.");
+            writer.WriteLine("guide workflow requires a subcommand. Supported: suggest, task.");
             WriteHelp(writer);
             return 1;
         }
@@ -31,13 +31,18 @@ internal static class GuideWorkflowCommand
         return subcommand switch
         {
             "suggest" => GuideWorkflowSuggestCommand.Execute(context, args[1..], writer),
+            // G335: `guide workflow task <task-name>` returns a
+            // bounded scaffold/init plan. Today only `init-host` is
+            // wired; future tasks plug in via the GuideWorkflowTaskCommand
+            // dispatcher.
+            "task" => GuideWorkflowTaskCommand.Execute(context, args[1..], writer),
             _ => UnknownSubcommand(writer, subcommand)
         };
     }
 
     private static int UnknownSubcommand(TextWriter writer, string subcommand)
     {
-        writer.WriteLine($"Unknown 'guide workflow' subcommand '{subcommand}'. Supported: suggest.");
+        writer.WriteLine($"Unknown 'guide workflow' subcommand '{subcommand}'. Supported: suggest, task.");
         WriteHelp(writer);
         return 1;
     }
@@ -45,9 +50,12 @@ internal static class GuideWorkflowCommand
     private static void WriteHelp(TextWriter writer)
     {
         writer.WriteLine("guide workflow");
-        writer.WriteLine("Usage: intent-cli guide workflow suggest [--domain <name>] (--goal <text> | --from-file <path>) [--format markdown|json]");
+        writer.WriteLine("Usage:");
+        writer.WriteLine("  intent-cli guide workflow suggest [--domain <name>] (--goal <text> | --from-file <path>) [--format markdown|json]");
+        writer.WriteLine("  intent-cli guide workflow task <task-name> [task-specific options]");
         writer.WriteLine();
         writer.WriteLine("Subcommands:");
         writer.WriteLine("- suggest — recommend a workflow + commands + rule topics for a broad operator goal");
+        writer.WriteLine("- task — bounded scaffold/init plans; today: `task init-host` explains the design / review-runtime / child-implementation roles and emits a scaffold plan (G335)");
     }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskCommand.cs
@@ -1,0 +1,55 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G335: dispatcher for the <c>guide workflow task</c> subcommand
+/// group. Peels the next token (the task name) and delegates to the
+/// per-task handler. Today only <c>init-host</c> is wired; future
+/// tasks (deploy-host, retire-host, migrate-host) can plug in
+/// without touching the router. Pure read-only — never mutates state,
+/// never launches an AI provider.
+/// </summary>
+internal static class GuideWorkflowTaskCommand
+{
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (args.Length == 0)
+        {
+            writer.WriteLine("guide workflow task requires a task name. Supported: init-host.");
+            WriteHelp(writer);
+            return 1;
+        }
+
+        var task = args[0];
+        return task switch
+        {
+            "init-host" => GuideWorkflowTaskInitHostCommand.Execute(context, args[1..], writer),
+            _ => UnknownTask(writer, task)
+        };
+    }
+
+    private static int UnknownTask(TextWriter writer, string task)
+    {
+        writer.WriteLine($"Unknown 'guide workflow task' name '{task}'. Supported: init-host.");
+        WriteHelp(writer);
+        return 1;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide workflow task");
+        writer.WriteLine("Usage: intent-cli guide workflow task <task-name> [task-specific options]");
+        writer.WriteLine();
+        writer.WriteLine("Tasks:");
+        writer.WriteLine("- init-host — explain host/review-runtime/child roles, name where `.intent-cli/` is required/optional/forbidden, emit scaffold plan (AGENTS.md / CLAUDE.md / host-binding.toml). Run with --role <role> for a single role; --force-host to scaffold a host role over an existing child cwd.");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskInitHostCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskInitHostCommand.cs
@@ -1,0 +1,402 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G335: read-only <c>intent-cli guide workflow task init-host</c>.
+/// Explains the three host/child roles a new project needs to choose
+/// between (design / review-runtime / child-implementation), names
+/// where <c>.intent-cli/</c> is required, optional, or forbidden, and
+/// emits a deterministic scaffold plan (AGENTS.md / CLAUDE.md /
+/// host-binding.toml suggestions plus the canonical
+/// <c>intent-cli intent init</c> incantation). It also surfaces the
+/// G300 / G333 invariant that initializing <c>.intent-cli/</c> inside
+/// a child implementation repo is forbidden unless the operator is
+/// deliberately upgrading that repo to a host.
+///
+/// Pure data — never reads parent host queue-state, never calls
+/// <c>gh</c>, never mutates state, never launches an AI provider. Safe
+/// from a child cwd that has no <c>.intent-cli/</c> directory
+/// (G299 / G333 bootstrap allow-list).
+/// </summary>
+internal static class GuideWorkflowTaskInitHostCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide workflow task init-host [--role design|review-runtime|child-implementation] [--force-host] [--format markdown|json]";
+
+    /// <summary>
+    /// G335: canonical role definitions for a new project. Mirrors the
+    /// runtime <see cref="HostOwnershipModel"/> roles but adds the
+    /// "what should I do FIRST" scaffold/init recipe each role needs
+    /// before its loop is wired up. Tests assert each role advertises
+    /// its <c>.intent-cli/</c> placement, its scaffold files, and at
+    /// least one canonical <c>intent-cli</c> command an external agent
+    /// can run.
+    /// </summary>
+    internal static readonly IReadOnlyList<HostRoleScaffold> RoleScaffolds = new[]
+    {
+        new HostRoleScaffold
+        {
+            Role = HostOwnershipModel.RoleDesign,
+            Summary = "Intent design / packet backlog workspace (e.g. MyIntentHost). Owns intents/<domain>/** and the packet/clarification scaffolds.",
+            DotIntentCliPlacement = "REQUIRED — the design host repo carries `.intent-cli/` at its root. Queue-state, runs.jsonl, packets, and clarifications all live here.",
+            ScaffoldFiles = new[]
+            {
+                "AGENTS.md — author the project-scoped agent guide; reference `intent-cli guide model --format json` and `intent-cli guide collaborate --format json` so the AI agent reads them via the CLI, not via copied prompts.",
+                "CLAUDE.md (optional) — operator-facing project guide for human + Claude collaboration.",
+                "host-binding.toml — declare this repo's role explicitly (`role = \"design\"`) so cross-repo tools can distinguish design vs review-runtime cwds without inferring from path."
+            },
+            InitCommands = new[]
+            {
+                "intent-cli intent init --domain <domain-name> [--target-repo <owner/repo>] --write",
+                "# Confirm `.intent-cli/` is provisioned and queue-state.json is empty:",
+                "intent-cli intent status --domain <domain-name> --format json",
+                "# Read the canonical capability JSON before any mutation:",
+                "intent-cli automation summary --domain <domain-name> --format json"
+            },
+            FirstLoop = "Run `intent-cli guide intent-work --format json` for the issue-publish / next-slice workflow."
+        },
+        new HostRoleScaffold
+        {
+            Role = HostOwnershipModel.RoleReviewRuntime,
+            Summary = "Review / closeout / runtime workspace (e.g. IntentSystemReview, SekibanAsAServiceReview). Pulls --ff-only, runs G316 review, owns `closeout pr`.",
+            DotIntentCliPlacement = "REQUIRED — the review-runtime workspace carries its own `.intent-cli/`. It is a separate local checkout of the same remote as the design host; it does NOT share the design host's `.intent-cli/` by path, but writes through the same intent-cli surfaces.",
+            ScaffoldFiles = new[]
+            {
+                "AGENTS.md — declare this is the review-runtime role and that approval / closeout commands run here, never from the design host or a child repo.",
+                "host-binding.toml — declare `role = \"review-runtime\"`; cross-repo tools refuse design-only mutations from this cwd.",
+                "(no CLAUDE.md required) — review-runtime is typically driven by intent-cli + gh from a controller; CLAUDE.md is operator-facing and lives in the design host."
+            },
+            InitCommands = new[]
+            {
+                "intent-cli intent init --domain <domain-name> [--target-repo <owner/repo>] --write",
+                "# Verify the host preflight surfaces are all installed:",
+                "intent-cli automation doctor --format json",
+                "intent-cli automation host-review-preflight --repo <owner/repo> --format json"
+            },
+            FirstLoop = "Run `intent-cli guide review --pr <n> --repo <owner/repo> --domain <d> --format json` for the G316 packet-aware review surface; closeout via `intent-cli closeout pr --pr <n> --repo <r> --pr-merged true --write --format json`."
+        },
+        new HostRoleScaffold
+        {
+            Role = HostOwnershipModel.RoleChildWorker,
+            Summary = "Per-issue child implementation worktree (issue-to-PR or PR-comment-fix). GitHub-contract-only.",
+            DotIntentCliPlacement = "FORBIDDEN — the implementation repo MUST NOT contain its own `.intent-cli/` directory (G300 / G333). Absence is the expected steady state. `intent-cli` runs against `--repo <owner/repo>` and uses GitHub labels only; parent host queue-state stays host-owned. Initializing `.intent-cli/` here is allowed ONLY if the operator is deliberately upgrading this checkout to a host role (pass --force-host to acknowledge).",
+            ScaffoldFiles = new[]
+            {
+                "AGENTS.md — declare child-implementation role; point at `intent-cli guide worker --format json` so loops read guidance from the CLI, not from local rules.",
+                "CLAUDE.md (optional) — operator-facing child loop notes; never duplicates host rules.",
+                "host-binding.toml — declare `role = \"child-implementation\"`; cross-repo tools refuse host writes from this cwd."
+            },
+            InitCommands = new[]
+            {
+                "# Do NOT run `intent-cli intent init` here. The child repo is GitHub-contract-only.",
+                "# Verify the global intent-cli is installed and fresh:",
+                "intent-cli automation doctor --format json",
+                "# Discover the loop surface:",
+                "intent-cli guide prompt-matrix --mode child-loop --format json"
+            },
+            FirstLoop = "Run the canonical wake body: `intent-cli worker next-action --repo <owner/repo> --workdir $PWD --format json`, dispatch on `action`, then `worker claim` / `worker result-summary` / `worker complete`."
+        }
+    };
+
+    /// <summary>
+    /// G335: explicit invariants the workflow guide must surface so
+    /// external agents do not mis-initialize a project. Tests pin
+    /// each invariant verbatim.
+    /// </summary>
+    internal static readonly IReadOnlyList<string> Invariants = new[]
+    {
+        "A child implementation repo MUST NOT contain its own `.intent-cli/` directory (G300 / G333). Initialize `.intent-cli/` only in design or review-runtime workspaces; never in a child cwd unless the operator is explicitly upgrading that cwd to a host role.",
+        "If the cwd already contains `.intent-cli/` AND the operator selected --role child-implementation, this guide refuses to scaffold and surfaces a structured stop — re-run with --force-host to override (you are deliberately turning this repo into a host).",
+        "Parent host queue-state, runs.jsonl, packet directories, intent tree, and review-runtime state are host-owned. Child implementation loops read GitHub issues / PRs / comments / labels / implementation-repo files only and MUST NOT inspect or mutate parent host state.",
+        "Prefer intent-cli-backed metadata mutation over hand-editing. Ask `intent-cli guide commands list --format json` or `intent-cli automation summary --domain <d> --format json` which command performs the transition, run that command, then validate the result. Routine automation MUST NOT directly edit queue-state, runs logs, publish artifacts, workflow labels, or runtime metadata by hand when a supported intent-cli command exists.",
+        "Never launch AI providers (Claude / Codex / any LLM) from intent-cli; the chat-first model has the human agent driving the conversation."
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var focusRole, out var forceHost, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var visibleRoles = string.IsNullOrEmpty(focusRole)
+            ? RoleScaffolds
+            : RoleScaffolds.Where(r => string.Equals(r.Role, focusRole, StringComparison.Ordinal)).ToArray();
+
+        var refusalReasons = new List<string>();
+        if (!string.IsNullOrEmpty(focusRole) && visibleRoles.Count == 0)
+        {
+            refusalReasons.Add($"--role '{focusRole}' did not resolve to a known role (design / review-runtime / child-implementation).");
+        }
+
+        // G335: surface the child-cwd guard explicitly. The guide
+        // detects whether the bootstrap context's repo root carries a
+        // local `.intent-cli/` and refuses to scaffold a
+        // child-implementation role when one already exists — unless
+        // --force-host is passed to acknowledge the upgrade.
+        var hasDotIntentCli = ChildCwdHasDotIntentCli(context);
+        var childRoleSelected = string.Equals(focusRole, HostOwnershipModel.RoleChildWorker, StringComparison.Ordinal);
+        if (hasDotIntentCli && childRoleSelected && !forceHost)
+        {
+            refusalReasons.Add("The current cwd already contains `.intent-cli/`, but --role child-implementation was selected. Re-run with --force-host to explicitly upgrade this repo to a host role, or cd to a directory without `.intent-cli/` if you intended to scaffold a child-implementation checkout.");
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            var payload = new InitHostGuidance
+            {
+                Usage = UsageLine,
+                Roles = visibleRoles,
+                Invariants = Invariants,
+                FocusRole = string.IsNullOrEmpty(focusRole) ? null : focusRole,
+                CwdHasDotIntentCli = hasDotIntentCli,
+                ForceHost = forceHost,
+                Refusals = refusalReasons.Count == 0 ? null : refusalReasons
+            };
+            writer.Write(JsonSerializer.Serialize(payload, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(visibleRoles, hasDotIntentCli, forceHost, refusalReasons, writer);
+        }
+
+        return refusalReasons.Count == 0 ? 0 : 1;
+    }
+
+    private static bool ChildCwdHasDotIntentCli(CliContext context)
+    {
+        // G335: only inspect the bootstrap context's repo root. Never
+        // climb the filesystem or read state from elsewhere.
+        var root = context.RepoRoot;
+        if (string.IsNullOrEmpty(root))
+        {
+            return false;
+        }
+
+        try
+        {
+            return Directory.Exists(Path.Combine(root, ".intent-cli"));
+        }
+        catch (Exception ex) when (ex is ArgumentException or PathTooLongException)
+        {
+            return false;
+        }
+    }
+
+    private static void WriteMarkdown(
+        IReadOnlyList<HostRoleScaffold> roles,
+        bool hasDotIntentCli,
+        bool forceHost,
+        IReadOnlyList<string> refusals,
+        TextWriter writer)
+    {
+        writer.WriteLine("# intent-cli — init-host workflow guide");
+        writer.WriteLine();
+        writer.WriteLine(UsageLine);
+        writer.WriteLine();
+        writer.WriteLine("Pick the role this new repo will play. A single remote can have multiple local workspaces — typically one design host, one or more review-runtime workspaces, and one per-issue child worktree at a time.");
+        writer.WriteLine();
+        writer.WriteLine($"_Detected `.intent-cli/` in cwd: **{(hasDotIntentCli ? "yes" : "no")}**; --force-host: **{(forceHost ? "yes" : "no")}**._");
+        writer.WriteLine();
+
+        if (refusals.Count > 0)
+        {
+            writer.WriteLine("## Refusals");
+            foreach (var reason in refusals)
+            {
+                writer.WriteLine($"- {reason}");
+            }
+            writer.WriteLine();
+        }
+
+        foreach (var role in roles)
+        {
+            writer.WriteLine($"## Role: {role.Role}");
+            writer.WriteLine();
+            writer.WriteLine($"- Summary: {role.Summary}");
+            writer.WriteLine($"- `.intent-cli/` placement: {role.DotIntentCliPlacement}");
+            writer.WriteLine();
+            writer.WriteLine("### Scaffold files");
+            foreach (var file in role.ScaffoldFiles)
+            {
+                writer.WriteLine($"- {file}");
+            }
+            writer.WriteLine();
+            writer.WriteLine("### Init commands");
+            foreach (var cmd in role.InitCommands)
+            {
+                writer.WriteLine($"- `{cmd}`");
+            }
+            writer.WriteLine();
+            writer.WriteLine($"### First loop");
+            writer.WriteLine($"- {role.FirstLoop}");
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Invariants");
+        foreach (var line in Invariants)
+        {
+            writer.WriteLine($"- {line}");
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string focusRole,
+        out bool forceHost,
+        out string format,
+        out string error)
+    {
+        focusRole = string.Empty;
+        forceHost = false;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            switch (arg)
+            {
+                case "--help":
+                    // Treat as harmless; the calling dispatcher already
+                    // handled the standalone help case.
+                    break;
+                case "--role":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "--role requires a value (design, review-runtime, or child-implementation).";
+                        return false;
+                    }
+                    var requestedRole = args[i + 1];
+                    var normalizedRole = NormalizeRoleArgument(requestedRole);
+                    if (normalizedRole is null)
+                    {
+                        error = $"--role '{requestedRole}' did not resolve to a known role (design / review-runtime / child-implementation).";
+                        return false;
+                    }
+                    focusRole = normalizedRole;
+                    i++;
+                    break;
+                case "--force-host":
+                    forceHost = true;
+                    break;
+                case "--format":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[i + 1];
+                    if (!string.Equals(requestedFormat, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    i++;
+                    break;
+                default:
+                    error = $"Unknown argument '{arg}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string? NormalizeRoleArgument(string raw)
+    {
+        // Accept both the canonical role IDs and the "child-implementation"
+        // alias the issue advertises. The runtime ownership model uses
+        // "child-worker" internally, but external operators learn the
+        // role from the init-host guide first, so accept both spellings.
+        if (string.Equals(raw, HostOwnershipModel.RoleDesign, StringComparison.OrdinalIgnoreCase))
+        {
+            return HostOwnershipModel.RoleDesign;
+        }
+        if (string.Equals(raw, HostOwnershipModel.RoleReviewRuntime, StringComparison.OrdinalIgnoreCase))
+        {
+            return HostOwnershipModel.RoleReviewRuntime;
+        }
+        if (string.Equals(raw, HostOwnershipModel.RoleChildWorker, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(raw, "child-implementation", StringComparison.OrdinalIgnoreCase))
+        {
+            return HostOwnershipModel.RoleChildWorker;
+        }
+        return null;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+/// <summary>
+/// G335: one role's init-host scaffold entry. <c>role</c> matches the
+/// canonical <see cref="HostOwnershipModel"/> identifier; the
+/// child-worker role accepts both <c>child-worker</c> and the
+/// <c>child-implementation</c> alias on input.
+/// </summary>
+internal sealed record HostRoleScaffold
+{
+    [JsonPropertyName("role")]
+    public required string Role { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("dot_intent_cli_placement")]
+    public required string DotIntentCliPlacement { get; init; }
+
+    [JsonPropertyName("scaffold_files")]
+    public required IReadOnlyList<string> ScaffoldFiles { get; init; }
+
+    [JsonPropertyName("init_commands")]
+    public required IReadOnlyList<string> InitCommands { get; init; }
+
+    [JsonPropertyName("first_loop")]
+    public required string FirstLoop { get; init; }
+}
+
+/// <summary>
+/// G335: full payload for <c>guide workflow task init-host --format json</c>.
+/// </summary>
+internal sealed record InitHostGuidance
+{
+    [JsonPropertyName("usage")]
+    public required string Usage { get; init; }
+
+    [JsonPropertyName("focus_role")]
+    public string? FocusRole { get; init; }
+
+    [JsonPropertyName("cwd_has_dot_intent_cli")]
+    public required bool CwdHasDotIntentCli { get; init; }
+
+    [JsonPropertyName("force_host")]
+    public required bool ForceHost { get; init; }
+
+    [JsonPropertyName("roles")]
+    public required IReadOnlyList<HostRoleScaffold> Roles { get; init; }
+
+    [JsonPropertyName("invariants")]
+    public required IReadOnlyList<string> Invariants { get; init; }
+
+    [JsonPropertyName("refusals")]
+    public IReadOnlyList<string>? Refusals { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskInitHostCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskInitHostCommandTests.cs
@@ -1,0 +1,343 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G335: tests for <c>intent-cli guide workflow task init-host</c>.
+/// The command surface must explain the three host roles (design /
+/// review-runtime / child-implementation), state where
+/// <c>.intent-cli/</c> is required, optional, or forbidden, emit a
+/// scaffold plan, and refuse to scaffold a child-implementation role
+/// over an existing <c>.intent-cli/</c> cwd unless <c>--force-host</c>
+/// is set.
+/// </summary>
+public sealed class GuideWorkflowTaskInitHostCommandTests : IDisposable
+{
+    private readonly string emptyCwd = Directory.CreateTempSubdirectory("init-host-tests-empty-").FullName;
+    private readonly string hostCwd = Directory.CreateTempSubdirectory("init-host-tests-host-").FullName;
+
+    public GuideWorkflowTaskInitHostCommandTests()
+    {
+        // Seed the "host" cwd with a `.intent-cli/` directory so the
+        // guard fires for child-implementation requests.
+        Directory.CreateDirectory(Path.Combine(hostCwd, ".intent-cli"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(emptyCwd))
+        {
+            Directory.Delete(emptyCwd, recursive: true);
+        }
+        if (Directory.Exists(hostCwd))
+        {
+            Directory.Delete(hostCwd, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Execute_NoFilter_ListsAllThreeRolesAndInvariants_ExitZero()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        // All three role IDs must appear.
+        Assert.Contains("design", output, StringComparison.Ordinal);
+        Assert.Contains("review-runtime", output, StringComparison.Ordinal);
+        Assert.Contains("child-worker", output, StringComparison.Ordinal);
+        // The acceptance criteria explicitly require each role to
+        // state where `.intent-cli/` is required / optional / forbidden.
+        Assert.Contains("REQUIRED", output, StringComparison.Ordinal);
+        Assert.Contains("FORBIDDEN", output, StringComparison.Ordinal);
+        // Scaffold files must include the three files named in the
+        // acceptance criteria.
+        Assert.Contains("AGENTS.md", output, StringComparison.Ordinal);
+        Assert.Contains("CLAUDE.md", output, StringComparison.Ordinal);
+        Assert.Contains("host-binding.toml", output, StringComparison.Ordinal);
+        // Invariants must include the metadata-mutation prohibition.
+        Assert.Contains("Prefer intent-cli-backed metadata mutation", output, StringComparison.Ordinal);
+        // Child isolation invariant.
+        Assert.Contains("Parent host queue-state", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_ReturnsStableShape()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+        Assert.True(root.TryGetProperty("usage", out _));
+        Assert.True(root.TryGetProperty("cwd_has_dot_intent_cli", out var cwdProp));
+        Assert.False(cwdProp.GetBoolean());
+        Assert.True(root.TryGetProperty("force_host", out var forceProp));
+        Assert.False(forceProp.GetBoolean());
+        Assert.True(root.TryGetProperty("roles", out var rolesProp));
+        Assert.Equal(JsonValueKind.Array, rolesProp.ValueKind);
+        Assert.Equal(3, rolesProp.GetArrayLength());
+        Assert.True(root.TryGetProperty("invariants", out var invProp));
+        Assert.True(invProp.GetArrayLength() >= 5);
+        // Each role must have the required fields.
+        foreach (var role in rolesProp.EnumerateArray())
+        {
+            Assert.True(role.TryGetProperty("role", out _));
+            Assert.True(role.TryGetProperty("summary", out _));
+            Assert.True(role.TryGetProperty("dot_intent_cli_placement", out _));
+            Assert.True(role.TryGetProperty("scaffold_files", out _));
+            Assert.True(role.TryGetProperty("init_commands", out _));
+            Assert.True(role.TryGetProperty("first_loop", out _));
+        }
+    }
+
+    [Theory]
+    [InlineData("design", "design")]
+    [InlineData("review-runtime", "review-runtime")]
+    [InlineData("child-worker", "child-worker")]
+    // G335 alias: external users learn "child-implementation" from
+    // the issue title; accept both spellings on input.
+    [InlineData("child-implementation", "child-worker")]
+    public void Execute_RoleFilter_ReturnsOnlyThatRole(string requested, string normalized)
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--role", requested, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var roles = document.RootElement.GetProperty("roles");
+        Assert.Equal(1, roles.GetArrayLength());
+        Assert.Equal(normalized, roles[0].GetProperty("role").GetString());
+        Assert.Equal(normalized, document.RootElement.GetProperty("focus_role").GetString());
+    }
+
+    [Fact]
+    public void Execute_ChildImplementationRoleOverExistingDotIntentCli_RefusesAndExitsOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(hostCwd),
+            new[] { "--role", "child-implementation", "--format", "json" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.True(document.RootElement.GetProperty("cwd_has_dot_intent_cli").GetBoolean());
+        Assert.False(document.RootElement.GetProperty("force_host").GetBoolean());
+        Assert.True(document.RootElement.TryGetProperty("refusals", out var refusals));
+        Assert.True(refusals.GetArrayLength() >= 1);
+        var combined = string.Join(" ", refusals.EnumerateArray().Select(r => r.GetString()));
+        Assert.Contains("already contains", combined, StringComparison.Ordinal);
+        Assert.Contains("--force-host", combined, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ChildImplementationRoleWithForceHost_OverridesGuardExitsZero()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(hostCwd),
+            new[] { "--role", "child-implementation", "--force-host", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.True(document.RootElement.GetProperty("cwd_has_dot_intent_cli").GetBoolean());
+        Assert.True(document.RootElement.GetProperty("force_host").GetBoolean());
+        // No refusals when --force-host is set.
+        if (document.RootElement.TryGetProperty("refusals", out var refusals))
+        {
+            // Null is OK (omitted via WhenWritingNull); else must be empty.
+            Assert.True(refusals.ValueKind == JsonValueKind.Null || refusals.GetArrayLength() == 0);
+        }
+    }
+
+    [Fact]
+    public void Execute_DesignRoleWithExistingDotIntentCli_NoRefusal()
+    {
+        // Design and review-runtime SHOULD live in a cwd with
+        // `.intent-cli/`; only child-implementation triggers the
+        // guard.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(hostCwd),
+            new[] { "--role", "design", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.True(document.RootElement.GetProperty("cwd_has_dot_intent_cli").GetBoolean());
+        if (document.RootElement.TryGetProperty("refusals", out var refusals))
+        {
+            Assert.True(refusals.ValueKind == JsonValueKind.Null || refusals.GetArrayLength() == 0);
+        }
+    }
+
+    [Fact]
+    public void Execute_UnknownRole_ExitsOneWithError()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--role", "nope" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("did not resolve", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ExitsOneWithError()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--unknown" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    // ---- dispatcher (`guide workflow task`) tests --------------------------
+
+    [Fact]
+    public void GuideWorkflowTaskCommand_NoTask_ExitsOneWithUsage()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(emptyCwd),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Supported: init-host", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowTaskCommand_UnknownTask_ExitsOneWithSupportedList()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "deploy-host" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Unknown 'guide workflow task' name 'deploy-host'", output, StringComparison.Ordinal);
+        Assert.Contains("Supported: init-host", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowTaskCommand_InitHostDispatch_ReturnsInitHostGuidance()
+    {
+        // The dispatcher must thread `init-host` (plus any options)
+        // into GuideWorkflowTaskInitHostCommand without losing args.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "init-host", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        // The init-host payload is identifiable by its usage line.
+        Assert.Contains("guide workflow task init-host", document.RootElement.GetProperty("usage").GetString(), StringComparison.Ordinal);
+    }
+
+    // ---- guide workflow parent dispatcher -----------------------------------
+
+    [Fact]
+    public void GuideWorkflowCommand_DispatchesTaskSubcommand()
+    {
+        // `guide workflow task ...` must reach the task dispatcher
+        // through the existing GuideWorkflowCommand entry; the help
+        // line also advertises the new subcommand.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "task", "init-host", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("guide workflow task init-host", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowCommand_HelpMentionsTaskSubcommand()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--help" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("suggest", output, StringComparison.Ordinal);
+        Assert.Contains("task", output, StringComparison.Ordinal);
+        Assert.Contains("init-host", output, StringComparison.Ordinal);
+    }
+
+    // ---- guide help integration --------------------------------------------
+
+    [Fact]
+    public void GuideHelpCommand_WorkflowGuides_InitPhasePointsToTaskInitHost()
+    {
+        // G335: the `init` workflow guide pointer must now route an
+        // external user to `task init-host` first, so they see the
+        // role explanation BEFORE running `intent init --write`.
+        var initPointer = GuideHelpCommand.WorkflowGuides
+            .FirstOrDefault(p => string.Equals(p.Phase, "init", StringComparison.Ordinal));
+        Assert.NotNull(initPointer);
+        Assert.Contains("guide workflow task init-host", initPointer!.Command, StringComparison.Ordinal);
+        Assert.Contains("intent init", string.Join(" ", initPointer.SeeAlso ?? Array.Empty<string>()), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext(string repoRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `intent-cli guide workflow task init-host [--role design|review-runtime|child-implementation] [--force-host] [--format markdown|json]` — the new-project entry point that names the three host/child roles, states where `.intent-cli/` is required/optional/forbidden, and emits a scaffold plan (AGENTS.md / CLAUDE.md / host-binding.toml + the canonical `intent-cli intent init` incantation).
- Adds a child-cwd guard: scaffolding `--role child-implementation` over an existing `.intent-cli/` cwd refuses (exit 1) unless `--force-host` is set. The JSON payload exposes `cwd_has_dot_intent_cli`, `force_host`, and `refusals[]` so consumers can branch deterministically.
- Adds the dispatchers: `guide workflow task <task-name>` under `guide workflow`. Today only `init-host` is wired; future tasks plug in via `GuideWorkflowTaskCommand`.
- Updates the G334 `guide help` workflow guides + the top-level help so the `init` phase now routes external users through `guide workflow task init-host` first, with `intent init --write` as a see-also for host roles.

## Test plan

- [x] `dotnet test tests/IntentSystem.Cli.Tests --filter GuideWorkflowTaskInitHost` — 17 new tests pass.
- [x] `dotnet test tests/IntentSystem.Cli.Tests --filter GuideWorkflow` — 49 tests pass (suggest + new task surface).
- [x] `dotnet test tests/IntentSystem.Cli.Tests --filter CommandRouterTests` — 118 tests pass (G334 regression check, including the parity-guard test that pins the `init` workflow phase).
- [x] Smoke-tested: `guide workflow task init-host` returns all three roles + invariants; `--role design` filters to one role; `--role child-implementation` from a cwd with `.intent-cli/` refuses with `exit 1` and surfaces the `--force-host` hint; `--force-host` overrides and exits 0.
- [x] G334 bootstrap allow-list already includes `guide workflow ...`, so the new task is reachable from a child cwd without `.intent-cli/`.

Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)