### PR TITLE
G348: Add same-repository host and implementation topology guidance

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -61,14 +61,28 @@ internal static class GuidePromptMatrixCommand
         @"^[1-9][0-9]*[mh]$",
         RegexOptions.Compiled);
 
+    private const string TopologySameRepo = "same-repo";
+
     private const string UsageLine =
-        "Usage: intent-cli guide prompt-matrix [--mode child-loop|host-loop|child-oneshot|host-oneshot] [--domain <name>] [--target-repo <owner/repo>] [--agent claude|codex|generic|copilot] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--format markdown|json]";
+        "Usage: intent-cli guide prompt-matrix [--mode child-loop|host-loop|child-oneshot|host-oneshot] [--topology same-repo] [--domain <name>] [--target-repo <owner/repo>] [--agent claude|codex|generic|copilot] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--format markdown|json]";
 
     private static readonly string[] ForbiddenSources =
     [
         "intents/rules/**",
         "local skill files (gh-issue-to-pr, gh-fix-pr-comment, etc.)",
         "copied prompt files"
+    ];
+
+    /// <summary>
+    /// G348: additional forbidden sources added to child prompts when
+    /// <c>--topology same-repo</c> is set. In same-repo topology the
+    /// host metadata paths are visible in the child checkout but MUST
+    /// NOT be read or mutated by implementation agents.
+    /// </summary>
+    private static readonly string[] SameRepoAdditionalForbiddenSources =
+    [
+        ".intent-cli/** (visible in same-repo checkout but FORBIDDEN for implementation agents — do not read, write, or commit host queue-state, runs.jsonl, packet artifacts, or config from an implementation PR branch)",
+        "intents/** (visible in same-repo checkout but FORBIDDEN for implementation work — intent authoring, clarification recording, and spec updates are host-design tasks, not implementation tasks)"
     ];
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
@@ -83,14 +97,14 @@ internal static class GuidePromptMatrixCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var mode, out var format, out var domain, out var targetRepo, out var agent, out var frequency, out var baseBranchPolicy, out var error))
+        if (!TryParseArguments(args, out var mode, out var format, out var domain, out var targetRepo, out var agent, out var frequency, out var baseBranchPolicy, out var topology, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
             return 1;
         }
 
-        var entries = BuildEntries(context, mode, domain, targetRepo, agent, frequency, baseBranchPolicy);
+        var entries = BuildEntries(context, mode, domain, targetRepo, agent, frequency, baseBranchPolicy, topology);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
@@ -120,7 +134,8 @@ internal static class GuidePromptMatrixCommand
         string? targetRepo,
         string? agent,
         string? frequency,
-        string? baseBranchPolicy)
+        string? baseBranchPolicy,
+        string? topology)
     {
         var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
         var targetRepoPlaceholder = string.IsNullOrWhiteSpace(targetRepo) ? "<TARGET-REPO>" : targetRepo;
@@ -130,18 +145,20 @@ internal static class GuidePromptMatrixCommand
             ? context.Config.Project.BaseBranchPolicy
             : baseBranchPolicy;
 
+        var isSameRepo = string.Equals(topology, TopologySameRepo, StringComparison.Ordinal);
+
         var resolvedAgentForDispatch = NormalizeAgent(agent);
         var all = new[]
         {
             string.Equals(resolvedAgentForDispatch, AgentCopilot, StringComparison.Ordinal)
                 ? BuildCopilotChildLoop(resolvedPolicy)
-                : BuildChildLoop(domainPlaceholder, agent, frequency, resolvedPolicy),
+                : BuildChildLoop(domainPlaceholder, agent, frequency, resolvedPolicy, isSameRepo),
             string.Equals(resolvedAgentForDispatch, AgentCopilot, StringComparison.Ordinal)
                 ? BuildCopilotUnsupportedHostMode(ModeHostLoop, KindLoop, TargetHost, resolvedPolicy)
                 : BuildHostLoop(domainPlaceholder, targetRepoPlaceholder, agent, frequency, resolvedPolicy),
             string.Equals(resolvedAgentForDispatch, AgentCopilot, StringComparison.Ordinal)
                 ? BuildCopilotChildOneshot(resolvedPolicy)
-                : BuildChildOneshot(domainPlaceholder, resolvedPolicy),
+                : BuildChildOneshot(domainPlaceholder, resolvedPolicy, isSameRepo),
             string.Equals(resolvedAgentForDispatch, AgentCopilot, StringComparison.Ordinal)
                 ? BuildCopilotHostOneshot(targetRepoPlaceholder, resolvedPolicy)
                 : BuildHostOneshot(domainPlaceholder, targetRepoPlaceholder, resolvedPolicy)
@@ -261,6 +278,18 @@ $@"Base branch policy: `{baseBranchPolicy}` (expected base branch: `{expected}`)
 - {targetRoleVerb} this policy mechanically: derive the PR base branch from `intent-cli` config (`base_branch_policy`), never from prompt memory. Use `intent-cli automation base-branch-check --repo <r> --pr <n> --policy {baseBranchPolicy} --actual-base $(gh pr view <n> --repo <r> --json baseRefName --jq .baseRefName) --format json` to flag mismatches.";
     }
 
+    /// <summary>
+    /// G348: same-repo topology block inserted into child prompts when
+    /// <c>--topology same-repo</c> is set. The block names the two
+    /// forbidden host-metadata path groups that are visible in a same-repo
+    /// checkout but must NOT be read or mutated by implementation agents.
+    /// </summary>
+    private static string RenderSameRepoTopologyBlock() =>
+$@"Same-repo topology (G348): the implementation repo and host intent metadata (`.intent-cli/`, `intents/`) are in the SAME repository. Both paths are visible in this checkout, but they are FORBIDDEN for implementation agents:
+- `.intent-cli/**` — FORBIDDEN: do not read, write, or commit host queue-state, runs.jsonl, packet artifacts, or config from an implementation PR branch. Host metadata mutations go through `intent-cli automation` / `intent-cli worker` command surfaces only.
+- `intents/**` — FORBIDDEN: intent authoring, clarification recording, and spec updates are host-design tasks. Do not edit intent tree files from an implementation PR branch.
+- Implementation PRs MUST target the integration branch (e.g. `main-ai`), NOT `main`. Verify with: `gh pr view <n> --repo <r> --json baseRefName --jq .baseRefName` must equal the integration branch configured in `base_branch_policy`.";
+
     // G345: Copilot-specific base-branch block. Copilot MUST NOT invoke
     // `intent-cli` from the implementation side, so the policy is expressed
     // as a GitHub-facts-only check (`gh pr view ... --json baseRefName`) and
@@ -277,17 +306,18 @@ $@"Base branch policy: `{baseBranchPolicy}` (expected base branch: `{expected}`)
 - Base-branch policy enforcement is HOST / operator-owned. Copilot does NOT invoke any `intent-cli` command from the implementation side; the host's intent review loop runs the mismatch check on its own cadence.";
     }
 
