### PR TITLE
G336: guided intent interview / clarification workflow

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -510,7 +510,7 @@ internal static class CommandRouter
     internal static readonly IReadOnlyList<string> WorkflowGuidePointersHelp = new[]
     {
         "init — `intent-cli guide workflow task init-host --format json` (pick design / review-runtime / child-implementation role + scaffold plan, G335) then `intent-cli intent init --domain <name> --target-repo <r> --write` for host roles.",
-        "interview — `intent-cli interview next-question --domain <d> --format json` (durable Q/A artifact).",
+        "interview — `intent-cli guide workflow task intent-interview --format json` (product-owner interview / clarification loop guide, G336) then `intent-cli interview next-question --domain <d> --format json` for the durable Q/A artifact.",
         "packet — `intent-cli packet draft --execution-unit <id> --target-repo <r> --format markdown` (canonical packet scaffold).",
         "issue — `intent-cli issue publish-flow <id> --repo <r> --write --format json` (publish next-slice issue).",
         "automation — `intent-cli automation summary --domain <d> --format json` (label-driven capability JSON) + `intent-cli automation doctor` (CLI freshness).",

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -53,9 +53,9 @@ internal static class GuideHelpCommand
         new WorkflowGuidePointer
         {
             Phase = "interview",
-            Command = "intent-cli interview next-question --domain <name> --format json",
-            Purpose = "Drive the durable per-domain Q/A artifact. Use `interview record-answer` to persist responses and `interview compile` to assemble the source document.",
-            SeeAlso = new[] { "intent-cli interview record-answer", "intent-cli interview compile" }
+            Command = "intent-cli guide workflow task intent-interview --format json",
+            Purpose = "Product-owner interview / clarification loop guide (G336). Explains the background/question/options/pros-cons/recommendation question structure, distinguishes interview (new concept) from clarification (existing blocker), names durable artifact paths, and lists the canonical `intent-cli interview` / `intent-cli clarification` commands.",
+            SeeAlso = new[] { "intent-cli interview next-question --domain <d> --format json", "intent-cli interview record-answer", "intent-cli interview compile", "intent-cli clarification next" }
         },
         new WorkflowGuidePointer
         {

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowCommand.cs
@@ -56,6 +56,6 @@ internal static class GuideWorkflowCommand
         writer.WriteLine();
         writer.WriteLine("Subcommands:");
         writer.WriteLine("- suggest — recommend a workflow + commands + rule topics for a broad operator goal");
-        writer.WriteLine("- task — bounded scaffold/init plans; today: `task init-host` explains the design / review-runtime / child-implementation roles and emits a scaffold plan (G335)");
+        writer.WriteLine("- task — bounded scaffold/init plans; today: `task init-host` explains the design / review-runtime / child-implementation roles and emits a scaffold plan (G335), `task intent-interview` explains the product-owner interview / clarification loop and the canonical question structure (G336)");
     }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskCommand.cs
@@ -1,12 +1,18 @@
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// G335: dispatcher for the <c>guide workflow task</c> subcommand
-/// group. Peels the next token (the task name) and delegates to the
-/// per-task handler. Today only <c>init-host</c> is wired; future
-/// tasks (deploy-host, retire-host, migrate-host) can plug in
-/// without touching the router. Pure read-only — never mutates state,
-/// never launches an AI provider.
+/// G335 / G336: dispatcher for the <c>guide workflow task</c>
+/// subcommand group. Peels the next token (the task name) and
+/// delegates to the per-task handler. Tasks today:
+/// <list type="bullet">
+///   <item><c>init-host</c> (G335) — host/child/review role
+///         scaffold plan;</item>
+///   <item><c>intent-interview</c> (G336) — product-owner
+///         interview / clarification loop guidance.</item>
+/// </list>
+/// Future tasks (deploy-host, retire-host, migrate-host) can plug
+/// in without touching the router. Pure read-only — never mutates
+/// state, never launches an AI provider.
 /// </summary>
 internal static class GuideWorkflowTaskCommand
 {
@@ -24,7 +30,7 @@ internal static class GuideWorkflowTaskCommand
 
         if (args.Length == 0)
         {
-            writer.WriteLine("guide workflow task requires a task name. Supported: init-host.");
+            writer.WriteLine("guide workflow task requires a task name. Supported: init-host, intent-interview.");
             WriteHelp(writer);
             return 1;
         }
@@ -33,13 +39,17 @@ internal static class GuideWorkflowTaskCommand
         return task switch
         {
             "init-host" => GuideWorkflowTaskInitHostCommand.Execute(context, args[1..], writer),
+            // G336: intent-interview surfaces the product-owner
+            // interview / clarification loop (question structure,
+            // commands, stop conditions, durability invariants).
+            "intent-interview" => GuideWorkflowTaskIntentInterviewCommand.Execute(context, args[1..], writer),
             _ => UnknownTask(writer, task)
         };
     }
 
     private static int UnknownTask(TextWriter writer, string task)
     {
-        writer.WriteLine($"Unknown 'guide workflow task' name '{task}'. Supported: init-host.");
+        writer.WriteLine($"Unknown 'guide workflow task' name '{task}'. Supported: init-host, intent-interview.");
         WriteHelp(writer);
         return 1;
     }
@@ -50,6 +60,7 @@ internal static class GuideWorkflowTaskCommand
         writer.WriteLine("Usage: intent-cli guide workflow task <task-name> [task-specific options]");
         writer.WriteLine();
         writer.WriteLine("Tasks:");
-        writer.WriteLine("- init-host — explain host/review-runtime/child roles, name where `.intent-cli/` is required/optional/forbidden, emit scaffold plan (AGENTS.md / CLAUDE.md / host-binding.toml). Run with --role <role> for a single role; --force-host to scaffold a host role over an existing child cwd.");
+        writer.WriteLine("- init-host — explain host/review-runtime/child roles, name where `.intent-cli/` is required/optional/forbidden, emit scaffold plan (AGENTS.md / CLAUDE.md / host-binding.toml). Run with --role <role> for a single role; --force-host to scaffold a host role over an existing child cwd (G335).");
+        writer.WriteLine("- intent-interview — product-owner interview / clarification loop guide. Explains the background/question/options/pros-cons/recommendation question structure, distinguishes interview (new concept) from clarification (existing blocker), names the durable artifact paths, lists the canonical commands (G336).");
     }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskIntentInterviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskIntentInterviewCommand.cs
