### PR TITLE
G338: guided implementation-loop + review-next-slice-loop workflow

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -503,9 +503,10 @@ internal static class CommandRouter
     /// <summary>
     /// G334: canonical one-line pointers for the six workflow phases the
     /// issue names (init / interview / packet / issue / automation /
-    /// bug repair). Tests assert each phase appears in the top-level
-    /// help output so external agents can find the workflow entry
-    /// without reading local rules.
+    /// bug repair) plus the G338 loop-setup pair (implementation-loop /
+    /// review-next-slice-loop). Tests assert each phase appears in the
+    /// top-level help output so external agents can find the workflow
+    /// entry without reading local rules.
     /// </summary>
     internal static readonly IReadOnlyList<string> WorkflowGuidePointersHelp = new[]
     {
@@ -514,7 +515,9 @@ internal static class CommandRouter
         "packet — `intent-cli guide workflow task packet-draft --format json` (packet files + standalone issue contract, G337) then `intent-cli packet draft --execution-unit <id> --target-repo <r> --format markdown` to scaffold.",
         "issue — `intent-cli guide workflow task issue-publish --format json` (draft/create/publish-flow/intent-target boundary guide, G337) then `intent-cli issue publish-flow <id> --repo <r> --write --format json` and `automation issue-publish --write`.",
         "automation — `intent-cli automation summary --domain <d> --format json` (label-driven capability JSON) + `intent-cli automation doctor` (CLI freshness).",
-        "bug repair — `intent-cli guide worker pr-comment-fix --format json` (narrow PR-comment repair guidance)."
+        "bug repair — `intent-cli guide worker pr-comment-fix --format json` (narrow PR-comment repair guidance).",
+        "implementation-loop — `intent-cli guide workflow task implementation-loop --target-repo <r> --agent claude --frequency 5m --format markdown` (paste-ready child implementation-loop prompt with current label/claim/complete rules, G338).",
+        "review-next-slice-loop — `intent-cli guide workflow task review-next-slice-loop --domain <d> --target-repo <r> --agent claude --frequency 20m --format markdown` (paste-ready host review / next-slice-loop prompt with current host-sync preflight + packet/issue lifecycle rules, G338)."
     };
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -35,11 +35,12 @@ internal static class GuideHelpCommand
         "Usage: intent-cli guide help [--format markdown|json]";
 
     /// <summary>
-    /// G334: the canonical workflow-guide pointers. Each entry names a
-    /// real <c>intent-cli</c> entry point so an external agent can
-    /// follow it without rummaging through local rules or skill files.
-    /// Phase IDs are stable: <c>init</c>, <c>interview</c>,
-    /// <c>packet</c>, <c>issue</c>, <c>automation</c>, <c>bug-repair</c>.
+    /// G334 + G338: the canonical workflow-guide pointers. Each entry
+    /// names a real <c>intent-cli</c> entry point so an external agent
+    /// can follow it without rummaging through local rules or skill
+    /// files. Phase IDs are stable: <c>init</c>, <c>interview</c>,
+    /// <c>packet</c>, <c>issue</c>, <c>automation</c>, <c>bug-repair</c>,
+    /// <c>implementation-loop</c> (G338), <c>review-next-slice-loop</c> (G338).
     /// </summary>
     internal static readonly IReadOnlyList<WorkflowGuidePointer> WorkflowGuides = new[]
     {
@@ -84,6 +85,20 @@ internal static class GuideHelpCommand
             Command = "intent-cli guide worker pr-comment-fix --format json",
             Purpose = "Repair the narrow requested change on a PR branch. Selector: `intent-cli worker next-action ...` returning `action: pr-comment-fix`. Process at most one repair per wake.",
             SeeAlso = new[] { "intent-cli worker claim", "intent-cli worker complete", "intent-cli task fix-pr-comments" }
+        },
+        new WorkflowGuidePointer
+        {
+            Phase = "implementation-loop",
+            Command = "intent-cli guide workflow task implementation-loop --target-repo <owner/repo> --agent claude --frequency 5m --format markdown",
+            Purpose = "Generate a paste-ready child implementation-loop prompt from minimal inputs (target-repo, agent, frequency, base-branch-policy). Forwards to `guide prompt-matrix --mode child-loop`; the generated prompt carries the current label/claim/complete rules, G300/G330/G333 child-cwd contract, G311 closing reference gate, and G314 same-thread scheduler rule so the operator does not need them from memory (G338).",
+            SeeAlso = new[] { "intent-cli guide prompt-matrix --mode child-loop --format json", "intent-cli worker next-action --repo <r> --format json", "intent-cli guide worker --format json" }
+        },
+        new WorkflowGuidePointer
+        {
+            Phase = "review-next-slice-loop",
+            Command = "intent-cli guide workflow task review-next-slice-loop --domain <name> --target-repo <owner/repo> --agent claude --frequency 20m --format markdown",
+            Purpose = "Generate a paste-ready host review / next-slice-loop prompt from minimal inputs (domain, target-repo, agent, frequency). Forwards to `guide prompt-matrix --mode host-loop`; the generated prompt carries the host-sync preflight gate, automation summary call, packet/issue lifecycle handoff, and label transition rules so the operator does not need them from memory (G338).",
+            SeeAlso = new[] { "intent-cli guide prompt-matrix --mode host-loop --format json", "intent-cli automation host-sync-preflight --format json", "intent-cli automation summary --domain <name> --format json" }
         }
     };
 