-    private static GuidePromptMatrixEntry BuildChildLoop(string domainPlaceholder, string? agent, string? frequency, string baseBranchPolicy)
+    private static GuidePromptMatrixEntry BuildChildLoop(string domainPlaceholder, string? agent, string? frequency, string baseBranchPolicy, bool isSameRepo = false)
     {
         var resolvedAgent = NormalizeAgent(agent);
         var frequencyBlock = RenderFrequencyBlock(agent, frequency);
         var basePolicyBlock = RenderBaseBranchPolicyBlock(baseBranchPolicy, "Honor");
+        var sameRepoBlock = isSameRepo ? $"\n{RenderSameRepoTopologyBlock()}" : string.Empty;
         var prompt =
 $@"Set up the child implementation loop for the repo in the current worktree. Run the loop body exactly once per wake; the operator or scheduler drives subsequent wakes.
 
 {frequencyBlock}
 
-{basePolicyBlock}
+{basePolicyBlock}{sameRepoBlock}
 
 If the installed CLI surface is stale or any required automation command is missing, abort the wake before any mutation: `intent-cli automation doctor --format json` (or `automation host-review-preflight` reporting `stale-host-cli`) is the canonical signal — refresh the installed CLI; never fall back to raw `gh` label mutation. The installed CLI may come from a global dotnet tool install on `PATH` (e.g. `$HOME/.dotnet/tools/intent-cli`); that is the default local-testing route and the doctor reports `binary_source: path-global-tool` in that case. A cwd-local `.intent-cli/bin/intent-cli` shim still wins when present (`binary_source: cwd-local-shim`) and `INTENT_CLI_INSTALLED_PATH` pins a specific binary for version-specific tests (`binary_source: explicit-override`).
 
@@ -328,13 +358,17 @@ Hard rules:
   - `worker complete --write` returns errors that are not the expected `linked_pr_synced: false` queue-state warning.
 - Process at most one action per wake.";
 
+        var forbiddenSources = isSameRepo
+            ? [.. ForbiddenSources, .. SameRepoAdditionalForbiddenSources]
+            : (IReadOnlyList<string>)ForbiddenSources;
+
         return new GuidePromptMatrixEntry
         {
             Mode = ModeChildLoop,
             Kind = KindLoop,
             Target = TargetChild,
             FrequencyGuidance = ResolvedFrequencyGuidance(frequency),
-            ForbiddenSources = ForbiddenSources,
+            ForbiddenSources = forbiddenSources,
             FirstCalls =
             [
                 "intent-cli guide model --format json",
@@ -347,6 +381,7 @@ Hard rules:
             Frequency = string.IsNullOrWhiteSpace(frequency) ? null : frequency,
             BaseBranchPolicy = baseBranchPolicy,
             ExpectedBaseBranch = BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy),
+            Topology = isSameRepo ? TopologySameRepo : null,
         };
     }
 
