### PR TITLE
G347: Propagate base branch policy into published child issue contracts

### DIFF
--- a/src/IntentSystem.Cli/Commands/GitHubPrLookupResult.cs
+++ b/src/IntentSystem.Cli/Commands/GitHubPrLookupResult.cs
@@ -52,6 +52,13 @@ internal sealed record GitHubPrLookupResult
     [JsonPropertyName("closingIssuesReferences")]
     public IReadOnlyList<GitHubPrClosingIssueReference> ClosingIssuesReferences { get; init; }
         = Array.Empty<GitHubPrClosingIssueReference>();
+
+    /// <summary>
+    /// G347: the PR's base branch name as returned by <c>gh pr view --json baseRefName</c>.
+    /// Used by <c>worker complete</c> to validate the PR targets the expected branch.
+    /// </summary>
+    [JsonPropertyName("baseRefName")]
+    public string BaseRefName { get; init; } = string.Empty;
 }
 
 /// <summary>

--- a/src/IntentSystem.Cli/Commands/IGitHubPrLookup.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubPrLookup.cs
@@ -42,7 +42,7 @@ internal sealed class GhCliGitHubPrLookup : IGitHubPrLookup
     /// <see cref="DeriveMergedFromState"/>.
     /// </summary>
     internal const string PrViewJsonFields =
-        "number,state,title,body,labels,isDraft,closed,mergedAt,closedAt,closingIssuesReferences";
+        "number,state,title,body,labels,isDraft,closed,mergedAt,closedAt,closingIssuesReferences,baseRefName";
 
     /// <summary>
     /// G204 follow-up: builds the <c>gh pr view</c> argument list shared by

--- a/src/IntentSystem.Cli/Commands/IssueValidateBodyValidator.cs
+++ b/src/IntentSystem.Cli/Commands/IssueValidateBodyValidator.cs
@@ -25,7 +25,10 @@ internal static class IssueValidateBodyValidator
         "Out Of Scope",
         "Acceptance Criteria",
         "Verification",
-        "Related Links"
+        "Related Links",
+        // G347: child implementation agents must know the expected PR base branch
+        // from the issue body alone (no host metadata access in child-cwd mode).
+        "Base Branch Policy"
     ];
 
     private static readonly IReadOnlyDictionary<string, string[]> HeadingAliases =

--- a/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
@@ -44,7 +44,11 @@ internal static class PacketDraftCommand
             "Out Of Scope",
             "Acceptance Criteria",
             "Verification",
-            "Related Links"
+            "Related Links",
+            // G347: base branch policy must be explicit in the published contract so
+            // child implementation agents can choose the correct PR base branch
+            // without reading host metadata.
+            "Base Branch Policy"
         };
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
@@ -107,12 +111,23 @@ internal static class PacketDraftCommand
             Directory.CreateDirectory(packetDirectory);
         }
 
+        // G347: resolve base branch policy from host config so the published
+        // contract section carries the project-specific expected base branch.
+        var baseBranchPolicy = context.Config.Project.BaseBranchPolicy;
+        if (string.IsNullOrWhiteSpace(baseBranchPolicy))
+        {
+            baseBranchPolicy = CliRuntimeContracts.DefaultBaseBranchPolicy;
+        }
+        var expectedBaseBranch = BaseBranchPolicyContract.IsKnownPolicy(baseBranchPolicy)
+            ? BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy)
+            : CliRuntimeContracts.DirectMainBaseBranch;
+
         var planned = new[]
         {
             ("packet.yaml", BuildPacketYaml(executionUnit, domain, targetRepo)),
             ("implementation.md", BuildImplementationMd(executionUnit)),
             ("review-context.md", BuildReviewContextMd(executionUnit)),
-            ("github-body.md", BuildGithubBodyMd(executionUnit))
+            ("github-body.md", BuildGithubBodyMd(executionUnit, baseBranchPolicy, expectedBaseBranch))
         };
 
         var files = new List<PacketDraftFile>();
@@ -241,8 +256,13 @@ internal static class PacketDraftCommand
             """;
     }
 
-    private static string BuildGithubBodyMd(string executionUnit)
+    private static string BuildGithubBodyMd(string executionUnit, string baseBranchPolicy, string expectedBaseBranch)
     {
+        // G347: derive policy-specific branch instruction for the mandatory contract section.
+        var branchInstruction = string.Equals(baseBranchPolicy, CliRuntimeContracts.MainAiBaseBranchPolicy, StringComparison.Ordinal)
+            ? $"Open all child PRs against `{expectedBaseBranch}`. Do NOT target `main` directly — the human operator periodically merges `{expectedBaseBranch}` → `main`."
+            : $"Open all child PRs against `{expectedBaseBranch}` directly.";
+
         return $"""
             ## Goal
 