@@ -1,0 +1,358 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G336: read-only <c>intent-cli guide workflow task intent-interview</c>.
+/// Surfaces the canonical product-owner interview loop for an external
+/// agent that does not already know intent-system. Two distinct
+/// modes are advertised:
+/// <list type="bullet">
+///   <item><strong>interview</strong> — new concept shaping. The
+///         durable artifact lives under
+///         <c>intents/&lt;domain&gt;/interview/**</c> and is driven
+///         by <c>intent-cli interview next-question</c> /
+///         <c>record-answer</c> / <c>compile</c>.</item>
+///   <item><strong>clarification</strong> — repair an existing
+///         intent that has hit a Hard Clarification blocker. The
+///         durable artifact lives under
+///         <c>intents/&lt;domain&gt;/clarifications/**</c> and is
+///         driven by <c>intent-cli clarification next</c> /
+///         <c>answer</c>.</item>
+/// </list>
+///
+/// Each question must follow the
+/// <em>background → question → options → pros/cons → recommendation</em>
+/// structure (acceptance criterion). The guide returns the canonical
+/// outline plus a worked example so an AI agent can format every
+/// question consistently without referencing local rules or skill
+/// prompt files.
+///
+/// Pure read-only — never reads parent host queue-state, never calls
+/// <c>gh</c>, never mutates state, never launches an AI provider.
+/// </summary>
+internal static class GuideWorkflowTaskIntentInterviewCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide workflow task intent-interview [--mode interview|clarification] [--format markdown|json]";
+
+    internal const string ModeInterview = "interview";
+    internal const string ModeClarification = "clarification";
+
+    /// <summary>
+    /// G336: structural outline every product-owner question must
+    /// follow. Tests pin every section so future drift in tooling
+    /// cannot silently relax the contract.
+    /// </summary>
+    internal static readonly IReadOnlyList<QuestionSection> QuestionStructure = new[]
+    {
+        new QuestionSection
+        {
+            Section = "background",
+            Purpose = "One short paragraph the AI agent fills in BEFORE asking — names the intent slice, the durable artifact path, and what the agent already knows. Operators must not have to re-explain context.",
+            ExampleLine = "We are shaping intent `intent-cli` slice G336 (guided intent interview). The current interview log lives under `intents/intent-cli/interview/2026-05-12-g336.md`. We have already recorded the slice goal and the in-scope statement."
+        },
+        new QuestionSection
+        {
+            Section = "question",
+            Purpose = "Exactly one focused question the operator can answer in a single sentence or paragraph. NEVER bundle multiple decisions in one question — split them and ask the most blocking one first.",
+            ExampleLine = "Should the durable interview artifact live under `intents/<domain>/interview/<date>-<slice>.md` (per-slice file) or `intents/<domain>/interview/log.md` (rolling log)?"
+        },
+        new QuestionSection
+        {
+            Section = "options",
+            Purpose = "Bullet-listed candidate answers. Two or three is usual; one explicit `none-of-the-above-please-clarify` option keeps the operator from feeling boxed in.",
+            ExampleLine = "Options:\n- per-slice file (one markdown per slice)\n- rolling log (single markdown appended forever)\n- none of the above — please describe the durable layout you prefer"
+        },
+        new QuestionSection
+        {
+            Section = "pros-cons",
+            Purpose = "Concise pros/cons per option so the operator does not have to derive trade-offs from scratch. Three bullets per option max; surface the durability / discoverability trade-off explicitly.",
+            ExampleLine = "Per-slice file pros: easy to grep by slice ID. Cons: more files in `intents/`.\nRolling log pros: single artifact, no naming bikeshed. Cons: harder to find slice boundaries during review."
+        },
+        new QuestionSection
+        {
+            Section = "recommendation",
+            Purpose = "The AI agent's recommended pick + one-sentence reason, called out as a recommendation (not a decision). The operator stays the source of truth; the recommendation only saves them a turn.",
+            ExampleLine = "Recommendation: per-slice file — it pairs naturally with the per-slice issue/PR cadence and grep-by-slice is the most common query."
+        }
+    };
+
+    /// <summary>
+    /// G336: mode-specific guidance. Tests pin each mode's commands,
+    /// durable-artifact path, and stop conditions.
+    /// </summary>
+    internal static readonly IReadOnlyList<InterviewModeGuidance> Modes = new[]
+    {
+        new InterviewModeGuidance
+        {
+            Mode = ModeInterview,
+            Purpose = "Shape a NEW concept into a durable intent. The conversation produces the intent tree update and unblocks `intent next-slice` for the first time.",
+            DurableArtifactPath = "intents/<domain>/interview/<date>-<slice>.md (or the per-domain default — confirm via `intent-cli interview compile --domain <d> --format json`).",
+            Commands = new[]
+            {
+                "intent-cli interview next-question --domain <domain-name> --format json",
+                "intent-cli interview record-answer --domain <domain-name> --question-id <id> --answer-file <path> --write --format json",
+                "intent-cli interview compile --domain <domain-name> --format json",
+                "intent-cli intent draft-from-interview --domain <domain-name> --write --format json"
+            },
+            StopConditions = new[]
+            {
+                "`interview compile` reports `status: complete` and an intent tree update is staged.",
+                "Operator explicitly closes the interview (no further open questions, no Hard Clarification raised).",
+                "Three consecutive answers are `none of the above — please describe`: stop and surface a Hard Clarification so the operator can re-shape the slice rather than continuing to guess."
+            },
+            FollowUp = "After compile completes, run `intent-cli intent next-slice --dry-run --domain <d> --format json` to confirm the slice is now `issue-cut-ready`. If `clarification-required`, switch to the `clarification` mode (below) to repair the blocker."
+        },
+        new InterviewModeGuidance
+        {
+            Mode = ModeClarification,
+            Purpose = "REPAIR an existing intent that has hit a Hard Clarification blocker. The interview's job is to extract exactly enough operator input to unblock `intent next-slice`; it MUST NOT pretend to be a fresh-concept interview.",
+            DurableArtifactPath = "intents/<domain>/clarifications/<clarification-id>.json (created by `clarify open` or `clarification next` — never hand-edited).",
+            Commands = new[]
+            {
+                "intent-cli clarification status --domain <domain-name> --format json",
+                "intent-cli clarification next --domain <domain-name> --format json",
+                "intent-cli clarification answer --domain <domain-name> --clarification-id <id> --answer-file <path> --write --format json",
+                "intent-cli clarify draft --domain <domain-name> --clarification-id <id> --format markdown",
+                "intent-cli clarify record --domain <domain-name> --clarification-id <id> --write --format json"
+            },
+            StopConditions = new[]
+            {
+                "`clarification status` reports the blocker as `answered`; `intent next-slice --dry-run` no longer returns `clarification-required`.",
+                "Operator explicitly closes the clarification with a `won't-fix` or `out-of-scope` answer; the intent tree update is then optional, not blocking.",
+                "Operator answer reveals the blocker is actually a fresh-concept gap (interview-class): stop the clarification cleanly via `clarify record --won't-fix`, then start a new interview via `interview next-question`."
+            },
+            FollowUp = "After answering, re-run `intent-cli intent next-slice --dry-run --domain <d> --format json`. If still blocked, the next clarification will be queued and `clarification next` returns it."
+        }
+    };
+
+    /// <summary>
+    /// G336: explicit invariants every interview/clarification surface
+    /// must surface. Tests pin each invariant verbatim.
+    /// </summary>
+    internal static readonly IReadOnlyList<string> Invariants = new[]
+    {
+        "Interview is for shaping a NEW concept; clarification is for repairing an EXISTING intent. Do not run an interview to repair a Hard Clarification, and do not run a clarification to invent a new concept — surface the wrong-mode mismatch instead.",
+        "Every question follows the background → question → options → pros/cons → recommendation structure. One focused question per turn. Recommendations are advisory; the operator is the source of truth.",
+        "Generated questions are durable. Interview questions live under `intents/<domain>/interview/**`; clarification questions live under `intents/<domain>/clarifications/**`. Never hand-edit these files when a supported `intent-cli interview` or `intent-cli clarify` / `clarification` command exists.",
+        "Prefer intent-cli-backed metadata mutation over hand-editing. Ask `intent-cli guide commands list --format json` or `intent-cli automation summary --domain <d> --format json` which command performs the transition, run that command, then validate the result.",
+        "Child implementation loops MUST NOT inspect or mutate parent host queue-state, runs logs, packet directories, intent tree, review-runtime state, local rules, or local skills (G300 / G330 / G333). Interview / clarification artifacts are host-owned.",
+        "Never launch AI providers (Claude / Codex / any LLM) from intent-cli. The chat-first model has the human agent driving the conversation."
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var mode, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var visibleModes = string.IsNullOrEmpty(mode)
+            ? Modes
+            : Modes.Where(m => string.Equals(m.Mode, mode, StringComparison.Ordinal)).ToArray();
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            var payload = new IntentInterviewGuidance
+            {
+                Usage = UsageLine,
+                FocusMode = string.IsNullOrEmpty(mode) ? null : mode,
+                QuestionStructure = QuestionStructure,
+                Modes = visibleModes,
+                Invariants = Invariants
+            };
+            writer.Write(JsonSerializer.Serialize(payload, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(visibleModes, writer);
+        }
+
+        return 0;
+    }
+
+    private static void WriteMarkdown(IReadOnlyList<InterviewModeGuidance> modes, TextWriter writer)
+    {
+        writer.WriteLine("# intent-cli — intent interview / clarification workflow guide");
+        writer.WriteLine();
+        writer.WriteLine(UsageLine);
+        writer.WriteLine();
+        writer.WriteLine("Two modes; pick the right one BEFORE asking any question.");
+        writer.WriteLine();
+
+        writer.WriteLine("## Question structure (mandatory)");
+        writer.WriteLine();
+        writer.WriteLine("Every question to the operator MUST include all five sections in order:");
+        writer.WriteLine();
+        writer.WriteLine("| section | purpose | example |");
+        writer.WriteLine("|---------|---------|---------|");
+        foreach (var s in QuestionStructure)
+        {
+            writer.WriteLine($"| `{s.Section}` | {s.Purpose} | {s.ExampleLine.Replace("\n", " ")} |");
+        }
+        writer.WriteLine();
+
+        foreach (var m in modes)
+        {
+            writer.WriteLine($"## Mode: {m.Mode}");
+            writer.WriteLine();
+            writer.WriteLine($"- Purpose: {m.Purpose}");
+            writer.WriteLine($"- Durable artifact: `{m.DurableArtifactPath}`");
+            writer.WriteLine();
+            writer.WriteLine("### Commands");
+            foreach (var c in m.Commands)
+            {
+                writer.WriteLine($"- `{c}`");
+            }
+            writer.WriteLine();
+            writer.WriteLine("### Stop conditions");
+            foreach (var s in m.StopConditions)
+            {
+                writer.WriteLine($"- {s}");
+            }
+            writer.WriteLine();
+            writer.WriteLine("### Follow up");
+            writer.WriteLine($"- {m.FollowUp}");
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Invariants");
+        foreach (var line in Invariants)
+        {
+            writer.WriteLine($"- {line}");
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string mode, out string format, out string error)
+    {
+        mode = string.Empty;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            switch (arg)
+            {
+                case "--help":
+                    break;
+                case "--mode":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "--mode requires a value (interview or clarification).";
+                        return false;
+                    }
+                    var raw = args[i + 1];
+                    if (!string.Equals(raw, ModeInterview, StringComparison.Ordinal)
+                        && !string.Equals(raw, ModeClarification, StringComparison.Ordinal))
+                    {
+                        error = $"--mode '{raw}' did not resolve (use interview or clarification).";
+                        return false;
+                    }
+                    mode = raw;
+                    i++;
+                    break;
+                case "--format":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var fmt = args[i + 1];
+                    if (!string.Equals(fmt, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(fmt, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{fmt}').";
+                        return false;
+                    }
+                    format = fmt;
+                    i++;
+                    break;
+                default:
+                    error = $"Unknown argument '{arg}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+/// <summary>
+/// G336: one structural section of a product-owner question.
+/// </summary>
+internal sealed record QuestionSection
+{
+    [JsonPropertyName("section")]
+    public required string Section { get; init; }
+
+    [JsonPropertyName("purpose")]
+    public required string Purpose { get; init; }
+
+    [JsonPropertyName("example_line")]
+    public required string ExampleLine { get; init; }
+}
+
+/// <summary>
+/// G336: guidance for one interview mode (new concept vs blocker repair).
+/// </summary>
+internal sealed record InterviewModeGuidance
+{
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("purpose")]
+    public required string Purpose { get; init; }
+
+    [JsonPropertyName("durable_artifact_path")]
+    public required string DurableArtifactPath { get; init; }
+
+    [JsonPropertyName("commands")]
+    public required IReadOnlyList<string> Commands { get; init; }
+
+    [JsonPropertyName("stop_conditions")]
+    public required IReadOnlyList<string> StopConditions { get; init; }
+
+    [JsonPropertyName("follow_up")]
+    public required string FollowUp { get; init; }
+}
+
+/// <summary>
+/// G336: full JSON payload.
+/// </summary>
+internal sealed record IntentInterviewGuidance
+{
+    [JsonPropertyName("usage")]
+    public required string Usage { get; init; }
+
+    [JsonPropertyName("focus_mode")]
+    public string? FocusMode { get; init; }
+
+    [JsonPropertyName("question_structure")]
+    public required IReadOnlyList<QuestionSection> QuestionStructure { get; init; }
+
+    [JsonPropertyName("modes")]
+    public required IReadOnlyList<InterviewModeGuidance> Modes { get; init; }
+
+    [JsonPropertyName("invariants")]
+    public required IReadOnlyList<string> Invariants { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskIntentInterviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskIntentInterviewCommand.cs
@@ -92,13 +92,19 @@ internal static class GuideWorkflowTaskIntentInterviewCommand
         {
             Mode = ModeInterview,
             Purpose = "Shape a NEW concept into a durable intent. The conversation produces the intent tree update and unblocks `intent next-slice` for the first time.",
-            DurableArtifactPath = "intents/<domain>/interview/<date>-<slice>.md (or the per-domain default — confirm via `intent-cli interview compile --domain <d> --format json`).",
+            DurableArtifactPath = "intents/<domain>/interview/<date>-<slice>.md (or the per-domain default — confirm via `intent-cli interview compile --session <session-id> [--domain <d>] --format json`).",
+            // PR #776 reviewer fix: command examples MUST match the
+            // real CLI signatures. The interview surface is
+            // session-keyed (`--session <id>`), uses `--question` +
+            // `--from-file` for record-answer, and `--session` for
+            // compile / draft-from-interview. Domain is optional and
+            // falls back to the host config.
             Commands = new[]
             {
-                "intent-cli interview next-question --domain <domain-name> --format json",
-                "intent-cli interview record-answer --domain <domain-name> --question-id <id> --answer-file <path> --write --format json",
-                "intent-cli interview compile --domain <domain-name> --format json",
-                "intent-cli intent draft-from-interview --domain <domain-name> --write --format json"
+                "intent-cli interview next-question --session <session-id> [--domain <domain-name>] --format json",
+                "intent-cli interview record-answer --session <session-id> --question <question-id> --from-file <answer-path> [--domain <domain-name>] [--prompt <text>] --write --format json",
+                "intent-cli interview compile --session <session-id> [--domain <domain-name>] --format json",
+                "intent-cli intent draft-from-interview --session <session-id> [--domain <domain-name>] --write --format json"
             },
             StopConditions = new[]
             {
@@ -113,19 +119,25 @@ internal static class GuideWorkflowTaskIntentInterviewCommand
             Mode = ModeClarification,
             Purpose = "REPAIR an existing intent that has hit a Hard Clarification blocker. The interview's job is to extract exactly enough operator input to unblock `intent next-slice`; it MUST NOT pretend to be a fresh-concept interview.",
             DurableArtifactPath = "intents/<domain>/clarifications/<clarification-id>.json (created by `clarify open` or `clarification next` — never hand-edited).",
+            // PR #776 reviewer fix: `clarification answer` is a choice
+            // / note flow (the prompt-matrix surface), not a file
+            // upload. `clarify record` consumes a recorded decision
+            // packet via `--from-file`, and `clarify draft` is keyed
+            // on `--question` (the open question text), not a
+            // clarification id.
             Commands = new[]
             {
-                "intent-cli clarification status --domain <domain-name> --format json",
-                "intent-cli clarification next --domain <domain-name> --format json",
-                "intent-cli clarification answer --domain <domain-name> --clarification-id <id> --answer-file <path> --write --format json",
-                "intent-cli clarify draft --domain <domain-name> --clarification-id <id> --format markdown",
-                "intent-cli clarify record --domain <domain-name> --clarification-id <id> --write --format json"
+                "intent-cli clarification status [--domain <domain-name>] --format json",
+                "intent-cli clarification next [--domain <domain-name>] --format json",
+                "intent-cli clarification answer --domain <domain-name> --id <clarification-id> --choice <option-id> [--note <text>] --write --format json",
+                "intent-cli clarify draft --domain <domain-name> --question <open-question-text> --format markdown",
+                "intent-cli clarify record --domain <domain-name> --from-file <decision-packet-path> [--dry-run]"
             },
             StopConditions = new[]
             {
                 "`clarification status` reports the blocker as `answered`; `intent next-slice --dry-run` no longer returns `clarification-required`.",
-                "Operator explicitly closes the clarification with a `won't-fix` or `out-of-scope` answer; the intent tree update is then optional, not blocking.",
-                "Operator answer reveals the blocker is actually a fresh-concept gap (interview-class): stop the clarification cleanly via `clarify record --won't-fix`, then start a new interview via `interview next-question`."
+                "Operator explicitly closes the clarification with a `won't-fix` or `out-of-scope` choice; the intent tree update is then optional, not blocking.",
+                "Operator answer reveals the blocker is actually a fresh-concept gap (interview-class): stop the clarification cleanly (record the decision via `clarify record --from-file`), then start a new interview via `interview next-question --session <id>`."
             },
             FollowUp = "After answering, re-run `intent-cli intent next-slice --dry-run --domain <d> --format json`. If still blocked, the next clarification will be queued and `clarification next` returns it."
         }

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskIntentInterviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskIntentInterviewCommandTests.cs
@@ -237,6 +237,122 @@ public sealed class GuideWorkflowTaskIntentInterviewCommandTests
         Assert.Contains("interview record-answer", seeAlso, StringComparison.Ordinal);
     }
 
+    // ---- PR #776 regression: guide command examples match real CLI ----
+
+    [Fact]
+    public void InterviewModeCommands_FlagsExistInActualCliCommandSource()
+    {
+        // Regression test for the PR #776 review finding: each
+        // `--flag` named in the guide's interview-mode command
+        // examples MUST exist as a parser case in the real command's
+        // source file. The original draft had `--question-id` /
+        // `--answer-file` that no command implements; this check
+        // catches drift immediately by greppimg the command source
+        // for `case "--flag":` entries.
+        AssertGuideExampleFlagsExistInSource(
+            "interview",
+            new Dictionary<string, string>
+            {
+                ["intent-cli interview next-question"] = "src/IntentSystem.Cli/Commands/InterviewNextQuestionCommand.cs",
+                ["intent-cli interview record-answer"] = "src/IntentSystem.Cli/Commands/InterviewRecordAnswerCommand.cs",
+                ["intent-cli interview compile"] = "src/IntentSystem.Cli/Commands/InterviewCompileCommand.cs",
+                ["intent-cli intent draft-from-interview"] = "src/IntentSystem.Cli/Commands/IntentDraftFromInterviewCommand.cs"
+            });
+    }
+
+    [Fact]
+    public void ClarificationModeCommands_FlagsExistInActualCliCommandSource()
+    {
+        // Same regression check for the clarification mode. The
+        // original draft had `--clarification-id` / `--answer-file`
+        // and a non-existent `--write` flag on `clarify record`
+        // (which is `--from-file` / `--dry-run`); the reviewer
+        // surfaced this and the fix routes each example to the real
+        // flag set.
+        AssertGuideExampleFlagsExistInSource(
+            "clarification",
+            new Dictionary<string, string>
+            {
+                ["intent-cli clarification status"] = "src/IntentSystem.Cli/Commands/ClarificationCommand.cs",
+                ["intent-cli clarification next"] = "src/IntentSystem.Cli/Commands/ClarificationCommand.cs",
+                ["intent-cli clarification answer"] = "src/IntentSystem.Cli/Commands/ClarificationCommand.cs",
+                ["intent-cli clarify draft"] = "src/IntentSystem.Cli/Commands/ClarifyDraftCommand.cs",
+                ["intent-cli clarify record"] = "src/IntentSystem.Cli/Commands/ClarifyRecordCommand.cs"
+            });
+    }
+
+    private static void AssertGuideExampleFlagsExistInSource(
+        string modeId,
+        IReadOnlyDictionary<string, string> commandPrefixToSourcePath)
+    {
+        var mode = GuideWorkflowTaskIntentInterviewCommand.Modes
+            .First(m => string.Equals(m.Mode, modeId, StringComparison.Ordinal));
+
+        var flagPattern = new System.Text.RegularExpressions.Regex(
+            @"--[a-z][a-z-]*",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        var repoRoot = FindRepoRoot();
+
+        foreach (var commandLine in mode.Commands)
+        {
+            var commandPrefix = ExtractCommandPrefix(commandLine);
+            Assert.True(
+                commandPrefixToSourcePath.ContainsKey(commandPrefix),
+                $"Guide example references command '{commandPrefix}' but the test has no source path mapping for it.");
+
+            var relativePath = commandPrefixToSourcePath[commandPrefix];
+            var fullPath = Path.Combine(repoRoot, relativePath);
+            Assert.True(File.Exists(fullPath), $"Expected command source file at {fullPath}");
+            var source = File.ReadAllText(fullPath);
+
+            foreach (System.Text.RegularExpressions.Match match in flagPattern.Matches(commandLine))
+            {
+                var flag = match.Value;
+                // The flag must appear in the source as a parser
+                // case label. We tolerate either `case "--flag":` or
+                // a plain string mention because some commands keep
+                // flag names in const tables; the key invariant is
+                // that the literal flag string is present.
+                Assert.True(
+                    source.Contains($"\"{flag}\"", StringComparison.Ordinal),
+                    $"Guide example for `{commandPrefix}` mentions flag `{flag}` that does not appear in {relativePath}. The guide example must match the real CLI surface.");
+            }
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        // Walk upward from the test binary until we find a `src`
+        // folder (the repo root).
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null && !Directory.Exists(Path.Combine(dir, "src")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        Assert.NotNull(dir);
+        return dir!;
+    }
+
+    private static string ExtractCommandPrefix(string commandLine)
+    {
+        // Read tokens until we hit a flag, an `[optional]`, or a
+        // `<placeholder>` — the prefix is the command itself.
+        var tokens = commandLine.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var parts = new List<string>();
+        foreach (var token in tokens)
+        {
+            if (token.StartsWith("--", StringComparison.Ordinal)
+                || token.StartsWith("[", StringComparison.Ordinal)
+                || token.StartsWith("<", StringComparison.Ordinal))
+            {
+                break;
+            }
+            parts.Add(token);
+        }
+        return string.Join(" ", parts);
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskIntentInterviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskIntentInterviewCommandTests.cs
@@ -1,0 +1,256 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G336: tests for <c>intent-cli guide workflow task intent-interview</c>.
+/// The surface must explain the canonical question structure
+/// (background / question / options / pros-cons / recommendation),
+/// distinguish interview (new concept) from clarification (existing
+/// blocker), surface the durable-artifact paths, list the canonical
+/// commands per mode, and enumerate stop conditions plus the
+/// no-hand-edit / no-host-state / no-AI-launch invariants.
+/// </summary>
+public sealed class GuideWorkflowTaskIntentInterviewCommandTests
+{
+    [Fact]
+    public void Execute_NoFilter_ListsBothModesAndAllStructureSections_ExitZero()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIntentInterviewCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        // Both modes present.
+        Assert.Contains("Mode: interview", output, StringComparison.Ordinal);
+        Assert.Contains("Mode: clarification", output, StringComparison.Ordinal);
+        // All five question structure sections present (acceptance criterion 1).
+        foreach (var section in new[] { "background", "question", "options", "pros-cons", "recommendation" })
+        {
+            Assert.Contains(section, output, StringComparison.Ordinal);
+        }
+        // Durable artifact paths surfaced (acceptance criterion 4).
+        Assert.Contains("intents/<domain>/interview", output, StringComparison.Ordinal);
+        Assert.Contains("intents/<domain>/clarifications", output, StringComparison.Ordinal);
+        // Canonical commands (acceptance criterion 3).
+        Assert.Contains("intent-cli interview next-question", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli interview record-answer", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli interview compile", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli clarification next", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli clarification answer", output, StringComparison.Ordinal);
+        // Stop conditions section appears per mode.
+        Assert.Contains("Stop conditions", output, StringComparison.Ordinal);
+        // Interview vs clarification distinction (acceptance criterion 2).
+        Assert.Contains("Interview is for shaping a NEW concept; clarification is for repairing an EXISTING intent.", output, StringComparison.Ordinal);
+        // No AI provider launch invariant.
+        Assert.Contains("Never launch AI providers", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_ReturnsStableShape()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIntentInterviewCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.TryGetProperty("usage", out _));
+        Assert.True(root.TryGetProperty("question_structure", out var structureProp));
+        Assert.Equal(5, structureProp.GetArrayLength());
+        // Section IDs are part of the stable shape consumers can pin.
+        var sectionIds = structureProp.EnumerateArray().Select(s => s.GetProperty("section").GetString()).ToArray();
+        Assert.Equal(new[] { "background", "question", "options", "pros-cons", "recommendation" }, sectionIds);
+        Assert.True(root.TryGetProperty("modes", out var modesProp));
+        Assert.Equal(2, modesProp.GetArrayLength());
+        var modeIds = modesProp.EnumerateArray().Select(m => m.GetProperty("mode").GetString()).ToArray();
+        Assert.Equal(new[] { "interview", "clarification" }, modeIds);
+        // Each mode must carry the required keys.
+        foreach (var mode in modesProp.EnumerateArray())
+        {
+            Assert.True(mode.TryGetProperty("purpose", out _));
+            Assert.True(mode.TryGetProperty("durable_artifact_path", out _));
+            Assert.True(mode.TryGetProperty("commands", out _));
+            Assert.True(mode.TryGetProperty("stop_conditions", out _));
+            Assert.True(mode.TryGetProperty("follow_up", out _));
+        }
+        Assert.True(root.TryGetProperty("invariants", out var invariants));
+        Assert.True(invariants.GetArrayLength() >= 6);
+    }
+
+    [Theory]
+    [InlineData("interview")]
+    [InlineData("clarification")]
+    public void Execute_ModeFilter_ReturnsOnlyThatMode(string requestedMode)
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIntentInterviewCommand.Execute(
+            CreateContext(),
+            new[] { "--mode", requestedMode, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var modes = document.RootElement.GetProperty("modes");
+        Assert.Equal(1, modes.GetArrayLength());
+        Assert.Equal(requestedMode, modes[0].GetProperty("mode").GetString());
+        Assert.Equal(requestedMode, document.RootElement.GetProperty("focus_mode").GetString());
+    }
+
+    [Fact]
+    public void Execute_UnknownMode_ExitsOneWithError()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIntentInterviewCommand.Execute(
+            CreateContext(),
+            new[] { "--mode", "bogus" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("did not resolve", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ExitsOneWithError()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIntentInterviewCommand.Execute(
+            CreateContext(),
+            new[] { "--bogus" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Invariants_IncludeMetadataMutationGuidance()
+    {
+        // G336 acceptance: routine automation must prefer intent-cli-
+        // backed metadata mutation over hand-editing.
+        var combined = string.Join(" ", GuideWorkflowTaskIntentInterviewCommand.Invariants);
+        Assert.Contains("Prefer intent-cli-backed metadata mutation", combined, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Invariants_IncludeChildIsolationRule()
+    {
+        // G336 acceptance: child implementation loops must not inspect
+        // or mutate parent host state.
+        var combined = string.Join(" ", GuideWorkflowTaskIntentInterviewCommand.Invariants);
+        Assert.Contains("Child implementation loops MUST NOT inspect or mutate parent host queue-state", combined, StringComparison.Ordinal);
+    }
+
+    // ---- dispatcher tests --------------------------------------------------
+
+    [Fact]
+    public void GuideWorkflowTaskCommand_NoTask_NamesIntentInterview()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Supported: init-host, intent-interview", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowTaskCommand_IntentInterviewDispatch_ReturnsIntentInterviewGuidance()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(),
+            new[] { "intent-interview", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        // The intent-interview payload is identifiable by its usage line.
+        Assert.Contains("guide workflow task intent-interview", document.RootElement.GetProperty("usage").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowCommand_DispatchesIntentInterviewThroughTask()
+    {
+        // `guide workflow task intent-interview ...` must reach the
+        // task dispatcher through the existing GuideWorkflowCommand
+        // entry, mirroring the G335 init-host path.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowCommand.Execute(
+            CreateContext(),
+            new[] { "task", "intent-interview", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("guide workflow task intent-interview", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowCommand_HelpMentionsIntentInterview()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowCommand.Execute(
+            CreateContext(),
+            new[] { "--help" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("intent-interview", output, StringComparison.Ordinal);
+        Assert.Contains("G336", output, StringComparison.Ordinal);
+    }
+
+    // ---- guide help integration (G334/G336) --------------------------------
+
+    [Fact]
+    public void GuideHelpCommand_WorkflowGuides_InterviewPhasePointsToIntentInterview()
+    {
+        // G336: the `interview` workflow guide pointer must now route
+        // an external agent to `task intent-interview` first.
+        var interviewPointer = GuideHelpCommand.WorkflowGuides
+            .FirstOrDefault(p => string.Equals(p.Phase, "interview", StringComparison.Ordinal));
+        Assert.NotNull(interviewPointer);
+        Assert.Contains("guide workflow task intent-interview", interviewPointer!.Command, StringComparison.Ordinal);
+        var seeAlso = string.Join(" ", interviewPointer.SeeAlso ?? Array.Empty<string>());
+        Assert.Contains("interview next-question", seeAlso, StringComparison.Ordinal);
+        Assert.Contains("interview record-answer", seeAlso, StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `intent-cli guide workflow task intent-interview [--mode interview|clarification] [--format markdown|json]`. Two modes:
  - **interview** — shaping a NEW concept (`intents/<domain>/interview/**`, `intent-cli interview next-question` / `record-answer` / `compile` / `intent draft-from-interview`).
  - **clarification** — repairing an EXISTING blocker (`intents/<domain>/clarifications/**`, `intent-cli clarification status` / `next` / `answer` and `clarify draft` / `record`).
- Emits the canonical 5-section question structure every product-owner question must follow: background → question → options → pros-cons → recommendation, with a worked example per section.
- Six invariants: interview-vs-clarification distinction, question structure mandatory, durable artifacts (no hand-edit when an intent-cli command exists), metadata-mutation preference over hand-editing, child isolation, no AI provider launch.
- Wires the new task into the G335 `guide workflow task` dispatcher (today: `init-host`, `intent-interview`); updates GuideHelpCommand and CommandRouter top-level help so the `interview` workflow phase now routes external agents through `task intent-interview` first.

## Test plan

- [x] `dotnet test tests/IntentSystem.Cli.Tests --filter GuideWorkflowTaskIntentInterview` — 13 new tests pass.
- [x] `dotnet test tests/IntentSystem.Cli.Tests --filter \"GuideWorkflow|CommandRouterTests\"` — 180 tests pass (G334/G335 regression check).
- [x] Smoke-tested `guide workflow task intent-interview` (both markdown + JSON), `--mode interview`, `--mode clarification`, and the unknown-mode / unknown-argument error paths.
- [x] G334 bootstrap allow-list already includes `guide workflow ...`, so the new task is reachable from a child cwd without `.intent-cli/`.

Closes #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)