@@ -448,15 +483,16 @@ Hard rules:
         };
     }
 
-    private static GuidePromptMatrixEntry BuildChildOneshot(string domainPlaceholder, string baseBranchPolicy)
+    private static GuidePromptMatrixEntry BuildChildOneshot(string domainPlaceholder, string baseBranchPolicy, bool isSameRepo = false)
     {
         var basePolicyBlock = RenderBaseBranchPolicyBlock(baseBranchPolicy, "Honor");
+        var sameRepoBlock = isSameRepo ? $"\n{RenderSameRepoTopologyBlock()}" : string.Empty;
         var prompt =
 $@"Run one child implementation/update wake exactly once.
 
 Do not create or update any automation, loop, cron, monitor, reminder, or recurring wakeup. This is a one-shot execution. Frequency is forbidden.
 
-{basePolicyBlock}
+{basePolicyBlock}{sameRepoBlock}
 
 First-call sequence (read-only; required before any mutation):
 1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
@@ -496,13 +532,17 @@ Hard rules:
 - Process at most one action per wake.
 - Do not create a cron, monitor, scheduler, reminder, or new thread after completing this wake.";
 
+        var forbiddenSourcesOneshot = isSameRepo
+            ? [.. ForbiddenSources, .. SameRepoAdditionalForbiddenSources]
+            : (IReadOnlyList<string>)ForbiddenSources;
+
         return new GuidePromptMatrixEntry
         {
             Mode = ModeChildOneshot,
             Kind = KindOneshot,
             Target = TargetChild,
             FrequencyGuidance = FrequencyGuidanceOneshot,
-            ForbiddenSources = ForbiddenSources,
+            ForbiddenSources = forbiddenSourcesOneshot,
             FirstCalls =
             [
                 "intent-cli guide model --format json",
@@ -513,6 +553,7 @@ Hard rules:
             Prompt = prompt,
             BaseBranchPolicy = baseBranchPolicy,
             ExpectedBaseBranch = BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy),
+            Topology = isSameRepo ? TopologySameRepo : null,
         };
     }
 
@@ -923,6 +964,7 @@ Hard rules:
         out string? agent,
         out string? frequency,
         out string? baseBranchPolicy,
+        out string? topology,
         out string error)
     {
         mode = null;
@@ -932,6 +974,7 @@ Hard rules:
         agent = null;
         frequency = null;
         baseBranchPolicy = null;
+        topology = null;
         error = string.Empty;
 
         for (var index = 0; index < args.Length; index++)
@@ -1052,6 +1095,23 @@ Hard rules:
                     index++;
                     break;
 
+                case "--topology":
+                    // G348: only 'same-repo' is a recognized topology value.
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = $"--topology requires a value ({TopologySameRepo}).";
+                        return false;
+                    }
+                    var requestedTopology = args[index + 1].Trim();
+                    if (!string.Equals(requestedTopology, TopologySameRepo, StringComparison.Ordinal))
+                    {
+                        error = $"--topology must be '{TopologySameRepo}' (got '{requestedTopology}').";
+                        return false;
+                    }
+                    topology = requestedTopology;
+                    index++;
+                    break;
+
                 default:
                     error = $"Unknown argument '{argument}'.";
                     return false;
@@ -1074,10 +1134,11 @@ Hard rules:
         writer.WriteLine($"- {ModeHostOneshot}  one-shot host review/next-slice");
         writer.WriteLine();
         writer.WriteLine("Omit --mode to get all four entries.");