@@ -287,6 +307,13 @@ internal static class PacketDraftCommand
             ## Related Links
 
             - TODO
+
+            ## Base Branch Policy
+
+            Policy: `{baseBranchPolicy}`
+            Expected PR base branch: `{expectedBaseBranch}`
+
+            {branchInstruction}
             """;
     }
 

--- a/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
@@ -44,6 +44,14 @@ internal static class WorkerCompleteCommand
     public static Func<IGitHubPrLookup>? PrLookupFactory { get; set; }
 
     /// <summary>
+    /// G347 test seam: tests inject a fake <see cref="IGitHubIssueLookup"/>
+    /// here so the base-branch policy check on <c>--kind issue --outcome
+    /// pr-created</c> can be exercised without GitHub network access.
+    /// When null, the command shells out via <see cref="GhCliGitHubIssueLookup"/>.
+    /// </summary>
+    public static Func<IGitHubIssueLookup>? IssueLookupFactory { get; set; }
+
+    /// <summary>
     /// Test sentinel: must NEVER be invoked. Tests assert it remains
     /// uninvoked across all command paths.
     /// </summary>
@@ -183,6 +191,21 @@ internal static class WorkerCompleteCommand
                     writer.WriteLine($"- {step}");
                 }
                 return 1;
+            }
+
+            // G347: base-branch check — when the source issue body carries a
+            // `## Base Branch Policy` section and the PR has a known baseRefName,
+            // refuse if they disagree. The check is best-effort: if the issue
+            // lookup fails or the section is absent we allow the completion so
+            // older issues without the section aren't blocked.
+            if (!string.IsNullOrWhiteSpace(prLookupResult.BaseRefName))
+            {
+                var baseBranchCheckResult = TryCheckBaseBranchFromIssue(
+                    repo!, number, prLookupResult.BaseRefName, writer);
+                if (baseBranchCheckResult == BaseBranchCheckOutcome.Mismatch)
+                {
+                    return 1;
+                }
             }
         }
 
@@ -426,6 +449,125 @@ internal static class WorkerCompleteCommand
         {
             return (false, $"failed to sync linked_pr for issue #{sourceIssueNumber} in queue-state.json: {exception.Message}");
         }
+    }
+
+    /// <summary>
+    /// G347: looks up the source issue body and parses the <c>## Base Branch Policy</c>
+    /// section to extract the expected PR base branch. Compares with
+    /// <paramref name="actualBaseBranch"/> and writes a repair instruction to
+    /// <paramref name="writer"/> on mismatch. Returns <see cref="BaseBranchCheckOutcome.Mismatch"/>
+    /// when the check definitively fails (issue body found, section found, branches differ);
+    /// returns <see cref="BaseBranchCheckOutcome.Ok"/> on match or when the check is
+    /// inconclusive (lookup error, section absent).
+    /// </summary>
+    private static BaseBranchCheckOutcome TryCheckBaseBranchFromIssue(
+        string repo,
+        int issueNumber,
+        string actualBaseBranch,
+        TextWriter writer)
+    {
+        IGitHubIssueLookup issueLookup;
+        try
+        {
+            issueLookup = IssueLookupFactory?.Invoke() ?? new GhCliGitHubIssueLookup();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            // Inconclusive — allow completion.
+            return BaseBranchCheckOutcome.Ok;
+        }
+
+        GitHubIssueLookupResult issueResult;
+        try
+        {
+            issueResult = issueLookup.Lookup(repo, issueNumber);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            // Inconclusive — allow completion.
+            _ = exception;
+            return BaseBranchCheckOutcome.Ok;
+        }
+
+        var expectedBase = ParseExpectedBaseBranchFromIssueBody(issueResult.Body);
+        if (string.IsNullOrWhiteSpace(expectedBase))
+        {
+            // No Base Branch Policy section in the issue body — allow completion.
+            return BaseBranchCheckOutcome.Ok;
+        }
+
+        if (string.Equals(expectedBase, actualBaseBranch, StringComparison.Ordinal))
+        {
+            return BaseBranchCheckOutcome.Ok;
+        }
+
+        writer.WriteLine(
+            $"refused to complete issue #{issueNumber} as `pr-created`: PR base branch mismatch (G347). "
+            + $"Issue contract requires `{expectedBase}` but PR targets `{actualBaseBranch}`.");
+        writer.WriteLine(
+            $"- Repair: update the PR base branch to `{expectedBase}` (via the GitHub UI or the gh CLI), "
+            + "then re-run `worker complete`.");
+        return BaseBranchCheckOutcome.Mismatch;
+    }
+
+    /// <summary>
+    /// G347: parses the <c>## Base Branch Policy</c> section of an issue body and
+    /// extracts the value after <c>Expected PR base branch: `</c>. Returns null when
+    /// the section or the field is not present.
+    /// </summary>
+    internal static string? ParseExpectedBaseBranchFromIssueBody(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return null;
+        }
+
+        var lines = body.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var inSection = false;
+        foreach (var rawLine in lines)
+        {
+            var trimmed = rawLine.Trim();
+            if (trimmed.StartsWith("## ", StringComparison.Ordinal))
+            {
+                var heading = trimmed[3..].Trim();
+                inSection = string.Equals(heading, "Base Branch Policy", StringComparison.OrdinalIgnoreCase);
+                continue;
+            }
+
+            if (!inSection)
+            {
+                continue;
+            }
+
+            // Match lines like:
+            //   Expected PR base branch: `main`
+            //   Expected PR base branch: `main-ai`
+            const string prefix = "Expected PR base branch:";
+            if (!trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var value = trimmed[prefix.Length..].Trim();
+            // Strip surrounding backticks.
+            if (value.Length >= 2 && value[0] == '`' && value[^1] == '`')
+            {
+                value = value[1..^1];
+            }
+
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    private enum BaseBranchCheckOutcome
+    {
+        Ok,
+        Mismatch,
     }
 
     private static string ResolveQueueStatePath(CliContext context)

--- a/tests/IntentSystem.Cli.Tests/IssuePrepareCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePrepareCommandTests.cs
@@ -198,6 +198,12 @@ public sealed class IssuePrepareCommandTests : IDisposable
         ## Related Links
 
         - Host runbook: intents/rules/automations/runbook.md
+
+        ## Base Branch Policy
+
+        Policy: `direct-main`
+        Expected PR base branch: `main`
+        Open all child PRs against `main` directly.
         """;
 
     internal sealed class IssuePrepareWorkspace : IDisposable

