### PR TITLE
G341: host-loop-next-action + diagnostics publish issue-cut-ready instead of true-idle

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -57,6 +57,22 @@ internal static class AutomationHostLoopNextActionCommand
             return 1;
         }
 
+        // G341: when the operator omits `--domain`, fall back to the
+        // host's configured domain (`context.Config.Project.Domain`).
+        // Without this fallback, the next-slice probe at line ~98 is
+        // skipped and a real `issue-cut-ready` candidate falls through
+        // to `true-idle`, contradicting G318's "host loop must never
+        // report true-idle when a candidate is ready to publish"
+        // contract.
+        if (string.IsNullOrWhiteSpace(parsed.Domain))
+        {
+            var configuredDomain = context.Config?.Project?.Domain;
+            if (!string.IsNullOrWhiteSpace(configuredDomain))
+            {
+                parsed = parsed with { Domain = configuredDomain.Trim() };
+            }
+        }
+
         IReadOnlyList<GitHubAutomationPrCandidate> openPrs;
         IReadOnlyList<GitHubAutomationIssueCandidate> openIssues;
         try

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
@@ -46,6 +46,7 @@ internal static class AutomationHostReviewDiagnosticsCommand
                 out var repo,
                 out var workdir,
                 out var candidate,
+                out var domain,
                 out var clarificationRequired,
                 out var staleClarificationMetadata,
                 out var reconcileUnsafeStopKinds,
@@ -58,6 +59,19 @@ internal static class AutomationHostReviewDiagnosticsCommand
         {
             writer.WriteLine(error);
             return 1;
+        }
+
+        // G341: when the operator omits `--domain`, fall back to the
+        // host's configured domain. Needed so the next-slice probe
+        // below can run without requiring the operator to type the
+        // domain every time.
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            var configuredDomain = context.Config?.Project?.Domain;
+            if (!string.IsNullOrWhiteSpace(configuredDomain))
+            {
+                domain = configuredDomain.Trim();
+            }
         }
 
         var resolvedWorkdir = ResolveWorkdir(context, workdir);
@@ -135,6 +149,28 @@ internal static class AutomationHostReviewDiagnosticsCommand
             return 1;
         }
 
+        // G341: when the operator did not pre-supply `--candidate`,
+        // auto-probe `intent next-slice --dry-run` so a real
+        // `issue-cut-ready` candidate is classified as
+        // `issue-publish-ready` rather than `true-idle`. Mirrors the
+        // G318 auto-probe in `automation host-loop-next-action` so
+        // both surfaces agree on the same next-slice signal.
+        // Fail-soft: a probe error (queue-state missing, packet root
+        // unreadable) falls through to the existing
+        // candidate-not-supplied path so the host loop never crashes.
+        if (string.IsNullOrWhiteSpace(candidate) && !string.IsNullOrWhiteSpace(domain))
+        {
+            var probe = NextSliceDryRunProbeFactory?.Invoke(context)
+                ?? new IntentCliNextSliceDryRunProbe(context);
+            var probed = probe.Probe(repo!, domain!);
+            if (probed != null
+                && string.Equals(probed.RecommendedOutcome, "issue-cut-ready", StringComparison.Ordinal)
+                && !string.IsNullOrWhiteSpace(probed.ExecutionUnit))
+            {
+                candidate = probed.ExecutionUnit;
+            }
+        }
+
         var result = AutomationHostReviewDiagnosticsAnalyzer.Analyze(
             repo!,
             openPrs,
@@ -152,11 +188,21 @@ internal static class AutomationHostReviewDiagnosticsCommand
         return 0;
     }
 
