### PR TITLE
G337: guided packet-draft + issue-publish workflow

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -511,8 +511,8 @@ internal static class CommandRouter
     {
         "init — `intent-cli guide workflow task init-host --format json` (pick design / review-runtime / child-implementation role + scaffold plan, G335) then `intent-cli intent init --domain <name> --target-repo <r> --write` for host roles.",
         "interview — `intent-cli guide workflow task intent-interview --format json` (product-owner interview / clarification loop guide, G336) then `intent-cli interview next-question --domain <d> --format json` for the durable Q/A artifact.",
-        "packet — `intent-cli packet draft --execution-unit <id> --target-repo <r> --format markdown` (canonical packet scaffold).",
-        "issue — `intent-cli issue publish-flow <id> --repo <r> --write --format json` (publish next-slice issue).",
+        "packet — `intent-cli guide workflow task packet-draft --format json` (packet files + standalone issue contract, G337) then `intent-cli packet draft --execution-unit <id> --target-repo <r> --format markdown` to scaffold.",
+        "issue — `intent-cli guide workflow task issue-publish --format json` (draft/create/publish-flow/intent-target boundary guide, G337) then `intent-cli issue publish-flow <id> --repo <r> --write --format json` and `automation issue-publish --write`.",
         "automation — `intent-cli automation summary --domain <d> --format json` (label-driven capability JSON) + `intent-cli automation doctor` (CLI freshness).",
         "bug repair — `intent-cli guide worker pr-comment-fix --format json` (narrow PR-comment repair guidance)."
     };

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -60,16 +60,16 @@ internal static class GuideHelpCommand
         new WorkflowGuidePointer
         {
             Phase = "packet",
-            Command = "intent-cli packet draft --execution-unit <id> --target-repo <owner/repo> --format markdown",
-            Purpose = "Scaffold the canonical packet directory (packet.yaml / implementation.md / review-context.md / github-body.md). Read-only without --write.",
-            SeeAlso = new[] { "intent-cli guide intent-work --format json" }
+            Command = "intent-cli guide workflow task packet-draft --format json",
+            Purpose = "Packet directory layout + standalone issue contract sections every `github-body.md` must satisfy BEFORE `issue publish-flow` (G337). After reading the contract, run `intent-cli packet draft` to scaffold the four files.",
+            SeeAlso = new[] { "intent-cli packet draft --execution-unit <id> --target-repo <owner/repo> --format markdown", "intent-cli issue validate-body --from-file <path> --format json", "intent-cli guide intent-work --format json" }
         },
         new WorkflowGuidePointer
         {
             Phase = "issue",
-            Command = "intent-cli issue publish-flow <execution-unit-id> --repo <owner/repo> --write --format json",
-            Purpose = "Publish a next-slice GitHub issue end-to-end: validate packet → create issue → advance durable state. After publish, run `automation issue-publish --write` to apply `intent-target`.",
-            SeeAlso = new[] { "intent-cli automation issue-publish", "intent-cli guide intent-work --format json" }
+            Command = "intent-cli guide workflow task issue-publish --format json",
+            Purpose = "Draft → create → publish-flow → automation issue-publish boundary guide (G337). Names the four publish stages, the intent-target FINAL-boundary rule, and the stop conditions that surface missing contract sections before GitHub mutation.",
+            SeeAlso = new[] { "intent-cli issue publish-flow <id> --repo <r> --write --format json", "intent-cli automation issue-publish --repo <r> --issue <n> --write", "intent-cli guide intent-work --format json" }
         },
         new WorkflowGuidePointer
         {

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowCommand.cs
@@ -56,6 +56,6 @@ internal static class GuideWorkflowCommand
         writer.WriteLine();
         writer.WriteLine("Subcommands:");
         writer.WriteLine("- suggest — recommend a workflow + commands + rule topics for a broad operator goal");
-        writer.WriteLine("- task — bounded scaffold/init plans; today: `task init-host` explains the design / review-runtime / child-implementation roles and emits a scaffold plan (G335), `task intent-interview` explains the product-owner interview / clarification loop and the canonical question structure (G336)");
+        writer.WriteLine("- task — bounded scaffold/init plans; today: `task init-host` (G335), `task intent-interview` (G336), `task packet-draft` (G337: packet files + standalone issue contract), `task issue-publish` (G337: draft/create/publish-flow/automation issue-publish boundary)");
     }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskCommand.cs
@@ -1,14 +1,18 @@
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// G335 / G336: dispatcher for the <c>guide workflow task</c>
+/// G335 / G336 / G337: dispatcher for the <c>guide workflow task</c>
 /// subcommand group. Peels the next token (the task name) and
 /// delegates to the per-task handler. Tasks today:
 /// <list type="bullet">
 ///   <item><c>init-host</c> (G335) — host/child/review role
 ///         scaffold plan;</item>
 ///   <item><c>intent-interview</c> (G336) — product-owner
-///         interview / clarification loop guidance.</item>
+///         interview / clarification loop guidance;</item>
+///   <item><c>packet-draft</c> (G337) — packet files + standalone
+///         issue contract;</item>
+///   <item><c>issue-publish</c> (G337) — draft / create /
+///         publish-flow / automation issue-publish boundary.</item>
 /// </list>
 /// Future tasks (deploy-host, retire-host, migrate-host) can plug
 /// in without touching the router. Pure read-only — never mutates
@@ -30,7 +34,7 @@ internal static class GuideWorkflowTaskCommand
 
         if (args.Length == 0)
         {
-            writer.WriteLine("guide workflow task requires a task name. Supported: init-host, intent-interview.");
+            writer.WriteLine("guide workflow task requires a task name. Supported: init-host, intent-interview, packet-draft, issue-publish.");
             WriteHelp(writer);
             return 1;
         }
@@ -43,13 +47,20 @@ internal static class GuideWorkflowTaskCommand
             // interview / clarification loop (question structure,
             // commands, stop conditions, durability invariants).
             "intent-interview" => GuideWorkflowTaskIntentInterviewCommand.Execute(context, args[1..], writer),