-        writer.WriteLine("--domain, --target-repo, --agent, and --frequency are optional; provide them to render a concrete paste-ready prompt instead of one with placeholders.");
+        writer.WriteLine("--domain, --target-repo, --agent, --frequency, and --topology are optional; provide them to render a concrete paste-ready prompt instead of one with placeholders.");
         writer.WriteLine("--agent values: claude (same-thread `/loop`), codex (current-thread heartbeat), generic, copilot (G345 — assignment-oriented; supported for child-oneshot, returns structured unsupported-loop guidance for child-loop, structured host-oneshot-human-driven guidance for host-oneshot, and structured unsupported-mode-agent-combination for host-loop).");
         writer.WriteLine("--frequency examples: 5m, 20m, 1h. Omit to keep the rendered prompt's ask-the-operator instruction.");
         writer.WriteLine($"--base-branch-policy values: {CliRuntimeContracts.DirectMainBaseBranchPolicy} (default; child PRs target `{CliRuntimeContracts.DirectMainBaseBranch}`), {CliRuntimeContracts.MainAiBaseBranchPolicy} (child PRs target `{CliRuntimeContracts.MainAiIntegrationBaseBranch}`).");
+        writer.WriteLine($"--topology values: {TopologySameRepo} (G348 — adds same-repo forbidden-path guidance to child prompts; host intent metadata paths `.intent-cli/**` and `intents/**` are visible but forbidden for implementation agents).");
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -1122,6 +1183,13 @@ internal sealed record GuidePromptMatrixEntry
 
     [JsonPropertyName("expected_base_branch")]
     public string? ExpectedBaseBranch { get; init; }
+
+    /// <summary>
+    /// G348: topology hint; <c>"same-repo"</c> when <c>--topology same-repo</c>
+    /// was passed, null otherwise.
+    /// </summary>
+    [JsonPropertyName("topology")]
+    public string? Topology { get; init; }
 
     /// <summary>
     /// G345: structured classification when the requested agent does not

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskInitHostCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskInitHostCommand.cs
@@ -26,7 +26,7 @@ internal static class GuideWorkflowTaskInitHostCommand
     private const string FormatMarkdown = "markdown";
 
     private const string UsageLine =
-        "Usage: intent-cli guide workflow task init-host [--role design|review-runtime|child-implementation] [--force-host] [--format markdown|json]";
+        "Usage: intent-cli guide workflow task init-host [--role design|review-runtime|child-implementation] [--topology same-repo] [--force-host] [--format markdown|json]";
 
     /// <summary>
     /// G335: canonical role definitions for a new project. Mirrors the
@@ -104,6 +104,36 @@ internal static class GuideWorkflowTaskInitHostCommand
     };
 
     /// <summary>
+    /// G348: same-repo topology guidance emitted when
+    /// <c>--topology same-repo</c> is passed. Documents the branch
+    /// strategy, the forbidden paths for implementation agents, and
+    /// the warning when no base-branch policy is configured.
+    /// </summary>
+    internal static readonly SameRepoTopologyGuidance SameRepoTopology = new()
+    {
+        Summary = "Same-repository topology: host intent metadata (`.intent-cli/`, `intents/`) and application code live in the same GitHub repository. Implementation PRs target an integration branch (e.g. `main-ai`); a human periodically merges the integration branch to `main`. This topology is useful for small or early projects but requires strict path discipline to prevent implementation agents from corrupting host metadata.",
+        BranchStrategy = new[]
+        {
+            "Implementation PRs MUST target the integration branch (e.g. `main-ai`), NOT `main`. Configure `base_branch_policy: main-ai` in `.intent-cli/config.yaml`.",
+            "Host metadata changes (queue-state, runs.jsonl, packets, intent tree) are committed directly to the integration branch by the host loop via intent-cli command surfaces only — never by implementation agents.",
+            "A human (or a dedicated automation) periodically opens a `main-ai → main` PR to batch-merge accepted implementation work into the stable branch.",
+            "Implementation PRs never target `main` directly; the integration branch is the gate."
+        },
+        ForbiddenPathsForImplementation = new[]
+        {
+            ".intent-cli/** — host queue-state, runs.jsonl, packet artifacts, config. Visible in the same-repo checkout but FORBIDDEN for implementation agents. Never read, write, or commit these paths from an implementation PR branch.",
+            "intents/** — intent tree, specs, rules, clarifications. Visible in the same-repo checkout but FORBIDDEN for implementation work. Intent authoring and clarification recording are host-design tasks, not implementation tasks.",
+        },
+        HostConstraints = new[]
+        {
+            "All host metadata mutations (queue-state, runs.jsonl, publish artifacts, workflow labels) MUST go through the installed intent-cli command surfaces (`intent-cli automation ...`, `intent-cli worker ...`, `intent-cli intent ...`, `intent-cli packet ...`, `intent-cli issue ...`). Never hand-edit these files directly.",
+            "Host metadata changes committed to the integration branch are automatically visible to the next implementation PR; no separate host repo checkout is required in same-repo topology.",
+            "The design host and review-runtime roles BOTH run from the same local checkout of this one repository. The `.intent-cli/` directory is present and REQUIRED for host operations; it is FORBIDDEN for implementation agents working on feature branches."
+        },
+        Warning = "SAME-REPO TOPOLOGY WARNING: when `base_branch_policy` is not configured (or is `direct-main`), child implementation agents will default to targeting `main` directly. In a same-repo project this is almost certainly wrong. Set `base_branch_policy: main-ai` in `.intent-cli/config.yaml` and ensure every published child issue includes a `Base Branch Policy` section pointing at the integration branch."
+    };
+
+    /// <summary>
     /// G335: explicit invariants the workflow guide must surface so
     /// external agents do not mis-initialize a project. Tests pin
     /// each invariant verbatim.