+    /// <summary>
+    /// G341: testability seam for the auto-probe of
+    /// <c>intent next-slice --dry-run</c>. Production uses
+    /// <see cref="IntentCliNextSliceDryRunProbe"/>; tests inject a
+    /// fake to model `issue-cut-ready` / `no-actionable-item`
+    /// outcomes without touching live queue-state.
+    /// </summary>
+    public static Func<CliContext, INextSliceDryRunProbe>? NextSliceDryRunProbeFactory { get; set; }
+
     private static bool TryParseArguments(
         string[] args,
         out string? repo,
         out string? workdir,
         out string? candidate,
+        out string? domain,
         out bool clarificationRequired,
         out bool staleClarificationMetadata,
         out IReadOnlyList<string> reconcileUnsafeStopKinds,
@@ -170,6 +216,7 @@ internal static class AutomationHostReviewDiagnosticsCommand
         repo = null;
         workdir = null;
         candidate = null;
+        domain = null;
         clarificationRequired = false;
         staleClarificationMetadata = false;
         var unsafeStops = new List<string>();
@@ -211,6 +258,15 @@ internal static class AutomationHostReviewDiagnosticsCommand
                         return false;
                     }
                     candidate = args[index + 1].Trim();
+                    index++;
+                    break;
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+                    domain = args[index + 1].Trim();
                     index++;
                     break;
                 case "--clarification-required":
@@ -361,7 +417,7 @@ internal static class AutomationHostReviewDiagnosticsCommand
     private static void WriteHelp(TextWriter writer)
     {
         writer.WriteLine("automation host-review-diagnostics");
-        writer.WriteLine("Usage: intent-cli automation host-review-diagnostics [--repo <owner/repo>] [--workdir <path>] [--candidate <execution-unit>] [--clarification-required] [--stale-clarification-metadata] [--reconcile-unsafe-stop <kind> ...] [--reconcile-repairs-available <N>] [--allow-wip-cap-override] [--pr-draft true|false] [--format text|json]");
+        writer.WriteLine("Usage: intent-cli automation host-review-diagnostics [--repo <owner/repo>] [--workdir <path>] [--candidate <execution-unit>] [--domain <name>] [--clarification-required] [--stale-clarification-metadata] [--reconcile-unsafe-stop <kind> ...] [--reconcile-repairs-available <N>] [--allow-wip-cap-override] [--pr-draft true|false] [--format text|json]");
         writer.WriteLine("Read-only host-loop convergence diagnostic. Classifies stuck-reviewing, missing-target-on-pr, request-update-rereview-conflict, wip-cap-blocked, clarification-required, stale-host-cli, review-pr-actionable, issue-publish-ready, unsafe-metadata, repaired-and-retry, draft-merge-blocked (G297), and true-idle (G286). Stale clarification metadata surfaces in `warnings` without flipping the terminal class. With `--allow-wip-cap-override` (G288) and a complete candidate, an in-flight intent-target item is bypassed for one publish; the override surfaces as `wip-cap-overridden` in `warnings`. With `--pr-draft true` and a selected review PR (G297), the diagnostic returns `draft-merge-blocked` so the host loop can release the review lease and surface the gap. Never mutates GitHub or local state.");
     }
 }

--- a/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
@@ -387,12 +387,14 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_NextSliceProbe_IsNotInvoked_WhenDomainMissing()
+    public void Execute_NextSliceProbe_IsNotInvoked_WhenDomainMissingAndConfigEmpty()
     {
-        // G318 safety rail: `intent next-slice --dry-run` requires a
-        // domain. Without `--domain` the probe is skipped to avoid an
-        // unconditional in-process invocation that the analyzer cannot
-        // use anyway.
+        // G318 safety rail + G341 update: `intent next-slice --dry-run`
+        // requires a domain. The probe is skipped only when neither
+        // `--domain` is supplied nor the CliContext config carries a
+        // configured domain. G341 added the config-domain fallback so
+        // operators can run `automation host-loop-next-action --repo X`
+        // without re-typing the domain every time.
         AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
             prs: Array.Empty<GitHubAutomationPrCandidate>(),
             issues: Array.Empty<GitHubAutomationIssueCandidate>());
@@ -403,15 +405,63 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
 
         using var writer = new StringWriter();
         var exit = AutomationHostLoopNextActionCommand.Execute(
-            CreateContext(),
+            CreateContextWithoutDomain(),
             ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
             writer);
 
         Assert.Equal(0, exit);
-        Assert.False(probeWasInvoked, "probe must not run without --domain");
+        Assert.False(probeWasInvoked, "probe must not run when neither --domain nor config domain is available");
         Assert.Equal("true-idle",
             JsonDocument.Parse(writer.ToString()).RootElement.GetProperty("classification").GetString());
     }