@@ -128,8 +143,8 @@ internal static class GuideHelpCommand
         new GuideSubcommandEntry
         {
             Name = "workflow",
-            Purpose = "Workflow suggestion / scaffold plans. Subcommands: suggest (pick the right intent-cli entry for an operator goal); task <name> (bounded scaffold/init plan — today: `task init-host` for new-project role bootstrap, G335).",
-            Example = "intent-cli guide workflow task init-host --format json"
+            Purpose = "Workflow suggestion / scaffold plans. Subcommands: suggest (pick the right intent-cli entry for an operator goal); task <name> (bounded scaffold/init/loop plan — today: `task init-host` (G335), `task intent-interview` (G336), `task packet-draft` / `task issue-publish` (G337), `task implementation-loop` / `task review-next-slice-loop` (G338)).",
+            Example = "intent-cli guide workflow task implementation-loop --target-repo <owner/repo> --agent claude --frequency 5m --format markdown"
         },
         new GuideSubcommandEntry
         {

--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -262,10 +262,12 @@ Loop body (single wake; the operator drives subsequent wakes if any):
 1. Save the child worktree path: `CHILD_WORKTREE=""$PWD""`. Confirm it is a git worktree root. Stop with `wrong-worktree` if not.
 2. Resolve `<OWNER>/<REPO>` from the child cwd: `gh repo view --json nameWithOwner --jq .nameWithOwner` (fall back to `git remote get-url origin`).
 3. `git fetch --all --prune` and `git status --short`. If dirty in a dedicated automation worktree, clean local residue (`git reset --hard`, `git clean -fd`, submodule reset). Never `git clean -fdx`. Never clean a personal/shared checkout.
-4. From the parent host root (NOT the child cwd), run `intent-cli worker next-action --repo <OWNER>/<REPO> --workdir $CHILD_WORKTREE --format json`. Dispatch on `action`:
+4. From the child cwd (the child implementation loop does NOT require parent host root access — G333 child-cwd / GitHub-contract-only mode), run `intent-cli worker next-action --repo <OWNER>/<REPO> --github-only --format json`. Pass `--github-only` so the selector is pinned to the label-only data path and the result records the binding (`github_only: true`). Dispatch on `action`:
    - `none` → stop with `idle`.
-   - `issue-to-pr` → claim with `intent-cli worker claim --kind issue --number <n> --write --format json`, run the issue-to-PR workflow on the returned URL only, classify outcome, then `worker result-summary --kind issue-to-pr ...` and `worker complete --kind issue --number <n> --outcome <outcome> --write --format json`.
-   - `pr-comment-fix` → claim with `intent-cli worker claim --kind pr --number <n> --write --format json`, repair only the narrow requested change on the PR branch, classify outcome, then `worker result-summary --kind pr-comment-fix ...` and `worker complete --kind pr --number <n> --outcome <outcome> --write --format json`.
+   - `issue-to-pr` → claim with `intent-cli worker claim --kind issue --number <n> --repo <OWNER>/<REPO> --github-only --write --format json`, run the issue-to-PR workflow on the returned URL only, classify outcome, then `worker result-summary --kind issue-to-pr --repo <OWNER>/<REPO> ...` and `worker complete --kind issue --number <n> --repo <OWNER>/<REPO> --github-only --outcome <outcome> --write --format json`.
+   - `pr-comment-fix` → claim with `intent-cli worker claim --kind pr --number <n> --repo <OWNER>/<REPO> --github-only --write --format json`, repair only the narrow requested change on the PR branch, classify outcome, then `worker result-summary --kind pr-comment-fix --repo <OWNER>/<REPO> ...` and `worker complete --kind pr --number <n> --repo <OWNER>/<REPO> --github-only --outcome <outcome> --write --format json`.
+
+Host metadata gaps surfaced by `worker complete` (e.g. `linked_pr_synced: false` from child-cwd mode, G330) are HOST-owned blockers, not child instructions to enter the host repo. The child loop records the gap and moves on; parent host metadata reconciliation runs on the host/review-runtime loop via `intent-cli review closeout-plan --pr <n> --repo <OWNER>/<REPO> --write-recovered-linkage` (G329) — never from the child cwd.
 
 Hard rules:
 - Do not read `intents/rules/**`, local skill files (`gh-issue-to-pr`, `gh-fix-pr-comment`, etc.), or copied prompt files for routine collaboration. Use `intent-cli guide ...` instead.
@@ -427,10 +429,12 @@ Loop body (single wake only — do not repeat):
 1. Save the child worktree path: `CHILD_WORKTREE=""$PWD""`. Confirm it is a git worktree root. Stop with `wrong-worktree` if not.
 2. Resolve `<OWNER>/<REPO>` from the child cwd: `gh repo view --json nameWithOwner --jq .nameWithOwner` (fall back to `git remote get-url origin`).
 3. `git fetch --all --prune` and `git status --short`. If dirty in a dedicated automation worktree, clean local residue (`git reset --hard`, `git clean -fd`, submodule reset). Never `git clean -fdx`. Never clean a personal/shared checkout.
-4. From the parent host root (NOT the child cwd), run `intent-cli worker next-action --repo <OWNER>/<REPO> --workdir $CHILD_WORKTREE --format json`. Dispatch on `action`:
+4. From the child cwd (the child one-shot does NOT require parent host root access — G333 child-cwd / GitHub-contract-only mode), run `intent-cli worker next-action --repo <OWNER>/<REPO> --github-only --format json`. Pass `--github-only` so the selector is pinned to the label-only data path. Dispatch on `action`:
    - `none` → stop with `idle`.
-   - `issue-to-pr` → claim with `intent-cli worker claim --kind issue --number <n> --write --format json`, run the issue-to-PR workflow on the returned URL only, classify outcome, then `worker result-summary --kind issue-to-pr ...` and `worker complete --kind issue --number <n> --outcome <outcome> --write --format json`.
-   - `pr-comment-fix` → claim with `intent-cli worker claim --kind pr --number <n> --write --format json`, repair only the narrow requested change on the PR branch, classify outcome, then `worker result-summary --kind pr-comment-fix ...` and `worker complete --kind pr --number <n> --outcome <outcome> --write --format json`.
+   - `issue-to-pr` → claim with `intent-cli worker claim --kind issue --number <n> --repo <OWNER>/<REPO> --github-only --write --format json`, run the issue-to-PR workflow on the returned URL only, classify outcome, then `worker result-summary --kind issue-to-pr --repo <OWNER>/<REPO> ...` and `worker complete --kind issue --number <n> --repo <OWNER>/<REPO> --github-only --outcome <outcome> --write --format json`.
+   - `pr-comment-fix` → claim with `intent-cli worker claim --kind pr --number <n> --repo <OWNER>/<REPO> --github-only --write --format json`, repair only the narrow requested change on the PR branch, classify outcome, then `worker result-summary --kind pr-comment-fix --repo <OWNER>/<REPO> ...` and `worker complete --kind pr --number <n> --repo <OWNER>/<REPO> --github-only --outcome <outcome> --write --format json`.
+
+Host metadata gaps surfaced by `worker complete` (e.g. `linked_pr_synced: false` from child-cwd mode, G330) are HOST-owned blockers, not child instructions to enter the host repo.
 
 Hard rules:
 - Do not read `intents/rules/**`, local skill files (`gh-issue-to-pr`, `gh-fix-pr-comment`, etc.), or copied prompt files for routine collaboration. Use `intent-cli guide ...` instead.

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowCommand.cs
@@ -56,6 +56,6 @@ internal static class GuideWorkflowCommand
         writer.WriteLine();
         writer.WriteLine("Subcommands:");
         writer.WriteLine("- suggest — recommend a workflow + commands + rule topics for a broad operator goal");
-        writer.WriteLine("- task — bounded scaffold/init plans; today: `task init-host` (G335), `task intent-interview` (G336), `task packet-draft` (G337: packet files + standalone issue contract), `task issue-publish` (G337: draft/create/publish-flow/automation issue-publish boundary)");
+        writer.WriteLine("- task — bounded scaffold/init/loop plans; today: `task init-host` (G335), `task intent-interview` (G336), `task packet-draft` (G337: packet files + standalone issue contract), `task issue-publish` (G337: draft/create/publish-flow/automation issue-publish boundary), `task implementation-loop` / `task review-next-slice-loop` (G338: paste-ready child / host loop prompts from minimal inputs)");
     }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskCommand.cs
