### PR TITLE
G342: safe-repair lane auto-probes for host-loop + diagnostics

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -38,6 +38,22 @@ internal static class AutomationHostLoopNextActionCommand
     /// </summary>
     public static Func<CliContext, INextSliceDryRunProbe>? NextSliceDryRunProbeFactory { get; set; }
 
+    /// <summary>
+    /// G342: testability seam for the publish-recovery auto-probe.
+    /// Production uses <see cref="IntentCliPublishRecoveryProbe"/>;
+    /// tests inject a fake to model recoverable / unsafe-stop /
+    /// no-repairs outcomes without touching live queue-state.
+    /// </summary>
+    public static Func<CliContext, IPublishRecoveryProbe>? PublishRecoveryProbeFactory { get; set; }
+
+    /// <summary>
+    /// G342: testability seam for the host-sync-preflight auto-probe.
+    /// Production uses <see cref="IntentCliHostSyncPreflightProbe"/>;
+    /// tests inject a fake to model clean / behind / dirty-*
+    /// classifications without touching the local git working tree.
+    /// </summary>
+    public static Func<CliContext, IHostSyncPreflightProbe>? HostSyncPreflightProbeFactory { get; set; }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
@@ -170,16 +186,62 @@ internal static class AutomationHostLoopNextActionCommand
             }
         }
 
+        // G342: auto-probe `automation publish-recovery --dry-run` when
+        // the operator did not pre-supply `--publish-recovery-repairs`.
+        // An `safe_repairs.Count > 0` outcome surfaces the existing
+        // `repair-host-metadata` analyzer lane (mutationAllowed: true,
+        // recommends `automation publish-recovery --write`); without
+        // this probe the lane would only fire when the operator typed
+        // the count, and recoverable `linked_pr` blockers would fall
+        // through to true-idle.
+        var publishRecoveryRepairsAvailable = parsed.PublishRecoveryRepairsAvailable;
+        if (publishRecoveryRepairsAvailable == 0)
+        {
+            var recoveryProbe = PublishRecoveryProbeFactory?.Invoke(context)
+                ?? new IntentCliPublishRecoveryProbe(context);
+            var recoveryProbed = recoveryProbe.Probe(parsed.Repo);
+            if (recoveryProbed != null && recoveryProbed.SafeRepairCount > 0)
+            {
+                publishRecoveryRepairsAvailable = recoveryProbed.SafeRepairCount;
+            }
+        }
+
+        // G342: auto-probe `automation host-sync-preflight` when the
+        // operator did not pre-supply `--sync-classification` /
+        // `--safe-stash-required`. `dirty-unrelated-submodule` flips
+        // to the `safe-stash` analyzer lane (recommends
+        // `workspace-guard --mode begin --write`);
+        // `dirty-host-durable-state` and `dirty-mixed` flip to the
+        // `dirty-host-state` block-and-surface lane so the host loop
+        // never silently publishes on top of dirty durable state.
+        var syncClassification = parsed.SyncClassification;
+        var safeStashRequired = parsed.SafeStashRequired;
+        if (string.IsNullOrWhiteSpace(syncClassification) && !safeStashRequired)
+        {
+            var syncProbe = HostSyncPreflightProbeFactory?.Invoke(context)
+                ?? new IntentCliHostSyncPreflightProbe(context);
+            var syncProbed = syncProbe.Probe();
+            if (syncProbed != null
+                && !string.Equals(syncProbed.Classification, HostSyncPreflightAnalyzer.ClassificationClean, StringComparison.Ordinal))
+            {
+                syncClassification = syncProbed.Classification;
+                if (string.Equals(syncProbed.Classification, HostSyncPreflightAnalyzer.ClassificationDirtyUnrelatedSubmodule, StringComparison.Ordinal))
+                {
+                    safeStashRequired = true;
+                }
+            }
+        }
+
         var input = new HostLoopNextActionInput
         {
             Repo = parsed.Repo,
             Domain = parsed.Domain,
             StaleCli = parsed.StaleCli,
-            SyncClassification = parsed.SyncClassification,
-            SafeStashRequired = parsed.SafeStashRequired,
+            SyncClassification = syncClassification,
+            SafeStashRequired = safeStashRequired,
             ActionableReviewPr = actionableReviewPr,
             ApprovedPrPendingMergeCloseout = approvedPr,
-            PublishRecoveryRepairsAvailable = parsed.PublishRecoveryRepairsAvailable,
+            PublishRecoveryRepairsAvailable = publishRecoveryRepairsAvailable,
             PublishLifecycleDriftCount = parsed.PublishLifecycleDriftCount,
             NextSliceIssueCutReady = nextSliceIssueCutReady,
             PublishNextSliceExecutionUnit = publishNextSliceExecutionUnit,

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
@@ -171,6 +171,23 @@ internal static class AutomationHostReviewDiagnosticsCommand
             }
         }
 