+
+    [Fact]
+    public void Execute_NextSliceProbe_FallsBackToConfiguredDomain_WhenDomainFlagMissing()
+    {
+        // G341: when the operator omits `--domain`, the command falls
+        // back to `context.Config.Project.Domain` so a real
+        // `issue-cut-ready` next-slice candidate is surfaced as
+        // `publish-next-issue` instead of `true-idle`. Mirrors the
+        // SekibanAsAService SKS-G239 case in the G341 packet.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        var probeWasInvoked = false;
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "SKS-G239" },
+            onProbe: () => probeWasInvoked = true);
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(), // configured domain = "intent-cli"
+            ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        Assert.True(probeWasInvoked, "probe must run when --domain is omitted but config carries a domain");
+        var root = JsonDocument.Parse(writer.ToString()).RootElement;
+        Assert.Equal("publish-next-issue", root.GetProperty("classification").GetString());
+        Assert.Contains("SKS-G239", root.GetProperty("recommended_command").GetString(), StringComparison.Ordinal);
+        Assert.True(root.GetProperty("mutation_allowed").GetBoolean());
+        // The emitted domain field should carry the fallback so the
+        // operator can see which domain drove the classification.
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+    }
+
+    private static CliContext CreateContextWithoutDomain() =>
+        new()
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = string.Empty,
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
 
     private sealed class FakeNextSliceProbe : INextSliceDryRunProbe
     {

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
@@ -736,6 +736,168 @@ public sealed class AutomationHostReviewDiagnosticsCommandTests : IDisposable
         Assert.Contains("--pr-draft must be 'true' or 'false'", writer.ToString(), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Execute_NextSliceProbe_AutoPopulatesCandidate_WhenDomainFlagOrConfigPresent()
+    {
+        // G341: when no `--candidate` is supplied, the command must
+        // auto-probe `intent next-slice --dry-run`. A returned
+        // `issue-cut-ready` outcome flips the classification from
+        // `true-idle` to `issue-publish-ready`, mirroring the
+        // SekibanAsAService SKS-G239 case in the G341 packet.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+        var probeWasInvoked = false;
+        AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "SKS-G239" },
+            onProbe: () => probeWasInvoked = true);
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context, // configured domain = "intent-cli"
+                ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.True(probeWasInvoked, "probe must run when --candidate omitted and config carries a domain");
+            var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+            Assert.Equal("issue-publish-ready", result.Classification);
+            Assert.NotNull(result.RecommendedNextCommand);
+            Assert.Contains("SKS-G239", result.RecommendedNextCommand!, StringComparison.Ordinal);
+            Assert.Contains("packet draft", result.RecommendedNextCommand!, StringComparison.Ordinal);
+            Assert.Contains("issue publish-flow", result.RecommendedNextCommand!, StringComparison.Ordinal);
+            Assert.Contains("automation issue-publish", result.RecommendedNextCommand!, StringComparison.Ordinal);
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_NextSliceProbe_DomainFlag_OverridesConfiguredDomain()
+    {
+        // G341: `--domain` wins over the configured domain so an
+        // operator can probe a different domain on the same host.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+        string? probedDomain = null;
+        AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null },
+            onProbeArgs: (_, d) => probedDomain = d);
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context, // configured domain = "intent-cli"
+                ["--repo", "owner/repo", "--domain", "sekiban-as-a-service", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal("sekiban-as-a-service", probedDomain);
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_NextSliceProbe_OperatorCandidateOverridesProbeResult()
+    {
+        // G341: when the operator pre-supplies `--candidate`, the
+        // probe is skipped — the operator-supplied value wins so
+        // upstream tooling that already computed the candidate can
+        // route through `--candidate` and bypass the probe.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+        var probeWasInvoked = false;
+        AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "OTHER" },
+            onProbe: () => probeWasInvoked = true);
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context,
+                ["--repo", "owner/repo", "--candidate", "OPERATOR-G123", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.False(probeWasInvoked, "probe must not run when --candidate is operator-supplied");
+            var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+            Assert.Equal("issue-publish-ready", result.Classification);
+            Assert.Contains("OPERATOR-G123", result.RecommendedNextCommand!, StringComparison.Ordinal);
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_TrueIdle_RemainsPossible_WhenNextSliceAlsoIdle()
+    {
+        // G341 acceptance: `true-idle` is still emitted when no
+        // review PR, no WIP, no clarification, AND next-slice probe
+        // reports `no-actionable-item`. Guards against an over-
+        // aggressive fallback that would never report true idle.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+        AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context,
+                ["--repo", "owner/repo", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+            Assert.Equal("true-idle", result.Classification);
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    /// <summary>
+    /// G341: deterministic stand-in for <see cref="INextSliceDryRunProbe"/>
+    /// used by the host-review-diagnostics tests. Returns a canned
+    /// <see cref="NextSliceProbeResult"/> and records the (repo, domain)
+    /// pair the command passed in.
+    /// </summary>
+    private sealed class FakeNextSliceProbe : INextSliceDryRunProbe
+    {
+        private readonly NextSliceProbeResult? _canned;
+        private readonly Action? _onProbe;
+        private readonly Action<string, string>? _onProbeArgs;
+
+        public FakeNextSliceProbe(
+            NextSliceProbeResult? canned,
+            Action? onProbe = null,
+            Action<string, string>? onProbeArgs = null)
+        {
+            _canned = canned;
+            _onProbe = onProbe;
+            _onProbeArgs = onProbeArgs;
+        }
+
+        public NextSliceProbeResult? Probe(string repo, string domain)
+        {
+            _onProbe?.Invoke();
+            _onProbeArgs?.Invoke(repo, domain);
+            return _canned;
+        }
+    }
+
     private static GitHubAutomationPrCandidate BuildPr(
         int number,
         string title,


### PR DESCRIPTION
## Summary

- The SekibanAsAService review/next-slice automation stopped with \`true-idle\` even though \`intent next-slice --dry-run\` reported a valid \`issue-cut-ready\` candidate (SKS-G239) with no review PR / no WIP / no clarification. Root cause: \`host-loop-next-action\` only ran the G318 next-slice probe when \`--domain\` was explicitly supplied, and \`host-review-diagnostics\` had no next-slice probe at all — both surfaces fell silently to \`true-idle\` when invoked with just \`--repo\`.
- \`AutomationHostLoopNextActionCommand\`: falls back to \`context.Config.Project.Domain\` when \`--domain\` is omitted, so the G318 auto-probe runs for the configured host domain and surfaces \`publish-next-issue\`.
- \`AutomationHostReviewDiagnosticsCommand\`: now accepts \`--domain <name>\` (with the same config-domain fallback) and auto-probes \`intent next-slice --dry-run\` when \`--candidate\` is not supplied. An \`issue-cut-ready\` probe populates \`candidate\` so the analyzer reaches the existing \`issue-publish-ready\` branch and emits the \`packet draft → issue publish-flow → automation issue-publish\` chain command. A \`NextSliceDryRunProbeFactory\` testability seam mirrors the pattern in \`host-loop-next-action\`.

## Test plan (matches issue acceptance criteria)

- [x] \`host-loop-next-action\` returns \`publish-next-issue\` (not \`true-idle\`) for the SKS-G239-shaped state — \`Execute_NextSliceProbe_FallsBackToConfiguredDomain_WhenDomainFlagMissing\`.
- [x] \`host-review-diagnostics\` returns \`issue-publish-ready\` for the same state — \`Execute_NextSliceProbe_AutoPopulatesCandidate_WhenDomainFlagOrConfigPresent\`. Recommended next command names the candidate execution unit and target repo.
- [x] Returned action identifies the candidate execution unit (\`SKS-G239\`) and target repo in both surfaces.
- [x] \`true-idle\` remains possible when next-slice probe also returns \`no-actionable-item\` — \`Execute_TrueIdle_RemainsPossible_WhenNextSliceAlsoIdle\`.
- [x] WIP cap, Hard Clarification, and PR review/merge semantics unchanged — all 397 existing tests under \`Automation|HostLoop\` pass.
- [x] Updated existing \`Execute_NextSliceProbe_IsNotInvoked_WhenDomainMissing\` → \`_WhenDomainMissingAndConfigEmpty\` to reflect the G341 fallback behaviour.
- [x] Added regression for \`--domain\` flag override and operator-supplied \`--candidate\` short-circuit.

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)