--- a/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
@@ -773,6 +773,11 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
 
             ## Related Links
             - x
+
+            ## Base Branch Policy
+            Policy: `direct-main`
+            Expected PR base branch: `main`
+            Open all child PRs against `main` directly.
             """;
     }
 
@@ -812,6 +817,11 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
 
             ## Related Links
             - x
+
+            ## Base Branch Policy
+            Policy: `direct-main`
+            Expected PR base branch: `main`
+            Open all child PRs against `main` directly.
             """;
     }
 

--- a/tests/IntentSystem.Cli.Tests/IssueValidateBodyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssueValidateBodyCommandTests.cs
@@ -247,6 +247,12 @@ public sealed class IssueValidateBodyCommandTests
         ## Related Links
 
         - Host runbook: intents/rules/automations/runbook.md
+
+        ## Base Branch Policy
+
+        Policy: `direct-main`
+        Expected PR base branch: `main`
+        Open all child PRs against `main` directly.
         """;
 
     private sealed class IssueValidateBodyWorkspace : IDisposable

--- a/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
@@ -181,6 +181,57 @@ public sealed class PacketDraftCommandTests
         Assert.Contains("--execution-unit", writer.ToString(), StringComparison.Ordinal);
     }
 
+    // ----- G347: Base Branch Policy section in generated github-body.md -----
+
+    [Fact]
+    public void Execute_G347_GeneratedGithubBodyIncludesBaseBranchPolicySection()
+    {
+        // G347 AC: the generated github-body.md must contain a non-empty
+        // `## Base Branch Policy` section with a parseable
+        // `Expected PR base branch:` line. This locks the section shape so
+        // downstream consumers (worker complete G347 check) can always parse it.
+        using var workspace = new PacketDraftWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G347", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G347");
+        var githubBody = File.ReadAllText(Path.Combine(packetDir, "github-body.md"));
+
+        Assert.Contains("## Base Branch Policy", githubBody, StringComparison.Ordinal);
+        Assert.Contains("Expected PR base branch:", githubBody, StringComparison.Ordinal);
+
+        // The parser used by worker-complete must be able to extract the value.
+        var extracted = WorkerCompleteCommand.ParseExpectedBaseBranchFromIssueBody(githubBody);
+        Assert.NotNull(extracted);
+        Assert.False(string.IsNullOrWhiteSpace(extracted));
+    }
+
+    [Fact]
+    public void Execute_G347_GeneratedGithubBodyContainsDirectMainPolicyByDefault()
+    {
+        // G347 AC: when the project config has no BaseBranchPolicy the default
+        // (`direct-main` → `main`) is stamped into the generated body.
+        using var workspace = new PacketDraftWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G347B"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G347B");
+        var githubBody = File.ReadAllText(Path.Combine(packetDir, "github-body.md"));
+
+        Assert.Contains("Policy: `direct-main`", githubBody, StringComparison.Ordinal);
+        Assert.Contains("Expected PR base branch: `main`", githubBody, StringComparison.Ordinal);
+    }
+
     private sealed class PacketDraftWorkspace : IDisposable
     {
         public PacketDraftWorkspace()

--- a/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
@@ -552,6 +552,11 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
 
             ## Related Links
             - x
+
+            ## Base Branch Policy
+            Policy: `direct-main`
+            Expected PR base branch: `main`
+            Open all child PRs against `main` directly.
             """;
     }
 