@@ -123,7 +153,7 @@ internal static class GuideWorkflowTaskInitHostCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
-        if (!TryParseArguments(args, out var focusRole, out var forceHost, out var format, out var error))
+        if (!TryParseArguments(args, out var focusRole, out var forceHost, out var topology, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
@@ -152,6 +182,19 @@ internal static class GuideWorkflowTaskInitHostCommand
             refusalReasons.Add("The current cwd already contains `.intent-cli/`, but --role child-implementation was selected. Re-run with --force-host to explicitly upgrade this repo to a host role, or cd to a directory without `.intent-cli/` if you intended to scaffold a child-implementation checkout.");
         }
 
+        // G348: resolve same-repo topology, including any policy-absent warning.
+        var isSameRepo = string.Equals(topology, "same-repo", StringComparison.Ordinal);
+        var sameRepoGuidance = isSameRepo ? SameRepoTopology : null;
+
+        // G348: when same-repo but no non-default base-branch policy configured,
+        // warn — direct-main means PRs target `main`, which is wrong for same-repo.
+        var baseBranchPolicy = context.Config.Project.BaseBranchPolicy;
+        var sameRepoPolicyWarning = isSameRepo &&
+            (string.IsNullOrWhiteSpace(baseBranchPolicy) ||
+             string.Equals(baseBranchPolicy, CliRuntimeContracts.DirectMainBaseBranchPolicy, StringComparison.Ordinal))
+            ? SameRepoTopology.Warning
+            : null;
+
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
             var payload = new InitHostGuidance
@@ -160,16 +203,19 @@ internal static class GuideWorkflowTaskInitHostCommand
                 Roles = visibleRoles,
                 Invariants = Invariants,
                 FocusRole = string.IsNullOrEmpty(focusRole) ? null : focusRole,
+                Topology = string.IsNullOrEmpty(topology) ? null : topology,
                 CwdHasDotIntentCli = hasDotIntentCli,
                 ForceHost = forceHost,
-                Refusals = refusalReasons.Count == 0 ? null : refusalReasons
+                Refusals = refusalReasons.Count == 0 ? null : refusalReasons,
+                SameRepoTopology = sameRepoGuidance,
+                SameRepoPolicyWarning = sameRepoPolicyWarning
             };
             writer.Write(JsonSerializer.Serialize(payload, JsonOptions));
             writer.WriteLine();
         }
         else
         {
-            WriteMarkdown(visibleRoles, hasDotIntentCli, forceHost, refusalReasons, writer);
+            WriteMarkdown(visibleRoles, hasDotIntentCli, forceHost, refusalReasons, sameRepoGuidance, sameRepoPolicyWarning, writer);
         }
 
         return refusalReasons.Count == 0 ? 0 : 1;
@@ -200,6 +246,8 @@ internal static class GuideWorkflowTaskInitHostCommand
         bool hasDotIntentCli,
         bool forceHost,
         IReadOnlyList<string> refusals,