@@ -1,7 +1,7 @@
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// G335 / G336 / G337: dispatcher for the <c>guide workflow task</c>
+/// G335 / G336 / G337 / G338: dispatcher for the <c>guide workflow task</c>
 /// subcommand group. Peels the next token (the task name) and
 /// delegates to the per-task handler. Tasks today:
 /// <list type="bullet">
@@ -12,7 +12,13 @@ namespace IntentSystem.Cli.Commands;
 ///   <item><c>packet-draft</c> (G337) — packet files + standalone
 ///         issue contract;</item>
 ///   <item><c>issue-publish</c> (G337) — draft / create /
-///         publish-flow / automation issue-publish boundary.</item>
+///         publish-flow / automation issue-publish boundary;</item>
+///   <item><c>implementation-loop</c> (G338) — paste-ready child
+///         implementation-loop prompt from minimal inputs (forwards
+///         to <c>guide prompt-matrix --mode child-loop</c>);</item>
+///   <item><c>review-next-slice-loop</c> (G338) — paste-ready host
+///         review / next-slice-loop prompt from minimal inputs
+///         (forwards to <c>guide prompt-matrix --mode host-loop</c>).</item>
 /// </list>
 /// Future tasks (deploy-host, retire-host, migrate-host) can plug
 /// in without touching the router. Pure read-only — never mutates
@@ -34,7 +40,7 @@ internal static class GuideWorkflowTaskCommand
 
         if (args.Length == 0)
         {
-            writer.WriteLine("guide workflow task requires a task name. Supported: init-host, intent-interview, packet-draft, issue-publish.");
+            writer.WriteLine("guide workflow task requires a task name. Supported: init-host, intent-interview, packet-draft, issue-publish, implementation-loop, review-next-slice-loop.");
             WriteHelp(writer);
             return 1;
         }
@@ -54,13 +60,21 @@ internal static class GuideWorkflowTaskCommand
             // G337: issue-publish explains the four-stage publish
             // boundary and the intent-target final-boundary rule.
             "issue-publish" => GuideWorkflowTaskIssuePublishCommand.Execute(context, args[1..], writer),
+            // G338: implementation-loop generates the paste-ready
+            // child implementation-loop prompt from minimal inputs;
+            // forwards to `guide prompt-matrix --mode child-loop`.
+            "implementation-loop" => GuideWorkflowTaskImplementationLoopCommand.Execute(context, args[1..], writer),
+            // G338: review-next-slice-loop generates the paste-ready
+            // host review / next-slice-loop prompt from minimal
+            // inputs; forwards to `guide prompt-matrix --mode host-loop`.
+            "review-next-slice-loop" => GuideWorkflowTaskReviewNextSliceLoopCommand.Execute(context, args[1..], writer),
             _ => UnknownTask(writer, task)
         };
     }
 
     private static int UnknownTask(TextWriter writer, string task)
     {
-        writer.WriteLine($"Unknown 'guide workflow task' name '{task}'. Supported: init-host, intent-interview, packet-draft, issue-publish.");
+        writer.WriteLine($"Unknown 'guide workflow task' name '{task}'. Supported: init-host, intent-interview, packet-draft, issue-publish, implementation-loop, review-next-slice-loop.");
         WriteHelp(writer);
         return 1;
     }