@@ -1110,6 +1115,11 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
 
             ## Related Links
             - x
+
+            ## Base Branch Policy
+            Policy: `direct-main`
+            Expected PR base branch: `main`
+            Open all child PRs against `main` directly.
             """;
     }
 

--- a/tests/IntentSystem.Cli.Tests/TaskingPublishReviewedBridgeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskingPublishReviewedBridgeCommandTests.cs
@@ -747,7 +747,8 @@ public sealed class TaskingPublishReviewedBridgeCommandTests : IDisposable
         + "## Out Of Scope\n\n- Adjacent refactors.\n\n"
         + "## Acceptance Criteria\n\n- Deterministic behaviour described here.\n\n"
         + "## Verification\n\nRun the focused suite.\n\n"
-        + "## Related Links\n\n- Host runbook: intents/rules/automations/runbook.md\n";
+        + "## Related Links\n\n- Host runbook: intents/rules/automations/runbook.md\n\n"
+        + "## Base Branch Policy\n\nPolicy: `direct-main`\nExpected PR base branch: `main`\nOpen all child PRs against `main` directly.\n";
 
     private sealed class BridgeWorkspace : IDisposable
     {

--- a/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
@@ -29,6 +29,11 @@ public sealed class WorkerCompleteCommandTests : IDisposable
         // G311-focused tests override this factory to exercise the
         // gate's failure paths.
         WorkerCompleteCommand.PrLookupFactory = () => new PermissivePrLookup();
+        // G347: permissive default — pre-existing tests don't set a baseRefName
+        // on the fake PR lookup (empty string), so the G347 check is skipped
+        // entirely for them. Set the factory to null here; G347-focused tests
+        // set it explicitly.
+        WorkerCompleteCommand.IssueLookupFactory = null;
     }
 
     public void Dispose()
@@ -36,6 +41,7 @@ public sealed class WorkerCompleteCommandTests : IDisposable
         WorkerCompleteCommand.MutatorFactory = null;
         WorkerCompleteCommand.NestedProviderLauncher = null;
         WorkerCompleteCommand.PrLookupFactory = null;
+        WorkerCompleteCommand.IssueLookupFactory = null;
     }
 
     [Fact]
@@ -1101,6 +1107,208 @@ public sealed class WorkerCompleteCommandTests : IDisposable
         Assert.Empty(mutator.AppliedTransitions);
     }
 
+    // ----- G347: base-branch gate on `--kind issue --outcome pr-created` -----
+
+    [Fact]
+    public void Execute_G347_RefusesPrCreatedWhenPrTargetsWrongBaseBranch()
+    {
+        // G347 AC: when the source issue body contains `## Base Branch Policy`
+        // with `Expected PR base branch: \`main\`` and the PR targets `main-ai`,
+        // the command must refuse and emit the G347 error message.
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        // PR body has closing reference and correct base branch embedded,
+        // but targets wrong base branch.
+        WorkerCompleteCommand.PrLookupFactory = () => new StubPrLookup
+        {
+            Body = "Closes #797",
+            ClosingIssuesReferences = new[]
+            {
+                new GitHubPrClosingIssueReference { Number = 797, Repository = null },
+            },
+            BaseRefName = "main-ai",    // WRONG — issue contract says `main`
+        };
+        WorkerCompleteCommand.IssueLookupFactory = () => new StubIssueLookup
+        {
+            Body = IssuePrepareCommandTests.CompleteValidBody,   // contains Base Branch Policy: direct-main / main
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "797",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated,
+                "--pr", "800",
+            },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("G347", output, StringComparison.Ordinal);
+        Assert.Contains("main-ai", output, StringComparison.Ordinal);
+        Assert.Contains("main", output, StringComparison.Ordinal);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_G347_AllowsPrCreatedWhenPrTargetsCorrectBaseBranch()
+    {
+        // G347 AC: when PR targets the same branch the issue contract mandates,
+        // the completion must proceed normally.
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        WorkerCompleteCommand.PrLookupFactory = () => new StubPrLookup
+        {
+            Body = "Closes #797",
+            ClosingIssuesReferences = new[]
+            {
+                new GitHubPrClosingIssueReference { Number = 797, Repository = null },
+            },
+            BaseRefName = "main",    // CORRECT — issue contract says `main`
+        };
+        WorkerCompleteCommand.IssueLookupFactory = () => new StubIssueLookup
+        {
+            Body = IssuePrepareCommandTests.CompleteValidBody,
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "797",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated,
+                "--pr", "800",
+                "--format", "json",
+            },
+            writer);
+
+        // Dry-run succeeds (proceeds), no mutations.
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.True(result.Proceed);
+    }
+
+    [Fact]
+    public void Execute_G347_AllowsPrCreatedWhenIssueBodyHasNoBaseBranchSection()
+    {
+        // G347 AC: when the issue body lacks the `## Base Branch Policy` section
+        // the check is inconclusive and completion must be allowed (best-effort).
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        WorkerCompleteCommand.PrLookupFactory = () => new StubPrLookup
+        {
+            Body = "Closes #797",
+            ClosingIssuesReferences = new[]
+            {
+                new GitHubPrClosingIssueReference { Number = 797, Repository = null },
+            },
+            BaseRefName = "any-branch",
+        };
+        // Issue body without a Base Branch Policy section.
+        WorkerCompleteCommand.IssueLookupFactory = () => new StubIssueLookup
+        {
+            Body = "## Goal\n\nSomething.\n\n## Verification\n\nRun tests.",
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "797",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated,
+                "--pr", "800",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.True(result.Proceed);
+    }
+
+    [Fact]
+    public void Execute_G347_AllowsPrCreatedWhenIssueLookupThrows()
+    {
+        // G347 AC: best-effort — when the issue lookup throws (network error,
+        // auth issue, etc.) the command treats the check as inconclusive and
+        // allows the completion.
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        WorkerCompleteCommand.PrLookupFactory = () => new StubPrLookup
+        {
+            Body = "Closes #797",
+            ClosingIssuesReferences = new[]
+            {
+                new GitHubPrClosingIssueReference { Number = 797, Repository = null },
+            },
+            BaseRefName = "wrong-base",
+        };
+        WorkerCompleteCommand.IssueLookupFactory = () => new ThrowingIssueLookup();
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "797",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated,
+                "--pr", "800",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.True(result.Proceed);
+    }
+
+    // G347 unit tests for the standalone body-parser helper.
+
+    [Theory]
+    [InlineData("## Base Branch Policy\nPolicy: `direct-main`\nExpected PR base branch: `main`\n", "main")]
+    [InlineData("## Base Branch Policy\nPolicy: `main-ai`\nExpected PR base branch: `main-ai`\n", "main-ai")]
+    [InlineData("## Base Branch Policy\nExpected PR base branch: `main`\nPolicy: `direct-main`\n", "main")]
+    [InlineData("## Other Heading\nExpected PR base branch: `main`\n", null)]  // not inside section
+    [InlineData("", null)]
+    [InlineData("  ", null)]
+    public void ParseExpectedBaseBranchFromIssueBody_ParsesCorrectly(string body, string? expected)
+    {
+        var result = WorkerCompleteCommand.ParseExpectedBaseBranchFromIssueBody(body);
+        Assert.Equal(expected, result);
+    }
+
     private static string StripCsharpComments(string source)
     {
         var noBlockComments = System.Text.RegularExpressions.Regex.Replace(
@@ -1166,6 +1374,9 @@ public sealed class WorkerCompleteCommandTests : IDisposable
         public IReadOnlyList<GitHubPrClosingIssueReference> ClosingIssuesReferences { get; init; }
             = Array.Empty<GitHubPrClosingIssueReference>();
 
+        /// <summary>G347: actual base branch reported by the PR (empty = G347 check skipped).</summary>
+        public string BaseRefName { get; init; } = string.Empty;
+
         public GitHubPrLookupResult Lookup(string repo, int prNumber) => new()
         {
             Number = prNumber,
@@ -1173,7 +1384,35 @@ public sealed class WorkerCompleteCommandTests : IDisposable
             Title = "stub",
             Body = Body,
             ClosingIssuesReferences = ClosingIssuesReferences,
+            BaseRefName = BaseRefName,
         };
+    }
+
+    /// <summary>
+    /// G347: parametric <see cref="IGitHubIssueLookup"/> fake for testing the
+    /// base-branch policy section parser without shelling out to <c>gh</c>.
+    /// </summary>
+    internal sealed class StubIssueLookup : IGitHubIssueLookup
+    {
+        public string Body { get; init; } = string.Empty;
+
+        public GitHubIssueLookupResult Lookup(string repo, int issueNumber) => new()
+        {
+            Number = issueNumber,
+            State = "OPEN",
+            Title = "stub issue",
+            Body = Body,
+        };
+    }
+
+    /// <summary>
+    /// G347: fake <see cref="IGitHubIssueLookup"/> that always throws so tests
+    /// can verify the best-effort (inconclusive) path lets the completion proceed.
+    /// </summary>
+    internal sealed class ThrowingIssueLookup : IGitHubIssueLookup
+    {
+        public GitHubIssueLookupResult Lookup(string repo, int issueNumber) =>
+            throw new InvalidOperationException("simulated gh issue view failure");
     }
 
     internal sealed class FakeMutator : IGitHubLabelMutator

--- a/tests/IntentSystem.Cli.Tests/WorkerIssuePreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerIssuePreflightCommandTests.cs
@@ -683,6 +683,11 @@ public sealed class WorkerIssuePreflightCommandTests : IDisposable
 
             ## Related Links
             - https://example.com/link
+
+            ## Base Branch Policy
+            Policy: `direct-main`
+            Expected PR base branch: `main`
+            Open all child PRs against `main` directly.
             """;
     }
 