+        // G342: auto-probe `automation publish-recovery --dry-run`
+        // when the operator did not pre-supply
+        // `--publish-recovery-repairs-available`. A `safe_repairs > 0`
+        // outcome surfaces the existing `publish-recovery-ready`
+        // diagnostics lane (the deterministic `linked_pr` recovery
+        // path) instead of falling through to `true-idle`.
+        if (publishRecoveryRepairsAvailable == 0)
+        {
+            var recoveryProbe = PublishRecoveryProbeFactory?.Invoke(context)
+                ?? new IntentCliPublishRecoveryProbe(context);
+            var recoveryProbed = recoveryProbe.Probe(repo!);
+            if (recoveryProbed != null && recoveryProbed.SafeRepairCount > 0)
+            {
+                publishRecoveryRepairsAvailable = recoveryProbed.SafeRepairCount;
+            }
+        }
+
         var result = AutomationHostReviewDiagnosticsAnalyzer.Analyze(
             repo!,
             openPrs,
@@ -196,6 +213,14 @@ internal static class AutomationHostReviewDiagnosticsCommand
     /// outcomes without touching live queue-state.
     /// </summary>
     public static Func<CliContext, INextSliceDryRunProbe>? NextSliceDryRunProbeFactory { get; set; }
+
+    /// <summary>
+    /// G342: testability seam for the publish-recovery auto-probe.
+    /// Mirrors the seam in <see cref="AutomationHostLoopNextActionCommand"/>
+    /// so both surfaces agree on the same `linked_pr` recoverable
+    /// signal.
+    /// </summary>
+    public static Func<CliContext, IPublishRecoveryProbe>? PublishRecoveryProbeFactory { get; set; }
 
     private static bool TryParseArguments(
         string[] args,

--- a/src/IntentSystem.Cli/Commands/ISafeRepairProbes.cs
+++ b/src/IntentSystem.Cli/Commands/ISafeRepairProbes.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G342: testability seam for the auto-probe of
+/// <c>intent-cli automation publish-recovery --format json</c>.
+/// Production uses <see cref="IntentCliPublishRecoveryProbe"/>; tests
+/// inject a fake to model recoverable / unsafe-stop / no-repairs
+/// outcomes without touching live queue-state.
+/// </summary>
+internal interface IPublishRecoveryProbe
+{
+    PublishRecoveryProbeResult? Probe(string repo);
+}
+
+/// <summary>
+/// G342: minimal projection of the publish-recovery dry-run output.
+/// Only the counts the host-loop analyzer needs surface here; richer
+/// per-repair detail stays in the full command output for operators
+/// who run it directly.
+/// </summary>
+internal sealed record PublishRecoveryProbeResult
+{
+    public required int SafeRepairCount { get; init; }
+    public required int UnsafeStopCount { get; init; }
+}
+
+/// <summary>
+/// G342: in-process invoker of <see cref="AutomationPublishRecoveryCommand"/>.
+/// Reuses the host's existing <see cref="CliContext"/> so queue-state
+/// resolves from the parent host root, not a child worktree. Fail-soft:
+/// returns <see langword="null"/> on any error so the host loop never
+/// crashes when publish-recovery itself is unhealthy.
+/// </summary>
+internal sealed class IntentCliPublishRecoveryProbe : IPublishRecoveryProbe
+{
+    private readonly CliContext _context;
+
+    public IntentCliPublishRecoveryProbe(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    public PublishRecoveryProbeResult? Probe(string repo)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var args = new[]
+        {
+            "--repo", repo,
+            "--dry-run",
+            "--format", "json"
+        };
+
+        using var buffer = new StringWriter();
+        int exitCode;
+        try
+        {
+            exitCode = AutomationPublishRecoveryCommand.Execute(_context, args, buffer);
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException)
+        {
+            return null;
+        }
+
+        if (exitCode != 0)
+        {
+            return null;
+        }
+
+        var stdout = buffer.ToString();
+        if (string.IsNullOrWhiteSpace(stdout))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(stdout);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            var safeRepairCount = 0;
+            if (root.TryGetProperty("safe_repairs", out var safeRepairsElement)
+                && safeRepairsElement.ValueKind == JsonValueKind.Array)
+            {
+                safeRepairCount = safeRepairsElement.GetArrayLength();
+            }
+
+            var unsafeStopCount = 0;
+            if (root.TryGetProperty("unsafe_stops", out var unsafeStopsElement)
+                && unsafeStopsElement.ValueKind == JsonValueKind.Array)
+            {
+                unsafeStopCount = unsafeStopsElement.GetArrayLength();
+            }
+
+            return new PublishRecoveryProbeResult
+            {
+                SafeRepairCount = safeRepairCount,
+                UnsafeStopCount = unsafeStopCount
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// G342: testability seam for the auto-probe of
+/// <c>intent-cli automation host-sync-preflight --format json</c>.
+/// </summary>
+internal interface IHostSyncPreflightProbe
+{
+    HostSyncPreflightProbeResult? Probe();
+}
+
+/// <summary>
+/// G342: minimal projection of the host-sync-preflight output. Only
+/// the classification string the host-loop analyzer needs is exposed;
+/// the full preflight report stays for operators who run the command
+/// directly.
+/// </summary>
+internal sealed record HostSyncPreflightProbeResult
+{
+    public required string Classification { get; init; }
+}
+
+/// <summary>
+/// G342: in-process invoker of <see cref="AutomationHostSyncPreflightCommand"/>.
+/// Resolves the working tree from the host context. Fail-soft: returns
+/// <see langword="null"/> on any error so the host loop falls through
+/// to its existing analyzer lanes when the preflight is unhealthy.
+/// </summary>
+internal sealed class IntentCliHostSyncPreflightProbe : IHostSyncPreflightProbe
+{
+    private readonly CliContext _context;
+
+    public IntentCliHostSyncPreflightProbe(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    public HostSyncPreflightProbeResult? Probe()
+    {
+        var args = new[] { "--format", "json" };
+        using var buffer = new StringWriter();
+        int exitCode;
+        try
+        {
+            exitCode = AutomationHostSyncPreflightCommand.Execute(_context, args, buffer);
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException)
+        {
+            return null;
+        }
+
+        // host-sync-preflight uses exit code 0 ONLY for the `clean`
+        // classification; other classifications (behind-origin /
+        // dirty-*) still produce useful JSON on stdout with a
+        // non-zero exit. Probe the JSON regardless of exit code.
+        var stdout = buffer.ToString();
+        if (string.IsNullOrWhiteSpace(stdout))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(stdout);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            if (root.TryGetProperty("classification", out var classificationElement)
+                && classificationElement.ValueKind == JsonValueKind.String)
+            {
+                var classification = classificationElement.GetString();
+                if (!string.IsNullOrWhiteSpace(classification))
+                {
+                    return new HostSyncPreflightProbeResult { Classification = classification! };
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        return null;
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
@@ -448,6 +448,198 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
         Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
     }
 
+    [Fact]
+    public void Execute_PublishRecoveryProbe_SurfacesRepairHostMetadata_WhenSafeRepairsAvailable()
+    {
+        // G342: when `automation publish-recovery --dry-run` reports
+        // safe_repairs > 0 (the deterministic `linked_pr` recovery
+        // case), the host loop must surface `repair-host-metadata`
+        // instead of falling through to `true-idle`.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = _ => new FakePublishRecoveryProbe(
+            new PublishRecoveryProbeResult { SafeRepairCount = 1, UnsafeStopCount = 0 });
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = _ => new FakeHostSyncPreflightProbe(
+            new HostSyncPreflightProbeResult { Classification = HostSyncPreflightAnalyzer.ClassificationClean });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContext(),
+                ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            var root = JsonDocument.Parse(writer.ToString()).RootElement;
+            Assert.Equal("repair-host-metadata", root.GetProperty("classification").GetString());
+            Assert.True(root.GetProperty("mutation_allowed").GetBoolean());
+            Assert.Contains("publish-recovery", root.GetProperty("recommended_command").GetString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = null;
+            AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_HostSyncPreflightProbe_SurfacesSafeStash_WhenDirtyUnrelatedSubmodule()
+    {
+        // G342: when host-sync-preflight reports
+        // `dirty-unrelated-submodule` (the recoverable workspace
+        // case), the host loop must surface `safe-stash` with the
+        // `workspace-guard --mode begin --write` recommendation
+        // instead of falling through to `true-idle`.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = _ => new FakePublishRecoveryProbe(
+            new PublishRecoveryProbeResult { SafeRepairCount = 0, UnsafeStopCount = 0 });
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = _ => new FakeHostSyncPreflightProbe(
+            new HostSyncPreflightProbeResult { Classification = HostSyncPreflightAnalyzer.ClassificationDirtyUnrelatedSubmodule });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContext(),
+                ["--repo", "owner/repo", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            var root = JsonDocument.Parse(writer.ToString()).RootElement;
+            Assert.Equal("safe-stash", root.GetProperty("classification").GetString());
+            Assert.True(root.GetProperty("mutation_allowed").GetBoolean());
+            Assert.Contains("workspace-guard", root.GetProperty("recommended_command").GetString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = null;
+            AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_HostSyncPreflightProbe_SurfacesDirtyHostState_WhenDurableStateDirty()
+    {
+        // G342: when host-sync-preflight reports
+        // `dirty-host-durable-state` (NOT recoverable — operator
+        // must commit/revert), the host loop must surface
+        // `dirty-host-state` with `mutation_allowed: false` and a
+        // structured stop. This is the unambiguous-block lane that
+        // protects against publishing on top of dirty durable state.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = _ => new FakePublishRecoveryProbe(
+            new PublishRecoveryProbeResult { SafeRepairCount = 0, UnsafeStopCount = 0 });
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = _ => new FakeHostSyncPreflightProbe(
+            new HostSyncPreflightProbeResult { Classification = HostSyncPreflightAnalyzer.ClassificationDirtyDurableState });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContext(),
+                ["--repo", "owner/repo", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            var root = JsonDocument.Parse(writer.ToString()).RootElement;
+            Assert.Equal("dirty-host-state", root.GetProperty("classification").GetString());
+            Assert.False(root.GetProperty("mutation_allowed").GetBoolean());
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = null;
+            AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_TrueIdle_RemainsPossible_WhenAllSafeRepairProbesIdle()
+    {
+        // G342 acceptance: `true-idle` is still emitted when every
+        // safe-repair probe (next-slice, publish-recovery,
+        // host-sync-preflight) reports no actionable signal.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = _ => new FakePublishRecoveryProbe(
+            new PublishRecoveryProbeResult { SafeRepairCount = 0, UnsafeStopCount = 0 });
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = _ => new FakeHostSyncPreflightProbe(
+            new HostSyncPreflightProbeResult { Classification = HostSyncPreflightAnalyzer.ClassificationClean });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContext(),
+                ["--repo", "owner/repo", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            Assert.Equal("true-idle",
+                JsonDocument.Parse(writer.ToString()).RootElement.GetProperty("classification").GetString());
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = null;
+            AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_OperatorSupplied_PublishRecoveryRepairs_BypassesProbe()
+    {
+        // G342: when the operator pre-supplies
+        // `--publish-recovery-repairs <N>`, the probe is skipped so
+        // upstream tooling that already computed the count routes
+        // through the operator value.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        var probeInvoked = false;
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = _ => new FakePublishRecoveryProbe(
+            canned: null) { };
+        // Use a probe that records invocation so we can assert it was bypassed.
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = _ =>
+        {
+            probeInvoked = true;
+            return new FakePublishRecoveryProbe(new PublishRecoveryProbeResult { SafeRepairCount = 99, UnsafeStopCount = 0 });
+        };
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContext(),
+                ["--repo", "owner/repo", "--publish-recovery-repairs", "1", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            Assert.False(probeInvoked, "publish-recovery probe must not run when --publish-recovery-repairs is operator-supplied");
+            // The operator-supplied value (1) wins, surfacing
+            // repair-host-metadata regardless of probe.
+            Assert.Equal("repair-host-metadata",
+                JsonDocument.Parse(writer.ToString()).RootElement.GetProperty("classification").GetString());
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = null;
+        }
+    }
+
     private static CliContext CreateContextWithoutDomain() =>
         new()
         {
@@ -462,6 +654,31 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
                 }
             }
         };
+
+    /// <summary>
+    /// G342: deterministic stand-in for the publish-recovery probe.
+    /// Returns the canned safe-repair / unsafe-stop counts the host
+    /// loop tests need to drive the analyzer's `repair-host-metadata`
+    /// lane without touching live queue-state.
+    /// </summary>
+    private sealed class FakePublishRecoveryProbe : IPublishRecoveryProbe
+    {
+        private readonly PublishRecoveryProbeResult? _canned;
+        public FakePublishRecoveryProbe(PublishRecoveryProbeResult? canned) { _canned = canned; }
+        public PublishRecoveryProbeResult? Probe(string repo) => _canned;
+    }
+
+    /// <summary>
+    /// G342: deterministic stand-in for the host-sync-preflight probe.
+    /// Tests drive `safe-stash` / `dirty-host-state` lanes by canning
+    /// classifications without touching the local git working tree.
+    /// </summary>
+    private sealed class FakeHostSyncPreflightProbe : IHostSyncPreflightProbe
+    {
+        private readonly HostSyncPreflightProbeResult? _canned;
+        public FakeHostSyncPreflightProbe(HostSyncPreflightProbeResult? canned) { _canned = canned; }
+        public HostSyncPreflightProbeResult? Probe() => _canned;
+    }
 
     private sealed class FakeNextSliceProbe : INextSliceDryRunProbe
     {

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
@@ -868,6 +868,89 @@ public sealed class AutomationHostReviewDiagnosticsCommandTests : IDisposable
         }
     }
 
+    [Fact]
+    public void Execute_PublishRecoveryProbe_SurfacesPublishRecoveryReady_WhenSafeRepairsAvailable()
+    {
+        // G342: when `automation publish-recovery --dry-run` reports
+        // safe_repairs > 0, the diagnostics must surface
+        // `publish-recovery-ready` (the `linked_pr` deterministic
+        // recovery lane) instead of `true-idle`. Mirrors the
+        // host-loop-next-action probe so both surfaces agree.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+        AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+        AutomationHostReviewDiagnosticsCommand.PublishRecoveryProbeFactory = _ => new FakePublishRecoveryProbe(
+            new PublishRecoveryProbeResult { SafeRepairCount = 1, UnsafeStopCount = 0 });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context,
+                ["--repo", "owner/repo", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+            Assert.Equal("publish-recovery-ready", result.Classification);
+            Assert.NotNull(result.RecommendedNextCommand);
+            Assert.Contains("publish-recovery", result.RecommendedNextCommand!, StringComparison.Ordinal);
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+            AutomationHostReviewDiagnosticsCommand.PublishRecoveryProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_OperatorSupplied_PublishRecoveryRepairs_BypassesProbe_InDiagnostics()
+    {
+        // G342: when the operator pre-supplies
+        // `--publish-recovery-repairs-available <N>`, the diagnostics
+        // skip the probe and use the operator value verbatim.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+        AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+        var probeInvoked = false;
+        AutomationHostReviewDiagnosticsCommand.PublishRecoveryProbeFactory = _ =>
+        {
+            probeInvoked = true;
+            return new FakePublishRecoveryProbe(new PublishRecoveryProbeResult { SafeRepairCount = 99, UnsafeStopCount = 0 });
+        };
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context,
+                ["--repo", "owner/repo", "--publish-recovery-repairs-available", "1", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.False(probeInvoked, "publish-recovery probe must not run when operator pre-supplied the count");
+            var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+            Assert.Equal("publish-recovery-ready", result.Classification);
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+            AutomationHostReviewDiagnosticsCommand.PublishRecoveryProbeFactory = null;
+        }
+    }
+
+    /// <summary>
+    /// G342: deterministic stand-in for the publish-recovery probe.
+    /// </summary>
+    private sealed class FakePublishRecoveryProbe : IPublishRecoveryProbe
+    {
+        private readonly PublishRecoveryProbeResult? _canned;
+        public FakePublishRecoveryProbe(PublishRecoveryProbeResult? canned) { _canned = canned; }
+        public PublishRecoveryProbeResult? Probe(string repo) => _canned;
+    }
+
     /// <summary>
     /// G341: deterministic stand-in for <see cref="INextSliceDryRunProbe"/>
     /// used by the host-review-diagnostics tests. Returns a canned


### PR DESCRIPTION
## Summary

- The host loop returned \`true-idle\` too often for recoverable conditions because its analyzer expected operator-supplied flags (\`--publish-recovery-repairs\`, \`--sync-classification\`, \`--safe-stash-required\`) to drive safe-repair lanes. Operators running \`automation host-loop-next-action --repo X\` from a host session typically did NOT type those flags, so the deterministic recovery paths (\`linked_pr\` publish-recovery, dirty-unrelated safe-stash, dirty-host-state structured stop) were invisible.
- G341 added auto-probing for next-slice; G342 adds the matching auto-probes for \`automation publish-recovery\` and \`automation host-sync-preflight\` so the existing analyzer lanes fire from the recoverable signal alone.
- New \`ISafeRepairProbes.cs\` with two interfaces + in-process implementations + two testability seam factories on each surface (\`PublishRecoveryProbeFactory\`, \`HostSyncPreflightProbeFactory\`).
- \`host-loop-next-action\` runs both auto-probes; \`host-review-diagnostics\` runs the publish-recovery probe (no sync-classification input in that surface).

## Test plan (matches issue acceptance criteria)

- [x] \`host-loop-next-action\` returns \`repair-host-metadata\` (NOT \`true-idle\`) when publish-recovery has safe repairs — \`Execute_PublishRecoveryProbe_SurfacesRepairHostMetadata_WhenSafeRepairsAvailable\`.
- [x] \`host-loop-next-action\` returns \`safe-stash\` with \`workspace-guard\` recommendation for \`dirty-unrelated-submodule\` — \`Execute_HostSyncPreflightProbe_SurfacesSafeStash_WhenDirtyUnrelatedSubmodule\`.
- [x] Ambiguous metadata still returns structured stop: \`dirty-host-durable-state\` flips to \`dirty-host-state\` with \`mutation_allowed: false\` — \`Execute_HostSyncPreflightProbe_SurfacesDirtyHostState_WhenDurableStateDirty\`.
- [x] \`true-idle\` remains reachable when every safe-repair probe is empty — \`Execute_TrueIdle_RemainsPossible_WhenAllSafeRepairProbesIdle\`.
- [x] Operator-supplied flags bypass probes — \`Execute_OperatorSupplied_PublishRecoveryRepairs_BypassesProbe\` + diagnostics mirror.
- [x] \`host-review-diagnostics\` mirror returns \`publish-recovery-ready\` for the same signal — \`Execute_PublishRecoveryProbe_SurfacesPublishRecoveryReady_WhenSafeRepairsAvailable\`.
- [x] WIP cap, Hard Clarification, and PR review/merge semantics unchanged — \`dotnet test --filter "Automation|HostLoop|HostSync"\` passes 416/416.
- [x] Generated automation guidance says to use intent-cli repair commands (\`publish-recovery --write\`, \`workspace-guard --mode begin --write\`), not manual file edits — verified via recommended-command assertions.

Closes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)