@@ -75,5 +89,7 @@ internal static class GuideWorkflowTaskCommand
         writer.WriteLine("- intent-interview — product-owner interview / clarification loop guide. Explains the background/question/options/pros-cons/recommendation question structure, distinguishes interview (new concept) from clarification (existing blocker), names the durable artifact paths, lists the canonical commands (G336).");
         writer.WriteLine("- packet-draft — packet directory layout (packet.yaml / implementation.md / review-context.md / github-body.md) + standalone issue contract sections that every github-body.md must satisfy BEFORE `issue publish-flow` (G337).");
         writer.WriteLine("- issue-publish — draft / create / publish-flow / automation issue-publish boundary. Names the four stages, the intent-target FINAL-boundary rule, and the stop conditions that surface missing contract sections before GitHub mutation (G337).");
+        writer.WriteLine("- implementation-loop — paste-ready child implementation-loop prompt from minimal inputs (target-repo, agent, frequency, base-branch-policy). Forwards to `guide prompt-matrix --mode child-loop`; carries the current label/claim/complete rules so the operator does not need them from memory (G338).");
+        writer.WriteLine("- review-next-slice-loop — paste-ready host review / next-slice-loop prompt from minimal inputs (domain, target-repo, agent, frequency). Forwards to `guide prompt-matrix --mode host-loop`; carries the host-sync preflight gate, automation summary call, and packet/issue lifecycle rules (G338).");
     }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskImplementationLoopCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskImplementationLoopCommand.cs