+        SameRepoTopologyGuidance? sameRepoGuidance,
+        string? sameRepoPolicyWarning,
         TextWriter writer)
     {
         writer.WriteLine("# intent-cli — init-host workflow guide");
@@ -250,17 +298,52 @@ internal static class GuideWorkflowTaskInitHostCommand
         {
             writer.WriteLine($"- {line}");
         }
+
+        // G348: emit same-repo topology section when --topology same-repo is set.
+        if (sameRepoGuidance is not null)
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Same-Repo Topology (--topology same-repo)");
+            writer.WriteLine();
+            writer.WriteLine(sameRepoGuidance.Summary);
+            writer.WriteLine();
+            writer.WriteLine("### Branch strategy");
+            foreach (var item in sameRepoGuidance.BranchStrategy)
+            {
+                writer.WriteLine($"- {item}");
+            }
+            writer.WriteLine();
+            writer.WriteLine("### Forbidden paths for implementation agents");
+            foreach (var item in sameRepoGuidance.ForbiddenPathsForImplementation)
+            {
+                writer.WriteLine($"- {item}");
+            }
+            writer.WriteLine();
+            writer.WriteLine("### Host constraints");
+            foreach (var item in sameRepoGuidance.HostConstraints)
+            {
+                writer.WriteLine($"- {item}");
+            }
+
+            if (sameRepoPolicyWarning is not null)
+            {
+                writer.WriteLine();
+                writer.WriteLine($"⚠ {sameRepoPolicyWarning}");
+            }
+        }
     }
 
     private static bool TryParseArguments(
         string[] args,
         out string focusRole,
         out bool forceHost,
+        out string topology,
         out string format,
         out string error)
     {
         focusRole = string.Empty;
         forceHost = false;
+        topology = string.Empty;
         format = FormatMarkdown;
         error = string.Empty;
 
@@ -291,6 +374,22 @@ internal static class GuideWorkflowTaskInitHostCommand
                     break;
                 case "--force-host":
                     forceHost = true;
+                    break;
+                case "--topology":
+                    // G348: only 'same-repo' is a recognized topology option.
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "--topology requires a value (same-repo).";
+                        return false;
+                    }
+                    var requestedTopology = args[i + 1];
+                    if (!string.Equals(requestedTopology, "same-repo", StringComparison.Ordinal))
+                    {
+                        error = $"--topology must be 'same-repo' (got '{requestedTopology}').";
+                        return false;
+                    }
+                    topology = requestedTopology;
+                    i++;
                     break;
                 case "--format":
                     if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
@@ -385,6 +484,9 @@ internal sealed record InitHostGuidance
     [JsonPropertyName("focus_role")]
     public string? FocusRole { get; init; }
 
+    [JsonPropertyName("topology")]
+    public string? Topology { get; init; }
+
     [JsonPropertyName("cwd_has_dot_intent_cli")]
     public required bool CwdHasDotIntentCli { get; init; }
 
@@ -399,4 +501,34 @@ internal sealed record InitHostGuidance
 
     [JsonPropertyName("refusals")]
     public IReadOnlyList<string>? Refusals { get; init; }
+
+    /// <summary>G348: same-repo topology guidance; null when <c>--topology</c> is not set.</summary>
+    [JsonPropertyName("same_repo_topology")]
+    public SameRepoTopologyGuidance? SameRepoTopology { get; init; }
+
+    /// <summary>G348: warning string when same-repo topology is active but no non-default base-branch policy is configured; null otherwise.</summary>
+    [JsonPropertyName("same_repo_policy_warning")]
+    public string? SameRepoPolicyWarning { get; init; }
+}
+
+/// <summary>
+/// G348: same-repo topology guidance emitted when
+/// <c>--topology same-repo</c> is passed to <c>guide workflow task init-host</c>.
+/// </summary>
+internal sealed record SameRepoTopologyGuidance
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("branch_strategy")]
+    public required IReadOnlyList<string> BranchStrategy { get; init; }
+
+    [JsonPropertyName("forbidden_paths_for_implementation")]
+    public required IReadOnlyList<string> ForbiddenPathsForImplementation { get; init; }
+
+    [JsonPropertyName("host_constraints")]
+    public required IReadOnlyList<string> HostConstraints { get; init; }
+
+    [JsonPropertyName("warning")]
+    public required string Warning { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
@@ -1823,4 +1823,125 @@ public sealed class GuidePromptMatrixCommandTests
             }
         };
     }