### PR DESCRIPTION
## Summary

- `PacketDraftCommand`: stamps `## Base Branch Policy` section (policy name, expected base branch, per-policy instruction) into generated `github-body.md`; adds `"Base Branch Policy"` to `RequiredContractSections`
- `IssueValidateBodyValidator`: adds `"Base Branch Policy"` to `RequiredHeadings` so submitted bodies must include the section
- `WorkerCompleteCommand`: gates `--kind issue --outcome pr-created` on a new G347 base-branch check — reads source issue body, parses `Expected PR base branch`, refuses when it disagrees with the PR's actual `baseRefName` (best-effort: skips on lookup error or absent section so older issues are not blocked)
- `GitHubPrLookupResult` / `IGitHubPrLookup`: add `baseRefName` field to carry actual PR base branch through the G311/G347 check path
- Test fixtures: add `## Base Branch Policy` section to all existing contract body helpers in six test files
- New tests: G347-specific in `WorkerCompleteCommandTests` (mismatch refused, match allowed, absent section allowed, lookup-throws allowed, parser unit-tests) and `PacketDraftCommandTests` (section present and parseable, default `direct-main` policy stamped)

## Test plan

- [x] All 2859 tests in `IntentSystem.Cli.Tests` pass (0 failures, 1 pre-existing skip)
- [x] `WorkerCompleteCommandTests.SourceScan_AnalyzerAndCommand_ContainNoProcessStartOrGhMutationLiterals` passes (repair message uses `gh CLI` prose, not `gh pr edit` literal)
- [x] G347-specific test suite: 4 new `WorkerCompleteCommandTests` tests + 2 new `PacketDraftCommandTests` tests all green
- [x] Pre-existing `RunCommandTests` and `RunFixCommandTests` all pass

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)