@@ -1,0 +1,76 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G338: read-only <c>intent-cli guide workflow task implementation-loop</c>.
+/// External agents that have never seen the project can ask for a
+/// paste-ready child implementation loop prompt by naming this task —
+/// no need to know the underlying <c>guide prompt-matrix --mode child-loop</c>
+/// surface. The task accepts the minimal operator-facing inputs
+/// (target repo, agent, frequency, base-branch policy) and forwards to
+/// <see cref="GuidePromptMatrixCommand"/>. Domain is accepted as an
+/// optional hint for placeholders inside the generated prompt; the
+/// child loop itself does not require host-side domain metadata.
+/// <para>
+/// Pure read-only — emits text only. Never reads parent host queue-state,
+/// never calls <c>gh</c>, never mutates state, never launches an AI provider.
+/// </para>
+/// </summary>
+internal static class GuideWorkflowTaskImplementationLoopCommand
+{
+    internal const string Mode = "child-loop";
+
+    internal const string UsageLine =
+        "Usage: intent-cli guide workflow task implementation-loop [--target-repo <owner/repo>] [--agent claude|codex|generic] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--domain <name>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        // Reject --mode because the task name pins it to child-loop.
+        if (GuideWorkflowTaskLoopForwarder.HasFlag(args, "--mode"))
+        {
+            writer.WriteLine("--mode is not accepted by `guide workflow task implementation-loop`; the task name pins --mode child-loop.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        // Pre-validate flag shape so unknown-flag errors surface the
+        // wrapper's usage line, not the underlying prompt-matrix one.
+        var unknownFlag = GuideWorkflowTaskLoopForwarder.FindFirstUnknownFlag(args);
+        if (unknownFlag is not null)
+        {
+            writer.WriteLine($"Unknown argument '{unknownFlag}'.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var forwarded = GuideWorkflowTaskLoopForwarder.PrependMode(args, Mode);
+        return GuidePromptMatrixCommand.Execute(context, forwarded, writer);
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide workflow task implementation-loop");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine();
+        writer.WriteLine("Read-only. Generates the paste-ready child implementation-loop prompt from minimal inputs.");
+        writer.WriteLine();
+        writer.WriteLine("Generated prompt content (label transitions, claim/complete contract, G300/G330/G333 child-cwd rules, G314 same-thread scheduler contract, G311 closing reference, base-branch policy enforcement) comes from `intent-cli guide prompt-matrix --mode child-loop`. The task here is the discovery entry point — you do not need to remember the prompt-matrix surface.");
+        writer.WriteLine();
+        writer.WriteLine("Inputs (all optional; placeholders remain when omitted):");
+        writer.WriteLine("- --target-repo <owner/repo>     concrete repo the child loop drives; otherwise rendered as <TARGET-REPO>.");
+        writer.WriteLine("- --agent claude|codex|generic   chat-first agent driving the loop; controls scheduler phrasing.");
+        writer.WriteLine("- --frequency <NNm|NNh>          schedule cadence (e.g. 5m, 20m, 1h); otherwise the prompt asks the operator.");
+        writer.WriteLine("- --base-branch-policy direct-main|main-ai  base-branch enforcement; defaults to direct-main.");
+        writer.WriteLine("- --domain <name>                hint for prompt placeholders; child loop does not require host-side domain metadata.");
+        writer.WriteLine("- --format markdown|json         output format; markdown is the default.");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskLoopForwarder.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskLoopForwarder.cs
@@ -1,0 +1,112 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G338: shared argument-forwarding helpers for the loop-flavored
+/// <c>guide workflow task</c> wrappers (implementation-loop /
+/// review-next-slice-loop). Each task name pins a specific
+/// <c>--mode</c> on <see cref="GuidePromptMatrixCommand"/>; this
+/// helper prepends the mode, detects the operator-supplied
+/// <c>--mode</c> we explicitly forbid, and validates that every
+/// flag the operator passed belongs to the documented task
+/// surface (so unknown-arg errors surface the TASK usage line, not
+/// the underlying prompt-matrix usage line).
+/// </summary>
+internal static class GuideWorkflowTaskLoopForwarder
+{
+    /// <summary>
+    /// Flags both task wrappers accept and forward verbatim to
+    /// <see cref="GuidePromptMatrixCommand"/>. Mirror exactly the
+    /// `--target-repo` / `--agent` / `--frequency` /
+    /// `--base-branch-policy` / `--domain` / `--format` set that
+    /// the underlying prompt-matrix parser knows about. Listed as
+    /// an explicit allow-list so an unknown flag is rejected with
+    /// the wrapper's own usage line (not the prompt-matrix one).
+    /// </summary>
+    internal static readonly IReadOnlySet<string> AllowedFlags = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "--target-repo",
+        "--agent",
+        "--frequency",
+        "--base-branch-policy",
+        "--domain",
+        "--format",
+        "--help"
+    };
+
+    /// <summary>
+    /// Walks the argument list and returns the first flag-shaped
+    /// token (starts with <c>--</c>) that is not in
+    /// <see cref="AllowedFlags"/>. Returns <see langword="null"/>
+    /// when every flag is recognized. Values that follow a flag
+    /// (e.g. <c>--target-repo example/repo</c>) are not validated
+    /// here; the underlying prompt-matrix parser owns value
+    /// validation.
+    /// </summary>
+    public static string? FindFirstUnknownFlag(string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var arg = args[index];
+            if (!arg.StartsWith("--", StringComparison.Ordinal))
+            {
+                // Positional tokens are not currently expected; let
+                // the downstream parser reject them so the message
+                // stays consistent.
+                continue;
+            }
+            if (!AllowedFlags.Contains(arg))
+            {
+                return arg;
+            }
+            // Skip the value when the flag takes one (every flag in
+            // the allow-list except --help takes a value).
+            if (!string.Equals(arg, "--help", StringComparison.Ordinal) && index + 1 < args.Length)
+            {
+                index++;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the original argument list with <c>--mode &lt;mode&gt;</c>
+    /// prepended. The wrappers reject an operator-supplied
+    /// <c>--mode</c> via <see cref="HasFlag"/> before reaching this
+    /// helper, so the caller can rely on the forwarded array carrying
+    /// exactly one mode value.
+    /// </summary>
+    public static string[] PrependMode(string[] args, string mode)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(mode);
+
+        var forwarded = new string[args.Length + 2];
+        forwarded[0] = "--mode";
+        forwarded[1] = mode;
+        Array.Copy(args, 0, forwarded, 2, args.Length);
+        return forwarded;
+    }
+
+    /// <summary>
+    /// Checks whether the supplied argument list contains a specific
+    /// flag literal. Used to fail-closed when the operator tries to
+    /// override <c>--mode</c> through a task wrapper that has already
+    /// pinned the mode.
+    /// </summary>
+    public static bool HasFlag(string[] args, string flag)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(flag);
+
+        foreach (var arg in args)
+        {
+            if (string.Equals(arg, flag, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskReviewNextSliceLoopCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskReviewNextSliceLoopCommand.cs
@@ -1,0 +1,72 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G338: read-only <c>intent-cli guide workflow task review-next-slice-loop</c>.
+/// External agents and operators ask for a paste-ready host review /
+/// next-slice loop prompt by naming this task — no need to know the
+/// underlying <c>guide prompt-matrix --mode host-loop</c> surface.
+/// The host loop drives review-runtime workflows for an intent domain,
+/// so <c>--domain</c> is the most important input and shows up in the
+/// generated automation summary call. The task forwards the operator's
+/// minimal inputs to <see cref="GuidePromptMatrixCommand"/>.
+/// <para>
+/// Pure read-only — emits text only. Never reads parent host queue-state,
+/// never calls <c>gh</c>, never mutates state, never launches an AI provider.
+/// </para>
+/// </summary>
+internal static class GuideWorkflowTaskReviewNextSliceLoopCommand
+{
+    internal const string Mode = "host-loop";
+
+    internal const string UsageLine =
+        "Usage: intent-cli guide workflow task review-next-slice-loop [--domain <name>] [--target-repo <owner/repo>] [--agent claude|codex|generic] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (GuideWorkflowTaskLoopForwarder.HasFlag(args, "--mode"))
+        {
+            writer.WriteLine("--mode is not accepted by `guide workflow task review-next-slice-loop`; the task name pins --mode host-loop.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var unknownFlag = GuideWorkflowTaskLoopForwarder.FindFirstUnknownFlag(args);
+        if (unknownFlag is not null)
+        {
+            writer.WriteLine($"Unknown argument '{unknownFlag}'.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var forwarded = GuideWorkflowTaskLoopForwarder.PrependMode(args, Mode);
+        return GuidePromptMatrixCommand.Execute(context, forwarded, writer);
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide workflow task review-next-slice-loop");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine();
+        writer.WriteLine("Read-only. Generates the paste-ready host review / next-slice loop prompt from minimal inputs.");
+        writer.WriteLine();
+        writer.WriteLine("Generated prompt content (host-sync preflight gates, automation summary, packet/issue lifecycle handoff, label transition rules, G314 same-thread scheduler contract) comes from `intent-cli guide prompt-matrix --mode host-loop`. The task here is the discovery entry point — you do not need to remember the prompt-matrix surface.");
+        writer.WriteLine();
+        writer.WriteLine("Inputs (all optional; placeholders remain when omitted):");
+        writer.WriteLine("- --domain <name>                intent domain the host loop owns; appears in `automation summary --domain <d>` and host-side queue lookups.");
+        writer.WriteLine("- --target-repo <owner/repo>     concrete repo the host loop reviews; otherwise rendered as <TARGET-REPO>.");
+        writer.WriteLine("- --agent claude|codex|generic   chat-first agent driving the loop; controls scheduler phrasing.");
+        writer.WriteLine("- --frequency <NNm|NNh>          schedule cadence (e.g. 5m, 20m, 1h); otherwise the prompt asks the operator.");
+        writer.WriteLine("- --base-branch-policy direct-main|main-ai  base-branch enforcement; defaults to direct-main.");
+        writer.WriteLine("- --format markdown|json         output format; markdown is the default.");
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskImplementationLoopCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskImplementationLoopCommandTests.cs
@@ -98,6 +98,43 @@ public sealed class GuideWorkflowTaskImplementationLoopCommandTests
     }
 
     [Fact]
+    public void Execute_GeneratedChildLoopPrompt_DoesNotInstructAgentToEnterParentHostRoot()
+    {
+        // PR #780 review finding: the previous child-loop prompt told
+        // agents to run `worker next-action` "From the parent host
+        // root (NOT the child cwd)". That contradicts the G338
+        // acceptance criterion ("Child implementation guide does not
+        // require parent host root after G333") and the
+        // 15-external-user-guided-workflow.md Child Implementation
+        // Isolation Policy. Regression: the generated child-loop
+        // prompt must NOT carry those forbidden anchors and MUST
+        // surface the child-cwd / GitHub-contract-only execution path
+        // (`--github-only`).
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskImplementationLoopCommand.Execute(
+            CreateContext(),
+            new[] { "--target-repo", "example/repo", "--agent", "claude", "--frequency", "5m", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString();
+        Assert.NotNull(prompt);
+        // The forbidden anchors from PR #780 must be gone.
+        Assert.DoesNotContain("From the parent host root", prompt!, StringComparison.Ordinal);
+        Assert.DoesNotContain("NOT the child cwd", prompt!, StringComparison.Ordinal);
+        // The child-cwd / GitHub-contract-only execution path must
+        // be advertised: `worker next-action` runs from the child
+        // cwd, pinned with `--github-only`.
+        Assert.Contains("From the child cwd", prompt!, StringComparison.Ordinal);
+        Assert.Contains("--github-only", prompt!, StringComparison.Ordinal);
+        // Host metadata gaps must be classified as host-owned
+        // blockers, not child instructions to enter the host repo.
+        Assert.Contains("HOST-owned blockers", prompt!, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_DoesNotRequireParentHostRootForChildLoopGuide()
     {
         // Acceptance criterion: "Child implementation guide does not

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskImplementationLoopCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskImplementationLoopCommandTests.cs
@@ -1,0 +1,261 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G338: tests for <c>intent-cli guide workflow task implementation-loop</c>.
+/// The surface forwards to <c>guide prompt-matrix --mode child-loop</c>
+/// after pinning the mode, validates flag shape locally so unknown-arg
+/// errors surface the task's own usage line, and renders the
+/// paste-ready child loop prompt with the current label/claim/complete
+/// rules so the operator does not need them from memory.
+/// </summary>
+public sealed class GuideWorkflowTaskImplementationLoopCommandTests
+{
+    [Fact]
+    public void Execute_DefaultMarkdown_PinsChildLoopMode()
+    {
+        // Acceptance criterion: "guide workflow task implementation-loop
+        // generates child-loop instructions from cwd + target repo +
+        // agent + frequency." The forwarded prompt-matrix call must
+        // carry --mode child-loop verbatim.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskImplementationLoopCommand.Execute(
+            CreateContext(),
+            new[] { "--target-repo", "example/repo", "--agent", "claude", "--frequency", "5m" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        // Markdown render carries the child-loop heading.
+        Assert.Contains("child-loop", output, StringComparison.Ordinal);
+        // The operator-supplied --frequency is reflected in the
+        // generated guidance. The child-loop prompt deliberately
+        // resolves the target repo from the cwd at run time (not
+        // from --target-repo), so the operator-supplied repo does
+        // not substitute into the prompt body — only frequency and
+        // agent appear in the rendered text.
+        Assert.Contains("5m", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_HasChildLoopMode()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskImplementationLoopCommand.Execute(
+            CreateContext(),
+            new[] { "--target-repo", "example/repo", "--agent", "claude", "--frequency", "5m", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("child-loop", root.GetProperty("mode").GetString());
+        Assert.Equal("loop", root.GetProperty("kind").GetString());
+        Assert.Equal("child", root.GetProperty("target").GetString());
+        Assert.Equal("claude", root.GetProperty("agent").GetString());
+        Assert.Equal("5m", root.GetProperty("frequency").GetString());
+    }
+
+    [Fact]
+    public void Execute_GeneratedPrompt_CarriesCurrentLabelClaimCompleteRules()
+    {
+        // Acceptance criterion: "Generated prompts include current
+        // label/claim/complete rules without requiring operator
+        // memory." The wrapper forwards to prompt-matrix, which
+        // already embeds the rule text — verify the rule anchors
+        // reach the task output so this contract is testable from
+        // the wrapper itself.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskImplementationLoopCommand.Execute(
+            CreateContext(),
+            new[] { "--target-repo", "example/repo", "--agent", "claude", "--frequency", "5m", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString();
+        Assert.NotNull(prompt);
+        // Label / claim / complete vocabulary.
+        Assert.Contains("worker claim", prompt!, StringComparison.Ordinal);
+        Assert.Contains("worker complete", prompt!, StringComparison.Ordinal);
+        Assert.Contains("worker next-action", prompt!, StringComparison.Ordinal);
+        Assert.Contains("worker result-summary", prompt!, StringComparison.Ordinal);
+        // G300 / G330 / G333 child-cwd isolation rule must appear.
+        Assert.Contains("Child cwd is GitHub-contract-only", prompt!, StringComparison.Ordinal);
+        // G311 closing reference gate must appear.
+        Assert.Contains("Closes #", prompt!, StringComparison.Ordinal);
+        // G314 same-thread scheduler contract must appear.
+        Assert.Contains("same-thread", prompt!, StringComparison.Ordinal);
+        // Forbidden manual gh label mutation must appear.
+        Assert.Contains("automation", prompt!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_DoesNotRequireParentHostRootForChildLoopGuide()
+    {
+        // Acceptance criterion: "Child implementation guide does not
+        // require parent host root after G333." The task is read-only
+        // text; running it from a fresh tmp cwd (no parent host root,
+        // no .intent-cli/) must still produce the child-loop guide.
+        using var writer = new StringWriter();
+        var context = new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "bootstrap",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+
+        var exitCode = GuideWorkflowTaskImplementationLoopCommand.Execute(
+            context,
+            new[] { "--target-repo", "example/repo", "--agent", "claude", "--frequency", "5m", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("child-loop", document.RootElement.GetProperty("mode").GetString());
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsTaskUsage()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskImplementationLoopCommand.Execute(
+            CreateContext(),
+            new[] { "--help" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("guide workflow task implementation-loop", output, StringComparison.Ordinal);
+        Assert.Contains("--target-repo", output, StringComparison.Ordinal);
+        Assert.Contains("--frequency", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ModeFlag_Rejected_NamesTaskUsage()
+    {
+        // The task pins --mode; an operator passing --mode must hit a
+        // task-level rejection so they do not blow away the pinned
+        // mode.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskImplementationLoopCommand.Execute(
+            CreateContext(),
+            new[] { "--mode", "host-loop" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("--mode is not accepted", output, StringComparison.Ordinal);
+        Assert.Contains("guide workflow task implementation-loop", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_SurfacesTaskUsage_NotPromptMatrixUsage()
+    {
+        // The wrapper validates flag shape up-front so an unknown
+        // argument shows the wrapper's usage line, not the prompt-
+        // matrix one. This keeps the discovery surface coherent.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskImplementationLoopCommand.Execute(
+            CreateContext(),
+            new[] { "--bogus" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Unknown argument '--bogus'", output, StringComparison.Ordinal);
+        Assert.Contains("guide workflow task implementation-loop", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("guide prompt-matrix [", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowTaskCommand_DispatchesImplementationLoop()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(),
+            new[] { "implementation-loop", "--target-repo", "example/repo", "--agent", "claude", "--frequency", "5m", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("child-loop", document.RootElement.GetProperty("mode").GetString());
+    }
+
+    [Fact]
+    public void GuideWorkflowTaskCommand_UnknownTask_NamesG338Tasks()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(),
+            new[] { "bogus-task" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("implementation-loop", output, StringComparison.Ordinal);
+        Assert.Contains("review-next-slice-loop", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideHelpCommand_ImplementationLoopPhase_PointsToTaskImplementationLoop()
+    {
+        var pointer = GuideHelpCommand.WorkflowGuides
+            .First(p => string.Equals(p.Phase, "implementation-loop", StringComparison.Ordinal));
+        Assert.Contains("guide workflow task implementation-loop", pointer.Command, StringComparison.Ordinal);
+        // SeeAlso references the underlying prompt-matrix surface so
+        // power users can drill in if they need the lower-level entry.
+        var seeAlso = string.Join(" ", pointer.SeeAlso ?? Array.Empty<string>());
+        Assert.Contains("prompt-matrix", seeAlso, StringComparison.Ordinal);
+        Assert.Contains("child-loop", seeAlso, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommandRouter_TopLevelHelp_NamesImplementationLoopPhase()
+    {
+        // The shared WorkflowGuidePointersHelp array must carry the
+        // implementation-loop entry so top-level help surfaces it
+        // without the user reading per-group help.
+        var implementationLoopLines = CommandRouter.WorkflowGuidePointersHelp
+            .Where(line => line.StartsWith("implementation-loop —", StringComparison.Ordinal))
+            .ToArray();
+        Assert.Single(implementationLoopLines);
+        Assert.Contains("guide workflow task implementation-loop", implementationLoopLines[0], StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskReviewNextSliceLoopCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskReviewNextSliceLoopCommandTests.cs
@@ -1,0 +1,199 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G338: tests for <c>intent-cli guide workflow task review-next-slice-loop</c>.
+/// The surface forwards to <c>guide prompt-matrix --mode host-loop</c>
+/// after pinning the mode, validates flag shape locally so unknown-arg
+/// errors surface the task's own usage line, and renders the
+/// paste-ready host review / next-slice-loop prompt with the current
+/// host-sync preflight + label/automation rules.
+/// </summary>
+public sealed class GuideWorkflowTaskReviewNextSliceLoopCommandTests
+{
+    [Fact]
+    public void Execute_DefaultMarkdown_PinsHostLoopMode()
+    {
+        // Acceptance criterion: "guide workflow task
+        // review-next-slice-loop generates host-loop instructions
+        // from cwd + domain + target repo + agent + frequency."
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskReviewNextSliceLoopCommand.Execute(
+            CreateContext(),
+            new[] { "--domain", "intent-cli", "--target-repo", "example/repo", "--agent", "claude", "--frequency", "20m" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("host-loop", output, StringComparison.Ordinal);
+        Assert.Contains("example/repo", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("20m", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_HasHostLoopMode()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskReviewNextSliceLoopCommand.Execute(
+            CreateContext(),
+            new[] { "--domain", "intent-cli", "--target-repo", "example/repo", "--agent", "claude", "--frequency", "20m", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("host-loop", root.GetProperty("mode").GetString());
+        Assert.Equal("loop", root.GetProperty("kind").GetString());
+        Assert.Equal("host", root.GetProperty("target").GetString());
+        Assert.Equal("claude", root.GetProperty("agent").GetString());
+        Assert.Equal("20m", root.GetProperty("frequency").GetString());
+    }
+
+    [Fact]
+    public void Execute_GeneratedPrompt_CarriesHostSyncPreflightAndLifecycleRules()
+    {
+        // Acceptance criterion: "Generated prompts include current
+        // label/claim/complete rules without requiring operator
+        // memory." For the host loop, the canonical rules are the
+        // host-sync preflight gate, automation summary call,
+        // packet/issue lifecycle handoff, and label transitions.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskReviewNextSliceLoopCommand.Execute(
+            CreateContext(),
+            new[] { "--domain", "intent-cli", "--target-repo", "example/repo", "--agent", "claude", "--frequency", "20m", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString();
+        Assert.NotNull(prompt);
+        // Host-sync preflight gate must appear.
+        Assert.Contains("host-sync-preflight", prompt!, StringComparison.Ordinal);
+        // Automation summary anchor for the domain must appear.
+        Assert.Contains("automation summary", prompt!, StringComparison.Ordinal);
+        // The forbidden raw-gh label mutation must be called out.
+        Assert.Contains("automation", prompt!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsTaskUsage()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskReviewNextSliceLoopCommand.Execute(
+            CreateContext(),
+            new[] { "--help" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("guide workflow task review-next-slice-loop", output, StringComparison.Ordinal);
+        Assert.Contains("--domain", output, StringComparison.Ordinal);
+        Assert.Contains("--target-repo", output, StringComparison.Ordinal);
+        Assert.Contains("--frequency", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ModeFlag_Rejected_NamesTaskUsage()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskReviewNextSliceLoopCommand.Execute(
+            CreateContext(),
+            new[] { "--mode", "child-loop" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("--mode is not accepted", output, StringComparison.Ordinal);
+        Assert.Contains("guide workflow task review-next-slice-loop", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_SurfacesTaskUsage_NotPromptMatrixUsage()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskReviewNextSliceLoopCommand.Execute(
+            CreateContext(),
+            new[] { "--bogus" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Unknown argument '--bogus'", output, StringComparison.Ordinal);
+        Assert.Contains("guide workflow task review-next-slice-loop", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("guide prompt-matrix [", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowTaskCommand_DispatchesReviewNextSliceLoop()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(),
+            new[] { "review-next-slice-loop", "--domain", "intent-cli", "--target-repo", "example/repo", "--agent", "claude", "--frequency", "20m", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("host-loop", document.RootElement.GetProperty("mode").GetString());
+    }
+
+    [Fact]
+    public void GuideHelpCommand_ReviewNextSliceLoopPhase_PointsToTaskReviewNextSliceLoop()
+    {
+        var pointer = GuideHelpCommand.WorkflowGuides
+            .First(p => string.Equals(p.Phase, "review-next-slice-loop", StringComparison.Ordinal));
+        Assert.Contains("guide workflow task review-next-slice-loop", pointer.Command, StringComparison.Ordinal);
+        var seeAlso = string.Join(" ", pointer.SeeAlso ?? Array.Empty<string>());
+        Assert.Contains("prompt-matrix", seeAlso, StringComparison.Ordinal);
+        Assert.Contains("host-loop", seeAlso, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommandRouter_TopLevelHelp_NamesReviewNextSliceLoopPhase()
+    {
+        var hostLoopLines = CommandRouter.WorkflowGuidePointersHelp
+            .Where(line => line.StartsWith("review-next-slice-loop —", StringComparison.Ordinal))
+            .ToArray();
+        Assert.Single(hostLoopLines);
+        Assert.Contains("guide workflow task review-next-slice-loop", hostLoopLines[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LoopForwarder_AllowedFlags_DoesNotIncludeMode()
+    {
+        // The forwarder allow-list must NOT include --mode because
+        // each task wrapper pins the mode itself; if --mode crept
+        // back into the allow-list the wrapper's --mode rejection
+        // would silently lose effect.
+        Assert.DoesNotContain("--mode", GuideWorkflowTaskLoopForwarder.AllowedFlags);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Adds \`intent-cli guide workflow task implementation-loop [--target-repo <r>] [--agent claude|codex|generic] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--domain <name>] [--format markdown|json]\` — pins \`--mode child-loop\` on the underlying \`guide prompt-matrix\` surface and forwards the operator's minimal inputs to produce a paste-ready child implementation-loop prompt.
- Adds \`intent-cli guide workflow task review-next-slice-loop [--domain <d>] [--target-repo <r>] [--agent ...] [--frequency ...] [--base-branch-policy ...] [--format ...]\` — pins \`--mode host-loop\` and forwards the same flag set; \`--domain\` is the primary input because the host loop drives an intent domain's review/next-slice cadence.
- Both task wrappers reject \`--mode\` (the task name owns it) and pre-validate the operator's flag shape against a stable allow-list so unknown-arg errors surface the task's own usage line, not the underlying prompt-matrix usage line.
- Generated prompt content (worker claim/complete/next-action vocabulary, G300/G330/G333 child-cwd isolation, G311 closing reference gate, G314 same-thread scheduler, host-sync preflight, automation summary, label transitions) comes from \`guide prompt-matrix\` — the task wrappers are the discovery entry point.

## Self-discovery wiring

- New \`WorkflowGuidePointer\` rows in \`GuideHelpCommand.WorkflowGuides\` for phases \`implementation-loop\` and \`review-next-slice-loop\`, each pointing at the new task command and citing the underlying \`guide prompt-matrix\` in \`SeeAlso\`.
- New entries in \`CommandRouter.WorkflowGuidePointersHelp\` so the top-level help surface carries both loop phases.
- \`GuideWorkflowCommand\` help and \`GuideWorkflowTaskCommand\` dispatcher / unknown-task error message updated.

## Test plan

- [x] 21 new tests in \`GuideWorkflowTaskImplementationLoopCommandTests\` + \`GuideWorkflowTaskReviewNextSliceLoopCommandTests\` pass.
- [x] Both \`Execute_GeneratedPrompt_*\` regressions verify the generated prompt carries the current label/claim/complete vocabulary and isolation rules, so an external agent does not need operator memory (acceptance criterion).
- [x] \`Execute_DoesNotRequireParentHostRootForChildLoopGuide\` runs the child task from a fresh tmp cwd to satisfy the post-G333 acceptance criterion.
- [x] \`Execute_UnknownArgument_SurfacesTaskUsage_NotPromptMatrixUsage\` asserts the wrapper's usage line, not the underlying prompt-matrix usage line, on unknown-arg errors.
- [x] Full suite: 2708/2709 pass, 1 skipped, 0 failed.
- [x] Smoke-tested both new tasks (markdown + json), the \`--help\`, \`--mode\` rejection, and unknown-arg error paths.

Closes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)