+            // G337: packet-draft explains the four packet files and
+            // the standalone issue contract every github-body.md
+            // must carry.
+            "packet-draft" => GuideWorkflowTaskPacketDraftCommand.Execute(context, args[1..], writer),
+            // G337: issue-publish explains the four-stage publish
+            // boundary and the intent-target final-boundary rule.
+            "issue-publish" => GuideWorkflowTaskIssuePublishCommand.Execute(context, args[1..], writer),
             _ => UnknownTask(writer, task)
         };
     }
 
     private static int UnknownTask(TextWriter writer, string task)
     {
-        writer.WriteLine($"Unknown 'guide workflow task' name '{task}'. Supported: init-host, intent-interview.");
+        writer.WriteLine($"Unknown 'guide workflow task' name '{task}'. Supported: init-host, intent-interview, packet-draft, issue-publish.");
         WriteHelp(writer);
         return 1;
     }
@@ -62,5 +73,7 @@ internal static class GuideWorkflowTaskCommand
         writer.WriteLine("Tasks:");
         writer.WriteLine("- init-host — explain host/review-runtime/child roles, name where `.intent-cli/` is required/optional/forbidden, emit scaffold plan (AGENTS.md / CLAUDE.md / host-binding.toml). Run with --role <role> for a single role; --force-host to scaffold a host role over an existing child cwd (G335).");
         writer.WriteLine("- intent-interview — product-owner interview / clarification loop guide. Explains the background/question/options/pros-cons/recommendation question structure, distinguishes interview (new concept) from clarification (existing blocker), names the durable artifact paths, lists the canonical commands (G336).");
+        writer.WriteLine("- packet-draft — packet directory layout (packet.yaml / implementation.md / review-context.md / github-body.md) + standalone issue contract sections that every github-body.md must satisfy BEFORE `issue publish-flow` (G337).");
+        writer.WriteLine("- issue-publish — draft / create / publish-flow / automation issue-publish boundary. Names the four stages, the intent-target FINAL-boundary rule, and the stop conditions that surface missing contract sections before GitHub mutation (G337).");
     }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskIssuePublishCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskIssuePublishCommand.cs