+
+    // ----- G348: same-repo topology tests -----
+
+    [Fact]
+    public void Execute_G348_TopologySameRepo_ChildLoopIncludesSameRepoForbiddenSources()
+    {
+        // G348 AC: child-loop with --topology same-repo must include
+        // `.intent-cli/**` and `intents/**` in forbidden_sources.
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--topology", "same-repo", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var sources = document.RootElement.GetProperty("forbidden_sources")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(sources, s => s!.Contains(".intent-cli/**", StringComparison.Ordinal));
+        Assert.Contains(sources, s => s!.Contains("intents/**", StringComparison.Ordinal));
+        // Standard sources must still be present.
+        Assert.Contains(sources, s => s!.Contains("intents/rules/**", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_G348_TopologySameRepo_ChildLoopPromptDescribesForbiddenPaths()
+    {
+        // G348 AC: same-repo child-loop prompt must explain that
+        // .intent-cli/** and intents/** are visible but forbidden.
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--topology", "same-repo", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains(".intent-cli/**", prompt, StringComparison.Ordinal);
+        Assert.Contains("intents/**", prompt, StringComparison.Ordinal);
+        Assert.Contains("FORBIDDEN", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G348_TopologySameRepo_ChildLoopEntryRecordsTopology()
+    {
+        // G348: topology field must be "same-repo" in the JSON entry.
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--topology", "same-repo", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("same-repo", document.RootElement.GetProperty("topology").GetString());
+    }
+
+    [Fact]
+    public void Execute_G348_TopologySameRepo_ChildOneshotAlsoIncludesSameRepoForbiddenSources()
+    {
+        // G348 AC: child-oneshot with --topology same-repo must also include
+        // same-repo forbidden sources.
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-oneshot", "--topology", "same-repo", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var sources = document.RootElement.GetProperty("forbidden_sources")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(sources, s => s!.Contains(".intent-cli/**", StringComparison.Ordinal));
+        Assert.Contains(sources, s => s!.Contains("intents/**", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_G348_NoTopology_ForbiddenSourcesDoNotIncludeSameRepoPaths()
+    {
+        // G348: without --topology, .intent-cli/** must NOT appear in
+        // forbidden_sources (it is only added for same-repo topology).
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var sources = document.RootElement.GetProperty("forbidden_sources")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.DoesNotContain(sources, s => s!.Contains(".intent-cli/**", StringComparison.Ordinal));
+        // topology field must be absent/null.
+        if (document.RootElement.TryGetProperty("topology", out var topProp))
+        {
+            Assert.Equal(JsonValueKind.Null, topProp.ValueKind);
+        }
+    }
+
+    [Fact]
+    public void Execute_G348_UnknownTopology_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--topology", "cross-repo", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must be 'same-repo'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G348_Help_MentionsTopologyOption()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("--topology", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("same-repo", writer.ToString(), StringComparison.Ordinal);
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskInitHostCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskInitHostCommandTests.cs
@@ -324,6 +324,152 @@ public sealed class GuideWorkflowTaskInitHostCommandTests : IDisposable
         Assert.Contains("intent init", string.Join(" ", initPointer.SeeAlso ?? Array.Empty<string>()), StringComparison.Ordinal);
     }
 
+    // ----- G348: same-repo topology guidance -----
+
+    [Fact]
+    public void Execute_G348_TopologySameRepo_MarkdownIncludesSameRepoSection()
+    {
+        // G348 AC: `guide workflow task init-host --topology same-repo` must
+        // describe same-repo topology with branch strategy and forbidden paths.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            ["--topology", "same-repo"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Same-Repo Topology", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/**", output, StringComparison.Ordinal);
+        Assert.Contains("intents/**", output, StringComparison.Ordinal);
+        Assert.Contains("FORBIDDEN", output, StringComparison.Ordinal);
+        Assert.Contains("main-ai", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G348_TopologySameRepo_JsonIncludesSameRepoTopologyNode()
+    {
+        // G348 AC: JSON shape must include same_repo_topology with
+        // branch_strategy, forbidden_paths_for_implementation, host_constraints.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            ["--topology", "same-repo", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("same-repo", root.GetProperty("topology").GetString());
+        Assert.True(root.TryGetProperty("same_repo_topology", out var topology));
+        Assert.True(topology.TryGetProperty("summary", out _));
+        Assert.True(topology.TryGetProperty("branch_strategy", out var branchStrategy));
+        Assert.True(branchStrategy.GetArrayLength() >= 1);
+        Assert.True(topology.TryGetProperty("forbidden_paths_for_implementation", out var forbidden));
+        Assert.True(forbidden.GetArrayLength() >= 2);
+        Assert.True(topology.TryGetProperty("host_constraints", out var hostConstraints));
+        Assert.True(hostConstraints.GetArrayLength() >= 1);
+        Assert.True(topology.TryGetProperty("warning", out _));
+    }
+
+    [Fact]
+    public void Execute_G348_TopologySameRepoNoPolicy_EmitsPolicyWarning()
+    {
+        // G348 AC: when same-repo topology is selected but no base-branch
+        // policy is configured (default direct-main), a warning must appear.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            ["--topology", "same-repo", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.TryGetProperty("same_repo_policy_warning", out var warningProp));
+        Assert.NotNull(warningProp.GetString());
+        Assert.False(string.IsNullOrWhiteSpace(warningProp.GetString()));
+        Assert.Contains("main-ai", warningProp.GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G348_TopologySameRepoWithMainAiPolicy_NoPolicyWarning()
+    {
+        // G348 AC: when same-repo topology + main-ai policy is configured,
+        // the same_repo_policy_warning must be null (no warning needed).
+        using var writer = new StringWriter();
+        var context = CreateContextWithPolicy(emptyCwd, "main-ai");
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            context,
+            ["--topology", "same-repo", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        // When policy is main-ai, same_repo_policy_warning should be absent or null.
+        if (root.TryGetProperty("same_repo_policy_warning", out var warningProp))
+        {
+            Assert.True(warningProp.ValueKind == JsonValueKind.Null,
+                $"Expected same_repo_policy_warning to be null but got: {warningProp.GetString()}");
+        }
+    }
+
+    [Fact]
+    public void Execute_G348_NoTopology_SameRepoNodeAbsent()
+    {
+        // G348: when --topology is not passed, same_repo_topology must be absent.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        // topology and same_repo_topology should be absent (WhenWritingNull).
+        if (root.TryGetProperty("topology", out var topologyProp))
+        {
+            Assert.Equal(JsonValueKind.Null, topologyProp.ValueKind);
+        }
+        if (root.TryGetProperty("same_repo_topology", out var sameRepoProp))
+        {
+            Assert.Equal(JsonValueKind.Null, sameRepoProp.ValueKind);
+        }
+    }
+
+    [Fact]
+    public void Execute_G348_UnknownTopology_ExitsOneWithError()
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            ["--topology", "cross-repo"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must be 'same-repo'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G348_SameRepoTopologyGuidance_ForbiddenPathsNamesBothHostPaths()
+    {
+        // G348 AC: same-repo guidance must explicitly name both host-metadata
+        // path groups as forbidden for implementation agents.
+        var forbidden = GuideWorkflowTaskInitHostCommand.SameRepoTopology.ForbiddenPathsForImplementation;
+        var combined = string.Join(" ", forbidden);
+        Assert.Contains(".intent-cli/**", combined, StringComparison.Ordinal);
+        Assert.Contains("intents/**", combined, StringComparison.Ordinal);
+        Assert.Contains("FORBIDDEN", combined, StringComparison.Ordinal);
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext
@@ -336,6 +482,24 @@ public sealed class GuideWorkflowTaskInitHostCommandTests : IDisposable
                     Domain = "intent-cli",
                     ArtifactRoot = ".intent-cli",
                     WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+
+    private static CliContext CreateContextWithPolicy(string repoRoot, string baseBranchPolicy)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                    BaseBranchPolicy = baseBranchPolicy
                 }
             }
         };


### PR DESCRIPTION
## Summary

- `guide workflow task init-host --topology same-repo` now emits a structured `SameRepoTopologyGuidance` section explaining branch strategy, forbidden host-metadata paths (`.intent-cli/**`, `intents/**`), host constraints, and a policy warning when `base_branch_policy` is not set to `main-ai`.
- `guide prompt-matrix --topology same-repo` adds same-repo-specific forbidden paths to child-loop and child-oneshot entries and inserts an explicit guard block in the rendered prompt.
- 14 new tests cover JSON shape, markdown output, forbidden-path additions, policy-absent warning, policy-present silence, and unknown topology rejection.

## Test plan

- [x] All 2873 existing tests pass, 1 skipped (pre-existing skip)
- [x] 14 new G348 tests in `GuideWorkflowTaskInitHostCommandTests` and `GuidePromptMatrixCommandTests`
- [x] `guide workflow task init-host --topology same-repo --format json` returns `same_repo_topology` node
- [x] `guide prompt-matrix --mode child-loop --topology same-repo --format json` returns `.intent-cli/**` in `forbidden_sources`
- [x] Wrong topology value (`--topology cross-repo`) returns usage error

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)