### PR TITLE
G339: guided bug-to-intent-repair + packet backflow workflow

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -503,10 +503,11 @@ internal static class CommandRouter
     /// <summary>
     /// G334: canonical one-line pointers for the six workflow phases the
     /// issue names (init / interview / packet / issue / automation /
-    /// bug repair) plus the G338 loop-setup pair (implementation-loop /
-    /// review-next-slice-loop). Tests assert each phase appears in the
-    /// top-level help output so external agents can find the workflow
-    /// entry without reading local rules.
+    /// bug repair), the G338 loop-setup pair (implementation-loop /
+    /// review-next-slice-loop), and the G339 bug-to-intent-repair
+    /// chain. Tests assert each phase appears in the top-level help
+    /// output so external agents can find the workflow entry without
+    /// reading local rules.
     /// </summary>
     internal static readonly IReadOnlyList<string> WorkflowGuidePointersHelp = new[]
     {
@@ -517,7 +518,8 @@ internal static class CommandRouter
         "automation — `intent-cli automation summary --domain <d> --format json` (label-driven capability JSON) + `intent-cli automation doctor` (CLI freshness).",
         "bug repair — `intent-cli guide worker pr-comment-fix --format json` (narrow PR-comment repair guidance).",
         "implementation-loop — `intent-cli guide workflow task implementation-loop --target-repo <r> --agent claude --frequency 5m --format markdown` (paste-ready child implementation-loop prompt with current label/claim/complete rules, G338).",
-        "review-next-slice-loop — `intent-cli guide workflow task review-next-slice-loop --domain <d> --target-repo <r> --agent claude --frequency 20m --format markdown` (paste-ready host review / next-slice-loop prompt with current host-sync preflight + packet/issue lifecycle rules, G338)."
+        "review-next-slice-loop — `intent-cli guide workflow task review-next-slice-loop --domain <d> --target-repo <r> --agent claude --frequency 20m --format markdown` (paste-ready host review / next-slice-loop prompt with current host-sync preflight + packet/issue lifecycle rules, G338).",
+        "bug-to-intent-repair — `intent-cli guide workflow task bug-to-intent-repair --format json` (report → triage → plan → intent-repair → implementation-repair chain; classifies implementation-mismatch / intent-gap / packet-gap / rule-gap / metadata-workflow-gap; recommends packet creation when the bug is in intent-cli rules/guidance, G339)."
     };
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -35,12 +35,14 @@ internal static class GuideHelpCommand
         "Usage: intent-cli guide help [--format markdown|json]";
 
     /// <summary>
-    /// G334 + G338: the canonical workflow-guide pointers. Each entry
-    /// names a real <c>intent-cli</c> entry point so an external agent
-    /// can follow it without rummaging through local rules or skill
-    /// files. Phase IDs are stable: <c>init</c>, <c>interview</c>,
-    /// <c>packet</c>, <c>issue</c>, <c>automation</c>, <c>bug-repair</c>,
-    /// <c>implementation-loop</c> (G338), <c>review-next-slice-loop</c> (G338).
+    /// G334 + G338 + G339: the canonical workflow-guide pointers.
+    /// Each entry names a real <c>intent-cli</c> entry point so an
+    /// external agent can follow it without rummaging through local
+    /// rules or skill files. Phase IDs are stable: <c>init</c>,
+    /// <c>interview</c>, <c>packet</c>, <c>issue</c>,
+    /// <c>automation</c>, <c>bug-repair</c>, <c>implementation-loop</c>
+    /// (G338), <c>review-next-slice-loop</c> (G338),
+    /// <c>bug-to-intent-repair</c> (G339).
     /// </summary>
     internal static readonly IReadOnlyList<WorkflowGuidePointer> WorkflowGuides = new[]
     {
@@ -99,6 +101,13 @@ internal static class GuideHelpCommand
             Command = "intent-cli guide workflow task review-next-slice-loop --domain <name> --target-repo <owner/repo> --agent claude --frequency 20m --format markdown",
             Purpose = "Generate a paste-ready host review / next-slice-loop prompt from minimal inputs (domain, target-repo, agent, frequency). Forwards to `guide prompt-matrix --mode host-loop`; the generated prompt carries the host-sync preflight gate, automation summary call, packet/issue lifecycle handoff, and label transition rules so the operator does not need them from memory (G338).",
             SeeAlso = new[] { "intent-cli guide prompt-matrix --mode host-loop --format json", "intent-cli automation host-sync-preflight --format json", "intent-cli automation summary --domain <name> --format json" }
+        },
+        new WorkflowGuidePointer
+        {
+            Phase = "bug-to-intent-repair",
+            Command = "intent-cli guide workflow task bug-to-intent-repair --format json",
+            Purpose = "Guided bug-to-intent-repair workflow (G339). Five stages (report → triage → plan → intent-repair → implementation-repair) and five gap classifications (implementation-mismatch, intent-gap, packet-gap, rule-gap, metadata-workflow-gap). Recommends packet creation when the bug is in intent-cli rules/guidance rather than child code, preserves the original instruction reference and linked issue/PR refs across every link in the chain, and pins the FORBIDDEN raw `gh issue edit --add-label intent-target` rule from G337.",
+            SeeAlso = new[] { "intent-cli guide workflow task packet-draft --format json", "intent-cli guide workflow task issue-publish --format json", "intent-cli packet draft --execution-unit <unit> --target-repo <owner/repo> --format markdown", "intent-cli intent next-slice --dry-run --domain <name> --target-repo <owner/repo> --format json" }
         }
     };
 
@@ -143,8 +152,8 @@ internal static class GuideHelpCommand
         new GuideSubcommandEntry
         {
             Name = "workflow",
-            Purpose = "Workflow suggestion / scaffold plans. Subcommands: suggest (pick the right intent-cli entry for an operator goal); task <name> (bounded scaffold/init/loop plan — today: `task init-host` (G335), `task intent-interview` (G336), `task packet-draft` / `task issue-publish` (G337), `task implementation-loop` / `task review-next-slice-loop` (G338)).",
-            Example = "intent-cli guide workflow task implementation-loop --target-repo <owner/repo> --agent claude --frequency 5m --format markdown"
+            Purpose = "Workflow suggestion / scaffold plans. Subcommands: suggest (pick the right intent-cli entry for an operator goal); task <name> (bounded scaffold/init/loop/repair plan — today: `task init-host` (G335), `task intent-interview` (G336), `task packet-draft` / `task issue-publish` (G337), `task implementation-loop` / `task review-next-slice-loop` (G338), `task bug-to-intent-repair` (G339)).",
+            Example = "intent-cli guide workflow task bug-to-intent-repair --format markdown"
         },
         new GuideSubcommandEntry
         {

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowCommand.cs
@@ -56,6 +56,6 @@ internal static class GuideWorkflowCommand
         writer.WriteLine();
         writer.WriteLine("Subcommands:");
         writer.WriteLine("- suggest — recommend a workflow + commands + rule topics for a broad operator goal");
-        writer.WriteLine("- task — bounded scaffold/init/loop plans; today: `task init-host` (G335), `task intent-interview` (G336), `task packet-draft` (G337: packet files + standalone issue contract), `task issue-publish` (G337: draft/create/publish-flow/automation issue-publish boundary), `task implementation-loop` / `task review-next-slice-loop` (G338: paste-ready child / host loop prompts from minimal inputs)");
+        writer.WriteLine("- task — bounded scaffold/init/loop/repair plans; today: `task init-host` (G335), `task intent-interview` (G336), `task packet-draft` (G337: packet files + standalone issue contract), `task issue-publish` (G337: draft/create/publish-flow/automation issue-publish boundary), `task implementation-loop` / `task review-next-slice-loop` (G338: paste-ready child / host loop prompts from minimal inputs), `task bug-to-intent-repair` (G339: guided bug → intent repair chain with five gap classifications)");
     }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskBugToIntentRepairCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskBugToIntentRepairCommand.cs
@@ -39,45 +39,45 @@ internal static class GuideWorkflowTaskBugToIntentRepairCommand
         {
             Stage = "report",
             Purpose = "Capture the observed problem as a durable artifact: symptom, repro, environment, observed-vs-expected, and the original instruction or guide output that produced the wrong behavior. The report is the only stage that may be authored by anyone (operator, external agent, child loop reporting a failure); every later stage cites it.",
-            Command = "intent-cli guide automation report --format json",
-            Output = "A bug report draft (markdown body + structured metadata) with: symptom, environment, repro steps, observed/expected, original instruction reference (link to the prompt / guide command / spec section that produced the wrong behavior), and any linked issue/PR/commit refs.",
-            Boundary = "No GitHub mutation. The report is local until triage decides the repair path. If the operator wants the report public immediately, they can `gh issue create` against the implementation repo with the `bug` label — but the canonical handoff is into triage so the gap is classified before a repair lane is chosen.",
-            FailsOpen = "If `guide automation report` is unavailable on the installed CLI (`automation doctor` reports `stale-host-cli`), STOP — refresh the installed CLI; do NOT fall back to ad-hoc gh issue comments. The report is the durable head of the chain; freehand comments break the chain."
+            Command = "intent-cli bug report <domain> [<bug-id>] --title <text> [--text <text> | --from-file <path>] [--suspected-failure-locus <text>] [--instruction-refs <csv>] [--affected-intent-refs <csv>] [--affected-rule-spec-refs <csv>] [--clarification-candidates <csv>] [--execution-units <csv>] [--issues <csv>] [--prs <csv>] [--reviews <csv>]",
+            Output = "A durable bug report under the host's bug projection. The `--instruction-refs` flag preserves the link to the prompt / guide command / spec section that produced the wrong behavior; `--affected-intent-refs` / `--affected-rule-spec-refs` carry the cited intent / rule paths; `--execution-units` / `--issues` / `--prs` / `--reviews` carry the linked artifacts so every later stage can cite them.",
+            Boundary = "Runs on the HOST repo (the bug projection is host-owned). No GitHub mutation at this stage. If the operator wants the report public immediately, they can `gh issue create` against the implementation repo with the `bug` label — but the canonical handoff is into triage so the gap is classified before a repair lane is chosen.",
+            FailsOpen = "If `bug report` is unavailable on the installed CLI (`automation doctor` reports `stale-host-cli`), STOP — refresh the installed CLI; do NOT fall back to ad-hoc gh issue comments. The bug projection is the durable head of the chain; freehand comments break the chain."
         },
         new BugRepairStage
         {
             Stage = "triage",
             Purpose = "Classify the gap. Pick exactly one of the five classifications below. Triage is the decision point that picks the repair lane (intent-repair vs implementation-repair vs metadata-repair). Triage must cite the bug report and the classification rationale.",
-            Command = "intent-cli guide workflow task bug-to-intent-repair --format json",
-            Output = "A triage decision: classification id (one of the five), rationale, and the recommended next-stage command. Stored next to the bug report (operator's notes file or the bug issue body's `Triage:` section).",
-            Boundary = "No GitHub mutation. Triage is a reading exercise: read the bug report, the cited spec/rule/packet, and pick the lane. Triage does NOT create the repair artifact itself — that is the plan / intent-repair / implementation-repair stages.",
+            Command = "intent-cli bug triage <bug-id>",
+            Output = "A durable triage artifact (`.intent-cli/bugs/<bug-id>.triage.yaml`) carrying the classification id (one of the five below), rationale, recommended next-stage command, and references back to the bug report.",
+            Boundary = "Runs on the HOST repo (the bug projection is host-owned). No GitHub mutation. Triage is a reading exercise: read the bug report, the cited spec/rule/packet, pick the lane. Triage does NOT create the repair artifact itself — that is the plan / intent-repair / implementation-repair stages.",
             FailsOpen = "If two or more classifications fit, prefer `intent-gap` or `rule-gap` over `implementation-mismatch`. Child code that does the wrong thing because it followed wrong guidance is an intent/rule gap; fixing only the child code leaves the bad guidance to bite the next agent. The exception is `metadata-workflow-gap`, which always wins (label/queue-state bugs are host-owned)."
         },
         new BugRepairStage
         {
             Stage = "plan",
             Purpose = "For the chosen classification, derive the repair packet shape (when the lane is intent-repair / packet-gap / rule-gap) OR the child implementation issue shape (when the lane is implementation-mismatch) OR the host repair task (when the lane is metadata-workflow-gap). Plan output carries the execution-unit id, the design-host packet directory path (host repo only), and the in/out-of-scope split.",
-            Command = "intent-cli intent next-slice --dry-run --domain <domain> --target-repo <owner/repo> --format json",
-            Output = "A plan record: execution-unit id (e.g. `G34X`), repair lane, design-host packet directory the operator will scaffold, in-scope / out-of-scope split, acceptance criteria draft. Stored as `.intent-cli/issues/<unit>/plan.json` on the host repo.",
-            Boundary = "Plan runs on the HOST repo (design role). Child cwd does NOT plan repair packets — that is host-owned. If the bug surfaced from a child loop, the child loop reports the bug and STOPS; planning is operator-driven on the host.",
+            Command = "intent-cli bug plan <bug-id>",
+            Output = "A durable plan artifact (`.intent-cli/bugs/<bug-id>.plan.yaml`) carrying the execution-unit id (e.g. `G34X`), the repair lane, the design-host packet directory the operator will scaffold, the in-scope / out-of-scope split, and the acceptance-criteria draft.",
+            Boundary = "Plan runs on the HOST repo (design role). Child cwd does NOT plan repair packets — that is host-owned. If the bug surfaced from a child loop, the child loop reports the bug and STOPS; planning is operator-driven on the host. Use `intent-cli intent next-slice --dry-run --domain <domain> --target-repo <owner/repo> --format json` to confirm WIP cap / clarification-blockers before publishing the plan.",
             FailsOpen = "If `intent next-slice --dry-run` reports `wip-cap` or `clarification-required`, STOP — the host queue cannot accept the repair packet yet. Drain the existing in-progress slice (or run `clarification next`) before scheduling the bug repair."
         },
         new BugRepairStage
         {
             Stage = "intent-repair",
             Purpose = "Scaffold the repair packet (when the lane is intent-gap / packet-gap / rule-gap). The repair packet follows the standard G337 packet contract (`packet draft` → four files → `issue validate-body` → `issue publish-flow` → `automation issue-publish --write`). The repair PACKET is the canonical fix surface for guidance bugs; a child PR alone does NOT close the loop because the bad guidance remains in the rule/packet file.",
-            Command = "intent-cli packet draft --execution-unit <unit> --target-repo <owner/repo> --domain <domain> --format markdown",
-            Output = "The four packet files (`packet.yaml`, `implementation.md`, `review-context.md`, `github-body.md`) under the host design-host packet directory. The `github-body.md` MUST cite the original bug report and the cited spec/rule/packet section as `Related Links`, and MUST carry G311 `Closes #<bug-report-issue>` so the repair PR closes the bug.",
+            Command = "intent-cli bug intent-repair <bug-id>",
+            Output = "An intent-repair record (`.intent-cli/bugs/<bug-id>.intent-repair.yaml`) tying the bug's report / triage / plan artifacts to the scaffolded packet. Run `intent-cli packet draft --execution-unit <unit>` to scaffold the four packet files (`packet.yaml`, `implementation.md`, `review-context.md`, `github-body.md`). The `github-body.md` MUST cite the original bug report in `Related Links` AND carry G311 `Closes #<bug-report-issue>`.",
             Boundary = "Packet scaffolding runs on the HOST repo. The repair PACKET is host-side; the repair PR (when needed) is opened from a child cwd via the standard child loop after `automation issue-publish --write` labels the repair issue `intent-target`.",
             FailsOpen = "If `issue validate-body --from-file <github-body.md> --format json` reports missing contract sections, STOP and repair the body before publishing. The G337 issue-publish boundary applies verbatim to repair packets; the FORBIDDEN raw `gh issue edit --add-label intent-target` rule still applies."
         },
         new BugRepairStage
         {
             Stage = "implementation-repair",
-            Purpose = "OPTIONAL when the lane is implementation-mismatch — open a child implementation issue (with `intent-target`) so the child loop picks it up via `worker next-action`. Implementation-repair is NOT the primary lane: most bugs that surface in child PRs are caused by intent-gap or rule-gap upstream, so check triage's classification before defaulting here.",
-            Command = "intent-cli intent draft-issue --domain <domain> --target-repo <owner/repo> --execution-unit <unit> --format markdown",
-            Output = "An issue draft body (markdown) the operator publishes via the G337 publish-flow. After publish, the issue carries `intent-target` and the child loop picks it up on the next wake.",
-            Boundary = "Same host/child split as the standard issue-publish flow (G337). The repair issue is created on the implementation repo (e.g. J-Tech-Japan/intent-system); the child PR repair runs on the child cwd via the standard child loop.",
+            Purpose = "OPTIONAL when the lane is implementation-mismatch — scaffold an implementation-repair issue tied to the bug report so the child loop picks it up via `worker next-action`. Implementation-repair is NOT the primary lane: most bugs that surface in child PRs are caused by intent-gap or rule-gap upstream, so check triage's classification before defaulting here.",
+            Command = "intent-cli bug implementation-repair <bug-id> [--issue-number <n>] [--issue-url <url>] [--actor <name>] [--note <text>]",
+            Output = "An implementation-repair record on the bug projection linking the original bug report to the implementation-repair issue / PR. The issue is created on the implementation repo (e.g. J-Tech-Japan/intent-system) and picks up `intent-target` through the standard G337 publish-flow.",
+            Boundary = "The bug-implementation-repair record runs on the HOST repo (the bug projection is host-owned). The actual implementation-repair issue and PR run on the implementation repo via the standard issue/PR/child-loop lifecycle. Use `intent-cli issue draft <execution-unit>` if you want to scaffold the issue body directly from an existing packet artifact.",
             FailsOpen = "If triage classified the gap as intent-gap / packet-gap / rule-gap, do NOT also open an implementation-repair issue without an upstream intent-repair packet — the child PR would re-implement the wrong guidance. The intent-repair stage MUST land first."
         }
     };

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskBugToIntentRepairCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskBugToIntentRepairCommand.cs
@@ -1,0 +1,346 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G339: read-only <c>intent-cli guide workflow task bug-to-intent-repair</c>.
+/// Surfaces the guided bug-to-intent-repair workflow so observed
+/// automation failures and product bugs feed back into intent repair
+/// packets (and only optionally into child implementation issues),
+/// not just ad-hoc PR comments. The guide carries five stages
+/// (report → triage → plan → intent-repair → implementation-repair),
+/// five gap classifications (implementation-mismatch, intent-gap,
+/// packet-gap, rule-gap, metadata-workflow-gap), the canonical
+/// intent-cli commands per stage, stop conditions that surface
+/// missing artifacts BEFORE GitHub mutation, and the invariants
+/// every backflow must preserve (original refs, intent-cli-backed
+/// mutation, child isolation rule).
+///
+/// Pure read-only — never reads parent host queue-state, never calls
+/// <c>gh</c>, never mutates state, never launches an AI provider.
+/// </summary>
+internal static class GuideWorkflowTaskBugToIntentRepairCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide workflow task bug-to-intent-repair [--format markdown|json]";
+
+    /// <summary>
+    /// G339: the five workflow stages. Stable IDs (report / triage /
+    /// plan / intent-repair / implementation-repair) — tests pin
+    /// each by ID and the order must remain stable.
+    /// </summary>
+    internal static readonly IReadOnlyList<BugRepairStage> Stages = new[]
+    {
+        new BugRepairStage
+        {
+            Stage = "report",
+            Purpose = "Capture the observed problem as a durable artifact: symptom, repro, environment, observed-vs-expected, and the original instruction or guide output that produced the wrong behavior. The report is the only stage that may be authored by anyone (operator, external agent, child loop reporting a failure); every later stage cites it.",
+            Command = "intent-cli guide automation report --format json",
+            Output = "A bug report draft (markdown body + structured metadata) with: symptom, environment, repro steps, observed/expected, original instruction reference (link to the prompt / guide command / spec section that produced the wrong behavior), and any linked issue/PR/commit refs.",
+            Boundary = "No GitHub mutation. The report is local until triage decides the repair path. If the operator wants the report public immediately, they can `gh issue create` against the implementation repo with the `bug` label — but the canonical handoff is into triage so the gap is classified before a repair lane is chosen.",
+            FailsOpen = "If `guide automation report` is unavailable on the installed CLI (`automation doctor` reports `stale-host-cli`), STOP — refresh the installed CLI; do NOT fall back to ad-hoc gh issue comments. The report is the durable head of the chain; freehand comments break the chain."
+        },
+        new BugRepairStage
+        {
+            Stage = "triage",
+            Purpose = "Classify the gap. Pick exactly one of the five classifications below. Triage is the decision point that picks the repair lane (intent-repair vs implementation-repair vs metadata-repair). Triage must cite the bug report and the classification rationale.",
+            Command = "intent-cli guide workflow task bug-to-intent-repair --format json",
+            Output = "A triage decision: classification id (one of the five), rationale, and the recommended next-stage command. Stored next to the bug report (operator's notes file or the bug issue body's `Triage:` section).",
+            Boundary = "No GitHub mutation. Triage is a reading exercise: read the bug report, the cited spec/rule/packet, and pick the lane. Triage does NOT create the repair artifact itself — that is the plan / intent-repair / implementation-repair stages.",
+            FailsOpen = "If two or more classifications fit, prefer `intent-gap` or `rule-gap` over `implementation-mismatch`. Child code that does the wrong thing because it followed wrong guidance is an intent/rule gap; fixing only the child code leaves the bad guidance to bite the next agent. The exception is `metadata-workflow-gap`, which always wins (label/queue-state bugs are host-owned)."
+        },
+        new BugRepairStage
+        {
+            Stage = "plan",
+            Purpose = "For the chosen classification, derive the repair packet shape (when the lane is intent-repair / packet-gap / rule-gap) OR the child implementation issue shape (when the lane is implementation-mismatch) OR the host repair task (when the lane is metadata-workflow-gap). Plan output carries the execution-unit id, the design-host packet directory path (host repo only), and the in/out-of-scope split.",
+            Command = "intent-cli intent next-slice --dry-run --domain <domain> --target-repo <owner/repo> --format json",
+            Output = "A plan record: execution-unit id (e.g. `G34X`), repair lane, design-host packet directory the operator will scaffold, in-scope / out-of-scope split, acceptance criteria draft. Stored as `.intent-cli/issues/<unit>/plan.json` on the host repo.",
+            Boundary = "Plan runs on the HOST repo (design role). Child cwd does NOT plan repair packets — that is host-owned. If the bug surfaced from a child loop, the child loop reports the bug and STOPS; planning is operator-driven on the host.",
+            FailsOpen = "If `intent next-slice --dry-run` reports `wip-cap` or `clarification-required`, STOP — the host queue cannot accept the repair packet yet. Drain the existing in-progress slice (or run `clarification next`) before scheduling the bug repair."
+        },
+        new BugRepairStage
+        {
+            Stage = "intent-repair",
+            Purpose = "Scaffold the repair packet (when the lane is intent-gap / packet-gap / rule-gap). The repair packet follows the standard G337 packet contract (`packet draft` → four files → `issue validate-body` → `issue publish-flow` → `automation issue-publish --write`). The repair PACKET is the canonical fix surface for guidance bugs; a child PR alone does NOT close the loop because the bad guidance remains in the rule/packet file.",
+            Command = "intent-cli packet draft --execution-unit <unit> --target-repo <owner/repo> --domain <domain> --format markdown",
+            Output = "The four packet files (`packet.yaml`, `implementation.md`, `review-context.md`, `github-body.md`) under the host design-host packet directory. The `github-body.md` MUST cite the original bug report and the cited spec/rule/packet section as `Related Links`, and MUST carry G311 `Closes #<bug-report-issue>` so the repair PR closes the bug.",
+            Boundary = "Packet scaffolding runs on the HOST repo. The repair PACKET is host-side; the repair PR (when needed) is opened from a child cwd via the standard child loop after `automation issue-publish --write` labels the repair issue `intent-target`.",
+            FailsOpen = "If `issue validate-body --from-file <github-body.md> --format json` reports missing contract sections, STOP and repair the body before publishing. The G337 issue-publish boundary applies verbatim to repair packets; the FORBIDDEN raw `gh issue edit --add-label intent-target` rule still applies."
+        },
+        new BugRepairStage
+        {
+            Stage = "implementation-repair",
+            Purpose = "OPTIONAL when the lane is implementation-mismatch — open a child implementation issue (with `intent-target`) so the child loop picks it up via `worker next-action`. Implementation-repair is NOT the primary lane: most bugs that surface in child PRs are caused by intent-gap or rule-gap upstream, so check triage's classification before defaulting here.",
+            Command = "intent-cli intent draft-issue --domain <domain> --target-repo <owner/repo> --execution-unit <unit> --format markdown",
+            Output = "An issue draft body (markdown) the operator publishes via the G337 publish-flow. After publish, the issue carries `intent-target` and the child loop picks it up on the next wake.",
+            Boundary = "Same host/child split as the standard issue-publish flow (G337). The repair issue is created on the implementation repo (e.g. J-Tech-Japan/intent-system); the child PR repair runs on the child cwd via the standard child loop.",
+            FailsOpen = "If triage classified the gap as intent-gap / packet-gap / rule-gap, do NOT also open an implementation-repair issue without an upstream intent-repair packet — the child PR would re-implement the wrong guidance. The intent-repair stage MUST land first."
+        }
+    };
+
+    /// <summary>
+    /// G339: the five gap classifications triage chooses from.
+    /// Tests pin each by stable ID and verify the markdown +
+    /// JSON outputs surface them.
+    /// </summary>
+    internal static readonly IReadOnlyList<GapClassification> Classifications = new[]
+    {
+        new GapClassification
+        {
+            Id = "implementation-mismatch",
+            Description = "Child implementation code diverges from a correct intent/packet/rule. The guidance was right; the code is wrong.",
+            RepairLane = "implementation-repair",
+            ExampleSignal = "PR review finds a bug that contradicts the packet's `Acceptance Criteria` while the packet itself reads correctly to an external agent."
+        },
+        new GapClassification
+        {
+            Id = "intent-gap",
+            Description = "The intent statement (the durable Why / What in the host intent tree) is missing a requirement or contradicts a different intent. The agent followed the intent literally and still produced a bug.",
+            RepairLane = "intent-repair",
+            ExampleSignal = "Bug repro shows the agent did what the intent said; the intent itself does not capture the case the bug exposed (e.g. `intent next-slice` says `WIP cap 1` but does not say how to drain an abandoned slice)."
+        },
+        new GapClassification
+        {
+            Id = "packet-gap",
+            Description = "The packet (`github-body.md` / `implementation.md` / `review-context.md`) for an in-flight or recently-shipped execution unit is missing a contract section, an acceptance criterion, or an out-of-scope fence. The packet is host-owned, so the repair runs on the host design role.",
+            RepairLane = "intent-repair",
+            ExampleSignal = "A child PR shipped without the bug catch because the packet's `Verification` section did not require the test that would have caught it; or the packet's `Out Of Scope` did not fence a case the agent silently expanded into."
+        },
+        new GapClassification
+        {
+            Id = "rule-gap",
+            Description = "A guidance rule under `intents/rules/**` or a `guide` surface (e.g. `guide automation` / `guide worker` / `guide prompt-matrix`) is missing or contradicts a fact. The agent did what the rule said; the rule was wrong.",
+            RepairLane = "intent-repair",
+            ExampleSignal = "An external agent runs `guide automation` and follows its instructions, then hits a CLI that rejects the flag the guide named (e.g. PR #776 / #778 / #780 G336/G337/G338 findings). Repair runs through a packet that updates BOTH the rule text AND the guide output."
+        },
+        new GapClassification
+        {
+            Id = "metadata-workflow-gap",
+            Description = "GitHub workflow labels, host queue-state, runs.jsonl, publish artifacts, or runtime metadata are inconsistent with the actual GitHub state. This is a HOST-owned bug; the child loop cannot fix it and MUST NOT mutate parent metadata to compensate.",
+            RepairLane = "metadata-repair (host-owned)",
+            ExampleSignal = "`worker complete` reports `linked_pr_synced: false` from child-cwd mode (G330); the recovery path is `intent-cli review closeout-plan --pr <n> --repo <r> --write-recovered-linkage` on the HOST — never a raw gh label edit and never a child-side queue-state patch."
+        }
+    };
+
+    /// <summary>
+    /// G339: stop conditions that surface BEFORE any GitHub mutation.
+    /// Mirrors the G337 pattern — caught at triage / plan time so
+    /// the wrong repair lane never reaches publish-flow.
+    /// </summary>
+    internal static readonly IReadOnlyList<string> StopConditions = new[]
+    {
+        "Bug report is missing the original instruction reference (the link to the prompt / guide command / spec section that produced the wrong behavior): STOP — without the reference the triage cannot decide intent-gap vs rule-gap vs implementation-mismatch. Repair the report first.",
+        "Triage classification not cited in the plan: STOP — the plan must say which lane it is in and why. A plan that names neither the classification nor the rationale cannot be reviewed; the repair packet would be invisible to G316 packet-aware review.",
+        "Repair lane is `intent-gap` / `packet-gap` / `rule-gap` BUT the operator opens only an implementation-repair issue without an upstream intent-repair packet: STOP — the bad guidance remains; the next agent re-hits the same bug. The intent-repair packet is the canonical fix surface.",
+        "`issue validate-body --from-file <github-body.md> --format json` on the repair packet's `github-body.md` reports `errors[]` (missing contract sections, missing G311 closing reference to the bug-report issue): STOP — repair the body, re-validate, only then `issue publish-flow`.",
+        "Bug report references a metadata-workflow-gap (label/queue-state/runs/publish artifact wrong) BUT the operator is in a child cwd: STOP — child cwd is GitHub-contract-only (G300/G330/G333). The host runs the metadata repair via `review closeout-plan --write-recovered-linkage` / `automation publish-recovery` / `automation reconcile`; child cwd records the gap and exits.",
+        "Repair-packet `github-body.md` does not preserve the original bug report's instruction ref and linked issue/PR refs in `Related Links`: STOP — the chain (report → triage → plan → repair) breaks when the repair packet does not cite its parent."
+    };
+
+    /// <summary>
+    /// G339: explicit invariants every bug-to-intent-repair surface
+    /// advertises. Tests pin each invariant verbatim.
+    /// </summary>
+    internal static readonly IReadOnlyList<string> Invariants = new[]
+    {
+        "Original refs MUST be preserved across the chain: the bug report cites the original instruction (prompt / guide command / spec section); the triage cites the bug report; the plan cites the triage; the repair packet's `github-body.md` cites the bug report in `Related Links` AND carries G311 `Closes #<bug-report-issue>` so merging the repair PR closes the bug. Breaking the chain at any link makes the repair invisible to G316 packet-aware review.",
+        "Prefer intent-cli-backed metadata mutation over hand-editing. Ask `intent-cli guide commands list --format json` or `intent-cli automation summary --domain <d> --format json` which command performs the transition (`intent draft` / `packet draft` / `issue publish-flow` / `automation issue-publish` / `automation publish-recovery` / `review closeout-plan --write-recovered-linkage`), run that command, then validate the result. Do NOT directly edit queue-state, runs.jsonl, publish artifacts, workflow labels, or runtime metadata when a supported intent-cli command exists.",
+        "Child implementation isolation is preserved: child loops report bugs and STOP; they do NOT plan repair packets, do NOT mutate parent host queue-state / runs.jsonl / packet directories / intent tree / review-runtime state / local rules / local skills. Host metadata gaps are HOST-owned blockers; the metadata-workflow-gap classification routes them to the host loop, never back to the child.",
+        "Bugs in intent-cli rules or `guide` surfaces (rule-gap) repair through a PACKET that updates BOTH the underlying rule text AND the guide output, with a regression test that checks the guide output against the rule (mirrors G336 #776 / G337 #778 / G338 #780 fix pattern). A repair PR that only updates the rule text without the guide-output regression test leaves the next external agent reading stale guide output.",
+        "`intent-target` is the FINAL publish boundary for repair packets too — applied ONLY by `automation issue-publish --write` after `issue publish-flow` succeeds. Raw `gh issue edit --add-label intent-target` is FORBIDDEN for repair packets just as it is for normal slice packets (G337 invariant carries through verbatim).",
+        "Never launch AI providers (Claude / Codex / any LLM) from intent-cli. The chat-first model has the human agent driving the conversation; intent-cli emits text the agent acts on. This applies to every stage of the bug-to-intent-repair chain."
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            var payload = new BugToIntentRepairGuidance
+            {
+                Usage = UsageLine,
+                Stages = Stages,
+                Classifications = Classifications,
+                StopConditions = StopConditions,
+                Invariants = Invariants
+            };
+            writer.Write(JsonSerializer.Serialize(payload, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer);
+        }
+
+        return 0;
+    }
+
+    private static void WriteMarkdown(TextWriter writer)
+    {
+        writer.WriteLine("# intent-cli — bug-to-intent-repair workflow guide");
+        writer.WriteLine();
+        writer.WriteLine(UsageLine);
+        writer.WriteLine();
+        writer.WriteLine("Observed automation failures and product bugs feed back into intent repair packets, not ad-hoc PR comments. Five stages; five gap classifications; the original refs carry through every link.");
+        writer.WriteLine();
+
+        writer.WriteLine("## Stages");
+        writer.WriteLine();
+        foreach (var stage in Stages)
+        {
+            writer.WriteLine($"### {stage.Stage}");
+            writer.WriteLine();
+            writer.WriteLine($"- Purpose: {stage.Purpose}");
+            writer.WriteLine($"- Command: `{stage.Command}`");
+            writer.WriteLine($"- Output: {stage.Output}");
+            writer.WriteLine($"- Boundary: {stage.Boundary}");
+            writer.WriteLine($"- Fails-open behavior: {stage.FailsOpen}");
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Gap classifications");
+        writer.WriteLine();
+        writer.WriteLine("Triage MUST pick exactly one. Most bugs that surface in child PRs are caused by intent-gap or rule-gap upstream — check the rule/packet text before defaulting to implementation-mismatch.");
+        writer.WriteLine();
+        writer.WriteLine("| id | description | repair lane | example signal |");
+        writer.WriteLine("|----|-------------|-------------|----------------|");
+        foreach (var c in Classifications)
+        {
+            writer.WriteLine($"| `{c.Id}` | {c.Description} | `{c.RepairLane}` | {c.ExampleSignal} |");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Stop conditions (surface BEFORE GitHub mutation)");
+        foreach (var s in StopConditions)
+        {
+            writer.WriteLine($"- {s}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Invariants");
+        foreach (var line in Invariants)
+        {
+            writer.WriteLine($"- {line}");
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string format, out string error)
+    {
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            switch (arg)
+            {
+                case "--help":
+                    break;
+                case "--format":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[i + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    i++;
+                    break;
+                default:
+                    error = $"Unknown argument '{arg}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true
+    };
+}
+
+/// <summary>
+/// G339: one stage in the bug-to-intent-repair chain.
+/// </summary>
+internal sealed record BugRepairStage
+{
+    [JsonPropertyName("stage")]
+    public required string Stage { get; init; }
+
+    [JsonPropertyName("purpose")]
+    public required string Purpose { get; init; }
+
+    [JsonPropertyName("command")]
+    public required string Command { get; init; }
+
+    [JsonPropertyName("output")]
+    public required string Output { get; init; }
+
+    [JsonPropertyName("boundary")]
+    public required string Boundary { get; init; }
+
+    [JsonPropertyName("fails_open")]
+    public required string FailsOpen { get; init; }
+}
+
+/// <summary>
+/// G339: one gap classification triage chooses from.
+/// </summary>
+internal sealed record GapClassification
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    [JsonPropertyName("repair_lane")]
+    public required string RepairLane { get; init; }
+
+    [JsonPropertyName("example_signal")]
+    public required string ExampleSignal { get; init; }
+}
+
+/// <summary>
+/// G339: full JSON payload for <c>guide workflow task bug-to-intent-repair</c>.
+/// </summary>
+internal sealed record BugToIntentRepairGuidance
+{
+    [JsonPropertyName("usage")]
+    public required string Usage { get; init; }
+
+    [JsonPropertyName("stages")]
+    public required IReadOnlyList<BugRepairStage> Stages { get; init; }
+
+    [JsonPropertyName("classifications")]
+    public required IReadOnlyList<GapClassification> Classifications { get; init; }
+
+    [JsonPropertyName("stop_conditions")]
+    public required IReadOnlyList<string> StopConditions { get; init; }
+
+    [JsonPropertyName("invariants")]
+    public required IReadOnlyList<string> Invariants { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskCommand.cs
@@ -1,9 +1,10 @@
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// G335 / G336 / G337 / G338: dispatcher for the <c>guide workflow task</c>
-/// subcommand group. Peels the next token (the task name) and
-/// delegates to the per-task handler. Tasks today:
+/// G335 / G336 / G337 / G338 / G339: dispatcher for the
+/// <c>guide workflow task</c> subcommand group. Peels the next
+/// token (the task name) and delegates to the per-task handler.
+/// Tasks today:
 /// <list type="bullet">
 ///   <item><c>init-host</c> (G335) — host/child/review role
 ///         scaffold plan;</item>
@@ -18,7 +19,10 @@ namespace IntentSystem.Cli.Commands;
 ///         to <c>guide prompt-matrix --mode child-loop</c>);</item>
 ///   <item><c>review-next-slice-loop</c> (G338) — paste-ready host
 ///         review / next-slice-loop prompt from minimal inputs
-///         (forwards to <c>guide prompt-matrix --mode host-loop</c>).</item>
+///         (forwards to <c>guide prompt-matrix --mode host-loop</c>);</item>
+///   <item><c>bug-to-intent-repair</c> (G339) — guided bug-to-intent-repair
+///         workflow: report → triage → plan → intent-repair →
+///         implementation-repair, with five gap classifications.</item>
 /// </list>
 /// Future tasks (deploy-host, retire-host, migrate-host) can plug
 /// in without touching the router. Pure read-only — never mutates
@@ -40,7 +44,7 @@ internal static class GuideWorkflowTaskCommand
 
         if (args.Length == 0)
         {
-            writer.WriteLine("guide workflow task requires a task name. Supported: init-host, intent-interview, packet-draft, issue-publish, implementation-loop, review-next-slice-loop.");
+            writer.WriteLine("guide workflow task requires a task name. Supported: init-host, intent-interview, packet-draft, issue-publish, implementation-loop, review-next-slice-loop, bug-to-intent-repair.");
             WriteHelp(writer);
             return 1;
         }
@@ -68,13 +72,18 @@ internal static class GuideWorkflowTaskCommand
             // host review / next-slice-loop prompt from minimal
             // inputs; forwards to `guide prompt-matrix --mode host-loop`.
             "review-next-slice-loop" => GuideWorkflowTaskReviewNextSliceLoopCommand.Execute(context, args[1..], writer),
+            // G339: bug-to-intent-repair explains the report → triage
+            // → plan → intent-repair → implementation-repair chain
+            // and the five gap classifications so observed bugs feed
+            // back into intent repair packets, not ad-hoc comments.
+            "bug-to-intent-repair" => GuideWorkflowTaskBugToIntentRepairCommand.Execute(context, args[1..], writer),
             _ => UnknownTask(writer, task)
         };
     }
 
     private static int UnknownTask(TextWriter writer, string task)
     {
-        writer.WriteLine($"Unknown 'guide workflow task' name '{task}'. Supported: init-host, intent-interview, packet-draft, issue-publish, implementation-loop, review-next-slice-loop.");
+        writer.WriteLine($"Unknown 'guide workflow task' name '{task}'. Supported: init-host, intent-interview, packet-draft, issue-publish, implementation-loop, review-next-slice-loop, bug-to-intent-repair.");
         WriteHelp(writer);
         return 1;
     }
@@ -91,5 +100,6 @@ internal static class GuideWorkflowTaskCommand
         writer.WriteLine("- issue-publish — draft / create / publish-flow / automation issue-publish boundary. Names the four stages, the intent-target FINAL-boundary rule, and the stop conditions that surface missing contract sections before GitHub mutation (G337).");
         writer.WriteLine("- implementation-loop — paste-ready child implementation-loop prompt from minimal inputs (target-repo, agent, frequency, base-branch-policy). Forwards to `guide prompt-matrix --mode child-loop`; carries the current label/claim/complete rules so the operator does not need them from memory (G338).");
         writer.WriteLine("- review-next-slice-loop — paste-ready host review / next-slice-loop prompt from minimal inputs (domain, target-repo, agent, frequency). Forwards to `guide prompt-matrix --mode host-loop`; carries the host-sync preflight gate, automation summary call, and packet/issue lifecycle rules (G338).");
+        writer.WriteLine("- bug-to-intent-repair — guided bug-to-intent-repair workflow: report → triage → plan → intent-repair → implementation-repair. Classifies five gap types (implementation-mismatch, intent-gap, packet-gap, rule-gap, metadata-workflow-gap), recommends packet creation when the bug is in intent-cli rules/guidance rather than child code, and preserves original instruction / linked issue / PR refs across the chain (G339).");
     }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskBugToIntentRepairCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskBugToIntentRepairCommandTests.cs
@@ -88,11 +88,18 @@ public sealed class GuideWorkflowTaskBugToIntentRepairCommandTests
             Assert.Equal("intent-repair", match.GetProperty("repair_lane").GetString());
         }
 
-        // The intent-repair stage's command must scaffold via `packet draft`.
+        // The intent-repair stage must mention `packet draft` —
+        // either in the `command` line (when the stage's headline
+        // surface is `packet draft`) or in the `output` description
+        // (when the headline surface is the bug-lifecycle wrapper
+        // `bug intent-repair` and the packet scaffold is the
+        // follow-up step). Either form satisfies the acceptance
+        // criterion that the lane recommends packet creation.
         var intentRepair = document.RootElement.GetProperty("stages")
             .EnumerateArray()
             .First(s => string.Equals(s.GetProperty("stage").GetString(), "intent-repair", StringComparison.Ordinal));
-        Assert.Contains("packet draft", intentRepair.GetProperty("command").GetString(), StringComparison.Ordinal);
+        var combined = intentRepair.GetProperty("command").GetString() + " " + intentRepair.GetProperty("output").GetString();
+        Assert.Contains("packet draft", combined, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -231,6 +238,126 @@ public sealed class GuideWorkflowTaskBugToIntentRepairCommandTests
     }
 
     [Fact]
+    public void Execute_StageCommands_NameRealCliSurfaces()
+    {
+        // PR #782 review finding: the previous guide advertised
+        // `intent-cli guide automation report` (which does not
+        // accept `report`) and `intent-cli intent draft-issue`
+        // (which is not yet implemented). Regression: walk each
+        // stage's `command` string, peel the first
+        // `intent-cli <group> <subcommand>` pair, and assert the
+        // matching command source file exists. Mirrors the G338
+        // PR #780 "wrapper usage line" regression and the G336 /
+        // G337 flag-against-source pattern.
+        var repoRoot = FindRepoRoot();
+        var commandsDir = Path.Combine(repoRoot, "src/IntentSystem.Cli/Commands");
+
+        // Stable mapping from `intent-cli <group> <subcommand>` to
+        // the source file owning the dispatcher entry. Verified
+        // against `CommandRouter.CommandsByGroup` on PR #782 head.
+        var subcommandToSourceFile = new (string Prefix, string FileName)[]
+        {
+            ("bug report", "BugReportCommand.cs"),
+            ("bug triage", "BugTriageCommand.cs"),
+            // The dispatcher key is `bug plan`; the underlying
+            // class is BugExecutionCommand.cs (renamed dispatcher,
+            // kept class name).
+            ("bug plan", "BugExecutionCommand.cs"),
+            ("bug intent-repair", "BugIntentRepairCommand.cs"),
+            ("bug implementation-repair", "BugImplementationRepairCommand.cs"),
+            ("packet draft", "PacketDraftCommand.cs"),
+            ("issue draft", "IssueDraftCommand.cs"),
+            ("issue validate-body", "IssueValidateBodyCommand.cs"),
+            ("issue publish-flow", "IssuePublishFlowCommand.cs"),
+            ("automation issue-publish", "AutomationIssuePublishCommand.cs"),
+            ("automation doctor", "AutomationDoctorCommand.cs"),
+            ("intent next-slice", "IntentNextSliceCommand.cs"),
+            ("clarification next", "ClarificationCommand.cs"),
+            ("review closeout-plan", "ReviewCloseoutPlanCommand.cs"),
+            ("automation publish-recovery", "AutomationPublishRecoveryCommand.cs"),
+            ("automation reconcile", "AutomationReconcileCommand.cs"),
+            ("guide commands list", "GuideCommandsCommand.cs"),
+            ("automation summary", "AutomationSummaryCommand.cs")
+        };
+
+        // Match `intent-cli <token1> <token2>` inside backticks
+        // anywhere in the Command string.
+        var commandSnippet = new System.Text.RegularExpressions.Regex(
+            @"intent-cli\s+([a-z][a-z0-9-]*)\s+([a-z][a-z0-9-]*)",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        foreach (var stage in GuideWorkflowTaskBugToIntentRepairCommand.Stages)
+        {
+            var match = commandSnippet.Match(stage.Command);
+            Assert.True(
+                match.Success,
+                $"Stage `{stage.Stage}` command does not start with `intent-cli <group> <subcommand>`: `{stage.Command}`");
+
+            var prefix = $"{match.Groups[1].Value} {match.Groups[2].Value}";
+            var row = subcommandToSourceFile.FirstOrDefault(r => string.Equals(r.Prefix, prefix, StringComparison.Ordinal));
+            Assert.False(
+                row.Prefix is null,
+                $"Stage `{stage.Stage}` advertises `intent-cli {prefix}` but that prefix is not in the parity allow-list. Add a row (group/subcommand → source file) if the command is real, or change the stage to use an existing surface.");
+
+            var sourcePath = Path.Combine(commandsDir, row.FileName);
+            Assert.True(
+                File.Exists(sourcePath),
+                $"Stage `{stage.Stage}` advertises `intent-cli {prefix}` but the matching source file is missing: {sourcePath}");
+        }
+    }
+
+    [Fact]
+    public void StageCommands_AreReachableThroughCommandRouter()
+    {
+        // Defense-in-depth: even if the source file exists, the
+        // command must be wired into CommandRouter.CommandsByGroup
+        // for `intent-cli <group> <subcommand>` to actually
+        // dispatch. Walk every stage command and invoke it
+        // through CommandRouter.Execute with no args; the router
+        // must NOT reject with "Unknown 'group' subcommand" /
+        // "Command '... ...' is not yet implemented" / "Unknown
+        // command group".
+        var commandSnippet = new System.Text.RegularExpressions.Regex(
+            @"intent-cli\s+([a-z][a-z0-9-]*)\s+([a-z][a-z0-9-]*)",
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        foreach (var stage in GuideWorkflowTaskBugToIntentRepairCommand.Stages)
+        {
+            var match = commandSnippet.Match(stage.Command);
+            Assert.True(match.Success);
+            var group = match.Groups[1].Value;
+            var subcommand = match.Groups[2].Value;
+
+            using var writer = new StringWriter();
+            // Run with just the group/subcommand to confirm the
+            // dispatcher reaches the command's argument parser
+            // (which will reject with a command-specific usage
+            // message). The key signal we are guarding against is
+            // the router-level "Unknown 'group' subcommand" /
+            // "is not yet implemented" responses that mean a
+            // missing dispatcher entry.
+            CommandRouter.Execute(
+                new[] { group, subcommand },
+                CreateContext(),
+                writer);
+            var output = writer.ToString();
+
+            Assert.DoesNotContain(
+                $"Unknown '{group}' subcommand",
+                output,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                $"Command '{group} {subcommand}' is not yet implemented",
+                output,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "Unknown command group",
+                output,
+                StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
     public void Execute_UnknownArgument_ExitsOne()
     {
         using var writer = new StringWriter();
@@ -337,6 +464,17 @@ public sealed class GuideWorkflowTaskBugToIntentRepairCommandTests
         using var document = JsonDocument.Parse(writer.ToString());
         Assert.Equal(5, document.RootElement.GetProperty("stages").GetArrayLength());
         Assert.Equal(5, document.RootElement.GetProperty("classifications").GetArrayLength());
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null && !Directory.Exists(Path.Combine(dir, "src")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        Assert.NotNull(dir);
+        return dir!;
     }
 
     private static CliContext CreateContext()

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskBugToIntentRepairCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskBugToIntentRepairCommandTests.cs
@@ -1,0 +1,358 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G339: tests for <c>intent-cli guide workflow task bug-to-intent-repair</c>.
+/// The surface explains the report → triage → plan → intent-repair →
+/// implementation-repair chain, classifies five gap types, recommends
+/// packet creation when the bug is in intent-cli rules/guidance, and
+/// preserves the original instruction / linked issue / PR refs across
+/// the chain.
+/// </summary>
+public sealed class GuideWorkflowTaskBugToIntentRepairCommandTests
+{
+    [Fact]
+    public void Execute_ListsFiveStagesInOrder_ExitZero()
+    {
+        // Acceptance criterion: "guide workflow task bug-to-intent-repair
+        // explains report, triage, plan, intent-repair, and
+        // implementation-repair paths."
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskBugToIntentRepairCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        var stages = new[] { "report", "triage", "plan", "intent-repair", "implementation-repair" };
+        var lastIndex = -1;
+        foreach (var stage in stages)
+        {
+            var idx = output.IndexOf($"### {stage}", StringComparison.Ordinal);
+            Assert.True(idx > lastIndex, $"Stage `{stage}` did not appear in expected order in the output.");
+            lastIndex = idx;
+        }
+    }
+
+    [Fact]
+    public void Execute_ClassifiesFiveGapTypes()
+    {
+        // Acceptance criterion: "The guide classifies implementation
+        // mismatch, intent gap, packet gap, rule gap, and
+        // metadata/workflow gap."
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskBugToIntentRepairCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("`implementation-mismatch`", output, StringComparison.Ordinal);
+        Assert.Contains("`intent-gap`", output, StringComparison.Ordinal);
+        Assert.Contains("`packet-gap`", output, StringComparison.Ordinal);
+        Assert.Contains("`rule-gap`", output, StringComparison.Ordinal);
+        Assert.Contains("`metadata-workflow-gap`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RecommendsPacketCreationForRuleAndIntentGaps()
+    {
+        // Acceptance criterion: "It can recommend packet creation
+        // when the bug is in intent-cli rules/guidance rather than
+        // child implementation." The intent-gap / packet-gap /
+        // rule-gap classifications must route to the intent-repair
+        // lane (which scaffolds a packet via `packet draft`), and
+        // the intent-repair stage must mention `packet draft`.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskBugToIntentRepairCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var classifications = document.RootElement.GetProperty("classifications").EnumerateArray().ToList();
+
+        foreach (var name in new[] { "intent-gap", "packet-gap", "rule-gap" })
+        {
+            var match = classifications.First(c => string.Equals(c.GetProperty("id").GetString(), name, StringComparison.Ordinal));
+            Assert.Equal("intent-repair", match.GetProperty("repair_lane").GetString());
+        }
+
+        // The intent-repair stage's command must scaffold via `packet draft`.
+        var intentRepair = document.RootElement.GetProperty("stages")
+            .EnumerateArray()
+            .First(s => string.Equals(s.GetProperty("stage").GetString(), "intent-repair", StringComparison.Ordinal));
+        Assert.Contains("packet draft", intentRepair.GetProperty("command").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_PreservesOriginalAndLinkedRefsAcrossTheChain()
+    {
+        // Acceptance criterion: "It preserves original instruction
+        // refs and linked issue/PR refs." The invariants list must
+        // explicitly require chain preservation, and the
+        // intent-repair stage must require G311 closing reference
+        // to the bug report on the repair PR.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskBugToIntentRepairCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+
+        var invariants = document.RootElement.GetProperty("invariants")
+            .EnumerateArray()
+            .Select(e => e.GetString() ?? string.Empty)
+            .ToArray();
+        var chainInvariant = invariants.First(line => line.Contains("Original refs", StringComparison.Ordinal));
+        Assert.Contains("bug report", chainInvariant, StringComparison.Ordinal);
+        Assert.Contains("triage", chainInvariant, StringComparison.Ordinal);
+        Assert.Contains("plan", chainInvariant, StringComparison.Ordinal);
+        Assert.Contains("repair packet", chainInvariant, StringComparison.Ordinal);
+        Assert.Contains("Closes #", chainInvariant, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_StopConditionsSurfaceBeforeGitHubMutation()
+    {
+        // Mirrors the G337 acceptance pattern: stop conditions must
+        // catch missing artifacts BEFORE GitHub mutation.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskBugToIntentRepairCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var stops = document.RootElement.GetProperty("stop_conditions")
+            .EnumerateArray()
+            .Select(e => e.GetString() ?? string.Empty)
+            .ToArray();
+        Assert.NotEmpty(stops);
+        // Missing original instruction reference must be caught.
+        Assert.Contains(stops, s => s.Contains("original instruction reference", StringComparison.Ordinal));
+        // `issue validate-body` must gate publishing.
+        Assert.Contains(stops, s => s.Contains("issue validate-body", StringComparison.Ordinal));
+        // Child cwd / metadata-workflow-gap stop must be present.
+        Assert.Contains(stops, s => s.Contains("metadata-workflow-gap", StringComparison.Ordinal)
+            && s.Contains("child cwd", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_AdvertisesChildIsolationAndIntentTargetFinalBoundary()
+    {
+        // The G300/G330/G333 child isolation rule and the G337
+        // intent-target FINAL-boundary rule must carry through the
+        // bug-to-intent-repair surface.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskBugToIntentRepairCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Child implementation isolation", output, StringComparison.Ordinal);
+        Assert.Contains("intent-target", output, StringComparison.Ordinal);
+        Assert.Contains("FORBIDDEN", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_PrefersIntentCliBackedMutationOverHandEditing()
+    {
+        // The G338 / G339 baseline: the guide must tell agents to
+        // ask intent-cli which command performs a metadata
+        // transition, run that command, and validate the result.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskBugToIntentRepairCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("intent-cli-backed metadata mutation", output, StringComparison.Ordinal);
+        Assert.Contains("guide commands list", output, StringComparison.Ordinal);
+        Assert.Contains("automation summary", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_HasStableShape()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskBugToIntentRepairCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.TryGetProperty("usage", out _));
+        Assert.True(root.TryGetProperty("stages", out _));
+        Assert.True(root.TryGetProperty("classifications", out _));
+        Assert.True(root.TryGetProperty("stop_conditions", out _));
+        Assert.True(root.TryGetProperty("invariants", out _));
+
+        foreach (var stage in root.GetProperty("stages").EnumerateArray())
+        {
+            Assert.True(stage.TryGetProperty("stage", out _));
+            Assert.True(stage.TryGetProperty("purpose", out _));
+            Assert.True(stage.TryGetProperty("command", out _));
+            Assert.True(stage.TryGetProperty("output", out _));
+            Assert.True(stage.TryGetProperty("boundary", out _));
+            Assert.True(stage.TryGetProperty("fails_open", out _));
+        }
+        foreach (var classification in root.GetProperty("classifications").EnumerateArray())
+        {
+            Assert.True(classification.TryGetProperty("id", out _));
+            Assert.True(classification.TryGetProperty("description", out _));
+            Assert.True(classification.TryGetProperty("repair_lane", out _));
+            Assert.True(classification.TryGetProperty("example_signal", out _));
+        }
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ExitsOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskBugToIntentRepairCommand.Execute(
+            CreateContext(),
+            new[] { "--bogus" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_InvalidFormat_ExitsOne()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskBugToIntentRepairCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "yaml" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowTaskCommand_DispatchesBugToIntentRepair()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(),
+            new[] { "bug-to-intent-repair", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Contains("bug-to-intent-repair", document.RootElement.GetProperty("usage").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideWorkflowTaskCommand_UnknownTask_NamesG339Task()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(),
+            new[] { "bogus-task" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("bug-to-intent-repair", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideHelpCommand_BugToIntentRepairPhase_PointsToTaskBugToIntentRepair()
+    {
+        var pointer = GuideHelpCommand.WorkflowGuides
+            .First(p => string.Equals(p.Phase, "bug-to-intent-repair", StringComparison.Ordinal));
+        Assert.Contains("guide workflow task bug-to-intent-repair", pointer.Command, StringComparison.Ordinal);
+        var seeAlso = string.Join(" ", pointer.SeeAlso ?? Array.Empty<string>());
+        Assert.Contains("packet draft", seeAlso, StringComparison.Ordinal);
+        Assert.Contains("issue-publish", seeAlso, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommandRouter_TopLevelHelp_NamesBugToIntentRepairPhase()
+    {
+        var bugRepairLines = CommandRouter.WorkflowGuidePointersHelp
+            .Where(line => line.StartsWith("bug-to-intent-repair —", StringComparison.Ordinal))
+            .ToArray();
+        Assert.Single(bugRepairLines);
+        Assert.Contains("guide workflow task bug-to-intent-repair", bugRepairLines[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_DoesNotRequireParentHostRoot()
+    {
+        // Pure read-only surface: must produce the guidance from a
+        // fresh tmp cwd (no parent host root, no .intent-cli/).
+        using var writer = new StringWriter();
+        var context = new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "bootstrap",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+
+        var exitCode = GuideWorkflowTaskBugToIntentRepairCommand.Execute(
+            context,
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(5, document.RootElement.GetProperty("stages").GetArrayLength());
+        Assert.Equal(5, document.RootElement.GetProperty("classifications").GetArrayLength());
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Adds \`intent-cli guide workflow task bug-to-intent-repair [--format markdown|json]\` — surfaces the guided bug-to-intent-repair chain so observed automation failures and product bugs feed back into intent repair packets, not ad-hoc PR comments.
- Five stages with stable IDs (report → triage → plan → intent-repair → implementation-repair); each carries purpose, command, output, boundary, and fails-open behavior.
- Five gap classifications (implementation-mismatch, intent-gap, packet-gap, rule-gap, metadata-workflow-gap), each with stable ID, description, repair lane, and example signal. Triage MUST pick exactly one; ambiguous cases prefer intent-gap / rule-gap over implementation-mismatch so bad upstream guidance is repaired, not worked around in child code.
- Six stop conditions catch missing artifacts BEFORE GitHub mutation; six invariants pin the chain-preservation rule (original-instruction → bug-report → triage → plan → repair-packet → \`Closes #<bug-report-issue>\`), the intent-cli-backed-mutation preference, the G300/G330/G333 child isolation rule, the rule-gap regression-test pattern (mirrors G336/G337/G338 fix history), the G337 \`intent-target\` FINAL-boundary rule, and no AI-provider launch.
- Self-discovery wiring: new \`WorkflowGuidePointer\` row in \`GuideHelpCommand.WorkflowGuides\` for phase \`bug-to-intent-repair\`, new entry in \`CommandRouter.WorkflowGuidePointersHelp\`, \`GuideWorkflowCommand\` / \`GuideWorkflowTaskCommand\` help text and unknown-task error message updated.

## Test plan

- [x] 15 new tests in \`GuideWorkflowTaskBugToIntentRepairCommandTests\` pass.
- [x] \`Execute_RecommendsPacketCreationForRuleAndIntentGaps\` verifies the intent-gap / packet-gap / rule-gap classifications route to the \`intent-repair\` lane (per acceptance criterion: "recommends packet creation when the bug is in intent-cli rules/guidance rather than child implementation").
- [x] \`Execute_PreservesOriginalAndLinkedRefsAcrossTheChain\` verifies the chain-preservation invariant names the bug-report, triage, plan, repair-packet links and the G311 \`Closes #\` requirement.
- [x] \`Execute_StopConditionsSurfaceBeforeGitHubMutation\` catches missing original instruction refs, \`issue validate-body\` errors, and metadata-workflow-gap from a child cwd.
- [x] \`Execute_DoesNotRequireParentHostRoot\` runs the task from a fresh tmp cwd (G334 bootstrap-friendly).
- [x] Full filter \`GuideWorkflow|CommandRouterTests|GuideHelp\`: 237/237 pass.
- [x] Smoke-tested markdown + JSON output, the unknown-arg / invalid-format error paths, and the dispatcher entry.

Closes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)