@@ -88,7 +88,7 @@ internal static class GuideWorkflowTaskIssuePublishCommand
     {
         "Run `intent-cli issue publish-flow <execution-unit> --repo <r> --format json` (no `--write`) FIRST. If it reports `errors[]` naming missing contract sections, stop and repair the packet — `intent-cli guide workflow task packet-draft --format json` lists the required sections.",
         "`intent-cli issue validate-body --from-file <github-body.md> --format json` reports errors (missing `Closes #<source-issue>` / G311 reference, missing AC, missing Verification): stop, repair body, validate again.",
-        "`intent-cli automation host-sync-preflight --repo <r> --format json` reports `dirty-host-durable-state` without `durable-state-preflight` having converged: stop, do not publish on top of a dirty host.",
+        "`intent-cli automation host-sync-preflight --format json` (run from the host repo root) reports `dirty-host-durable-state` without `durable-state-preflight` having converged: stop, do not publish on top of a dirty host.",
         "`intent-cli automation publish-recovery --repo <r> --format json` reports `unsafe_stops`: stop, surface to the operator — never re-run `issue publish-flow` blindly.",
         "Operator names `intent-target` on the issue manually: refuse, point at `automation issue-publish` as the canonical write path."
     };

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskIssuePublishCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskIssuePublishCommand.cs
@@ -1,0 +1,244 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G337: read-only <c>intent-cli guide workflow task issue-publish</c>.
+/// Surfaces the draft / create / publish-flow / automation-issue-publish
+/// boundary so external agents do not collapse the four stages or
+/// apply <c>intent-target</c> by hand. Every external user of
+/// intent-cli has to learn this distinction once; the guide encodes
+/// it so it can be discovered from the CLI alone.
+///
+/// Pure read-only — never reads parent host queue-state, never calls
+/// <c>gh</c>, never mutates state, never launches an AI provider.
+/// </summary>
+internal static class GuideWorkflowTaskIssuePublishCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide workflow task issue-publish [--format markdown|json]";
+
+    /// <summary>
+    /// G337: the four publish stages, in order. Tests pin each stage
+    /// id and its boundary description.
+    /// </summary>
+    internal static readonly IReadOnlyList<PublishStage> Stages = new[]
+    {
+        new PublishStage
+        {
+            Stage = "draft",
+            Command = "intent-cli issue draft <execution-unit>",
+            Purpose = "Render the draft GitHub body artifact locally for review. Read-only with respect to GitHub.",
+            Boundary = "Stage boundary: ARTIFACT-only. No GitHub mutation, no `intent-target`, no queue-state advance. The operator inspects the rendered body and the packet directory before continuing.",
+            FailsOpen = "Hand-editing `github-body.md` directly is allowed during design as long as the standalone issue contract still passes `issue validate-body`. Routine automation goes through `packet draft --write` instead."
+        },
+        new PublishStage
+        {
+            Stage = "create",
+            Command = "intent-cli issue create <execution-unit>",
+            Purpose = "Create a GitHub issue from the prepared body. Mutates GitHub but does NOT apply `intent-target` — the issue lives in the repo as a normal issue until the host loop promotes it.",
+            Boundary = "Stage boundary: GITHUB issue exists; durable host state NOT yet advanced. The host's queue-state has not been moved through the publish lifecycle.",
+            FailsOpen = "If `create` fails halfway (issue created but durable state not advanced), the host recovery lane is `intent-cli automation publish-recovery --repo <r> --write` (G313 / G315), not raw `gh issue` cleanup."
+        },
+        new PublishStage
+        {
+            Stage = "publish-flow",
+            Command = "intent-cli issue publish-flow <execution-unit> --repo <owner/repo> [--domain <name>] [--write] [--format json|markdown]",
+            Purpose = "End-to-end publish: validate packet → create issue → advance durable state. Without `--write` this is a dry run that surfaces missing contract sections.",
+            Boundary = "Stage boundary: durable host state is now advanced (queue-state, packet publish.yaml, runs.jsonl). The issue is on GitHub but the `intent-target` LABEL has not been applied yet.",
+            FailsOpen = "If validation surfaces missing contract sections (Goal / AC / OOS / Verification / Closes ref etc.), STOP and repair the packet. `publish-flow` without `--write` is the canonical preflight."
+        },
+        new PublishStage
+        {
+            Stage = "automation issue-publish",
+            Command = "intent-cli automation issue-publish --repo <owner/repo> --issue <n> --write [--dry-run] [--format text|json]",
+            Purpose = "FINAL publish boundary: apply the `intent-target` label so the child implementation loop picks the issue up next. This is the ONE place `intent-target` is added.",
+            Boundary = "Stage boundary: `intent-target` is now on the GitHub issue. The child loop's `worker next-action` selector will return this issue as `action: issue-to-pr` on its next wake.",
+            FailsOpen = "Raw `gh issue edit --add-label intent-target` is FORBIDDEN — it skips the issue-publish capability check, the publish.yaml advance, and the host audit trail. If `automation issue-publish` refuses (missing publish.yaml, mismatched repo, host-sync-preflight not clean), repair the gap; never bypass."
+        }
+    };
+
+    /// <summary>
+    /// G337: explicit invariants every issue-publish surface advertises.
+    /// Tests pin each invariant verbatim. The <c>intent-target</c>
+    /// boundary statement is required by the acceptance criteria.
+    /// </summary>
+    internal static readonly IReadOnlyList<string> Invariants = new[]
+    {
+        "`intent-target` is the FINAL publish boundary, not the default for issue creation. It is applied ONLY by `intent-cli automation issue-publish --write` after `issue publish-flow` has advanced durable host state. Hand-applying `intent-target` via raw `gh` bypasses the publish lifecycle and is forbidden.",
+        "draft → create → publish-flow → automation issue-publish is a sequence, not a synonym set. Skipping a stage breaks host audit trail (no publish.yaml entry, no runs.jsonl event) and can deadlock the host-loop's WIP-cap check (G288).",
+        "`issue publish-flow` without `--write` is the canonical preflight: it surfaces missing contract sections (Goal / Why / AC / OOS / Verification / Closes ref) BEFORE any GitHub mutation. Always run the dry-run first.",
+        "WIP cap (G288) — only one `intent-target` issue/PR at a time per domain by default. If an issue/PR is already `intent-target` and the operator wants to publish another, pass `--allow-wip-cap-override` explicitly; the publish surface refuses silently otherwise.",
+        "Prefer intent-cli-backed metadata mutation over hand-editing. Routine automation MUST NOT directly edit queue-state, runs logs, publish artifacts, workflow labels, or runtime metadata by hand when a supported intent-cli command exists.",
+        "Child implementation loops MUST NOT inspect or mutate parent host queue-state, runs logs, packet directories, intent tree, review-runtime state, local rules, or local skills (G300 / G330 / G333). The publish surfaces are host-owned; child agents only ever see the issue once `intent-target` is applied by the host.",
+        "Never launch AI providers (Claude / Codex / any LLM) from intent-cli. The chat-first model has the human agent driving the conversation."
+    };
+
+    /// <summary>
+    /// G337: cross-stage stop conditions. The acceptance criterion
+    /// "surfaces missing contract sections before GitHub mutation"
+    /// pins the first entry; the rest enumerate the canonical refuse-
+    /// before-mutate gates an external agent must check.
+    /// </summary>
+    internal static readonly IReadOnlyList<string> StopConditions = new[]
+    {
+        "Run `intent-cli issue publish-flow <execution-unit> --repo <r> --format json` (no `--write`) FIRST. If it reports `errors[]` naming missing contract sections, stop and repair the packet — `intent-cli guide workflow task packet-draft --format json` lists the required sections.",
+        "`intent-cli issue validate-body --from-file <github-body.md> --format json` reports errors (missing `Closes #<source-issue>` / G311 reference, missing AC, missing Verification): stop, repair body, validate again.",
+        "`intent-cli automation host-sync-preflight --repo <r> --format json` reports `dirty-host-durable-state` without `durable-state-preflight` having converged: stop, do not publish on top of a dirty host.",
+        "`intent-cli automation publish-recovery --repo <r> --format json` reports `unsafe_stops`: stop, surface to the operator — never re-run `issue publish-flow` blindly.",
+        "Operator names `intent-target` on the issue manually: refuse, point at `automation issue-publish` as the canonical write path."
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            var payload = new IssuePublishGuidance
+            {
+                Usage = UsageLine,
+                Stages = Stages,
+                StopConditions = StopConditions,
+                Invariants = Invariants
+            };
+            writer.Write(JsonSerializer.Serialize(payload, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer);
+        }
+
+        return 0;
+    }
+
+    private static void WriteMarkdown(TextWriter writer)
+    {
+        writer.WriteLine("# intent-cli — issue-publish workflow guide");
+        writer.WriteLine();
+        writer.WriteLine(UsageLine);
+        writer.WriteLine();
+        writer.WriteLine("Four stages, in order. Each has an explicit mutation boundary; the FINAL stage is the only one that applies `intent-target`.");
+        writer.WriteLine();
+
+        foreach (var stage in Stages)
+        {
+            writer.WriteLine($"## {stage.Stage}");
+            writer.WriteLine();
+            writer.WriteLine($"- Command: `{stage.Command}`");
+            writer.WriteLine($"- Purpose: {stage.Purpose}");
+            writer.WriteLine($"- Boundary: {stage.Boundary}");
+            writer.WriteLine($"- Fails-open behavior: {stage.FailsOpen}");
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Stop conditions (surface BEFORE GitHub mutation)");
+        foreach (var s in StopConditions)
+        {
+            writer.WriteLine($"- {s}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Invariants");
+        foreach (var line in Invariants)
+        {
+            writer.WriteLine($"- {line}");
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string format, out string error)
+    {
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            switch (arg)
+            {
+                case "--help":
+                    break;
+                case "--format":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[i + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    i++;
+                    break;
+                default:
+                    error = $"Unknown argument '{arg}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true
+    };
+}
+
+/// <summary>
+/// G337: one publish stage with its mutation boundary.
+/// </summary>
+internal sealed record PublishStage
+{
+    [JsonPropertyName("stage")]
+    public required string Stage { get; init; }
+
+    [JsonPropertyName("command")]
+    public required string Command { get; init; }
+
+    [JsonPropertyName("purpose")]
+    public required string Purpose { get; init; }
+
+    [JsonPropertyName("boundary")]
+    public required string Boundary { get; init; }
+
+    [JsonPropertyName("fails_open")]
+    public required string FailsOpen { get; init; }
+}
+
+/// <summary>
+/// G337: full JSON payload.
+/// </summary>
+internal sealed record IssuePublishGuidance
+{
+    [JsonPropertyName("usage")]
+    public required string Usage { get; init; }
+
+    [JsonPropertyName("stages")]
+    public required IReadOnlyList<PublishStage> Stages { get; init; }
+
+    [JsonPropertyName("stop_conditions")]
+    public required IReadOnlyList<string> StopConditions { get; init; }
+
+    [JsonPropertyName("invariants")]
+    public required IReadOnlyList<string> Invariants { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskPacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskPacketDraftCommand.cs
@@ -1,0 +1,296 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G337: read-only <c>intent-cli guide workflow task packet-draft</c>.
+/// Surfaces the canonical packet directory layout (the four files an
+/// execution unit produces) and the standalone issue contract every
+/// GitHub-body must satisfy BEFORE the operator runs
+/// <c>intent-cli issue publish-flow</c>. External agents that have
+/// never seen the project should be able to derive the packet shape
+/// and the contract requirements from this surface alone — no local
+/// rules, no skill prompts.
+///
+/// Pure read-only — never reads parent host queue-state, never calls
+/// <c>gh</c>, never mutates state, never launches an AI provider.
+/// </summary>
+internal static class GuideWorkflowTaskPacketDraftCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide workflow task packet-draft [--format markdown|json]";
+
+    /// <summary>
+    /// G337: the four files every packet draft produces. Tests pin
+    /// each entry by name and require the purpose to mention what
+    /// the file does and when it is read.
+    /// </summary>
+    internal static readonly IReadOnlyList<PacketFileEntry> PacketFiles = new[]
+    {
+        new PacketFileEntry
+        {
+            Name = "packet.yaml",
+            Purpose = "Structured metadata for the slice (execution-unit id, title, summary, intent references, packet ownership, prepared-by-runtime flag). Drives the validate / publish lifecycle.",
+            ReadBy = "intent-cli packet draft / issue publish-flow / review closeout-plan / review run (G316)."
+        },
+        new PacketFileEntry
+        {
+            Name = "implementation.md",
+            Purpose = "Design + implementation notes for the slice. Captures the design host's reasoning so review and child-implementation agents can converge.",
+            ReadBy = "intent-cli review run / review closeout-plan / guide review (operators reading the spec)."
+        },
+        new PacketFileEntry
+        {
+            Name = "review-context.md",
+            Purpose = "G316 packet-aware review context: the intent references, scope boundaries, prior decisions, and the explicit packet-versus-PR delta the reviewer must cite.",
+            ReadBy = "intent-cli review run / guide review (the canonical input to the reviewer's approval summary)."
+        },
+        new PacketFileEntry
+        {
+            Name = "github-body.md",
+            Purpose = "The standalone GitHub issue body. MUST satisfy the standalone issue contract below — it is rendered into the public GitHub issue, so anything missing here breaks external-agent discoverability.",
+            ReadBy = "intent-cli issue draft / issue prepare / issue validate-body / issue publish / issue publish-flow / automation issue-publish."
+        }
+    };
+
+    /// <summary>
+    /// G337: standalone issue contract sections every <c>github-body.md</c>
+    /// must carry. Tests pin each section by id; the guide JSON
+    /// payload uses the same stable ids so consumers can branch on them.
+    /// </summary>
+    internal static readonly IReadOnlyList<IssueContractSection> IssueContractSections = new[]
+    {
+        new IssueContractSection { Section = "goal", Purpose = "One-paragraph statement of what shipping this slice produces. The agent reading the issue should be able to act on this without context." },
+        new IssueContractSection { Section = "why-this-slice-exists-now", Purpose = "Why this slice cannot wait. Names the blocker and the user observation that forced the slice." },
+        new IssueContractSection { Section = "current-observed-state", Purpose = "What an external agent or operator sees today, before the slice lands. Pins the regression target." },
+        new IssueContractSection { Section = "accepted-baseline-you-may-assume", Purpose = "What the agent does not have to relitigate (collaboration model, intent-cli routing, no-local-rule rule, etc.)." },
+        new IssueContractSection { Section = "target-repo-path-part", Purpose = "Exact repository / folder / surface the change must land in. Disambiguates host-vs-child mutation targets." },
+        new IssueContractSection { Section = "in-scope", Purpose = "Bullet list of what is in scope. Mirrors the slice goal; one slice cuts cleanly so this list stays small." },
+        new IssueContractSection { Section = "out-of-scope", Purpose = "Bullet list of what is explicitly NOT in this slice. Reviewers refuse PRs that broaden scope without an out-of-scope amendment." },
+        new IssueContractSection { Section = "acceptance-criteria", Purpose = "Testable, externally-verifiable criteria. Every criterion maps to a concrete assertion the reviewer can run." },
+        new IssueContractSection { Section = "verification", Purpose = "Which tests / generated assertions prove the criteria. CI + the reviewer cite this list before approval (G316)." },
+        new IssueContractSection { Section = "related-links", Purpose = "Predecessor slices and spec references (e.g. `specs/15-external-user-guided-workflow.md`). Operators trace the lineage without reading the host repo." },
+        new IssueContractSection { Section = "additional-required-guidance", Purpose = "Standing guardrails: prefer intent-cli-backed mutation, child isolation rule, no AI provider launch. Repeated on every slice so the issue is self-contained." }
+    };
+
+    /// <summary>
+    /// G337: the canonical commands an external agent runs to produce
+    /// a packet draft. Tests pin every flag against the corresponding
+    /// command source file (regression for the G336 PR #776 finding).
+    /// </summary>
+    internal static readonly IReadOnlyList<string> Commands = new[]
+    {
+        "intent-cli packet draft --execution-unit <execution-unit-id> [--domain <name>] [--target-repo <owner/repo>] --dry-run --format markdown",
+        "intent-cli packet draft --execution-unit <execution-unit-id> [--domain <name>] [--target-repo <owner/repo>] --format json"
+    };
+
+    /// <summary>
+    /// G337: stop conditions before any GitHub mutation. The guide
+    /// surfaces missing contract sections BEFORE the agent runs
+    /// `issue publish-flow`; this is the acceptance criterion
+    /// (`surfaces missing contract sections before GitHub mutation`).
+    /// </summary>
+    internal static readonly IReadOnlyList<string> StopConditions = new[]
+    {
+        "`packet draft --dry-run` flags missing files: stop, repair the design host packet directory before publishing. Hand-editing the four files is allowed during design; routine automation mutates them through `packet draft --write` only.",
+        "`issue validate-body --from-file <github-body.md> --format json` reports `errors[]` (missing contract sections): stop, repair the body, validate again, only then move to `issue publish-flow`.",
+        "`packet.yaml` lacks `intent_reference_paths` or names them with broad-domain placeholders: stop, narrow to PR-specific references. Broad-domain intent paths defeat G316 review-context isolation.",
+        "Operator names `intent-target` on the GitHub issue manually (raw `gh issue edit --add-label intent-target`): refuse, surface the gap — `intent-target` is the FINAL publish boundary applied by `automation issue-publish --write` after `issue publish-flow` succeeds, never the default."
+    };
+
+    /// <summary>
+    /// G337: explicit invariants every packet-draft surface advertises.
+    /// Tests pin each invariant verbatim.
+    /// </summary>
+    internal static readonly IReadOnlyList<string> Invariants = new[]
+    {
+        "A packet is the standalone unit of intent: the GitHub issue body alone must let an external agent reproduce the implementation, the review, and the closeout decision. If `github-body.md` requires reading the host packet directory to be understood, the slice is not yet ready to publish.",
+        "Packet ownership is design-side; runtime-created packets carry an explicit `runtime-created` flag in `packet.yaml`. The review-runtime workspace MUST NOT silently edit the four files; it goes through `packet draft --write` with the runtime ownership label (G326).",
+        "Prefer intent-cli-backed metadata mutation over hand-editing. Ask `intent-cli guide commands list --format json` or `intent-cli automation summary --domain <d> --format json` which command performs the transition, run that command, then validate the result.",
+        "Child implementation loops MUST NOT inspect or mutate parent host queue-state, runs logs, packet directories, intent tree, review-runtime state, local rules, or local skills (G300 / G330 / G333). The packet directory is host-owned; child agents see only the rendered GitHub issue body.",
+        "Never launch AI providers (Claude / Codex / any LLM) from intent-cli. The chat-first model has the human agent driving the conversation; intent-cli emits text the agent acts on."
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            var payload = new PacketDraftGuidance
+            {
+                Usage = UsageLine,
+                PacketFiles = PacketFiles,
+                IssueContractSections = IssueContractSections,
+                Commands = Commands,
+                StopConditions = StopConditions,
+                Invariants = Invariants
+            };
+            writer.Write(JsonSerializer.Serialize(payload, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer);
+        }
+
+        return 0;
+    }
+
+    private static void WriteMarkdown(TextWriter writer)
+    {
+        writer.WriteLine("# intent-cli — packet draft workflow guide");
+        writer.WriteLine();
+        writer.WriteLine(UsageLine);
+        writer.WriteLine();
+        writer.WriteLine("A packet is the standalone unit of intent. Four files; one execution unit.");
+        writer.WriteLine();
+
+        writer.WriteLine("## Packet files");
+        writer.WriteLine();
+        writer.WriteLine("| file | purpose | read by |");
+        writer.WriteLine("|------|---------|---------|");
+        foreach (var f in PacketFiles)
+        {
+            writer.WriteLine($"| `{f.Name}` | {f.Purpose} | {f.ReadBy} |");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Standalone issue contract");
+        writer.WriteLine();
+        writer.WriteLine("Every `github-body.md` MUST carry these sections in order. Missing sections are caught by `intent-cli issue validate-body --from-file <path> --format json` BEFORE any GitHub mutation:");
+        writer.WriteLine();
+        foreach (var section in IssueContractSections)
+        {
+            writer.WriteLine($"- **{section.Section}** — {section.Purpose}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Commands");
+        foreach (var c in Commands)
+        {
+            writer.WriteLine($"- `{c}`");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Stop conditions (surface BEFORE GitHub mutation)");
+        foreach (var s in StopConditions)
+        {
+            writer.WriteLine($"- {s}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Invariants");
+        foreach (var line in Invariants)
+        {
+            writer.WriteLine($"- {line}");
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string format, out string error)
+    {
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            switch (arg)
+            {
+                case "--help":
+                    break;
+                case "--format":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[i + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    i++;
+                    break;
+                default:
+                    error = $"Unknown argument '{arg}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true
+    };
+}
+
+/// <summary>
+/// G337: one file in the canonical packet directory.
+/// </summary>
+internal sealed record PacketFileEntry
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("purpose")]
+    public required string Purpose { get; init; }
+
+    [JsonPropertyName("read_by")]
+    public required string ReadBy { get; init; }
+}
+
+/// <summary>
+/// G337: one section of the standalone issue contract.
+/// </summary>
+internal sealed record IssueContractSection
+{
+    [JsonPropertyName("section")]
+    public required string Section { get; init; }
+
+    [JsonPropertyName("purpose")]
+    public required string Purpose { get; init; }
+}
+
+/// <summary>
+/// G337: full JSON payload for <c>guide workflow task packet-draft</c>.
+/// </summary>
+internal sealed record PacketDraftGuidance
+{
+    [JsonPropertyName("usage")]
+    public required string Usage { get; init; }
+
+    [JsonPropertyName("packet_files")]
+    public required IReadOnlyList<PacketFileEntry> PacketFiles { get; init; }
+
+    [JsonPropertyName("issue_contract_sections")]
+    public required IReadOnlyList<IssueContractSection> IssueContractSections { get; init; }
+
+    [JsonPropertyName("commands")]
+    public required IReadOnlyList<string> Commands { get; init; }
+
+    [JsonPropertyName("stop_conditions")]
+    public required IReadOnlyList<string> StopConditions { get; init; }
+
+    [JsonPropertyName("invariants")]
+    public required IReadOnlyList<string> Invariants { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskIssuePublishCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskIssuePublishCommandTests.cs
@@ -154,6 +154,77 @@ public sealed class GuideWorkflowTaskIssuePublishCommandTests
     }
 
     [Fact]
+    public void StopConditions_CommandExamples_FlagsExistInActualCliCommandSource()
+    {
+        // PR #778 review finding: a stop-condition example listed
+        // `automation host-sync-preflight --repo <r>` even though
+        // AutomationHostSyncPreflightCommand only accepts `--format`.
+        // This regression check walks every `intent-cli <cmd>` snippet
+        // inside backticks in each stop-condition string and asserts
+        // every `--flag` after a recognized subcommand prefix appears
+        // verbatim in the matching command's source file. Mirrors the
+        // G336 PR #776 fix pattern but operates on StopConditions so
+        // missing-flag drift surfaces before reaching the operator.
+        var repoRoot = FindRepoRoot();
+        var commandsDir = Path.Combine(repoRoot, "src/IntentSystem.Cli/Commands");
+
+        // Stable mapping from `intent-cli` subcommand prefix to the
+        // command source file that owns its flag parser. Add a new
+        // row whenever a new subcommand surfaces in StopConditions.
+        var subcommandToSourceFile = new (string Prefix, string FileName)[]
+        {
+            ("issue publish-flow", "IssuePublishFlowCommand.cs"),
+            ("issue validate-body", "IssueValidateBodyCommand.cs"),
+            ("automation host-sync-preflight", "AutomationHostSyncPreflightCommand.cs"),
+            ("automation publish-recovery", "AutomationPublishRecoveryCommand.cs"),
+            ("automation issue-publish", "AutomationIssuePublishCommand.cs"),
+            ("guide workflow task packet-draft", "GuideWorkflowTaskPacketDraftCommand.cs"),
+        };
+
+        var backtickSpan = new System.Text.RegularExpressions.Regex(
+            "`([^`]+)`",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+        var flagPattern = new System.Text.RegularExpressions.Regex(
+            @"--[a-z][a-z-]*",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        foreach (var stopCondition in GuideWorkflowTaskIssuePublishCommand.StopConditions)
+        {
+            foreach (System.Text.RegularExpressions.Match span in backtickSpan.Matches(stopCondition))
+            {
+                var code = span.Groups[1].Value;
+                if (!code.StartsWith("intent-cli ", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                // Strip the leading `intent-cli ` so prefix matching
+                // works without anchor surprises.
+                var afterCli = code.Substring("intent-cli ".Length);
+                var match = subcommandToSourceFile
+                    .Where(row => afterCli.StartsWith(row.Prefix, StringComparison.Ordinal))
+                    .OrderByDescending(row => row.Prefix.Length)
+                    .FirstOrDefault();
+                Assert.False(
+                    match.Prefix is null,
+                    $"Stop-condition references an unmapped `intent-cli` subcommand: `{code}`. Add a row to subcommandToSourceFile so its flags can be parity-checked.");
+
+                var sourcePath = Path.Combine(commandsDir, match.FileName);
+                Assert.True(File.Exists(sourcePath), $"Expected command source file is missing: {sourcePath}");
+                var source = File.ReadAllText(sourcePath);
+
+                foreach (System.Text.RegularExpressions.Match flagMatch in flagPattern.Matches(afterCli))
+                {
+                    var flag = flagMatch.Value;
+                    Assert.True(
+                        source.Contains($"\"{flag}\"", StringComparison.Ordinal),
+                        $"`{flag}` is missing from {match.FileName} but appears in stop-condition example: `{code}`");
+                }
+            }
+        }
+    }
+
+    [Fact]
     public void Execute_UnknownArgument_ExitsOne()
     {
         using var writer = new StringWriter();

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskIssuePublishCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskIssuePublishCommandTests.cs
@@ -1,0 +1,239 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G337: tests for <c>intent-cli guide workflow task issue-publish</c>.
+/// The surface must explain the draft / create / publish-flow /
+/// automation-issue-publish boundary, name the intent-target FINAL
+/// publish boundary, and surface missing contract sections before
+/// any GitHub mutation.
+/// </summary>
+public sealed class GuideWorkflowTaskIssuePublishCommandTests
+{
+    [Fact]
+    public void Execute_ListsFourStagesInOrder_ExitZero()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIssuePublishCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        var stages = new[] { "draft", "create", "publish-flow", "automation issue-publish" };
+        var lastIndex = -1;
+        foreach (var stage in stages)
+        {
+            var idx = output.IndexOf($"## {stage}", StringComparison.Ordinal);
+            // `## automation issue-publish` shows up with that literal
+            // heading; the others as `## draft`, `## create`, `## publish-flow`.
+            Assert.True(idx > lastIndex, $"Stage `{stage}` did not appear in expected order in the output.");
+            lastIndex = idx;
+        }
+    }
+
+    [Fact]
+    public void Execute_AdvertisesIntentTargetFinalBoundary()
+    {
+        // Acceptance criterion: "The guide warns that intent-target
+        // is final publish boundary, not issue creation default."
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIssuePublishCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("intent-target", output, StringComparison.Ordinal);
+        Assert.Contains("FINAL publish boundary", output, StringComparison.Ordinal);
+        // The forbidden raw-gh path must be called out.
+        Assert.Contains("FORBIDDEN", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_SurfacesMissingContractSectionsBeforeMutation()
+    {
+        // Acceptance criterion: "It surfaces missing contract
+        // sections before GitHub mutation."
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIssuePublishCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("BEFORE", output, StringComparison.Ordinal);
+        Assert.Contains("issue validate-body", output, StringComparison.Ordinal);
+        Assert.Contains("issue publish-flow", output, StringComparison.Ordinal);
+        Assert.Contains("--write", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_HasStableShape()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIssuePublishCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.TryGetProperty("usage", out _));
+        Assert.True(root.TryGetProperty("stages", out var stages));
+        Assert.Equal(4, stages.GetArrayLength());
+        var stageIds = stages.EnumerateArray().Select(s => s.GetProperty("stage").GetString()).ToArray();
+        Assert.Equal(new[] { "draft", "create", "publish-flow", "automation issue-publish" }, stageIds);
+        foreach (var stage in stages.EnumerateArray())
+        {
+            Assert.True(stage.TryGetProperty("command", out _));
+            Assert.True(stage.TryGetProperty("purpose", out _));
+            Assert.True(stage.TryGetProperty("boundary", out _));
+            Assert.True(stage.TryGetProperty("fails_open", out _));
+        }
+        Assert.True(root.TryGetProperty("stop_conditions", out _));
+        Assert.True(root.TryGetProperty("invariants", out _));
+    }
+
+    [Fact]
+    public void Stages_PublishFlowCommand_FlagsExistInActualCliCommandSource()
+    {
+        // The publish-flow stage example must use the real
+        // IssuePublishFlowCommand flag set. Regression for the G336
+        // PR #776 finding: keep guide examples in sync with real
+        // command surfaces.
+        var publishFlowStage = GuideWorkflowTaskIssuePublishCommand.Stages
+            .First(s => string.Equals(s.Stage, "publish-flow", StringComparison.Ordinal));
+        var flagPattern = new System.Text.RegularExpressions.Regex(
+            @"--[a-z][a-z-]*",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        var repoRoot = FindRepoRoot();
+        var publishFlowSource = File.ReadAllText(Path.Combine(repoRoot, "src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs"));
+
+        foreach (System.Text.RegularExpressions.Match m in flagPattern.Matches(publishFlowStage.Command))
+        {
+            var flag = m.Value;
+            Assert.True(
+                publishFlowSource.Contains($"\"{flag}\"", StringComparison.Ordinal),
+                $"`{flag}` is missing from IssuePublishFlowCommand.cs but appears in guide example: `{publishFlowStage.Command}`");
+        }
+    }
+
+    [Fact]
+    public void Stages_AutomationIssuePublishCommand_FlagsExistInActualCliCommandSource()
+    {
+        var stage = GuideWorkflowTaskIssuePublishCommand.Stages
+            .First(s => string.Equals(s.Stage, "automation issue-publish", StringComparison.Ordinal));
+        var flagPattern = new System.Text.RegularExpressions.Regex(
+            @"--[a-z][a-z-]*",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        var repoRoot = FindRepoRoot();
+        var source = File.ReadAllText(Path.Combine(repoRoot, "src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs"));
+
+        foreach (System.Text.RegularExpressions.Match m in flagPattern.Matches(stage.Command))
+        {
+            var flag = m.Value;
+            Assert.True(
+                source.Contains($"\"{flag}\"", StringComparison.Ordinal),
+                $"`{flag}` is missing from AutomationIssuePublishCommand.cs but appears in guide example: `{stage.Command}`");
+        }
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ExitsOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIssuePublishCommand.Execute(
+            CreateContext(),
+            new[] { "--bogus" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowTaskCommand_DispatchesIssuePublish()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(),
+            new[] { "issue-publish", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Contains("issue-publish", document.RootElement.GetProperty("usage").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideHelpCommand_IssuePhase_PointsToTaskIssuePublish()
+    {
+        var issuePointer = GuideHelpCommand.WorkflowGuides
+            .First(p => string.Equals(p.Phase, "issue", StringComparison.Ordinal));
+        Assert.Contains("guide workflow task issue-publish", issuePointer.Command, StringComparison.Ordinal);
+        var seeAlso = string.Join(" ", issuePointer.SeeAlso ?? Array.Empty<string>());
+        Assert.Contains("publish-flow", seeAlso, StringComparison.Ordinal);
+        Assert.Contains("automation issue-publish", seeAlso, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowTaskCommand_UnknownTask_NamesBothG337Tasks()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(),
+            new[] { "bogus-task" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("packet-draft", output, StringComparison.Ordinal);
+        Assert.Contains("issue-publish", output, StringComparison.Ordinal);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null && !Directory.Exists(Path.Combine(dir, "src")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        Assert.NotNull(dir);
+        return dir!;
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskPacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskPacketDraftCommandTests.cs
@@ -1,0 +1,179 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G337: tests for <c>intent-cli guide workflow task packet-draft</c>.
+/// The surface must explain the four packet files, the standalone
+/// issue contract sections, the canonical `packet draft` commands,
+/// and the stop conditions that surface missing contract sections
+/// before any GitHub mutation.
+/// </summary>
+public sealed class GuideWorkflowTaskPacketDraftCommandTests
+{
+    [Fact]
+    public void Execute_ListsFourPacketFilesAndContractSectionsAndCommands_ExitZero()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskPacketDraftCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        // Four packet files (acceptance criterion 1).
+        foreach (var file in new[] { "packet.yaml", "implementation.md", "review-context.md", "github-body.md" })
+        {
+            Assert.Contains(file, output, StringComparison.Ordinal);
+        }
+        // Required standalone issue contract sections.
+        foreach (var section in new[] { "goal", "why-this-slice-exists-now", "current-observed-state", "in-scope", "out-of-scope", "acceptance-criteria", "verification" })
+        {
+            Assert.Contains(section, output, StringComparison.Ordinal);
+        }
+        // Canonical commands.
+        Assert.Contains("intent-cli packet draft --execution-unit", output, StringComparison.Ordinal);
+        // Stop conditions surface BEFORE GitHub mutation (acceptance criterion 4).
+        Assert.Contains("BEFORE", output, StringComparison.Ordinal);
+        Assert.Contains("issue validate-body", output, StringComparison.Ordinal);
+        // intent-target warning (acceptance criterion 3).
+        Assert.Contains("intent-target", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_HasStableShape()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskPacketDraftCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.TryGetProperty("usage", out _));
+        Assert.True(root.TryGetProperty("packet_files", out var files));
+        Assert.Equal(4, files.GetArrayLength());
+        Assert.True(root.TryGetProperty("issue_contract_sections", out var sections));
+        Assert.True(sections.GetArrayLength() >= 7);
+        Assert.True(root.TryGetProperty("commands", out _));
+        Assert.True(root.TryGetProperty("stop_conditions", out _));
+        Assert.True(root.TryGetProperty("invariants", out _));
+
+        var fileNames = files.EnumerateArray().Select(f => f.GetProperty("name").GetString()).ToArray();
+        Assert.Equal(new[] { "packet.yaml", "implementation.md", "review-context.md", "github-body.md" }, fileNames);
+    }
+
+    [Fact]
+    public void PacketDraftCommands_FlagsExistInActualCliCommandSource()
+    {
+        // Regression test (mirroring the G336 / PR #776 fix): each
+        // --flag named in the guide's `packet draft` example MUST
+        // exist as a `case "--flag":` (or any literal string mention)
+        // in the real command source file.
+        var commands = GuideWorkflowTaskPacketDraftCommand.Commands;
+        var flagPattern = new System.Text.RegularExpressions.Regex(
+            @"--[a-z][a-z-]*",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        var repoRoot = FindRepoRoot();
+        var packetDraftSource = File.ReadAllText(Path.Combine(repoRoot, "src/IntentSystem.Cli/Commands/PacketDraftCommand.cs"));
+
+        foreach (var commandLine in commands)
+        {
+            foreach (System.Text.RegularExpressions.Match m in flagPattern.Matches(commandLine))
+            {
+                var flag = m.Value;
+                Assert.True(
+                    packetDraftSource.Contains($"\"{flag}\"", StringComparison.Ordinal),
+                    $"Guide example flag '{flag}' is missing from PacketDraftCommand.cs. Guide example: `{commandLine}`");
+            }
+        }
+    }
+
+    [Fact]
+    public void Invariants_IncludeIntentTargetFinalBoundaryWarning()
+    {
+        // Acceptance criterion: "The guide warns that intent-target
+        // is final publish boundary, not issue creation default."
+        var allCopy = string.Join(" ", GuideWorkflowTaskPacketDraftCommand.Invariants)
+            + " " + string.Join(" ", GuideWorkflowTaskPacketDraftCommand.StopConditions);
+        Assert.Contains("intent-target", allCopy, StringComparison.Ordinal);
+        Assert.Contains("FINAL publish boundary", allCopy, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ExitsOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskPacketDraftCommand.Execute(
+            CreateContext(),
+            new[] { "--bogus" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowTaskCommand_DispatchesPacketDraft()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(),
+            new[] { "packet-draft", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Contains("packet-draft", document.RootElement.GetProperty("usage").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideHelpCommand_PacketPhase_PointsToTaskPacketDraft()
+    {
+        var packetPointer = GuideHelpCommand.WorkflowGuides
+            .First(p => string.Equals(p.Phase, "packet", StringComparison.Ordinal));
+        Assert.Contains("guide workflow task packet-draft", packetPointer.Command, StringComparison.Ordinal);
+        var seeAlso = string.Join(" ", packetPointer.SeeAlso ?? Array.Empty<string>());
+        Assert.Contains("packet draft", seeAlso, StringComparison.Ordinal);
+        Assert.Contains("issue validate-body", seeAlso, StringComparison.Ordinal);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null && !Directory.Exists(Path.Combine(dir, "src")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        Assert.NotNull(dir);
+        return dir!;
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `intent-cli guide workflow task packet-draft [--format markdown|json]` — explains the four packet files (`packet.yaml` / `implementation.md` / `review-context.md` / `github-body.md`) and the eleven standalone issue contract sections every `github-body.md` must carry. Stable section IDs (`goal`, `why-this-slice-exists-now`, `current-observed-state`, `accepted-baseline-you-may-assume`, `target-repo-path-part`, `in-scope`, `out-of-scope`, `acceptance-criteria`, `verification`, `related-links`, `additional-required-guidance`) for downstream consumers to pin against.
- Adds `intent-cli guide workflow task issue-publish [--format markdown|json]` — explains the four-stage publish boundary (`draft` → `create` → `publish-flow` → `automation issue-publish`) with command, purpose, boundary, and fails-open guidance per stage. Pins the rule that `intent-target` is the FINAL publish boundary, applied ONLY by `automation issue-publish --write`, and that raw `gh issue edit --add-label intent-target` is forbidden.
- Both surfaces enumerate stop conditions that surface missing contract sections BEFORE any GitHub mutation (G337 acceptance criterion).
- Updates G334 / G335 / G336 surfaces: `guide help` `packet` and `issue` workflow pointers now route external agents through `task packet-draft` / `task issue-publish` first. CommandRouter top-level help mirrors the new entries.

## Test plan

- [x] 7 new `GuideWorkflowTaskPacketDraftCommandTests` + 10 new `GuideWorkflowTaskIssuePublishCommandTests` pass.
- [x] Regression checks grep the guide example `--flag`s against `PacketDraftCommand.cs`, `IssuePublishFlowCommand.cs`, and `AutomationIssuePublishCommand.cs` source files (mirrors the G336 PR #776 fix).
- [x] All 199 tests in the `GuideWorkflow|CommandRouterTests` filter pass.
- [x] Smoke-tested both commands (markdown + json), the unknown-arg / unknown-task / unknown-format error paths, and the parent dispatcher (`guide workflow task packet-draft`, `guide workflow task issue-publish`).
- [x] Bootstrap allow-list (G334 / G299) already covers `guide workflow ...` so both tasks reach from a child cwd without `.intent-cli/`.

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)